### PR TITLE
chore: default VITE_USE_MOCK off (real backend by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 VITE_API_BASE_URL=/api
-VITE_USE_MOCK=true
+VITE_USE_MOCK=false
 # Remote debug target when VITE_USE_MOCK=false (see .env.local). /api and the
 # OAuth2 login flow (/oauth2, /.well-known, /userinfo) are proxied there; the
 # gateway's hydra must have the openbkn-studio client seeded with a redirect_uri

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ COPY . .
 # which also runs `tsc -b`. Type safety is a CI gate (`pnpm lint:types` /
 # `pnpm check`), so the deployable artifact isn't blocked on an unrelated
 # typecheck regression. The browser bundle never needs tsc's output.
+# A deployed image must hit the REAL backend, so default the mock switch OFF
+# (services fall back to fixtures only when VITE_USE_MOCK !== "false"). Pass
+# --build-arg VITE_USE_MOCK=true for a gate-less demo/fixtures build.
+ARG VITE_USE_MOCK=false
+ENV VITE_USE_MOCK=${VITE_USE_MOCK}
 RUN pnpm exec vite build
 
 ########################### Stage 1 — runtime ###########################

--- a/src/framework/auth/dev-auth.ts
+++ b/src/framework/auth/dev-auth.ts
@@ -18,7 +18,7 @@ function readEnvRefreshToken() {
 }
 
 export function shouldUseDevAuth() {
-  return import.meta.env.DEV && import.meta.env.VITE_USE_MOCK === "false";
+  return import.meta.env.DEV && import.meta.env.VITE_USE_MOCK !== "true";
 }
 
 export function hasDevAccessToken() {

--- a/src/framework/auth/oauth.ts
+++ b/src/framework/auth/oauth.ts
@@ -51,7 +51,7 @@ export function shouldUseOAuthGate(mode: "hosted" | "standalone") {
   }
 
   // Mock-mode dev runs without a backend, so there is nothing to log in to.
-  return !import.meta.env.DEV || import.meta.env.VITE_USE_MOCK === "false";
+  return !import.meta.env.DEV || import.meta.env.VITE_USE_MOCK !== "true";
 }
 
 export function isOAuthCallbackPath(pathname = window.location.pathname) {

--- a/src/modules/account/services/profile.service.ts
+++ b/src/modules/account/services/profile.service.ts
@@ -21,7 +21,7 @@ export type ProfileUpdatePayload = {
   telephone?: string;
 };
 
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 type BackendMe = {
   id: string;

--- a/src/modules/api-keys/services/api-key.service.ts
+++ b/src/modules/api-keys/services/api-key.service.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/modules/api-keys/types/api-key";
 
 const API_PREFIX = "/safe/v1/me/api-keys";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 type BackendApiKey = {
   id: string;

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -49,7 +49,7 @@ type ListResponse<T> = {
   total_count: number;
 };
 
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 const wait = async <T,>(value: T, delay = 180) =>
   new Promise<T>((resolve) => {

--- a/src/modules/data-catalog/services/resource.service.ts
+++ b/src/modules/data-catalog/services/resource.service.ts
@@ -51,7 +51,7 @@ type ListResponse<T> = {
   total_count: number;
 };
 
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 const wait = async <T,>(value: T, delay = 180) =>
   new Promise<T>((resolve) => {

--- a/src/modules/data-connect/services/data-connect.service.ts
+++ b/src/modules/data-connect/services/data-connect.service.ts
@@ -57,7 +57,7 @@ type ListResponse<T> = {
   total_count: number;
 };
 
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 const mockConnectorTypes: DataConnectConnectorType[] = [
   {

--- a/src/modules/data-connect/services/scan.service.ts
+++ b/src/modules/data-connect/services/scan.service.ts
@@ -54,7 +54,7 @@ type ListResponse<T> = {
   total_count: number;
 };
 
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 let mockSchedules: DataConnectScanSchedule[] = [
   {

--- a/src/modules/execution-factory/services/function.service.ts
+++ b/src/modules/execution-factory/services/function.service.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/modules/execution-factory/types/function";
 
 const API_PREFIX = "/agent-operator-integration/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 const DEFAULT_BUSINESS_DOMAIN = "bd_public";
 
 function getBusinessDomainHeaders() {

--- a/src/modules/execution-factory/services/impex.service.ts
+++ b/src/modules/execution-factory/services/impex.service.ts
@@ -13,7 +13,7 @@ import type {
 } from "@/modules/execution-factory/types/impex";
 
 const API_PREFIX = "/agent-operator-integration/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 const IMPEX_EXPORT_TIMEOUT_MS = 60_000;
 
 function resolveExportFilename(

--- a/src/modules/execution-factory/services/mcp.service.ts
+++ b/src/modules/execution-factory/services/mcp.service.ts
@@ -49,7 +49,7 @@ type BackendMcpListResponse = {
 import { normalizeTimestamp } from "@/modules/execution-factory/utils/format-timestamp";
 
 const API_PREFIX = "/agent-operator-integration/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 const DEFAULT_BUSINESS_DOMAIN = "bd_public";
 
 let mockMcps: McpRecord[] = [

--- a/src/modules/execution-factory/services/operator.service.ts
+++ b/src/modules/execution-factory/services/operator.service.ts
@@ -90,7 +90,7 @@ type BackendOperatorRegisterResult = {
 };
 
 const API_PREFIX = "/agent-operator-integration/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 const DEFAULT_BUSINESS_DOMAIN = "bd_public";
 
 let mockOperators: OperatorRecord[] = [

--- a/src/modules/execution-factory/services/skill.service.ts
+++ b/src/modules/execution-factory/services/skill.service.ts
@@ -92,7 +92,7 @@ function buildMockFileSummaries(): SkillFileSummary[] {
 }
 
 const API_PREFIX = "/agent-operator-integration/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 const DEFAULT_BUSINESS_DOMAIN = "bd_public";
 
 type BackendSkillHistoryInfo = {

--- a/src/modules/execution-factory/services/template.service.ts
+++ b/src/modules/execution-factory/services/template.service.ts
@@ -2,7 +2,7 @@ import { http } from "@/framework/request/http";
 import { getRuntimeConfig } from "@/framework/runtime/config";
 
 const API_PREFIX = "/agent-operator-integration/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 function getBusinessDomainHeaders() {
   const businessDomainId =

--- a/src/modules/execution-factory/services/tool.service.ts
+++ b/src/modules/execution-factory/services/tool.service.ts
@@ -68,7 +68,7 @@ type BackendToolListResponse = {
 };
 
 const API_PREFIX = "/agent-operator-integration/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 const DEFAULT_BUSINESS_DOMAIN = "bd_public";
 
 const mockToolsByBox: Record<string, ToolRecord[]> = {

--- a/src/modules/execution-factory/services/toolbox.service.ts
+++ b/src/modules/execution-factory/services/toolbox.service.ts
@@ -46,7 +46,7 @@ type BackendToolboxListResponse = {
 };
 
 const API_PREFIX = "/agent-operator-integration/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 const DEFAULT_BUSINESS_DOMAIN = "bd_public";
 
 let mockToolboxes: ToolboxRecord[] = [

--- a/src/modules/knowledge-network/README.md
+++ b/src/modules/knowledge-network/README.md
@@ -149,7 +149,7 @@ services/
 
 ## 开发 Mock
 
-默认启用 mock（`VITE_USE_MOCK !== "false"`）。验收网络：`kn-domain-risk`。
+默认走真实后端；设 `VITE_USE_MOCK=true` 才启用 mock。验收网络：`kn-domain-risk`。
 
 对象类新建：`/knowledge-network/workspace/kn-domain-risk/object-types/create`
 

--- a/src/modules/knowledge-network/services/shared/runtime.ts
+++ b/src/modules/knowledge-network/services/shared/runtime.ts
@@ -34,7 +34,7 @@ export function readFileReaderText(result: string | ArrayBuffer | null | undefin
   return typeof result === "string" ? result : "{}";
 }
 
-export const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+export const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 /** Real-env integration defers metric/task APIs until the test backend is ready. */
 export const integrateWorkspaceMetrics = useMock;

--- a/src/modules/model-resources/services/llm.service.ts
+++ b/src/modules/model-resources/services/llm.service.ts
@@ -14,7 +14,7 @@ import type {
 } from "@/modules/model-resources/types/llm";
 
 const API_PREFIX = "/mf-model-manager/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 type BackendLlmModel = {
   model_id: string;

--- a/src/modules/model-resources/services/quota.service.ts
+++ b/src/modules/model-resources/services/quota.service.ts
@@ -16,7 +16,7 @@ import type {
 } from "@/modules/model-resources/types/quota";
 
 const API_PREFIX = "/mf-model-manager/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 type BackendModelQuota = {
   conf_id?: string;

--- a/src/modules/model-resources/services/small-model.service.ts
+++ b/src/modules/model-resources/services/small-model.service.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/modules/model-resources/types/small-model";
 
 const API_PREFIX = "/mf-model-manager/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 type BackendSmallModel = {
   model_id: string;

--- a/src/modules/model-resources/services/statistics.service.ts
+++ b/src/modules/model-resources/services/statistics.service.ts
@@ -12,7 +12,7 @@ import {
 } from "@/modules/model-resources/utils/statistics-chart";
 
 const API_PREFIX = "/mf-model-manager/v1";
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 type BackendStatisticsOverview = {
   summary?: {

--- a/src/modules/system-admin/services/admin.service.ts
+++ b/src/modules/system-admin/services/admin.service.ts
@@ -21,7 +21,7 @@ import type {
  * 后端暂不支持、已从写路径剔除（等后端反馈）：冻结/解冻、部门扩展字段
  * （负责人/编码/邮箱/备注）、用户↔部门归属写入。
  */
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 const ADMIN = "/safe/v1/admin";
 export const DEFAULT_NEW_USER_PASSWORD = "openbkn"; // 平台初始密码，首登提示改

--- a/src/modules/system-admin/services/authz.service.ts
+++ b/src/modules/system-admin/services/authz.service.ts
@@ -22,7 +22,7 @@ import type {
  *   - bkn-safe 不存资源名：真实模式下对象名需前端从各领域服务解析（见
  *     listAuthorizableObjects 的 TODO）。
  */
-const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const useMock = import.meta.env.VITE_USE_MOCK === "true";
 
 const ADMIN = "/safe/v1/admin";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,7 @@ function redirectRootToAppBase(): Plugin {
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, projectRoot, "");
   const devProxyOrigin = env.VITE_DEV_AUTH_ORIGIN || "http://118.196.7.174";
-  const useMock = env.VITE_USE_MOCK !== "false";
+  const useMock = env.VITE_USE_MOCK === "true";
   const agentOperatorProxyTarget =
     process.env.VITE_PROXY_TARGET ?? (useMock ? "http://127.0.0.1:9000" : devProxyOrigin);
   // ContextLoader「立即体验」直接打 agent-retrieval（REST /api/agent-retrieval/v1/...，MCP /api/agent-retrieval/v1/mcp）。


### PR DESCRIPTION
mock 之前是全局默认开（`useMock = VITE_USE_MOCK !== "false"`）—— 任何没显式设 env 的构建（含部署镜像、CI）都打包了 fixture 假数据。这就是线上模型管理是 demo、设默认不生效的根因。

翻成 **opt-in**：只有 `VITE_USE_MOCK === "true"` 才 mock，默认走真后端。

- 22 个 *.service 的 useMock + vite.config + kn runtime：`!== "false"` → `=== "true"`
- auth 门（shouldUseOAuthGate / shouldUseDevAuth）里"真实模式"判断 `=== "false"` → `!== "true"`（prod `!DEV` 不受影响，仅修 dev 一致性）
- `.env.example` 默认 `VITE_USE_MOCK=false`；kn README 说明更新
- Dockerfile 保留 ARG，`--build-arg VITE_USE_MOCK=true` 可构 demo 镜像

测试在 vitest env 的 `VITE_USE_MOCK="true"` 下跑，仍走 fixtures。验证：tsc + 21 测试 + eslint + build 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)