### PR TITLE
fix(data-catalog): show column count in resource list

### DIFF
--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -204,10 +204,10 @@ export function CatalogDetailPanel({
     },
     {
       dataIndex: "columnCount",
-      title: "Schema",
+      title: t("dataCatalog.resource.fieldCount"),
       // 列表接口用后端标量 column_count(schema_definition 不在列表返回);0 视为未返回
       render: (value: number) =>
-        value > 0 ? t("dataCatalog.resource.columnCount", { count: value }) : "—",
+        value > 0 ? <span className={styles.monoText}>{value}</span> : "—",
     },
     {
       dataIndex: "rowCount",

--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -203,14 +203,11 @@ export function CatalogDetailPanel({
       ),
     },
     {
-      dataIndex: "schema",
+      dataIndex: "columnCount",
       title: "Schema",
-      // 列表接口不返回 schema_definition/row_count(后端 GetByIDsBasic),
-      // 0 视为"未返回"显示占位,真实数字看详情
-      render: (_, record) =>
-        record.schema.length > 0
-          ? t("dataCatalog.resource.columnCount", { count: record.schema.length })
-          : "—",
+      // 列表接口用后端标量 column_count(schema_definition 不在列表返回);0 视为未返回
+      render: (value: number) =>
+        value > 0 ? t("dataCatalog.resource.columnCount", { count: value }) : "—",
     },
     {
       dataIndex: "rowCount",

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -114,6 +114,7 @@ export const dataCatalogEnUS = {
       indexState: "Index State",
       buildTasks: "Build Tasks",
       columnCount: "{{count}} columns",
+      fieldCount: "Fields",
       create: "New Resource",
       createTitle: "New Data Resource",
       created: "Resource created: {{name}}",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -110,6 +110,7 @@ export const dataCatalogZhCN = {
       indexState: "索引状态",
       buildTasks: "构建任务",
       columnCount: "{{count}} 列",
+      fieldCount: "字段数",
       create: "新建资源",
       createTitle: "新建数据资源",
       created: "资源已创建:{{name}}",

--- a/src/modules/data-catalog/services/resource.service.ts
+++ b/src/modules/data-catalog/services/resource.service.ts
@@ -30,6 +30,7 @@ type BackendSchemaField = {
 type BackendResource = {
   catalog_id: string;
   category?: string;
+  column_count?: number;
   description?: string;
   id: string;
   logic_type?: string;
@@ -86,6 +87,8 @@ function mapResource(item: BackendResource): CatalogResource {
       name: field.name ?? field.display_name ?? "",
       type: field.type ?? field.original_type ?? "string",
     })),
+    // 列表接口不返回 schema_definition,改用后端标量 column_count;详情接口回退到 schema 长度
+    columnCount: item.column_count ?? item.schema_definition?.length ?? 0,
     // 顶层 row_count 后端常缺省,实际行数在 source_metadata.properties 里
     rowCount: item.row_count ?? item.source_metadata?.properties?.row_count ?? 0,
     updatedAt: item.update_time ?? 0,
@@ -163,6 +166,7 @@ export async function createCatalogResource(input: ResourceCreateInput) {
               { name: "name", type: "varchar(128)" },
               { name: "updated_at", type: "datetime" },
             ],
+      columnCount: input.schema.length > 0 ? input.schema.length : 3,
       rowCount: 0,
       updatedAt: Date.now(),
       updateTime: formatMockTimestamp(Date.now()),
@@ -194,6 +198,7 @@ export async function createCatalogResource(input: ResourceCreateInput) {
       sourceIdentifier: input.sourceIdentifier,
       description: input.description,
       schema: input.schema,
+      columnCount: input.schema.length,
       rowCount: 0,
       updatedAt: Date.now(),
       updateTime: formatMockTimestamp(Date.now()),

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -8,6 +8,7 @@ export type ResourceSchemaField = {
 export type CatalogResource = {
   catalogId: string;
   category: ResourceCategory;
+  columnCount: number;
   description: string;
   id: string;
   name: string;


### PR DESCRIPTION
## Problem

The resource list Schema column rendered empty (—) while row count worked. The list endpoint returns a `column_count` scalar (it omits `schema_definition`), but the frontend was computing column count from `schema.length`, which is empty on the list path.

## Fix
- map backend `column_count` into `CatalogResource.columnCount` (fall back to `schema_definition.length` on the detail path)
- render the Schema column from `columnCount`
- backfill `columnCount` in mock literals

## Test
- tsc + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)