### PR TITLE
fix(execution-factory): verify quick API persistence

### DIFF
--- a/src/modules/execution-factory/services/quick-api.service.test.ts
+++ b/src/modules/execution-factory/services/quick-api.service.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerQuickApi } from "@/modules/execution-factory/services/quick-api.service";
+import { createTool } from "@/modules/execution-factory/services/tool.service";
+import {
+  createToolbox,
+  getToolbox,
+  listToolboxes,
+} from "@/modules/execution-factory/services/toolbox.service";
+import { listTools } from "@/modules/execution-factory/services/tool.service";
+
+vi.mock("@/modules/execution-factory/services/capability-bundle.service", () => ({
+  registerOpenApiBundle: vi.fn(),
+}));
+
+vi.mock("@/modules/execution-factory/services/toolbox.service", () => ({
+  createToolbox: vi.fn(),
+  getToolbox: vi.fn(),
+  listToolboxes: vi.fn(),
+}));
+
+vi.mock("@/modules/execution-factory/services/tool.service", () => ({
+  createTool: vi.fn(),
+  listTools: vi.fn(),
+}));
+
+const openapiSpec = JSON.stringify({
+  info: { title: "Quick Add Test", version: "1.0.0" },
+  openapi: "3.0.3",
+  servers: [{ url: "http://127.0.0.1:8095" }],
+  paths: {
+    "/health": {
+      get: {
+        operationId: "health",
+        responses: {
+          "200": { description: "OK" },
+        },
+        summary: "Health",
+      },
+    },
+  },
+});
+
+describe("registerQuickApi", () => {
+  beforeEach(() => {
+    vi.mocked(createToolbox).mockResolvedValue({
+      boxId: "box-1",
+      name: "Quick API Box",
+      status: "unpublish",
+      toolCount: 0,
+    });
+    vi.mocked(createTool).mockResolvedValue({
+      failureCount: 0,
+      failures: [],
+      successCount: 1,
+      successIds: ["tool-1"],
+    });
+    vi.mocked(getToolbox).mockResolvedValue({
+      boxId: "box-1",
+      name: "Quick API Box",
+      status: "unpublish",
+      toolCount: 1,
+    });
+    vi.mocked(listToolboxes).mockResolvedValue({
+      items: [
+        {
+          boxId: "box-1",
+          name: "Quick API Box",
+          status: "unpublish",
+          toolCount: 1,
+        },
+      ],
+      page: 1,
+      pageSize: 100,
+      total: 1,
+    });
+    vi.mocked(listTools).mockResolvedValue({
+      boxId: "box-1",
+      items: [{ name: "Health", status: "disabled", toolId: "tool-1" }],
+      page: 1,
+      pageSize: 100,
+      total: 1,
+    });
+  });
+
+  it("returns only after the created toolbox and tool are readable", async () => {
+    await expect(
+      registerQuickApi({
+        openapiSpec,
+        serviceUrl: "http://127.0.0.1:8095",
+        toolboxName: "Quick API Box",
+      }),
+    ).resolves.toEqual({ boxId: "box-1", toolIds: ["tool-1"] });
+
+    expect(listToolboxes).toHaveBeenCalledWith(
+      expect.objectContaining({ keyword: "Quick API Box" }),
+    );
+    expect(listTools).toHaveBeenCalledWith(
+      "box-1",
+      expect.objectContaining({ all: true }),
+    );
+  });
+
+  it("does not return a navigable result when the created tool is not persisted", async () => {
+    vi.mocked(listTools).mockResolvedValue({
+      boxId: "box-1",
+      items: [],
+      page: 1,
+      pageSize: 100,
+      total: 0,
+    });
+
+    await expect(
+      registerQuickApi({
+        openapiSpec,
+        serviceUrl: "http://127.0.0.1:8095",
+        toolboxName: "Quick API Box",
+      }),
+    ).rejects.toThrow("Tool creation was not persisted");
+  });
+
+  it("does not return a navigable result when the created toolbox is missing from list", async () => {
+    vi.mocked(listToolboxes).mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 100,
+      total: 0,
+    });
+
+    await expect(
+      registerQuickApi({
+        openapiSpec,
+        serviceUrl: "http://127.0.0.1:8095",
+        toolboxName: "Quick API Box",
+      }),
+    ).rejects.toThrow("Toolbox creation was not persisted");
+  });
+});

--- a/src/modules/execution-factory/services/quick-api.service.ts
+++ b/src/modules/execution-factory/services/quick-api.service.ts
@@ -7,9 +7,13 @@
 
 import { registerOpenApiBundle } from "@/modules/execution-factory/services/capability-bundle.service";
 
-import { createToolbox } from "@/modules/execution-factory/services/toolbox.service";
+import {
+  createToolbox,
+  getToolbox,
+  listToolboxes,
+} from "@/modules/execution-factory/services/toolbox.service";
 
-import { createTool } from "@/modules/execution-factory/services/tool.service";
+import { createTool, listTools } from "@/modules/execution-factory/services/tool.service";
 
 import type { OperatorSyncPublishInput } from "@/modules/execution-factory/types/operator-sync";
 
@@ -50,6 +54,62 @@ export type RegisterQuickApiResult = {
   operatorIds?: string[];
 
 };
