### PR TITLE
fix(execution-factory): preserve cURL service URL in quick add

### DIFF
--- a/src/modules/execution-factory/components/create-menu/AddCapabilityWizard.test.ts
+++ b/src/modules/execution-factory/components/create-menu/AddCapabilityWizard.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildQuickApiSubmitError } from "./quick-api-submit-error";
+
+describe("buildQuickApiSubmitError", () => {
+  it("maps backend URL validation details to the cURL field", () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        data: {
+          code: "AgentOperatorIntegration.BadRequest.OpenAPIInvalidURLFormat",
+          description: "URL格式错误，请检查URL是否符合规范",
+          details: "URL cannot be empty",
+        },
+      },
+    };
+
+    const result = buildQuickApiSubmitError(error);
+
+    expect(result.field).toBe("curlText");
+    expect(result.message).toContain("服务地址");
+    expect(result.message).toContain("URL cannot be empty");
+  });
+});

--- a/src/modules/execution-factory/components/create-menu/AddCapabilityWizard.tsx
+++ b/src/modules/execution-factory/components/create-menu/AddCapabilityWizard.tsx
@@ -55,6 +55,7 @@ import {
   type ImportOpenApiCapabilityFormHandle,
 } from "./ImportOpenApiCapabilityForm";
 import { QuickAddApiForm, type QuickAddApiFormHandle } from "./QuickAddApiForm";
+import { buildQuickApiSubmitError } from "./quick-api-submit-error";
 
 import styles from "./create-menu.module.css";
 
@@ -343,7 +344,9 @@ export function AddCapabilityWizard({
 
     } catch (error) {
 
-      void message.error(extractRequestErrorMessage(error));
+      const submitError = buildQuickApiSubmitError(error);
+      quickApiFormRef.current?.showSubmitError(submitError);
+      void message.error(submitError.message);
 
     } finally {
 

--- a/src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx
+++ b/src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx
@@ -50,8 +50,11 @@ type QuickAddApiFormProps = {
   onSubmit: (payload: { openapiSpec: string; serviceUrl: string; values: QuickAddApiFormValues }) => void;
 };
 
+type QuickAddApiSubmitErrorField = "curlText" | "serverUrl" | "apiUrl" | "summary" | "toolboxName";
+
 export type QuickAddApiFormHandle = {
   submit: () => void;
+  showSubmitError: (error: { field?: QuickAddApiSubmitErrorField; message: string }) => void;
 };
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"];
@@ -63,6 +66,15 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
   useImperativeHandle(ref, () => ({
     submit: () => {
       form.submit();
+    },
+    showSubmitError: ({ field, message }) => {
+      const targetField = field ?? (inputMode === "curl" ? "curlText" : "serverUrl");
+      setInputMode(targetField === "curlText" ? "curl" : "form");
+      setParseHint(message);
+      form.setFields([{ name: targetField, errors: [message] }]);
+      window.setTimeout(() => {
+        form.scrollToField(targetField, { behavior: "smooth", focus: true });
+      });
     },
   }));
   const [inputMode, setInputMode] = useState<"curl" | "form">("curl");
@@ -156,22 +168,27 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
       }
     }
 
-    const spec = buildSpecFromValues(values, inputMode);
-    if (!spec) {
+    const submission = buildSubmissionFromValues(values, inputMode);
+    if (!submission) {
       setParseHint(t("executionFactory.quickApiBuildFailed"));
       return;
     }
 
-    const validation = analyzeOpenApiDocumentText(spec);
+    const validation = analyzeOpenApiDocumentText(submission.openapiSpec);
     if (!validation.ok) {
       setParseHint(validation.reason);
       return;
     }
 
     onSubmit({
-      openapiSpec: spec,
-      serviceUrl: values.serverUrl,
-      values,
+      openapiSpec: submission.openapiSpec,
+      serviceUrl: submission.serviceUrl,
+      values: {
+        ...values,
+        serverUrl: submission.serviceUrl,
+        method: submission.method,
+        path: submission.path,
+      },
     });
   };
 
