### PR TITLE
feat(deploy): date-stamped versions + --latest by date (match bkn-foundry)

### DIFF
--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -68,7 +68,11 @@ jobs:
             VERSION="${GITHUB_REF_NAME#v}"
           else
             SANITIZED="$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"
-            VERSION="${BASE_VERSION}-${SANITIZED}.sha${SHORT_SHA}"
+            # Embed the commit date (UTC, fixed-width 14 digits) so the version
+            # sorts chronologically by string alone — "latest" resolution needs
+            # no local git history. Matches bkn-foundry's scheme.
+            COMMIT_DATE="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"
+            VERSION="${BASE_VERSION}-${SANITIZED}.${COMMIT_DATE}.sha${SHORT_SHA}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $VERSION"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -65,11 +65,12 @@ default_version() {
   [ -f "$cy" ] && sed -n 's/^version:[[:space:]]*//p' "$cy" | head -1 || true
 }
 
-# Newest "<semver>-main.sha<7hex>" build for a GHCR chart repo, ranked by the
-# sha's git COMMIT TIME — NOT SemVer: the sha suffix isn't monotonic, so a
-# lexical SemVer "latest" picks the wrong build. Mirrors bkn-foundry's
-# gen-dev-manifest. Anonymous for public packages; set GHCR_TOKEN (a PAT with
-# read:packages) for private ones. Prints nothing if it can't resolve.
+# Newest main build for a GHCR chart repo. The build version embeds a
+# fixed-width commit date (<semver>-main.<YYYYMMDDHHMMSS>.sha<7hex>), so the
+# newest is the lexical max — NOT SemVer (the sha suffix isn't monotonic) and
+# needs no git history. Mirrors bkn-foundry. Falls back to the legacy un-dated
+# form via git commit time. Anonymous for public packages; set GHCR_TOKEN (a
+# PAT with read:packages) for private ones. Prints nothing if it can't resolve.
 newest_main_build_version() {
   SSL_CERT_FILE="${SSL_CERT_FILE:-/etc/ssl/cert.pem}" \
   GHCR_AUTH="${GHCR_TOKEN:-${GITHUB_TOKEN:-}}" GHCR_USER="${GHCR_USER:-${USER:-x}}" \
@@ -89,16 +90,24 @@ try:
     tags = fetch(f"https://ghcr.io/v2/{repo}/tags/list", {"Authorization": f"Bearer {tok}"}).get("tags") or []
 except Exception:
     sys.exit(1)
-rx = re.compile(r'.*-main\.sha([0-9a-f]{7})$')
-def commit_time(sha):
-    try:
-        return int(subprocess.run(["git", "show", "-s", "--format=%ct", sha],
-                   capture_output=True, text=True).stdout.strip() or 0)
-    except Exception:
-        return 0
-cand = [(t, m.group(1)) for t in tags for m in [rx.match(t)] if m]
+# Preferred form embeds a fixed-width commit date (<semver>-main.<14d>.sha<7hex>)
+# → lexical max == newest, no git history needed. Fall back to the legacy
+# un-dated form (<semver>-main.sha<7hex>), ranked by the sha's git commit time.
+dated = re.compile(r'.*-main\.(\d{14})\.sha[0-9a-f]{7}$')
+cand = [(m.group(1), t) for t in tags for m in [dated.match(t)] if m]
 if cand:
-    print(max(cand, key=lambda ts: (commit_time(ts[1]), ts[0]))[0])
+    print(max(cand)[1])
+else:
+    legacy = re.compile(r'.*-main\.sha([0-9a-f]{7})$')
+    def commit_time(sha):
+        try:
+            return int(subprocess.run(["git", "show", "-s", "--format=%ct", sha],
+                       capture_output=True, text=True).stdout.strip() or 0)
+        except Exception:
+            return 0
+    old = [(t, m.group(1)) for t in tags for m in [legacy.match(t)] if m]
+    if old:
+        print(max(old, key=lambda ts: (commit_time(ts[1]), ts[0]))[0])
 PY
 }
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "check": "npm run lint:types && npm run test -- --run && npm run build"
   },
   "dependencies": {
-    "@monaco-editor/react": "^4.7.0",
+    "@ai-sdk/openai-compatible": "^3.0.1",
     "@ant-design/icons": "^6.1.0",
+    "@monaco-editor/react": "^4.7.0",
+    "ai": "^7.0.4",
     "antd": "^5.28.0",
     "axios": "^1.12.2",
     "dayjs": "^1.11.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/openai-compatible':
+        specifier: ^3.0.1
+        version: 3.0.1(zod@4.4.3)
       '@ant-design/icons':
         specifier: ^6.1.0
         version: 6.2.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      ai:
+        specifier: ^7.0.4
+        version: 7.0.4(zod@4.4.3)
       antd:
         specifier: ^5.28.0
         version: 5.29.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -101,6 +107,28 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@ai-sdk/gateway@4.0.4':
+    resolution: {integrity: sha512-xO0e9duft/uZlnDaIeBZmzTMjfdEz1kkDzWnhQNkJZZljsKWVi6IREZW9nAa+Dx6jYJssyxSUggaFYBAV1WZpw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@3.0.1':
+    resolution: {integrity: sha512-nUbQoGzdFZspb1cr6GUy+nR8Uvdi4/lCwTkdE9qKe+Qr2OVPsIKRIpyC9ewJ2uqUfl+1JlkWhPfR5l8bokNs4Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.1':
+    resolution: {integrity: sha512-p9Ra+dN4jjHrssXvklNf4nFvWbj1KePMfUOs7nue0NuoIMbYFBULhX4Vu0+6DWLnw3+UsLL9+RCKLtzzU43Qpg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
+    engines: {node: '>=22'}
 
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
@@ -739,6 +767,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -859,6 +890,10 @@ packages:
     resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -894,6 +929,9 @@ packages:
   '@vitest/utils@3.2.6':
     resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -911,6 +949,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@7.0.4:
+    resolution: {integrity: sha512-mZub080RWRxpWg8OY56KVnI3AoMVniccSWG+dwVb3nH81+GiNMDYBIdP41RLUivLpmU49pB7ssD7tvfIUaSaCA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -1205,6 +1249,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1400,6 +1448,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2141,6 +2192,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zrender@5.6.1:
     resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
 
@@ -2149,6 +2203,31 @@ snapshots:
   '@acemir/cssom@0.9.31': {}
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@ai-sdk/gateway@4.0.4(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.1(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@3.0.1(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.1(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.1(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.0':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ant-design/colors@7.2.1':
     dependencies:
@@ -2697,6 +2776,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.0':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -2864,6 +2945,8 @@ snapshots:
       '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@24.12.4))':
     dependencies:
       '@babel/core': 7.29.7
@@ -2918,6 +3001,8 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@workflow/serde@4.1.0': {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2931,6 +3016,13 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  ai@7.0.4(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.4(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.1(zod@4.4.3)
+      zod: 4.4.3
 
   ajv@6.15.0:
     dependencies:
@@ -3298,6 +3390,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventsource-parser@3.1.0: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -3486,6 +3580,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4244,6 +4340,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}
 
   zrender@5.6.1:
     dependencies:

--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.module.css
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.module.css
@@ -1,0 +1,407 @@
+/* 立即体验 · Agent 对话。复用 ExperienceScene .page 上级联的 --accent/--txt/--line 等变量。 */
+
+.root {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: #fff;
+}
+
+/* 顶部工具条 */
+.bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 22px;
+  border-bottom: 1px solid var(--line);
+  background: #fbfcfe;
+}
+.barField {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.barLabel {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--faint);
+  text-transform: uppercase;
+}
+.modelSelect {
+  min-width: 180px;
+}
+.barBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: none;
+  padding: 6px 8px;
+  font-size: 12.5px;
+  color: var(--txt2);
+  cursor: pointer;
+  border-radius: 7px;
+}
+.barBtn:hover:not(:disabled) {
+  color: var(--accent);
+  background: rgba(46, 104, 255, 0.08);
+}
+.barBtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* 系统提示词编辑 */
+.promptEdit {
+  flex: 0 0 auto;
+  padding: 12px 22px 14px;
+  border-bottom: 1px solid var(--line);
+  background: #fbfcfe;
+}
+.promptEdit textarea {
+  display: block;
+  width: 100%;
+  min-height: 84px;
+  resize: vertical;
+  border: 1px solid var(--field-bd);
+  border-radius: 10px;
+  padding: 11px 13px;
+  font-size: 12.5px;
+  line-height: 1.6;
+  font-family: var(--mono);
+  color: var(--txt);
+  background: #fff;
+  outline: none;
+}
+.promptEdit textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(46, 104, 255, 0.12);
+}
+.promptAct {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 8px;
+}
+.linkBtn {
+  border: 0;
+  background: none;
+  color: var(--accent);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+}
+.hint {
+  font-size: 11px;
+  color: var(--faint);
+}
+
+/* 消息滚动区 */
+.scroll {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 26px 0 30px;
+  min-height: 0;
+}
+.wrap {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 0 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+/* 空态 */
+.intro {
+  max-width: 768px;
+  margin: 0 auto;
+  padding: 52px 26px;
+  text-align: center;
+}
+.introGlyph {
+  width: 54px;
+  height: 54px;
+  border-radius: 16px;
+  margin: 0 auto 16px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 24px;
+  background: linear-gradient(135deg, #2762ff, #7b5cff);
+  box-shadow: 0 10px 26px rgba(91, 90, 255, 0.32);
+}
+.intro h3 {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--txt);
+  margin: 0 0 7px;
+}
+.intro p {
+  font-size: 13px;
+  color: var(--txt2);
+  margin: 0 0 20px;
+  line-height: 1.6;
+}
+.intro code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--chip);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.sugs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  justify-content: center;
+}
+.sug {
+  font-size: 12.5px;
+  color: var(--txt2);
+  background: var(--code);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 8px 13px;
+  cursor: pointer;
+  transition: 0.14s;
+}
+.sug:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* 消息气泡 */
+.msg {
+  display: flex;
+  gap: 13px;
+}
+.avatar {
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+.msgUser .avatar {
+  background: var(--chip);
+  color: var(--txt2);
+}
+.msgBot .avatar {
+  background: linear-gradient(135deg, #2762ff, #7b5cff);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(91, 90, 255, 0.3);
+}
+.bubble {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.who {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--txt2);
+  margin-bottom: 5px;
+  letter-spacing: 0.02em;
+}
+.txt {
+  font-size: 13.5px;
+  line-height: 1.72;
+  color: var(--txt);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* 工具调用卡片 */
+.calls {
+  margin: 4px 0 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.call {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--code);
+}
+.callHead {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 11px;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--txt2);
+  text-align: left;
+}
+.callHead:hover {
+  background: rgba(46, 104, 255, 0.06);
+}
+.verb {
+  flex: 0 0 auto;
+  font-size: 8.5px;
+  font-weight: 700;
+  color: #1f4fd4;
+  background: rgba(46, 104, 255, 0.13);
+  border-radius: 3px;
+  padding: 2px 5px;
+  letter-spacing: 0.03em;
+}
+.callName {
+  color: var(--txt);
+  font-weight: 600;
+}
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.dotOk {
+  background: #1f9d57;
+  box-shadow: 0 0 5px rgba(31, 157, 87, 0.6);
+}
+.dotRunning {
+  background: #c9821a;
+  box-shadow: 0 0 5px rgba(201, 130, 26, 0.6);
+}
+.dotError {
+  background: #d63a3a;
+  box-shadow: 0 0 5px rgba(214, 58, 58, 0.6);
+}
+.callMeta {
+  color: var(--faint);
+}
+.chev {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 10px;
+}
+.callBody {
+  border-top: 1px solid var(--line);
+}
+.callSec {
+  padding: 10px 12px;
+}
+.callSec + .callSec {
+  border-top: 1px dashed var(--line);
+}
+.callLbl {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--faint);
+  margin-bottom: 7px;
+  font-family: var(--mono);
+  word-break: break-all;
+}
+.callPre {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.65;
+  color: var(--txt);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow: auto;
+}
+
+/* 打字指示 */
+.typing {
+  display: inline-flex;
+  gap: 4px;
+  padding: 6px 0;
+}
+.typing i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--faint);
+  animation: blink 1.2s infinite;
+}
+.typing i:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.typing i:nth-child(3) {
+  animation-delay: 0.4s;
+}
+@keyframes blink {
+  0%,
+  60%,
+  100% {
+    opacity: 0.25;
+  }
+  30% {
+    opacity: 1;
+  }
+}
+
+/* 输入区 */
+.composer {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--line);
+  background: #fbfcfe;
+  padding: 14px 26px;
+}
+.cwrap {
+  max-width: 820px;
+  margin: 0 auto;
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+}
+.cInput {
+  flex: 1 1 auto;
+  resize: none;
+  max-height: 160px;
+  min-height: 44px;
+  border: 1px solid var(--field-bd);
+  border-radius: 13px;
+  padding: 12px 15px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  font-family: inherit;
+  color: var(--txt);
+  background: #fff;
+  outline: none;
+}
+.cInput:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(46, 104, 255, 0.12);
+}
+.sendBtn,
+.stopBtn {
+  height: 44px;
+  flex: 0 0 auto;
+  border-radius: 13px;
+  padding: 0 20px;
+  font-size: 13.5px;
+  font-weight: 600;
+  border: 0;
+  cursor: pointer;
+}
+.sendBtn {
+  background: var(--accent);
+  color: #fff;
+}
+.sendBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.stopBtn {
+  background: var(--chip);
+  color: var(--txt2);
+  border: 1px solid var(--field-bd);
+}

--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
@@ -1,0 +1,432 @@
+/**
+ * 立即体验 · Agent 对话 —— 前端编排的真实工具调用循环 UI。
+ * 模型走「模型工厂」(mf-model-api OpenAI 兼容)，检索工具走 agent-retrieval MCP；
+ * 上下文全在前端缓存（localStorage，按 kn_id 隔离）。see agent-chat.service.ts。
+ */
+
+import { DownOutlined, RightOutlined, ThunderboltFilled } from "@ant-design/icons";
+import { App, Select } from "antd";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { listLlmModels } from "@/modules/model-resources/services/llm.service";
+import type { LlmModel } from "@/modules/model-resources/types/llm";
+import {
+  buildAgentTools,
+  runAgentChat,
+  type AgentChatTurn,
+  type AgentChunk,
+} from "@/modules/knowledge-network/services/agent-chat.service";
+import {
+  listMcpTools,
+  type ContextLoaderEnv,
+  type McpToolDef,
+} from "@/modules/knowledge-network/services/context-loader.service";
+
+import styles from "./AgentChat.module.css";
+
+const DEFAULT_PROMPT =
+  "你是 BKN 业务知识网络的检索助手。基于当前知识网络上的对象类、关系类与逻辑属性回答用户问题。\n" +
+  "需要数据时调用提供的检索工具（search_schema / query_object_instance / query_instance_subgraph / run_sql 等），不要编造；" +
+  "kn_id 已锁定为当前网络，无需也不要修改。回答简洁、专业，使用中文，并在结论里说明依据。";
+
+const SUGGESTIONS = [
+  "这个知识网络里有哪些对象类和关系？",
+  "帮我查最近活跃的高价值客户",
+  "对象类之间是怎么关联的？",
+];
+
+type ToolCallView = {
+  id: string;
+  name: string;
+  args: unknown;
+  status: "running" | "done" | "error";
+  result?: string;
+  error?: string;
+  startedAt: number;
+  latencyMs?: number;
+};
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+  reasoning?: string;
+  toolCalls?: ToolCallView[];
+};
+
+type Persisted = { messages: ChatMessage[]; model: string; systemPrompt: string };
+
+function lsKey(knId: string): string {
+  return `bkn-studio:agentchat:${knId}`;
+}
+
+function loadPersisted(knId: string): Partial<Persisted> {
+  try {
+    const raw = localStorage.getItem(lsKey(knId));
+    return raw ? (JSON.parse(raw) as Partial<Persisted>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function formatArgs(args: unknown): string {
+  try {
+    return JSON.stringify(args, null, 2);
+  } catch {
+    return String(args);
+  }
+}
+
+/** 单条工具调用卡片（可折叠，展开看真实请求参数与响应）。 */
+function ToolCallCard({ call }: { call: ToolCallView }) {
+  const [open, setOpen] = useState(false);
+  const statusDot =
+    call.status === "running" ? styles.dotRunning : call.status === "error" ? styles.dotError : styles.dotOk;
+  const statusText =
+    call.status === "running" ? "调用中…" : call.status === "error" ? "失败" : `200 · ${call.latencyMs ?? "—"}ms`;
+  return (
+    <div className={`${styles.call} ${open ? styles.callOpen : ""}`}>
+      <button type="button" className={styles.callHead} onClick={() => setOpen((v) => !v)}>
+        <span className={styles.verb}>MCP</span>
+        <span className={styles.callName}>{call.name}</span>
+        <span className={`${styles.dot} ${statusDot}`} />
+        <span className={styles.callMeta}>{statusText}</span>
+        <span className={styles.chev}>{open ? <DownOutlined /> : <RightOutlined />}</span>
+      </button>
+      {open ? (
+        <div className={styles.callBody}>
+          <div className={styles.callSec}>
+            <div className={styles.callLbl}>请求 · tools/call → {call.name}</div>
+            <pre className={styles.callPre}>{formatArgs(call.args)}</pre>
+          </div>
+          <div className={styles.callSec}>
+            <div className={styles.callLbl}>{call.status === "error" ? "错误" : "响应"}</div>
+            <pre className={styles.callPre}>{call.status === "error" ? call.error : call.result ?? "—"}</pre>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function AgentChat({ env, networkName }: { env: ContextLoaderEnv; networkName?: string }) {
+  const { message } = App.useApp();
+  const knId = env.knId;
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [models, setModels] = useState<LlmModel[]>([]);
+  const [model, setModel] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState(DEFAULT_PROMPT);
+  const [promptOpen, setPromptOpen] = useState(false);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  // 缓存 MCP 工具定义（tools/list）；按 kn 失效重取。
+  const mcpToolsRef = useRef<{ knId: string; tools: McpToolDef[] } | null>(null);
+
+  // 载入持久化对话（按 kn 隔离）。
+  useEffect(() => {
+    const saved = loadPersisted(knId);
+    setMessages(Array.isArray(saved.messages) ? saved.messages : []);
+    if (saved.model) setModel(saved.model);
+    setSystemPrompt(saved.systemPrompt ?? DEFAULT_PROMPT);
+    mcpToolsRef.current = null;
+  }, [knId]);
+
+  // 拉模型列表（模型工厂），默认选系统默认模型。
+  useEffect(() => {
+    let cancelled = false;
+    listLlmModels({ page: 1, size: 100 })
+      .then((res) => {
+        if (cancelled) return;
+        setModels(res.items);
+        setModel((prev) => {
+          if (prev && res.items.some((m) => m.modelName === prev)) return prev;
+          return res.items.find((m) => m.default)?.modelName ?? res.items[0]?.modelName ?? "";
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setModels([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // 持久化（对话除外，对话在每轮结束时落盘，避免逐字写）。
+  const persist = useCallback(
+    (msgs: ChatMessage[]) => {
+      try {
+        const data: Persisted = { messages: msgs, model, systemPrompt };
+        localStorage.setItem(lsKey(knId), JSON.stringify(data));
+      } catch {
+        /* localStorage 不可用时忽略 */
+      }
+    },
+    [knId, model, systemPrompt],
+  );
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  /** 更新当前（最后一条）assistant 消息。 */
+  const updateAssistant = useCallback((updater: (prev: ChatMessage) => ChatMessage) => {
+    setMessages((prev) => {
+      if (prev.length === 0) return prev;
+      const next = [...prev];
+      const idx = next.length - 1;
+      next[idx] = updater(next[idx]!);
+      return next;
+    });
+  }, []);
+
+  const handleChunk = useCallback(
+    (chunk: AgentChunk) => {
+      switch (chunk.type) {
+        case "text":
+          updateAssistant((m) => ({ ...m, content: m.content + chunk.delta }));
+          break;
+        case "reasoning":
+          updateAssistant((m) => ({ ...m, reasoning: (m.reasoning ?? "") + chunk.delta }));
+          break;
+        case "tool-call":
+          updateAssistant((m) => ({
+            ...m,
+            toolCalls: [
+              ...(m.toolCalls ?? []),
+              { id: chunk.id, name: chunk.name, args: chunk.args, status: "running", startedAt: performance.now() },
+            ],
+          }));
+          break;
+        case "tool-result":
+          updateAssistant((m) => ({
+            ...m,
+            toolCalls: (m.toolCalls ?? []).map((tc) =>
+              tc.id === chunk.id
+                ? { ...tc, status: "done", result: chunk.result, latencyMs: Math.round(performance.now() - tc.startedAt) }
+                : tc,
+            ),
+          }));
+          break;
+        case "tool-error":
+          updateAssistant((m) => ({
+            ...m,
+            toolCalls: (m.toolCalls ?? []).map((tc) =>
+              tc.id === chunk.id ? { ...tc, status: "error", error: chunk.error } : tc,
+            ),
+          }));
+          break;
+        case "error":
+          updateAssistant((m) => ({ ...m, content: m.content + (m.content ? "\n\n" : "") + `⚠️ ${chunk.error}` }));
+          break;
+        case "finish":
+          break;
+        default:
+          break;
+      }
+    },
+    [updateAssistant],
+  );
+
+  const send = useCallback(
+    async (text: string) => {
+      const question = text.trim();
+      if (!question || busy) return;
+      if (!model) {
+        message.error("当前没有可用的大模型，请先在「模型工厂」配置默认模型");
+        return;
+      }
+
+      setBusy(true);
+      setInput("");
+
+      // 先拼历史（不含本轮），再 push user + assistant 占位。
+      const history: AgentChatTurn[] = messages.map((m) => ({ role: m.role, content: m.content }));
+      history.push({ role: "user", content: question });
+      setMessages((prev) => [
+        ...prev,
+        { role: "user", content: question },
+        { role: "assistant", content: "", toolCalls: [] },
+      ]);
+
+      try {
+        // 构造/复用工具：tools/list 按 kn 缓存；每轮新建会话以用当轮新鲜 token。
+        if (!mcpToolsRef.current || mcpToolsRef.current.knId !== knId) {
+          const tools = await listMcpTools(env);
+          mcpToolsRef.current = { knId, tools };
+        }
+        const tools = buildAgentTools(mcpToolsRef.current.tools, env, knId);
+
+        const controller = new AbortController();
+        abortRef.current = controller;
+        await runAgentChat({
+          env,
+          modelName: model,
+          system: systemPrompt,
+          history,
+          tools,
+          signal: controller.signal,
+          onChunk: handleChunk,
+        });
+      } catch (error) {
+        updateAssistant((m) => ({
+          ...m,
+          content: m.content + (m.content ? "\n\n" : "") + `⚠️ ${error instanceof Error ? error.message : String(error)}`,
+        }));
+      } finally {
+        abortRef.current = null;
+        setBusy(false);
+        setMessages((cur) => {
+          persist(cur);
+          return cur;
+        });
+      }
+    },
+    [busy, model, messages, env, knId, systemPrompt, handleChunk, updateAssistant, persist, message],
+  );
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const clearChat = useCallback(() => {
+    setMessages([]);
+    try {
+      localStorage.removeItem(lsKey(knId));
+    } catch {
+      /* ignore */
+    }
+  }, [knId]);
+
+  const modelOptions = useMemo(
+    () => models.map((m) => ({ value: m.modelName, label: m.default ? `${m.modelName} · 默认` : m.modelName })),
+    [models],
+  );
+
+  const empty = messages.length === 0;
+
+  return (
+    <div className={styles.root}>
+      {/* 顶部工具条：模型选择 + 系统提示词 + 清空 */}
+      <div className={styles.bar}>
+        <div className={styles.barField}>
+          <span className={styles.barLabel}>模型</span>
+          <Select
+            size="small"
+            className={styles.modelSelect}
+            value={model || undefined}
+            onChange={setModel}
+            options={modelOptions}
+            placeholder="选择模型"
+            disabled={busy}
+            popupMatchSelectWidth={false}
+          />
+        </div>
+        <button type="button" className={styles.barBtn} onClick={() => setPromptOpen((v) => !v)}>
+          <ThunderboltFilled /> 系统提示词 {promptOpen ? <DownOutlined /> : <RightOutlined />}
+        </button>
+        <button type="button" className={styles.barBtn} onClick={clearChat} disabled={busy || empty}>
+          清空对话
+        </button>
+      </div>
+      {promptOpen ? (
+        <div className={styles.promptEdit}>
+          <textarea
+            value={systemPrompt}
+            spellCheck={false}
+            onChange={(e) => setSystemPrompt(e.target.value)}
+            placeholder="系统提示词（修改即时生效，随对话一起发送）"
+          />
+          <div className={styles.promptAct}>
+            <button type="button" className={styles.linkBtn} onClick={() => setSystemPrompt(DEFAULT_PROMPT)}>
+              恢复默认
+            </button>
+            <span className={styles.hint}>kn_id 已锁定为 {knId}，无需在提示词里指定。</span>
+          </div>
+        </div>
+      ) : null}
+
+      {/* 消息区 */}
+      <div className={styles.scroll} ref={scrollRef}>
+        {empty ? (
+          <div className={styles.intro}>
+            <div className={styles.introGlyph}>
+              <ThunderboltFilled />
+            </div>
+            <h3>Agent 对话</h3>
+            <p>
+              用自然语言向 Agent 提问，它会基于知识网络 <code>{knId}</code>
+              {networkName ? `（${networkName}）` : ""} 调用检索工具并作答。
+            </p>
+            <div className={styles.sugs}>
+              {SUGGESTIONS.map((s) => (
+                <button key={s} type="button" className={styles.sug} onClick={() => void send(s)}>
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className={styles.wrap}>
+            {messages.map((m, i) => (
+              <div key={i} className={`${styles.msg} ${m.role === "user" ? styles.msgUser : styles.msgBot}`}>
+                <div className={styles.avatar}>{m.role === "user" ? "我" : <ThunderboltFilled />}</div>
+                <div className={styles.bubble}>
+                  <div className={styles.who}>{m.role === "user" ? "我" : "Agent"}</div>
+                  {m.toolCalls && m.toolCalls.length > 0 ? (
+                    <div className={styles.calls}>
+                      {m.toolCalls.map((tc) => (
+                        <ToolCallCard key={tc.id} call={tc} />
+                      ))}
+                    </div>
+                  ) : null}
+                  {m.content ? (
+                    <div className={styles.txt}>{m.content}</div>
+                  ) : m.role === "assistant" && busy && i === messages.length - 1 && (!m.toolCalls || m.toolCalls.length === 0) ? (
+                    <div className={styles.typing}>
+                      <i />
+                      <i />
+                      <i />
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 输入区 */}
+      <div className={styles.composer}>
+        <div className={styles.cwrap}>
+          <textarea
+            className={styles.cInput}
+            value={input}
+            rows={1}
+            placeholder="向 Agent 提问，例如：最近活跃的高价值客户有哪些？"
+            spellCheck={false}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void send(input);
+              }
+            }}
+          />
+          {busy ? (
+            <button type="button" className={styles.stopBtn} onClick={stop}>
+              停止
+            </button>
+          ) : (
+            <button type="button" className={styles.sendBtn} onClick={() => void send(input)} disabled={!input.trim()}>
+              发送
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -44,6 +44,7 @@ import {
   type KnRelationType,
   type McpToolDef,
 } from "@/modules/knowledge-network/services/context-loader.service";
+import { AgentChat } from "@/modules/knowledge-network/components/agent-chat/AgentChat";
 
 import styles from "./ExperienceScene.module.css";
 
@@ -839,21 +840,6 @@ function DataBrowserPanel({
   );
 }
 
-/* ============================ Agent 对话（待接入真实 Agent，先留空） ============================ */
-function AgentBlank() {
-  return (
-    <div className={styles.chat}>
-      <div className={styles.agentBlank}>
-        <div className={styles.introGlyph}>
-          <ThunderboltFilled />
-        </div>
-        <h3>Agent 对话</h3>
-        <p>待接入真实 Agent 检索对话，敬请期待。</p>
-      </div>
-    </div>
-  );
-}
-
 /* ============================ 主场景 ============================ */
 export function ExperienceScene() {
   const navigate = useNavigate();
@@ -873,7 +859,7 @@ export function ExperienceScene() {
   );
 
   const [network, setNetwork] = useState<{ name: string; slug: string } | null>(null);
-  const [mode, setMode] = useState<ContextLoaderMode>("mcp");
+  const [mode, setMode] = useState<ContextLoaderMode>("agent");
 
   // 请求基址：走当前源（dev 经 vite 代理转后端，避免浏览器跨域）。
   const [base] = useState(() => (typeof window !== "undefined" ? window.location.origin : "http://agent-retrieval:30779"));
@@ -1235,7 +1221,7 @@ export function ExperienceScene() {
       </div>
 
       {mode === "agent" ? (
-        <AgentBlank />
+        <AgentChat env={env} networkName={network?.name} />
       ) : (
         <div className={styles.main}>
           {/* 接口列表 */}

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -1,0 +1,173 @@
+/**
+ * 知识网络「立即体验 · Agent 对话」—— 前端编排的真实工具调用循环。
+ *
+ * 混合方案：用 Vercel AI SDK（streamText + tools）跑 LLM 多步工具循环 + 流式；
+ * 工具执行复用 context-loader 的会话级 MCP 客户端（initialize 一次、复用 session、注入锁定 kn_id）。
+ * 大模型走「模型工厂」OpenAI 兼容网关 /api/mf-model-api/v1/chat/completions（与 agent-retrieval 同 Bearer）。
+ * 对话上下文全在前端缓存（无后端会话），每轮把全量 messages 重发模型。
+ */
+
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { jsonSchema, stepCountIs, streamText, tool, type ModelMessage, type ToolSet } from "ai";
+
+import {
+  createMcpSession,
+  type ContextLoaderEnv,
+  type McpToolDef,
+} from "@/modules/knowledge-network/services/context-loader.service";
+
+/** 模型工厂 OpenAI 兼容前缀（与 model-api-guide.getModelApiBaseUrl 一致）。 */
+export const MODEL_API_PATH = "/api/mf-model-api/v1";
+
+/** 一轮最多工具步数，防止模型反复调工具跑飞。 */
+const MAX_STEPS = 8;
+
+export type AgentChatRole = "user" | "assistant";
+
+/** 缓存进 localStorage 的对话历史项（仅文本，工具步骤不进历史，仅用于重发上下文）。 */
+export type AgentChatTurn = { role: AgentChatRole; content: string };
+
+/** 流式推给 UI 的增量事件。 */
+export type AgentChunk =
+  | { type: "text"; delta: string }
+  | { type: "reasoning"; delta: string }
+  | { type: "tool-call"; id: string; name: string; args: unknown }
+  | { type: "tool-result"; id: string; result: string }
+  | { type: "tool-error"; id: string; error: string }
+  | { type: "error"; error: string }
+  | { type: "finish" };
+
+/**
+ * 把 MCP tools/list 的工具定义转成 AI SDK 工具集：
+ * - inputSchema 直接用 MCP 的 JSON Schema（jsonSchema() 包装）。
+ * - execute 走会话级 MCP 客户端，并强制注入锁定 kn_id（模型不可改）。
+ * 返回工具集 + 共享的 MCP 会话（复用同一 session）。
+ */
+export function buildAgentTools(mcpTools: McpToolDef[], env: ContextLoaderEnv, knId: string): ToolSet {
+  const session = createMcpSession(env);
+  const tools: ToolSet = {};
+  for (const def of mcpTools) {
+    if (!def.name) continue;
+    const schema =
+      def.inputSchema && typeof def.inputSchema === "object"
+        ? (def.inputSchema as Record<string, unknown>)
+        : { type: "object", properties: {} };
+    tools[def.name] = tool({
+      description: def.description ?? def.name,
+      inputSchema: jsonSchema(schema),
+      execute: async (input: unknown): Promise<string> => {
+        const args: Record<string, unknown> = {
+          ...(input && typeof input === "object" ? (input as Record<string, unknown>) : {}),
+          kn_id: knId,
+        };
+        const res = await session.callTool(def.name, args);
+        return res.text;
+      },
+    });
+  }
+  return tools;
+}
+
+/**
+ * 模型工厂网关兼容性 fetch：实测其 OpenAI 兼容 router 比标准更严——
+ * 不接受 assistant 消息的 `content: null`（报 "none is not an allowed value"）。
+ * 故在出站请求体里把任意 null content 归一为 ""，并剥掉回灌的 `reasoning_content`（思考不必回发）。
+ */
+const compatFetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  if (init?.body && typeof init.body === "string") {
+    try {
+      const parsed = JSON.parse(init.body) as { messages?: Array<Record<string, unknown>> };
+      if (Array.isArray(parsed.messages)) {
+        for (const m of parsed.messages) {
+          if (m && m.content === null) m.content = "";
+          if (m && "reasoning_content" in m) delete m.reasoning_content;
+        }
+        init = { ...init, body: JSON.stringify(parsed) };
+      }
+    } catch {
+      /* 非 JSON body 原样放行 */
+    }
+  }
+  return fetch(input, init);
+}) as typeof fetch;
+
+/** 构造模型工厂 OpenAI 兼容大模型实例（同源相对网关，带 Bearer + 兼容性 fetch）。 */
+function createChatModel(env: ContextLoaderEnv, modelName: string) {
+  const baseURL = `${env.base.replace(/\/+$/, "")}${MODEL_API_PATH}`;
+  const provider = createOpenAICompatible({
+    name: "mf-model-api",
+    baseURL,
+    headers: env.token ? { Authorization: `Bearer ${env.token}` } : {},
+    fetch: compatFetch,
+  });
+  return provider(modelName);
+}
+
+/**
+ * 跑一轮 Agent 对话：streamText 驱动模型工厂 + 工具循环，遍历 fullStream 把增量事件推给 onChunk。
+ * history 含本轮最新 user 消息（最后一项）。tools 由 buildAgentTools 预构造。
+ */
+export async function runAgentChat(params: {
+  env: ContextLoaderEnv;
+  modelName: string;
+  system: string;
+  history: AgentChatTurn[];
+  tools: ToolSet;
+  signal?: AbortSignal;
+  onChunk: (chunk: AgentChunk) => void;
+}): Promise<void> {
+  const { env, modelName, system, history, tools, signal, onChunk } = params;
+  const messages: ModelMessage[] = history.map((turn) => ({ role: turn.role, content: turn.content }));
+
+  try {
+    const result = streamText({
+      model: createChatModel(env, modelName),
+      system,
+      messages,
+      tools,
+      stopWhen: stepCountIs(MAX_STEPS),
+      abortSignal: signal,
+    });
+
+    for await (const part of result.fullStream) {
+      switch (part.type) {
+        case "text-delta":
+          if (part.text) onChunk({ type: "text", delta: part.text });
+          break;
+        case "reasoning-delta":
+          if (part.text) onChunk({ type: "reasoning", delta: part.text });
+          break;
+        case "tool-call":
+          onChunk({ type: "tool-call", id: part.toolCallId, name: part.toolName, args: part.input });
+          break;
+        case "tool-result":
+          onChunk({
+            type: "tool-result",
+            id: part.toolCallId,
+            result: typeof part.output === "string" ? part.output : JSON.stringify(part.output, null, 2),
+          });
+          break;
+        case "tool-error":
+          onChunk({
+            type: "tool-error",
+            id: part.toolCallId,
+            error: part.error instanceof Error ? part.error.message : String(part.error),
+          });
+          break;
+        case "error":
+          onChunk({ type: "error", error: part.error instanceof Error ? part.error.message : String(part.error) });
+          break;
+        default:
+          break;
+      }
+    }
+    onChunk({ type: "finish" });
+  } catch (error) {
+    if (signal?.aborted) {
+      onChunk({ type: "finish" });
+      return;
+    }
+    onChunk({ type: "error", error: error instanceof Error ? error.message : String(error) });
+    onChunk({ type: "finish" });
+  }
+}

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -596,6 +596,101 @@ export async function listMcpTools(env: ContextLoaderEnv): Promise<McpToolDef[]>
     .filter((tool) => tool.name);
 }
 
+/* ============================ 会话级 MCP 客户端（Agent 对话工具执行复用） ============================ */
+
+/**
+ * 从 MCP tools/call 信封抽出文本载荷：result.content[].text 合并；
+ * 无 content 时回退序列化 result；JSON-RPC error 时序列化 error。给大模型回灌用。
+ */
+export function mcpResultText(parsed: unknown): string {
+  if (!parsed || typeof parsed !== "object") return "";
+  const envelope = parsed as Record<string, unknown>;
+  const result = envelope.result;
+  if (!result || typeof result !== "object") {
+    return envelope.error ? JSON.stringify(envelope.error) : "";
+  }
+  const content = (result as Record<string, unknown>).content;
+  if (Array.isArray(content)) {
+    const texts = content
+      .map((item) => (item && typeof item === "object" ? (item as Record<string, unknown>).text : undefined))
+      .filter((value): value is string => typeof value === "string");
+    if (texts.length > 0) return texts.join("\n");
+  }
+  return JSON.stringify(result);
+}
+
+export type McpToolCallResult = { ok: boolean; text: string; latencyMs: number };
+
+export type McpSession = {
+  callTool(name: string, args: Record<string, unknown>): Promise<McpToolCallResult>;
+};
+
+/**
+ * 会话级 MCP 客户端：initialize 一次、缓存并复用 Mcp-Session-Id；
+ * 会话失效（400/404）时自动重连一次。供 Agent 对话的工具循环复用，避免每次调用重建会话。
+ */
+export function createMcpSession(env: ContextLoaderEnv): McpSession {
+  const url = mcpBase(env);
+  const baseHeaders = (): Record<string, string> => ({
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    ...authHeaders(env),
+  });
+  let sessionId: string | null = null;
+  let rpcId = 1;
+
+  async function initialize(): Promise<void> {
+    const initResp = await fetch(url, {
+      method: "POST",
+      headers: baseHeaders(),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: rpcId++,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "bkn-studio-agent", version: "1.0.0" } },
+      }),
+    });
+    sessionId = initResp.headers.get("mcp-session-id") ?? initResp.headers.get("Mcp-Session-Id");
+    if (!initResp.ok && !sessionId) {
+      throw new Error((await initResp.text()) || `MCP initialize 失败 (${initResp.status})`);
+    }
+    if (sessionId) {
+      await fetch(url, {
+        method: "POST",
+        headers: { ...baseHeaders(), "Mcp-Session-Id": sessionId },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+      }).catch(() => undefined);
+    }
+  }
+
+  function callOnce(name: string, args: Record<string, unknown>): Promise<Response> {
+    const headers = sessionId ? { ...baseHeaders(), "Mcp-Session-Id": sessionId } : baseHeaders();
+    return fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ jsonrpc: "2.0", id: rpcId++, method: "tools/call", params: { name, arguments: args } }),
+    });
+  }
+
+  return {
+    async callTool(name, args) {
+      const start = performance.now();
+      if (!sessionId) await initialize();
+      let response = await callOnce(name, args);
+      if (response.status === 400 || response.status === 404) {
+        // 会话失效 → 重连一次再试。
+        sessionId = null;
+        await initialize();
+        response = await callOnce(name, args);
+      }
+      const text = await response.text();
+      const parsed = parseMcpEnvelope(text);
+      const payload = parsed ? mcpResultText(parsed) : text;
+      return { ok: response.ok, text: payload || text, latencyMs: Math.round(performance.now() - start) };
+    },
+  };
+}
+
 /* ============================ 数据浏览器：知识网络 schema + 资源 ============================ */
 export type KnDataSource = { type?: string; id: string; name?: string };
 


### PR DESCRIPTION
照搬 bkn-foundry 最新方案:版本里嵌 **commit 日期**,`--latest` 按日期选,不再靠 git 查 sha 时间。

## 改动
- **release-studio.yml**:main 构建版本 `<semver>-main.<YYYYMMDDHHMMSS>.sha<7hex>`（UTC commit 日期，定宽 14 位）。`COMMIT_DATE="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"` —— 与 bkn-foundry reusable-test.yml 一致。
- **install.sh** resolver:优先解析 `-main.<14d>.sha<7>` → **字典序最大 == 最新**（定宽日期，无需查 git，浅克隆/异地 checkout 不会错排）。回退旧无日期形式（按 git commit 时间）。

## 为什么
sha 非单调 → 旧的 SemVer/commit-time 方案在浅克隆等场景会错排。嵌日期后字典序即时间序，最稳。bkn-foundry 已迁到这个方案。

验证:`bash -n` 过;合成测试日期取最新、混合优先日期、仅旧走 legacy 都对。

🤖 Generated with [Claude Code](https://claude.com/claude-code)