+
+const CONFIRM_ATTEMPTS = 3;
+const CONFIRM_RETRY_DELAY_MS = 150;
+
+function delay(ms: number) {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+}
+
+async function confirmQuickApiPersistence(input: {
+  boxId: string;
+  toolIds: string[];
+  toolboxName?: string;
+}) {
+  let toolboxVisible = false;
+  let toolsVisible = false;
+
+  for (let attempt = 1; attempt <= CONFIRM_ATTEMPTS; attempt += 1) {
+    const toolbox = await getToolbox(input.boxId).catch(() => null);
+    toolboxVisible = Boolean(toolbox);
+
+    if (toolboxVisible && input.toolboxName?.trim()) {
+      const list = await listToolboxes({
+        keyword: input.toolboxName.trim(),
+        page: 1,
+        pageSize: 100,
+      }).catch(() => null);
+      toolboxVisible = Boolean(
+        list?.items.some((item) => item.boxId === input.boxId),
+      );
+    }
+
+    if (toolboxVisible) {
+      const toolList = await listTools(input.boxId, {
+        all: true,
+        page: 1,
+        pageSize: 100,
+      }).catch(() => null);
+      const visibleToolIds = new Set(toolList?.items.map((item) => item.toolId) ?? []);
+      toolsVisible = input.toolIds.every((toolId) => visibleToolIds.has(toolId));
+    }
+
+    if (toolboxVisible && toolsVisible) {
+      return;
+    }
+
+    if (attempt < CONFIRM_ATTEMPTS) {
+      await delay(CONFIRM_RETRY_DELAY_MS);
+    }
+  }
+
+  if (!toolboxVisible) {
+    throw new Error("Toolbox creation was not persisted. Please retry saving.");
+  }
+
+  throw new Error("Tool creation was not persisted. Please retry saving.");
+}
 
 
 
@@ -100,6 +160,12 @@ export async function registerQuickApi(
     });
 
 
+
+    await confirmQuickApiPersistence({
+      boxId: bundle.boxId,
+      toolIds: bundle.toolIds,
+      toolboxName,
+    });
 
     return {
 
@@ -172,6 +238,12 @@ export async function registerQuickApi(
   }
 
 
+
+  await confirmQuickApiPersistence({
+    boxId,
+    toolIds: result.successIds,
+    toolboxName: input.toolboxName,
+  });
 
   return {
 


### PR DESCRIPTION
## 背景

处理 #32：能力工厂 Quick Add HTTP API 在保存后可能跳转到工具箱工具页，但后续管理列表/工具列表读不到刚创建的工具箱或工具，用户会看到空工具箱并误以为创建成功。

## 根因分析

Quick Add 原逻辑只要 `createToolbox` / `createTool` 返回 `boxId` 和 `toolIds` 就认为创建完成，然后关闭向导并跳转详情页。这个成功边界过早，没有确认返回的 ID 已经能被下游管理页读取：

- 能力管理列表依赖 `tool-box/list`
- 工具详情页依赖 `tool-box/{boxId}` 和 `tools/list`
- 调试/发布/导出都依赖工具真实持久化后可读

因此一旦后端返回成功形态但数据未真正可读，前端就会进入空工具箱页。

## 主要改动

- 在 `registerQuickApi` 返回前增加持久化确认：
  - 确认工具箱详情可读
  - 新建工具箱时确认该工具箱能从 `tool-box/list` 搜到
  - 确认 `createTool` 返回的所有 tool id 能从 `tools/list` 读到
- 增加短重试，兼容轻微读写可见性延迟。
- 如果确认失败，抛出明确错误，让向导停留在当前步骤并显示错误，不再跳转空工具箱。
- 新增服务层回归测试覆盖：
  - 成功路径必须读回工具箱和工具后才返回
  - 工具未持久化时拒绝返回可跳转结果
  - 工具箱未出现在列表时拒绝返回可跳转结果

## 影响范围

- `src/modules/execution-factory/services/quick-api.service.ts`
- `src/modules/execution-factory/services/quick-api.service.test.ts`

不改变 OpenAPI 解析、工具箱创建、工具创建接口契约；只收紧 Quick Add 的“创建成功”判断边界。

## 验证方式

通过：

- `pnpm exec vitest run src/modules/execution-factory/services/quick-api.service.test.ts`
- `npx playwright test specs/execution-factory/e2e-quick-api.spec.ts --grep QA-01|QA-04`
- `pnpm lint`：0 error，35 个既有 warning
- `pnpm build`：通过，存在既有 Vite chunk/import warning

额外说明：

- 在最新 `origin/main` 上执行 `pnpm test -- --run` 会触发一个与本 PR diff 无关的既有失败：`src/app/shell/console-navigation-capability-factory.test.ts` 期望隐藏 `execution-factory-lab`，但 `origin/main` 当前 `base-navigation.tsx` 仍包含该入口。本 PR diff 只包含 Quick Add 两个文件。

## 模块注册与对外入口检查

- 是否修改模块 `locales`：否
- 是否修改模块 `navigation.tsx`：否
- 是否修改模块 `routes.tsx`：否
- 是否修改 `module.manifest.ts`：否
- 是否影响外部接口契约：否，仅增加前端服务层成功后的读回确认

Fixes #32