### PR TITLE
build: bake VITE_USE_MOCK=false (real backend in the deployed image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ COPY . .
 # which also runs `tsc -b`. Type safety is a CI gate (`pnpm lint:types` /
 # `pnpm check`), so the deployable artifact isn't blocked on an unrelated
 # typecheck regression. The browser bundle never needs tsc's output.
+# A deployed image must hit the REAL backend: services fall back to the mock
+# fixtures unless VITE_USE_MOCK="false", so bake it off for builds. Pass
+# --build-arg VITE_USE_MOCK=true to produce a mock/demo image instead.
+ARG VITE_USE_MOCK=false
+ENV VITE_USE_MOCK=${VITE_USE_MOCK}
 RUN pnpm exec vite build
 
 ########################### Stage 1 — runtime ###########################


### PR DESCRIPTION
service 默认走 mock fixtures（除非 `VITE_USE_MOCK="false"`）。部署镜像必须用真后端，所以在**构建时**把它关掉 —— 一行 Dockerfile，源码逻辑不动。

- `ARG VITE_USE_MOCK=false` + `ENV`，`RUN vite build` 前烤进去
- `--build-arg VITE_USE_MOCK=true` 可构 mock/demo 镜像

线上镜像 `c14dbbe-real` 本就是用这个 env 构的，已是真后端，无需重部署。（之前那个 27 文件翻 polarity 的 PR #13 已按要求关闭回退。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)