### PR TITLE
fix(ci): use Node 22 for execution-factory vitest job

### DIFF
--- a/.github/workflows/ci-execution-factory.yml
+++ b/.github/workflows/ci-execution-factory.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Bump `node-version` from 20 to 22 in `ci-execution-factory.yml`.
- Fixes CI failure: pnpm 11.5.1 requires Node.js >= 22.13 on Linux runners (`ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`).

## Context
PR #1 merged before this one-line CI fix landed; main branch CI is still red on push.

## Test plan
- [ ] CI `L1 vitest (execution-factory)` passes on this PR