### PR TITLE
docs(deploy): fix stale --latest decision-basis comment (date, not commit time)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -112,7 +112,8 @@ PY
 }
 
 # Version to install when --latest is used (or --version omitted):
-#   GHCR OCI ref → newest main build by commit time (fallback: helm --devel)
+#   GHCR OCI ref → newest main build by commit DATE in the tag (no git lookup;
+#                  falls back to legacy commit-time, then helm --devel)
 #   other OCI ref → helm --devel (latest SemVer)
 #   local chart dir → its own Chart.yaml version
 resolve_latest_version() {


### PR DESCRIPTION
install.sh 的 `--latest` 实际已按**标签里的 commit 日期**取最新(#17),但 `resolve_latest_version` 的注释还写着 "by commit time"。只改注释,逻辑不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)