### PR TITLE
feat(deploy): install latest published version by default

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -18,7 +18,8 @@
 #
 # Usage:
 #   deploy/install.sh cluster [--namespace openbkn] [--version 0.1.0 | --latest]
-#                             [--chart <ref>] [--kube-context <ctx>] [--no-auth]
+#                             [--registry ghcr|swr] [--chart <ref>]
+#                             [--kube-context <ctx>] [--no-auth]
 #   deploy/install.sh local --foundry https://10.211.55.4 [--port 8080]
 #                           [--version 0.1.0] [--image <ref>] [--register]
 #                           [--no-auth] [--no-compose]
@@ -44,6 +45,10 @@ CHART_NAME="bkn-studio"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULT_CHART_OCI="oci://ghcr.io/openbkn-ai/charts/${CHART_NAME}"
 DEFAULT_IMAGE_REPO="ghcr.io/openbkn-ai/${CHART_NAME}"
+# Image registry bases for `cluster --registry ghcr|swr` — overrides the chart's
+# image.registry so the cluster pulls from a reachable mirror (SWR for CN).
+IMAGE_REGISTRY_GHCR="ghcr.io/openbkn-ai"
+IMAGE_REGISTRY_SWR="swr.cn-east-3.myhuaweicloud.com/openbkn-ai"
 # Pre-seeded by bkn-safe (clientSeed.extraWebRedirectUris default) — login works
 # on this origin with zero registration.
 SEEDED_LOCAL_ORIGIN="http://localhost:8000"
@@ -76,12 +81,13 @@ usage() { awk 'NR>=2{ if(/^#/){sub(/^# ?/,"");print} else exit }' "$0"; exit "${
 
 # ---------------------------------------------------------------- cluster ----
 cmd_cluster() {
-  local namespace="openbkn" version="" chart="$DEFAULT_CHART_OCI" kube_context="" no_auth="false" want_latest="false"
+  local namespace="openbkn" version="" chart="$DEFAULT_CHART_OCI" kube_context="" no_auth="false" want_latest="false" registry=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --namespace) namespace="$2"; shift 2;;
       --version) version="$2"; shift 2;;
       --latest) want_latest="true"; shift;;
+      --registry) registry="$2"; shift 2;;
       --chart) chart="$2"; shift 2;;
       --kube-context) kube_context="$2"; shift 2;;
       --no-auth) no_auth="true"; shift;;
@@ -108,6 +114,11 @@ cmd_cluster() {
   # chart's auth.enabled so studio installs gate-less (no bkn-safe).
   local sets=(--set image.tag="$version")
   [ "$no_auth" = "true" ] && sets+=(--set auth.enabled=false)
+  case "$registry" in
+    ""|ghcr) ;;  # chart default already points at GHCR
+    swr) sets+=(--set image.registry="$IMAGE_REGISTRY_SWR");;
+    *) die "--registry must be 'ghcr' or 'swr'";;
+  esac
 
   info "helm upgrade --install ${CHART_NAME} ${chart} (v${version}) -n ${namespace}${no_auth:+ (no-auth=$no_auth)}"
   helm upgrade --install "$CHART_NAME" "$chart" \

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -6,8 +6,8 @@
 #            the SAME host as /api, /oauth2, /.well-known, /userinfo — so the SPA
 #            is same-origin and the OAuth callback (https://<gateway>/studio/
 #            callback) is already seeded by bkn-safe. Nothing to register.
-#            --version pins a specific release; OMIT it to install the latest
-#            published version (resolved from the chart registry).
+#            --version pins a specific release; --latest (or omitting --version)
+#            installs the latest published version from the chart registry.
 #
 #   local    Run the studio image as a local container whose nginx ALSO reverse-
 #            proxies /api, /oauth2, /.well-known, /userinfo to a remote Foundry
@@ -17,7 +17,7 @@
 #            registered with bkn-safe unless it is the pre-seeded localhost:8000.
 #
 # Usage:
-#   deploy/install.sh cluster [--namespace openbkn] [--version 0.1.0]
+#   deploy/install.sh cluster [--namespace openbkn] [--version 0.1.0 | --latest]
 #                             [--chart <ref>] [--kube-context <ctx>] [--no-auth]
 #   deploy/install.sh local --foundry https://10.211.55.4 [--port 8080]
 #                           [--version 0.1.0] [--image <ref>] [--register]