@@ -312,15 +329,25 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
 );
 
 function buildSpecFromValues(values: QuickAddApiFormValues, inputMode: "curl" | "form") {
+  return buildSubmissionFromValues(values, inputMode)?.openapiSpec;
+}
+
+function buildSubmissionFromValues(values: QuickAddApiFormValues, inputMode: "curl" | "form") {
   if (inputMode === "curl" && values.curlText?.trim()) {
     const parsed = parseCurlCommand(values.curlText);
     if (parsed.ok) {
-      return buildOpenApiFromQuickApi({
+      const openapiSpec = buildOpenApiFromQuickApi({
         ...parsed.value,
         summary: values.summary || parsed.value.summary,
         description: values.description,
         queryParams: parsed.value.queryParams,
       });
+      return {
+        openapiSpec,
+        serviceUrl: parsed.value.serverUrl,
+        method: parsed.value.method,
+        path: parsed.value.path,
+      };
     }
   }
 
@@ -337,7 +364,7 @@ function buildSpecFromValues(values: QuickAddApiFormValues, inputMode: "curl" | 
     }
   }
 
-  return buildOpenApiFromQuickApi({
+  const openapiSpec = buildOpenApiFromQuickApi({
     method: values.method || "GET",
     serverUrl: values.serverUrl,
     path: values.path,
@@ -345,4 +372,11 @@ function buildSpecFromValues(values: QuickAddApiFormValues, inputMode: "curl" | 
     description: values.description,
     queryParams,
   });
+
+  return {
+    openapiSpec,
+    serviceUrl: values.serverUrl,
+    method: values.method || "GET",
+    path: values.path,
+  };
 }

--- a/src/modules/execution-factory/components/create-menu/quick-api-submit-error.ts
+++ b/src/modules/execution-factory/components/create-menu/quick-api-submit-error.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { extractRequestErrorMessage } from "@/framework/request/error-message";
+import { extractRequestErrorDetail } from "@/modules/execution-factory/utils/request-error-detail";
+
+export function buildQuickApiSubmitError(error: unknown) {
+  const detail = extractRequestErrorDetail(error);
+  const rawDetail =
+    typeof detail.detail === "string"
+      ? detail.detail
+      : detail.detail
+        ? JSON.stringify(detail.detail)
+        : "";
+  const messageParts = [detail.message, rawDetail].filter(Boolean);
+  const combined = [detail.code, detail.message, rawDetail].filter(Boolean).join(" ");
+  const isUrlError =
+    /OpenAPIInvalidURLFormat|URL cannot be empty|url format|invalid url|URL格式|URL/i.test(
+      combined,
+    );
+
+  if (!isUrlError) {
+    return {
+      message: messageParts.join("：") || extractRequestErrorMessage(error),
+    };
+  }
+
+  return {
+    field: "curlText" as const,
+    message:
+      "保存失败：未能提交有效的服务地址。请检查 cURL 命令中的完整 URL，并重新点击“识别接口信息”后再保存。" +
+      (rawDetail ? ` 后端返回：${rawDetail}` : ""),
+  };
+}

--- a/src/modules/execution-factory/utils/request-error-detail.ts
+++ b/src/modules/execution-factory/utils/request-error-detail.ts
@@ -22,6 +22,7 @@ type BackendErrorBody = {
   code?: string;
   description?: string;
   detail?: unknown;
+  details?: unknown;
   error?: string;
   message?: string;
   solution?: string;
@@ -41,7 +42,7 @@ export function extractRequestErrorDetail(error: unknown): RequestErrorDetail {
     message: data?.description ?? data?.message ?? message,
     code: data?.code,
     description: data?.description,
-    detail: data?.detail,
+    detail: data?.detail ?? data?.details,
     solution: data?.solution,
     link: data?.link,
   };

--- a/tests/e2e/specs/execution-factory/e2e-quick-api.spec.ts
+++ b/tests/e2e/specs/execution-factory/e2e-quick-api.spec.ts
@@ -11,6 +11,7 @@ import {
   gotoUnitsTab,
   openAddCapabilityWizard,
   triggerImpexExport,
+  waitForCategoryFieldReady,
 } from "../../helpers/execution-unit-ui";
 import {
   buildToolboxName,
@@ -77,6 +78,43 @@ test.describe("Execution Factory — Quick Add API lifecycle", () => {
     await expect(page).toHaveURL(new RegExp(`/execution-factory/toolboxes/${boxId}/tools`));
     await expectAppToast(page, /已添加到工具集|added to the toolset/i);
     await expect(page.getByRole("heading", { level: 3, name: toolboxName })).toBeVisible();
+  });
+
+  test("QA-01b: quick add API from cURL tab submits parsed service URL", async ({ page }) => {
+    const toolboxName = buildToolboxName("quick_api_curl");
+    const toolName = `manual_http_weather_${Date.now()}`;
+    const curl =
+      'curl -X GET "http://host.docker.internal:8080/proxy/uapis/weather"';
+
+    const drawer = await openAddCapabilityWizard(page, "toolbox");
+
+    await drawer.getByRole("textbox", { name: /cURL/i }).fill(curl);
+    await drawer.getByRole("button", { name: /识别接口信息|Detect API details/i }).click();
+    await drawer.getByLabel(/工具名称|Tool name/i).fill(toolName);
+    await drawer.getByRole("radio", { name: /新建工具集|New toolset/i }).check();
+    await drawer.getByLabel(/工具箱名称|Toolbox Name/i).fill(toolboxName);
+    await waitForCategoryFieldReady(page, drawer);
+    await expectOpenApiOperationsIoPreview(drawer, { containsText: /GET/i });
+
+    await drawer.locator(".ant-drawer-body").evaluate((body) => {
+      body.scrollTop = body.scrollHeight;
+    });
+
+    const saveButton = drawer.getByRole("button", { name: /保存并完成|Save and finish/i });
+    await saveButton.scrollIntoViewIfNeeded();
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+
+    await expect(page).toHaveURL(/\/execution-factory\/toolboxes\/[^/]+\/tools/, {
+      timeout: 180_000,
+    });
+    await expect(page.getByText("http://host.docker.internal:8080")).toBeVisible({
+      timeout: 30_000,
+    });
+    const currentUrl = new URL(page.url());
+    const boxId = currentUrl.pathname.match(/\/toolboxes\/([^/]+)/)?.[1] ?? "";
+    expect(boxId).toBeTruthy();
+    createdBoxIds.push(boxId);
   });
 
   test("QA-02: quick added toolset supports publish and export", async ({ page, request }) => {


### PR DESCRIPTION
﻿## Summary
- Fix quick-add HTTP API cURL mode so the parsed service URL, method, and path are submitted when saving.
- Map backend URL validation failures back to the cURL/service URL form area with actionable detail.
- Preserve backend `details` fields when extracting request error detail.
- Add unit and E2E regression coverage for issue #51.

## Linked Issue
Closes #51

## Test plan
- [x] `pnpm exec eslint src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx src/modules/execution-factory/components/create-menu/AddCapabilityWizard.tsx src/modules/execution-factory/components/create-menu/AddCapabilityWizard.test.ts src/modules/execution-factory/components/create-menu/quick-api-submit-error.ts src/modules/execution-factory/utils/request-error-detail.ts tests/e2e/specs/execution-factory/e2e-quick-api.spec.ts`
- [x] `pnpm test:execution-factory -- --run` (19 files, 62 tests)
- [x] `E2E_BASE_URL=http://127.0.0.1:5176 npm run test -- --grep "QA-01b" specs/execution-factory/e2e-quick-api.spec.ts` (1 passed)

## Notes
The broader `e2e-quick-api.spec.ts` suite was also attempted locally. Several pre-existing cases still used front-end mock IDs (`tb_...`) in this clean worktree environment and failed during backend publish/detail cleanup; the new #51 regression itself passed against the local browser flow and verifies the saved Server URL.
