### PR TITLE
feat(data-catalog): edit index config + full-text role

### DIFF
--- a/src/modules/data-catalog/components/BuildTaskModal.tsx
+++ b/src/modules/data-catalog/components/BuildTaskModal.tsx
@@ -11,6 +11,7 @@ import {
   BuildTaskConflictError,
   createBuildTask,
   listBuildTasks,
+  updateBuildTask,
 } from "@/modules/data-catalog/services/build-task.service";
 import { getCatalogResource } from "@/modules/data-catalog/services/resource.service";
 import type {
@@ -44,9 +45,10 @@ const isTextField = (type: string) => TEXT_TYPE_RE.test(type);
 
 export function BuildTaskModal({ onClose, onCreated, open, resource }: BuildTaskModalProps) {
   const { t } = useTranslation();
-  const { message } = useAppServices();
+  const { message, modal } = useAppServices();
   const navigate = useNavigate();
 
+  const [existingTask, setExistingTask] = useState<BuildTask | null>(null);
   const [mode, setMode] = useState<BuildMode>("batch");
   const [schema, setSchema] = useState<ResourceSchemaField[]>(resource.schema);
   const [schemaLoading, setSchemaLoading] = useState(false);
@@ -65,6 +67,7 @@ export function BuildTaskModal({ onClose, onCreated, open, resource }: BuildTask
       return;
     }
 
+    setExistingTask(null);
     setMode("batch");
     setEmbeddingFields([]);
     setBuildKeyFields([]);
@@ -97,6 +100,7 @@ export function BuildTaskModal({ onClose, onCreated, open, resource }: BuildTask
         existing = null;
       }
       if (existing) {
+        setExistingTask(existing);
         setMode(existing.mode);
         setEmbeddingFields(existing.embeddingFields);
         setBuildKeyFields(existing.buildKeyFields);
@@ -147,6 +151,10 @@ export function BuildTaskModal({ onClose, onCreated, open, resource }: BuildTask
     [modelId, models],
   );
 
+  // 已有 batch 任务 → 编辑模式(保存走 PUT + full 重建);streaming 暂不支持编辑
+  const isEditable = existingTask !== null && existingTask.mode === "batch";
+  const streamingLocked = existingTask !== null && existingTask.mode === "streaming";
+
   const toggleField = (
     field: string,
     list: string[],
@@ -177,19 +185,47 @@ export function BuildTaskModal({ onClose, onCreated, open, resource }: BuildTask
     }
 
     const useEmbedding = embeddingFields.length > 0 && selectedModel;
+    const payload = {
+      buildKeyFields,
+      embeddingFields,
+      embeddingModel: useEmbedding ? selectedModel.id : "",
+      modelDimensions: useEmbedding ? selectedModel.dimensions : 0,
+      fulltextFields,
+      fulltextAnalyzer: fulltextFields.length > 0 ? fulltextAnalyzer : undefined,
+    };
+
+    // 编辑:改字段会重建索引,二次确认后走 PUT
+    if (isEditable && existingTask) {
+      void modal.confirm({
+        title: t("dataCatalog.build.editConfirmTitle"),
+        content: t("dataCatalog.build.editConfirmContent"),
+        okText: t("dataCatalog.build.editConfirmOk"),
+        cancelText: t("common.cancel"),
+        onOk: async () => {
+          setSaving(true);
+          setError(null);
+          try {
+            await updateBuildTask(existingTask.id, payload);
+            message.success(t("dataCatalog.build.edited"));
+            onCreated(existingTask);
+            onClose();
+          } catch (submitError) {
+            setError(extractRequestErrorMessage(submitError));
+          } finally {
+            setSaving(false);
+          }
+        },
+      });
+      return;
+    }
 
     setSaving(true);
     setError(null);
     try {
       const task = await createBuildTask({
-        buildKeyFields,
-        embeddingFields,
-        embeddingModel: useEmbedding ? selectedModel.id : "",
+        ...payload,
         mode,
-        modelDimensions: useEmbedding ? selectedModel.dimensions : 0,
         resourceId: resource.id,
-        fulltextFields,
-        fulltextAnalyzer: fulltextFields.length > 0 ? fulltextAnalyzer : undefined,
       });
       message.success(t("dataCatalog.build.created", { id: task.id }));
       onCreated(task);
@@ -266,26 +302,33 @@ export function BuildTaskModal({ onClose, onCreated, open, resource }: BuildTask
       footer={
         <Space style={{ display: "flex", width: "100%" }}>
           <span style={{ marginRight: "auto", color: "#8b98ac", fontSize: 12 }}>
-            POST /vega-backend/v1/build-tasks
+            {isEditable
+              ? "PUT /vega-backend/v1/build-tasks/:id"
+              : "POST /vega-backend/v1/build-tasks"}
           </span>
           <AppButton onClick={onClose}>{t("common.cancel")}</AppButton>
           <AppButton
-            disabled={noModels && embeddingFields.length > 0}
+            disabled={streamingLocked || (noModels && embeddingFields.length > 0)}
             icon={<ThunderboltOutlined />}
             loading={saving}
             onClick={() => void handleSubmit()}
             type="primary"
           >
-            {t("dataCatalog.build.submit")}
+            {isEditable
+              ? t("dataCatalog.build.editSubmit")
+              : t("dataCatalog.build.submit")}
           </AppButton>
         </Space>
       }
       onCancel={onClose}
       open={open}
-      title={t("dataCatalog.build.title")}
+      title={isEditable ? t("dataCatalog.build.editTitle") : t("dataCatalog.build.title")}
       width={680}
     >
       <div style={{ display: "grid", gap: 18 }}>
+        {streamingLocked ? (
+          <Alert message={t("dataCatalog.build.streamingEditLocked")} showIcon type="info" />
+        ) : null}
         <div>
           <div style={{ marginBottom: 7, fontWeight: 600, fontSize: 13, color: "#3e4d66" }}>
             {t("dataCatalog.build.resource")}

--- a/src/modules/data-catalog/components/ResourceDetailPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceDetailPanel.tsx
@@ -156,6 +156,9 @@ export function ResourceDetailPanel({
           {roleSource?.embeddingFields.includes(record.name) ? (
             <span className={[styles.tag, styles.taskRunning].join(" ")}>embedding</span>
           ) : null}
+          {roleSource?.fulltextFields.includes(record.name) ? (
+            <span className={[styles.tag, styles.modeStreaming].join(" ")}>fulltext</span>
+          ) : null}
           {roleSource?.buildKeyFields.includes(record.name) ? (
             <span className={[styles.tag, styles.modeBatch].join(" ")}>build key</span>
           ) : null}
@@ -379,6 +382,18 @@ export function ResourceDetailPanel({
                         ))}
                       </span>
                     </div>
+                    {effective.fulltextFields.length > 0 ? (
+                      <div className={styles.descItem}>
+                        <span className={styles.descLabel}>fulltext_fields</span>
+                        <span className={styles.chipRow}>
+                          {effective.fulltextFields.map((field) => (
+                            <span className={styles.fieldChip} key={field}>
+                              {field}
+                            </span>
+                          ))}
+                        </span>
+                      </div>
+                    ) : null}
                     <div className={styles.descItem}>
                       <span className={styles.descLabel}>
                         {t("dataCatalog.task.model")}

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -166,6 +166,15 @@ export const dataCatalogEnUS = {
     build: {
       title: "Index Build · New BuildTask",
       submit: "Create & Start Build",
+      editTitle: "Edit Index Config",
+      editSubmit: "Save & Rebuild",
+      editConfirmTitle: "Save and rebuild the index?",
+      editConfirmContent:
+        "Changing fields rebuilds the index; during the rebuild this resource is served by the old index, then switches to the new config once done.",
+      editConfirmOk: "Save & Rebuild",
+      edited: "Saved; index rebuild started",
+      streamingEditLocked:
+        "Editing config is not supported for streaming tasks yet; delete and recreate to change it.",
       created: "Build task created: {{id}}",
       conflict:
         "This resource already has an active build task; wait for it or pause listening first.",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -160,6 +160,14 @@ export const dataCatalogZhCN = {
     build: {
       title: "索引构建 · 新建 BuildTask",
       submit: "创建并开始构建",
+      editTitle: "编辑索引配置",
+      editSubmit: "保存并重建",
+      editConfirmTitle: "保存并重建索引?",
+      editConfirmContent:
+        "修改字段会重建索引;重建期间该资源检索短暂以旧索引服务,完成后切换到新配置。",
+      editConfirmOk: "保存并重建",
+      edited: "已保存,开始重建索引",
+      streamingEditLocked: "流式任务暂不支持编辑配置,如需修改请删除后重建。",
       created: "构建任务已创建:{{id}}",
       conflict: "该资源已有进行中的构建任务,需等待完成或先暂停监听。",
       resource: "数据资源",

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -15,6 +15,7 @@ import type {
   BuildTaskCreateInput,
   BuildTaskListQuery,
   BuildTaskStatus,
+  BuildTaskUpdateInput,
 } from "@/modules/data-catalog/types/data-catalog";
 
 type BackendBuildTask = {
@@ -272,6 +273,41 @@ export async function resumeBuildTask(id: string) {
 
   // 后端语义:start = 恢复运行(body 可选)
   await http.post(`/vega-backend/v1/build-tasks/${id}/start`);
+}
+
+export async function updateBuildTask(
+  id: string,
+  input: BuildTaskUpdateInput,
+): Promise<void> {
+  if (useMock) {
+    const task = mockBuildTasks.find((item) => item.id === id);
+    if (task) {
+      task.embeddingFields = input.embeddingFields;
+      task.buildKeyFields = input.buildKeyFields;
+      task.embeddingModel = input.embeddingModel;
+      task.modelDimensions = input.modelDimensions;
+      task.fulltextFields = input.fulltextFields;
+      task.fulltextAnalyzer = input.fulltextAnalyzer ?? "";
+      task.status = "pending";
+      task.syncedCount = 0;
+      task.vectorizedCount = 0;
+      task.error = null;
+      emitMockChange();
+      ensureMockTicker();
+    }
+    await wait(undefined, 120);
+    return;
+  }
+
+  // 编辑配置 + 触发 full 重建(后端 drop 旧索引按新 mapping 重建)。仅 batch。
+  await http.put(`/vega-backend/v1/build-tasks/${id}`, {
+    build_key_fields: input.buildKeyFields.join(","),
+    embedding_fields: input.embeddingFields.join(","),
+    embedding_model: input.embeddingModel,
+    model_dimensions: input.modelDimensions,
+    fulltext_fields: input.fulltextFields.join(","),
+    fulltext_analyzer: input.fulltextAnalyzer || undefined,
+  });
 }
 
 export async function deleteBuildTask(

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -92,6 +92,15 @@ export type BuildTaskCreateInput = {
 
 export type FulltextAnalyzer = "hanlp_index" | "ik_max_word" | "standard";
 
+export type BuildTaskUpdateInput = {
+  buildKeyFields: string[];
+  embeddingFields: string[];
+  embeddingModel: string;
+  fulltextAnalyzer?: string;
+  fulltextFields: string[];
+  modelDimensions: number;
+};
+
 export type CatalogScanStatus = "failed" | "running" | "succeeded";
 
 export type CatalogScanRecord = {


### PR DESCRIPTION
## Summary

Frontend for editing an existing build task's index config, plus surfacing the full-text role in the resource schema.

## Changes
- **BuildTaskModal**: when a resource already has a batch task, the modal opens in edit mode — title/button become "Save & Rebuild", submit goes through `PUT /build-tasks/:id` with a rebuild confirmation. Streaming tasks are locked with a notice (backend only supports batch config edits).
- **ResourceDetailPanel**: schema index-role column shows a `fulltext` tag; effective index detail lists `fulltext_fields`.
- Fields prefill from the existing task; embedding model only required when embedding fields are selected.

## Depends on
- backend bkn-foundry#52 (`PUT /build-tasks/:id`) deployed for edit to work end-to-end

## Test
- tsc + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)