@@ -76,11 +76,12 @@ usage() { awk 'NR>=2{ if(/^#/){sub(/^# ?/,"");print} else exit }' "$0"; exit "${
 
 # ---------------------------------------------------------------- cluster ----
 cmd_cluster() {
-  local namespace="openbkn" version="" chart="$DEFAULT_CHART_OCI" kube_context="" no_auth="false"
+  local namespace="openbkn" version="" chart="$DEFAULT_CHART_OCI" kube_context="" no_auth="false" want_latest="false"
   while [ $# -gt 0 ]; do
     case "$1" in
       --namespace) namespace="$2"; shift 2;;
       --version) version="$2"; shift 2;;
+      --latest) want_latest="true"; shift;;
       --chart) chart="$2"; shift 2;;
       --kube-context) kube_context="$2"; shift 2;;
       --no-auth) no_auth="true"; shift;;
@@ -88,10 +89,16 @@ cmd_cluster() {
       *) die "unknown flag for 'cluster': $1";;
     esac
   done
+  # --latest (or --version latest, or omitting --version) installs the newest
+  # published release; an explicit --version pins one. The two are exclusive.
+  [ "$version" = "latest" ] && { want_latest="true"; version=""; }
+  if [ "$want_latest" = "true" ] && [ -n "$version" ]; then
+    die "--latest and --version are mutually exclusive"
+  fi
   if [ -z "$version" ]; then
     version="$(resolve_latest_version "$chart")"
     [ -n "$version" ] || die "could not resolve latest version from ${chart}; pass --version"
-    info "no --version given — installing latest published: ${version}"
+    info "installing latest published version: ${version}"
   fi
   command -v helm >/dev/null 2>&1 || die "helm not found"
   command -v kubectl >/dev/null 2>&1 || die "kubectl not found"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -6,6 +6,8 @@
 #            the SAME host as /api, /oauth2, /.well-known, /userinfo — so the SPA
 #            is same-origin and the OAuth callback (https://<gateway>/studio/
 #            callback) is already seeded by bkn-safe. Nothing to register.
+#            --version pins a specific release; OMIT it to install the latest
+#            published version (resolved from the chart registry).
 #
 #   local    Run the studio image as a local container whose nginx ALSO reverse-
 #            proxies /api, /oauth2, /.well-known, /userinfo to a remote Foundry
@@ -58,6 +60,17 @@ default_version() {
   [ -f "$cy" ] && sed -n 's/^version:[[:space:]]*//p' "$cy" | head -1 || true
 }
 
+# Latest published version for a chart ref. For an OCI ref helm resolves the
+# newest tag — with --devel, since main builds are pre-releases (0.1.0-<ref>.shaX)
+# that helm would otherwise skip. For a local chart dir it returns its own
+# version. Falls back to the checkout's Chart.yaml.
+resolve_latest_version() {
+  local chart="$1" v
+  v="$(helm show chart "$chart" --devel 2>/dev/null | sed -n 's/^version:[[:space:]]*//p' | head -1)"
+  [ -n "$v" ] && { echo "$v"; return; }
+  default_version
+}
+
 # Print the header comment block (line 2 until the first non-comment line).
 usage() { awk 'NR>=2{ if(/^#/){sub(/^# ?/,"");print} else exit }' "$0"; exit "${1:-0}"; }
 
@@ -75,8 +88,11 @@ cmd_cluster() {
       *) die "unknown flag for 'cluster': $1";;
     esac
   done
-  version="${version:-$(default_version)}"
-  [ -n "$version" ] || die "specify --version (chart + image tag to install)"
+  if [ -z "$version" ]; then
+    version="$(resolve_latest_version "$chart")"
+    [ -n "$version" ] || die "could not resolve latest version from ${chart}; pass --version"
+    info "no --version given — installing latest published: ${version}"
+  fi
   command -v helm >/dev/null 2>&1 || die "helm not found"
   command -v kubectl >/dev/null 2>&1 || die "kubectl not found"
   local kctx=(); [ -n "$kube_context" ] && kctx=(--kube-context "$kube_context")


### PR DESCRIPTION
`install.sh cluster` 之前必须传 `--version`，不传就回退到 checkout 里 `Chart.yaml` 的占位版本 `0.1.0`（不是已发布的真实版本）。

现在:
- **不传 `--version` → 装 registry 最新已发布版本**。用 `helm show chart <ref> --devel` 解析（main 构建是 prerelease `0.1.0-<ref>.shaX`，helm 默认跳过，故 `--devel`），再按解析出的具体版本安装。
- `--version <X>` 仍指定具体版本。
- 本地 `--chart <dir>` 解析为该目录自身 Chart.yaml 版本。

## 备注
- **不需要单独的 `latest` 标签** —— helm 按 SemVer 解析最新即可。
- **SWR 不支持 helm OCI chart**（`manifest invalid`，华为 SWR 是镜像仓库）→ chart 只发 ghcr；image 可 ghcr+SWR 两边。
- 已验证:chart 推 ghcr OK，`--devel` 解析出最新版本，`bash -n` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)