### PR TITLE
feat(execution-factory): add Agent capability manifest

### DIFF
--- a/docs/superpowers/plans/2026-07-06-agent-capability-manifest.md
+++ b/docs/superpowers/plans/2026-07-06-agent-capability-manifest.md
@@ -1,0 +1,61 @@
+# Agent Capability Manifest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the first production-safe slice of issue #47 by adding a read-only Agent-readable Capability Manifest layer for Execution Factory resources.
+
+**Architecture:** Keep existing Toolbox, Tool, MCP, Skill, and Operator models unchanged. Add a normalized manifest type and pure mapping helpers under `src/modules/execution-factory/`, then render an additive Agent readiness panel in the existing Tool and MCP detail views.
+
+**Tech Stack:** React, TypeScript, Ant Design, CSS Modules, Vitest, pnpm.
+
+---
+
+## Files
+
+- Create: `src/modules/execution-factory/types/capability-manifest.ts`
+- Create: `src/modules/execution-factory/utils/capability-manifest.ts`
+- Create: `src/modules/execution-factory/utils/capability-manifest.test.ts`
+- Create: `src/modules/execution-factory/components/CapabilityAgentReadinessPanel.tsx`
+- Create: `src/modules/execution-factory/components/CapabilityAgentReadinessPanel.module.css`
+- Modify: `src/modules/execution-factory/scenes/ToolboxToolsScene.tsx`
+- Modify: `src/modules/execution-factory/scenes/McpDetailScene.tsx`
+- Modify: `docs/superpowers/specs/2026-07-06-agent-capability-manifest-design.md`
+
+## Task 1: Add Manifest Mapping Tests
+
+- [ ] Write tests for Tool, MCP tool, Skill, and Operator source records.
+- [ ] Run `pnpm vitest run src/modules/execution-factory/utils/capability-manifest.test.ts` and confirm failure because the helper does not exist.
+
+## Task 2: Implement Manifest Types And Mapping Helpers
+
+- [ ] Add normalized manifest types.
+- [ ] Implement `buildToolCapabilityManifest`.
+- [ ] Implement `buildMcpToolCapabilityManifest`.
+- [ ] Implement `buildSkillCapabilityManifest`.
+- [ ] Implement `buildOperatorCapabilityManifest`.
+- [ ] Implement `getCapabilityReadiness`.
+- [ ] Run manifest tests and confirm pass.
+
+## Task 3: Add Read-Only Agent Readiness Panel
+
+- [ ] Add `CapabilityAgentReadinessPanel`.
+- [ ] Render intent, source type, test status, side effect, risk level, Agent visibility, invoke policy, input count, output count, and missing semantic guidance.
+- [ ] Add focused styles with CSS Modules.
+
+## Task 4: Integrate Panel Into Tool And MCP Detail Views
+
+- [ ] In `ToolboxToolsScene`, build a Tool manifest from the selected tool detail and render the panel above the input/output panel.
+- [ ] In `McpDetailScene`, build an MCP tool manifest from the selected MCP tool and render the panel above the JSON schema panel.
+- [ ] Keep existing debug, edit, import, export, and publish flows unchanged.
+
+## Task 5: Verify
+
+- [ ] Run `pnpm vitest run src/modules/execution-factory/utils/capability-manifest.test.ts`.
+- [ ] Run `pnpm test:execution-factory -- --run`.
+- [ ] Run `pnpm lint`.
+- [ ] Run `pnpm build`.
+
+## Scope Notes
+
+This implementation intentionally does not add backend persistence or editable semantic metadata. That belongs to the next issue slice after the read-only manifest and UI placement are validated.
+

--- a/docs/superpowers/specs/2026-07-06-agent-capability-manifest-design.md
+++ b/docs/superpowers/specs/2026-07-06-agent-capability-manifest-design.md
@@ -1,0 +1,612 @@
+# Agent Capability Manifest Design
+
+Issue: https://github.com/openbkn-ai/bkn-studio/issues/47
+
+## Goal
+
+Evolve the current Execution Factory from a human-oriented resource management
+surface into an Agent-readable capability governance surface.
+
+The current factory already covers capability management, capability market,
+sandbox runtime observability, toolboxes, tools, MCP services, Skill packages,
+operators, import/export, and publish lifecycle. The gap is not resource
+coverage. The gap is that capabilities are still mostly expressed as backend
+resources instead of semantic, verifiable, Agent-usable business capabilities.
+
+This design introduces a unified Capability Manifest and a semantic capability
+detail experience while preserving the existing execution-factory routes,
+services, resource models, and compatibility behavior.
+
+## Current Capability Surface
+
+The official Execution Factory currently exposes three major entries:
+
+- Capability Management: manages local toolboxes, MCP services, Skill packages,
+  and advanced operator resources.
+- Capability Market: browses, installs, and syncs published capabilities from
+  other business domains.
+- Sandbox Runtime Management: shows sandbox runtime health, sessions, tasks,
+  dependencies, and failure pressure.
+
+The current resource types already cover:
+
+- Toolbox: groups HTTP API tools and Function tools.
+- Tool: supports OpenAPI and Function metadata, debug, enable/disable, and
+  global parameters.
+- MCP service: supports SSE / Streamable HTTP registration, tool discovery, and
+  MCP tool debug.
+- Skill package: supports ZIP / SKILL.md import, file preview, edit, and release
+  history.
+- Operator: supports OpenAPI / Function registration, debug, execution control,
+  release history, and conversion to tool.
+- Import/export: supports OpenAPI import, ADP package import/export, market
+  install, and market sync.
+- Publish governance: supports unpublish, published, offline, and editing
+  states.
+
+## Problem
+
+### Resource Metadata Is Not Enough
+
+Existing models mostly expose resource-level fields:
+
+- name
+- description
+- status
+- category
+- schema
+- createUser / updateUser
+- releaseTime
+
+These fields are useful for people managing resources, but they are not enough
+for an Agent to reliably decide when and how to use a capability. For example,
+`customer_id: string` does not tell an Agent whether it means customer master
+data ID, phone number, user name, tenant ID, or an external system code.
+
+### Capability Types Do Not Share A Contract
+
+Tool, MCP, Skill, and Operator each have a valid internal model. Human users can
+understand the differences, but Agents need a normalized contract for discovery,
+selection, verification, and invocation planning.
+
+The system should keep the existing resource models but expose a unified
+capability view above them.
+
+### Debug Results Are Not Persisted As Capability Evidence
+
+Current debug flows are useful for one-time manual testing. Agent usage needs
+stronger evidence:
+
+- Which examples have passed?
+- When was the capability last verified?
+- What input was used?
+- What output shape was observed?
+- Was the result safe, partial, failed, or stale?
+- Does the capability have side effects?
+
+### Publish Status Is Not Agent Availability
+
+`published` means the resource is available in the platform lifecycle. It does
+not answer whether an Agent can see it, call it automatically, call it only after
+human approval, or call it only in read-only/test mode.
+
+## Product Principles
+
+1. Keep the existing resource model stable.
+   Do not replace Toolbox, Tool, MCP, Skill, or Operator in the first phase.
+
+2. Add an Agent-readable semantic layer.
+   The Agent-facing view should normalize different resource types into a single
+   Capability Manifest.
+
+3. Make capability quality visible.
+   A capability should clearly show whether it is well described, tested,
+   safe to call, and ready for Agent use.
+
+4. Preserve human governance.
+   Agent enablement is controlled by people. The system should support visible,
+   reviewable policies instead of implicit automation.
+
+5. Let semantics grow incrementally.
+   First support manually maintained semantic fields and validation evidence.
+   Later phases can add AI-assisted generation, schema inference, and automatic
+   recommendation.
+
+## User Stories
+
+### Business User
+
+As a business user, I want to open a capability detail page and immediately
+understand what business problem it solves, when I should use it, and when I
+should not use it, so that I do not have to reverse-engineer technical fields.
+
+Value:
+
+- Reduces onboarding cost.
+- Makes capability reuse easier across teams.
+- Helps business users choose the right capability without reading API specs.
+
+### Capability Creator
+
+As a capability creator, I want to explain each parameter in business language,
+provide examples, and mark important constraints, so that Agents and downstream
+users do not misuse identifiers, environment values, date ranges, or tenant
+fields.
+
+Value:
+
+- Prevents invalid calls caused by ambiguous parameter names.
+- Improves generated examples and debug data quality.
+- Converts tacit integration knowledge into reusable metadata.
+
+### Agent
+
+As an Agent, I want one normalized manifest for Tool, MCP, Skill, and Operator
+capabilities, so that I can search, rank, select, and plan calls without needing
+four separate resource-specific adapters.
+
+Value:
+
+- Improves autonomous tool selection.
+- Makes future Agent discovery APIs and MCP exposure simpler.
+- Supports cross-type capability recommendation and composition.
+
+### Platform Administrator
+
+As a platform administrator, I want to control whether each capability is hidden,
+discoverable, callable with approval, or callable automatically, so that Agent
+autonomy can grow under clear governance.
+
+Value:
+
+- Reduces production risk.
+- Makes side effects explicit.
+- Supports compliance and audit.
+
+### Operator / Auditor
+
+As an operator or auditor, I want to see recent verification status, example
+results, side effects, and risk level, so that I can judge whether a capability
+is safe to expose to Agents.
+
+Value:
+
+- Turns debug into reusable evidence.
+- Helps identify stale or broken capabilities.
+- Supports production readiness reviews.
+
+## Capability Manifest
+
+The Capability Manifest is a normalized view generated from the underlying
+resource plus semantic extensions.
+
+```ts
+export type CapabilitySourceType = "tool" | "mcp" | "skill" | "operator";
+
+export type CapabilitySideEffect =
+  | "none"
+  | "read"
+  | "write"
+  | "external_action"
+  | "unknown";
+
+export type CapabilityRiskLevel = "low" | "medium" | "high";
+
+export type CapabilityTestStatus = "untested" | "passed" | "failed" | "stale";
+
+export type AgentVisibility = "hidden" | "discoverable" | "callable";
+
+export type AgentInvokePolicy =
+  | "manual_only"
+  | "approval_required"
+  | "auto_allowed";
+
+export type CapabilityInputSemantic = {
+  name: string;
+  location?: "query" | "path" | "header" | "cookie" | "body" | "argument";
+  dataType?: string;
+  required?: boolean;
+  businessMeaning?: string;
+  examples?: unknown[];
+  defaultStrategy?: string;
+  constraints?: string[];
+  dependsOn?: string[];
+  sourceHint?: string;
+};
+
+export type CapabilityOutputSemantic = {
+  name: string;
+  path?: string;
+  dataType?: string;
+  businessMeaning?: string;
+  examples?: unknown[];
+  caveats?: string[];
+};
+
+export type CapabilityExample = {
+  title: string;
+  scenario?: string;
+  input: unknown;
+  expectedOutputSummary?: string;
+  verifiedAt?: number;
+  status?: CapabilityTestStatus;
+};
+
+export type CapabilityManifest = {
+  id: string;
+  sourceType: CapabilitySourceType;
+  sourceId: string;
+  title: string;
+  description?: string;
+  status: string;
+  category?: string;
+  intent?: string;
+  useCases?: string[];
+  antiUseCases?: string[];
+  inputSemantics?: CapabilityInputSemantic[];
+  outputSemantics?: CapabilityOutputSemantic[];
+  examples?: CapabilityExample[];
+  sideEffects?: CapabilitySideEffect;
+  authRequirements?: string[];
+  riskLevel?: CapabilityRiskLevel;
+  testStatus?: CapabilityTestStatus;
+  agentVisibility?: AgentVisibility;
+  agentInvokePolicy?: AgentInvokePolicy;
+  updatedAt?: number;
+};
+```
+
+## Source Mapping
+
+### Tool
+
+Tool is the highest-priority source because HTTP APIs and Function tools are the
+most direct Agent-callable capabilities.
+
+Initial mapping:
+
+- `toolId` -> `sourceId`
+- `name` -> `title`
+- `description` -> `description`
+- `metadataType` -> source subtype
+- `ioSpec.parameters` -> `inputSemantics`
+- `ioSpec.responses` -> `outputSemantics`
+- `status` -> lifecycle status
+- `useRule` -> invocation guidance
+
+Recommended semantic additions:
+
+- business intent
+- parameter business meanings
+- response field meanings
+- side effect classification
+- Agent invoke policy
+- verified examples
+
+### MCP
+
+MCP service should be represented as an external tool source plus local
+governance. Each discovered MCP tool can become a capability candidate.
+
+Initial mapping:
+
+- `mcpId` -> service source ID
+- MCP tool `name` -> capability title
+- MCP tool `description` -> description
+- MCP tool `inputSchema` -> input semantics seed
+- `mode`, `url`, and headers -> connection metadata
+
+Recommended semantic additions:
+
+- per-tool visibility policy
+- per-tool approval policy
+- service connection status
+- tool discovery freshness
+- call failure hints
+
+### Skill
+
+Skill packages should move from file-package management toward executable skill
+understanding.
+
+Initial mapping:
+
+- `skillId` -> `sourceId`
+- `name` -> `title`
+- `description` -> `description`
+- `version` -> version metadata
+- SKILL.md content -> semantic seed
+- file summary -> supporting artifacts
+
+Recommended semantic additions:
+
+- skill tasks
+- required context
+- executable entry points
+- dependencies
+- examples
+- safety boundaries
+
+### Operator
+
+Operator remains an advanced and compatibility-oriented capability source.
+
+Initial mapping:
+
+- `operatorId` -> `sourceId`
+- `name` -> `title`
+- `description` -> `description`
+- `metadataType` -> source subtype
+- `executeControl` -> runtime constraints
+- release history -> version evidence
+
+Recommended semantic additions:
+
+- orchestration use cases
+- retry behavior explanation
+- workflow node guidance
+- conversion relationship to Tool
+
+## UX Design
+
+### Capability Detail Tabs
+
+Each resource detail page should gradually converge toward the same information
+architecture:
+
+1. Overview
+   - title, type, lifecycle status, category
+   - business intent
+   - use cases and anti-use cases
+   - risk level and side effect badge
+   - Agent availability summary
+
+2. Inputs / Outputs
+   - technical schema
+   - business meaning per input
+   - examples and constraints
+   - output field explanations
+   - empty-state guidance when schema is missing
+
+3. Debug / Verification
+   - existing debug entry
+   - sample input
+   - latest result
+   - verification status
+   - failure reason and retry guidance
+
+4. Agent Usage
+   - visibility policy
+   - invoke policy
+   - approval requirements
+   - auth requirements
+   - generated Agent-facing usage summary
+
+5. Publish / Version
+   - existing publish state
+   - release history
+   - rollback or republish actions where supported
+
+6. Runtime / Observability
+   - recent calls
+   - success rate when available
+   - sandbox sessions when applicable
+   - errors and latency when available
+
+### Capability List Improvements
+
+The existing type tabs should remain, but list cards should expose Agent
+readiness:
+
+- semantic completeness
+- test status
+- risk level
+- Agent visibility
+- side effect
+
+Suggested filters:
+
+- Agent visible / hidden
+- callable automatically / approval required
+- tested / untested / failed
+- read-only / write / external action
+- semantic completeness
+
+### Creation Flow Improvements
+
+The current creation menu is already grouped by intent. The next improvement is
+to add semantic guidance after the technical resource is created:
+
+- "Explain business purpose"
+- "Explain key parameters"
+- "Add example"
+- "Run verification"
+- "Choose Agent policy"
+
+This should be a post-create readiness checklist rather than a blocking form in
+the first phase.
+
+## Data And Backend Strategy
+
+### Phase 1: Frontend Contract And Metadata Extension
+
+Use a frontend normalization layer to generate Capability Manifest from existing
+records and optional semantic metadata.
+
+This phase should avoid schema-breaking backend changes. If backend storage is
+needed, prefer one extensible metadata field per resource type rather than
+separate hard-coded columns for every semantic concept.
+
+Recommended storage shape:
+
+```ts
+type CapabilitySemanticMetadata = {
+  intent?: string;
+  useCases?: string[];
+  antiUseCases?: string[];
+  inputSemantics?: CapabilityInputSemantic[];
+  outputSemantics?: CapabilityOutputSemantic[];
+  examples?: CapabilityExample[];
+  sideEffects?: CapabilitySideEffect;
+  authRequirements?: string[];
+  riskLevel?: CapabilityRiskLevel;
+  agentVisibility?: AgentVisibility;
+  agentInvokePolicy?: AgentInvokePolicy;
+};
+```
+
+### Phase 2: Verification Evidence
+
+Persist selected debug runs as verification evidence.
+
+Recommended fields:
+
+- capability ID
+- source type and source ID
+- input snapshot
+- output summary
+- status
+- error summary
+- duration
+- verified by
+- verified at
+
+### Phase 3: Agent Discovery API / MCP
+
+Expose the manifest through a stable Agent-facing interface:
+
+- search capabilities by intent
+- get manifest by capability ID
+- get examples
+- get latest verification result
+- get invoke policy
+- request a test call
+
+This can later become an Execution Factory MCP server.
+
+## Implementation Phases
+
+### Phase 1: Design And Read-Only Manifest
+
+Deliverables:
+
+- Capability Manifest types.
+- Source-to-manifest normalization helpers.
+- Read-only semantic detail sections.
+- Unit tests for mapping Tool / MCP / Skill / Operator records.
+
+No backend mutation is required in this phase.
+
+### Phase 2: Editable Semantics
+
+Deliverables:
+
+- UI to edit business intent, use cases, parameter meanings, output meanings,
+  side effects, and Agent policy.
+- Service layer changes to save semantic metadata.
+- Validation for required semantic fields when Agent visibility is `callable`.
+
+### Phase 3: Verification Evidence
+
+Deliverables:
+
+- Save debug result as example or verification evidence.
+- Show latest verification status in list and detail pages.
+- Mark stale verification when capability metadata changes after last verified
+  run.
+
+### Phase 4: Agent Discovery Surface
+
+Deliverables:
+
+- Capability search API or service facade.
+- Agent-facing manifest endpoint.
+- MCP exposure design for BKN Agent integration.
+
+## Compatibility
+
+The first implementation should not remove or rename existing routes:
+
+- `/execution-factory/units`
+- `/execution-factory/catalog`
+- `/execution-factory/sandbox-runtime`
+- toolbox, MCP, Skill, and operator detail routes
+
+Existing actions must remain available:
+
+- create
+- edit
+- debug
+- publish
+- offline
+- import
+- export
+- market install
+- market sync
+
+The semantic layer is additive.
+
+## Testing Strategy
+
+Unit tests:
+
+- manifest mapping from Tool record
+- manifest mapping from MCP record and MCP tool schema
+- manifest mapping from Skill record
+- manifest mapping from Operator record
+- Agent policy validation
+- semantic completeness scoring
+
+Component tests:
+
+- detail overview renders semantic sections
+- missing semantics show useful empty guidance
+- risk and Agent policy badges render correctly
+- schema-derived input rows can be enriched with business meaning
+
+E2E tests:
+
+- create or load a Tool, open detail, view Agent Usage section
+- enrich parameter semantics, save, reload, and verify persistence
+- run debug and save result as verification evidence
+- filter list by Agent visibility and test status
+
+Manual QA:
+
+- verify HTTP API, OpenAPI import, MCP, Skill, Function, and Operator paths
+- verify existing publish/import/export flows are not blocked by missing
+  semantic metadata
+- verify existing market install/sync still works
+
+## Open Questions
+
+1. Should semantic metadata be saved in each resource service or a new shared
+   capability metadata service?
+2. Should Agent visibility default to `hidden` or `discoverable` for newly
+   published capabilities?
+3. Should `auto_allowed` require at least one passed verification example?
+4. Should write/external-action capabilities always require approval in the
+   first production phase?
+
+## Recommended First Issue Breakdown
+
+1. Add read-only Capability Manifest normalization.
+2. Add semantic overview sections to Tool detail first.
+3. Extend MCP and Skill detail pages with the same read-only manifest pattern.
+4. Add editable semantic metadata after the read-only structure is stable.
+5. Add verification evidence after debug flows are confirmed stable.
+
+## Implemented First Slice
+
+The first implementation slice keeps the feature additive and read-only:
+
+- Adds normalized Capability Manifest types.
+- Adds pure mapping helpers for Tool, MCP tool, Skill, and Operator records.
+- Adds readiness scoring based on intent, input semantics, output semantics,
+  verified examples, verification status, and Agent policy.
+- Adds a reusable Agent readiness panel.
+- Shows the panel in the Tool detail workflow and MCP tool detail workflow.
+
+The first slice intentionally does not persist editable semantic metadata or
+debug verification evidence. Those remain follow-up slices after the UI
+placement and manifest contract are validated.

--- a/src/modules/execution-factory/components/CapabilityAgentReadinessPanel.module.css
+++ b/src/modules/execution-factory/components/CapabilityAgentReadinessPanel.module.css
@@ -1,0 +1,76 @@
+.panel {
+  margin-bottom: 16px;
+  padding: 16px;
+  border: 1px solid rgba(18, 110, 227, 0.14);
+  border-radius: 8px;
+  background: #fbfdff;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.titleWrap {
+  min-width: 0;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(0, 0, 0, 0.88);
+  font-weight: 600;
+}
+
+.description {
+  margin-top: 4px;
+  color: rgba(0, 0, 0, 0.5);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.score {
+  min-width: 104px;
+  text-align: right;
+}
+
+.scoreValue {
+  color: #126ee3;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 28px;
+}
+
+.scoreLabel {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.sectionTitle {
+  margin-bottom: 8px;
+  color: rgba(0, 0, 0, 0.72);
+  font-weight: 600;
+}
+
+.missingList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.emptyText {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 13px;
+}
+

--- a/src/modules/execution-factory/components/CapabilityAgentReadinessPanel.tsx
+++ b/src/modules/execution-factory/components/CapabilityAgentReadinessPanel.tsx
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { RobotOutlined } from "@ant-design/icons";
+import { Alert, Progress, Tag } from "antd";
+import { useTranslation } from "react-i18next";
+
+import type {
+  AgentInvokePolicy,
+  AgentVisibility,
+  CapabilityManifest,
+  CapabilityRiskLevel,
+  CapabilitySideEffect,
+  CapabilityTestStatus,
+} from "@/modules/execution-factory/types/capability-manifest";
+import { getCapabilityReadiness } from "@/modules/execution-factory/utils/capability-manifest";
+
+import styles from "./CapabilityAgentReadinessPanel.module.css";
+
+type CapabilityAgentReadinessPanelProps = {
+  manifest: CapabilityManifest;
+};
+
+const riskColorMap: Record<CapabilityRiskLevel, string> = {
+  low: "green",
+  medium: "gold",
+  high: "red",
+};
+
+const visibilityColorMap: Record<AgentVisibility, string> = {
+  hidden: "default",
+  discoverable: "blue",
+  callable: "green",
+};
+
+const invokePolicyColorMap: Record<AgentInvokePolicy, string> = {
+  manual_only: "default",
+  approval_required: "gold",
+  auto_allowed: "green",
+};
+
+const testStatusColorMap: Record<CapabilityTestStatus, string> = {
+  untested: "default",
+  passed: "green",
+  failed: "red",
+  stale: "gold",
+};
+
+const sideEffectColorMap: Record<CapabilitySideEffect, string> = {
+  none: "green",
+  read: "blue",
+  write: "gold",
+  external_action: "red",
+  unknown: "default",
+};
+
+function sourceTypeLabel(sourceType: CapabilityManifest["sourceType"]) {
+  switch (sourceType) {
+    case "tool":
+      return "Tool";
+    case "mcp":
+      return "MCP Tool";
+    case "skill":
+      return "Skill";
+    case "operator":
+      return "Operator";
+    default:
+      return sourceType;
+  }
+}
+
+export function CapabilityAgentReadinessPanel({
+  manifest,
+}: CapabilityAgentReadinessPanelProps) {
+  const { t } = useTranslation();
+  const readiness = getCapabilityReadiness(manifest);
+
+  const sideEffects = manifest.sideEffects ?? "unknown";
+  const riskLevel = manifest.riskLevel ?? "medium";
+  const testStatus = manifest.testStatus ?? "untested";
+  const agentVisibility = manifest.agentVisibility ?? "hidden";
+  const agentInvokePolicy = manifest.agentInvokePolicy ?? "manual_only";
+
+  return (
+    <section className={styles.panel} data-testid="capability-agent-readiness">
+      <div className={styles.header}>
+        <div className={styles.titleWrap}>
+          <div className={styles.title}>
+            <RobotOutlined />
+            {t("executionFactory.agentReadiness.title", {
+              defaultValue: "Agent 可用性",
+            })}
+          </div>
+          <div className={styles.description}>
+            {manifest.intent ||
+              manifest.description ||
+              t("executionFactory.agentReadiness.emptyIntent", {
+                defaultValue: "暂未补充业务用途，Agent 只能基于名称和技术 schema 推断使用方式。",
+              })}
+          </div>
+        </div>
+        <div className={styles.score}>
+          <Progress
+            percent={readiness.score}
+            showInfo={false}
+            size="small"
+            status={readiness.level === "low" ? "exception" : "normal"}
+          />
+          <div className={styles.scoreValue}>{readiness.score}</div>
+          <div className={styles.scoreLabel}>
+            {t("executionFactory.agentReadiness.score", {
+              defaultValue: "就绪度",
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.tags}>
+        <Tag>{sourceTypeLabel(manifest.sourceType)}</Tag>
+        <Tag color={testStatusColorMap[testStatus]}>
+          {t(`executionFactory.agentReadiness.testStatus.${testStatus}`, {
+            defaultValue: `验证：${testStatus}`,
+          })}
+        </Tag>
+        <Tag color={sideEffectColorMap[sideEffects]}>
+          {t(`executionFactory.agentReadiness.sideEffects.${sideEffects}`, {
+            defaultValue: `副作用：${sideEffects}`,
+          })}
+        </Tag>
+        <Tag color={riskColorMap[riskLevel]}>
+          {t(`executionFactory.agentReadiness.risk.${riskLevel}`, {
+            defaultValue: `风险：${riskLevel}`,
+          })}
+        </Tag>
+        <Tag color={visibilityColorMap[agentVisibility]}>
+          {t(`executionFactory.agentReadiness.visibility.${agentVisibility}`, {
+            defaultValue: `Agent：${agentVisibility}`,
+          })}
+        </Tag>
+        <Tag color={invokePolicyColorMap[agentInvokePolicy]}>
+          {t(`executionFactory.agentReadiness.invokePolicy.${agentInvokePolicy}`, {
+            defaultValue: `调用：${agentInvokePolicy}`,
+          })}
+        </Tag>
+        <Tag>
+          {t("executionFactory.agentReadiness.inputCount", {
+            count: manifest.inputSemantics?.length ?? 0,
+            defaultValue: `输入：${manifest.inputSemantics?.length ?? 0}`,
+          })}
+        </Tag>
+        <Tag>
+          {t("executionFactory.agentReadiness.outputCount", {
+            count: manifest.outputSemantics?.length ?? 0,
+            defaultValue: `输出：${manifest.outputSemantics?.length ?? 0}`,
+          })}
+        </Tag>
+      </div>
+
+      {readiness.missing.length > 0 ? (
+        <Alert
+          message={t("executionFactory.agentReadiness.missingTitle", {
+            defaultValue: "建议补齐后再开放给 Agent 自动调用",
+          })}
+          description={
+            <div className={styles.missingList}>
+              {readiness.missing.map((item) => (
+                <Tag key={item}>{item}</Tag>
+              ))}
+            </div>
+          }
+          showIcon
+          type="info"
+        />
+      ) : (
+        <div className={styles.emptyText}>
+          {t("executionFactory.agentReadiness.ready", {
+            defaultValue: "语义、验证和调用策略已基本齐备，可作为 Agent 调用候选。",
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+

--- a/src/modules/execution-factory/scenes/McpDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/McpDetailScene.tsx
@@ -27,6 +27,7 @@ import type { McpDetailSceneProps } from "@/modules/execution-factory/contracts/
 import { PermissionGate } from "@/framework/permission/PermissionGate";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
+import { CapabilityAgentReadinessPanel } from "@/modules/execution-factory/components/CapabilityAgentReadinessPanel";
 import { DetailMetaPanel } from "@/modules/execution-factory/components/DetailMetaPanel";
 import { CreateMcpDrawer } from "@/modules/execution-factory/components/create-menu/CreateMcpDrawer";
 import { JsonSchemaIoPanel } from "@/modules/execution-factory/components/JsonSchemaIoPanel";
@@ -37,6 +38,7 @@ import {
   listMcpTools,
 } from "@/modules/execution-factory/services/mcp.service";
 import type { McpDetail, McpProxyTool, McpStatus } from "@/modules/execution-factory/types/mcp";
+import { buildMcpToolCapabilityManifest } from "@/modules/execution-factory/utils/capability-manifest";
 import {
   formatOptionalTimestamp,
   formatRecordHeaders,
@@ -219,6 +221,18 @@ export function McpDetailScene({ mcpId, onBack }: McpDetailSceneProps) {
     ];
   }, [record, selectedTool, t]);
 
+  const selectedToolManifest = useMemo(() => {
+    if (!record || !selectedTool) {
+      return null;
+    }
+
+    return buildMcpToolCapabilityManifest({
+      mcpId,
+      serviceName: record.name,
+      tool: selectedTool,
+    });
+  }, [mcpId, record, selectedTool]);
+
   return (
     <section className={styles.page}>
       <div className={styles.backRow}>
@@ -384,6 +398,9 @@ export function McpDetailScene({ mcpId, onBack }: McpDetailSceneProps) {
                   items={toolInfoItems}
                   title={t("executionFactory.mcpToolInfoTitle")}
                 />
+                {selectedToolManifest ? (
+                  <CapabilityAgentReadinessPanel manifest={selectedToolManifest} />
+                ) : null}
                 <div className={styles.ioPanel}>
                   <div className={styles.ioHeader}>
                     <span>{t("executionFactory.toolboxInputOutputTitle")}</span>

--- a/src/modules/execution-factory/scenes/ToolboxToolsScene.tsx
+++ b/src/modules/execution-factory/scenes/ToolboxToolsScene.tsx
@@ -28,6 +28,7 @@ import { useAppServices } from "@/framework/context/use-app-services";
 import { PermissionGate } from "@/framework/permission/PermissionGate";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
+import { CapabilityAgentReadinessPanel } from "@/modules/execution-factory/components/CapabilityAgentReadinessPanel";
 import { DetailMetaPanel } from "@/modules/execution-factory/components/DetailMetaPanel";
 import { ToolDebugModal } from "@/modules/execution-factory/components/ToolDebugModal";
 import { ToolFormDrawer } from "@/modules/execution-factory/components/ToolFormDrawer";
@@ -44,6 +45,7 @@ import {
 } from "@/modules/execution-factory/services/tool.service";
 import type { ToolboxRecord } from "@/modules/execution-factory/types/toolbox";
 import type { ToolRecord, ToolRunLogEntry, ToolStatus } from "@/modules/execution-factory/types/tool";
+import { buildToolCapabilityManifest } from "@/modules/execution-factory/utils/capability-manifest";
 import { formatExecutionUnitTime } from "@/modules/execution-factory/utils/format-timestamp";
 import { useImpexExport } from "@/modules/execution-factory/utils/use-impex-export";
 
@@ -360,6 +362,18 @@ export function ToolboxToolsScene({ boxId, onBack }: ToolboxToolsSceneProps) {
     ];
   }, [handleToggleStatus, selectedTool, t, toolbox?.serviceUrl, viewMode]);
 
+  const selectedToolManifest = useMemo(() => {
+    if (selectedToolDetail) {
+      return buildToolCapabilityManifest(selectedToolDetail);
+    }
+
+    if (!selectedTool) {
+      return null;
+    }
+
+    return buildToolCapabilityManifest(selectedTool);
+  }, [selectedTool, selectedToolDetail]);
+
   return (
     <>
       <section className={styles.page}>
@@ -628,6 +642,9 @@ export function ToolboxToolsScene({ boxId, onBack }: ToolboxToolsSceneProps) {
                       ) : null
                     }
                   />
+                  {selectedToolManifest ? (
+                    <CapabilityAgentReadinessPanel manifest={selectedToolManifest} />
+                  ) : null}
                   <div className={styles.ioPanel}>
                     <div className={styles.ioHeader}>
                       <span>{t("executionFactory.toolboxInputOutputTitle")}</span>

--- a/src/modules/execution-factory/types/capability-manifest.ts
+++ b/src/modules/execution-factory/types/capability-manifest.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export type CapabilitySourceType = "tool" | "mcp" | "skill" | "operator";
+
+export type CapabilitySideEffect =
+  | "none"
+  | "read"
+  | "write"
+  | "external_action"
+  | "unknown";
+
+export type CapabilityRiskLevel = "low" | "medium" | "high";
+
+export type CapabilityTestStatus = "untested" | "passed" | "failed" | "stale";
+
+export type AgentVisibility = "hidden" | "discoverable" | "callable";
+
+export type AgentInvokePolicy =
+  | "manual_only"
+  | "approval_required"
+  | "auto_allowed";
+
+export type CapabilityInputSemantic = {
+  name: string;
+  location?: "query" | "path" | "header" | "cookie" | "body" | "argument";
+  dataType?: string;
+  required?: boolean;
+  businessMeaning?: string;
+  examples?: unknown[];
+  defaultStrategy?: string;
+  constraints?: string[];
+  dependsOn?: string[];
+  sourceHint?: string;
+};
+
+export type CapabilityOutputSemantic = {
+  name: string;
+  path?: string;
+  dataType?: string;
+  businessMeaning?: string;
+  examples?: unknown[];
+  caveats?: string[];
+};
+
+export type CapabilityExample = {
+  title: string;
+  scenario?: string;
+  input: unknown;
+  expectedOutputSummary?: string;
+  verifiedAt?: number;
+  status?: CapabilityTestStatus;
+};
+
+export type CapabilityManifest = {
+  id: string;
+  sourceType: CapabilitySourceType;
+  sourceId: string;
+  sourceName?: string;
+  title: string;
+  description?: string;
+  status: string;
+  category?: string;
+  intent?: string;
+  useCases?: string[];
+  antiUseCases?: string[];
+  inputSemantics?: CapabilityInputSemantic[];
+  outputSemantics?: CapabilityOutputSemantic[];
+  examples?: CapabilityExample[];
+  sideEffects?: CapabilitySideEffect;
+  authRequirements?: string[];
+  riskLevel?: CapabilityRiskLevel;
+  testStatus?: CapabilityTestStatus;
+  agentVisibility?: AgentVisibility;
+  agentInvokePolicy?: AgentInvokePolicy;
+  updatedAt?: number;
+};
+
+export type CapabilityReadiness = {
+  score: number;
+  level: "low" | "medium" | "high";
+  missing: string[];
+};
+

--- a/src/modules/execution-factory/utils/capability-manifest.test.ts
+++ b/src/modules/execution-factory/utils/capability-manifest.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { McpProxyTool } from "@/modules/execution-factory/types/mcp";
+import type { OperatorDetail } from "@/modules/execution-factory/types/operator";
+import type { SkillRecord } from "@/modules/execution-factory/types/skill";
+import type { ToolDetail } from "@/modules/execution-factory/types/tool";
+import {
+  buildMcpToolCapabilityManifest,
+  buildOperatorCapabilityManifest,
+  buildSkillCapabilityManifest,
+  buildToolCapabilityManifest,
+  getCapabilityReadiness,
+} from "@/modules/execution-factory/utils/capability-manifest";
+
+describe("capability-manifest", () => {
+  it("maps an OpenAPI tool into an Agent-readable manifest", () => {
+    const tool: ToolDetail = {
+      toolId: "tool-customer-search",
+      name: "Search customers",
+      description: "Find customers by keyword.",
+      status: "enabled",
+      metadataType: "openapi",
+      method: "GET",
+      path: "/customers",
+      serverUrl: "https://crm.example.com",
+      useRule: "Use when a user mentions a customer name but not the customer ID.",
+      ioSpec: {
+        parameters: [
+          {
+            name: "keyword",
+            in: "query",
+            required: true,
+            description: "Customer name, phone, or external code.",
+            type: "string",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Matched customers.",
+            example: { items: [{ customer_id: "C001", name: "Acme" }] },
+          },
+        },
+      },
+    };
+
+    const manifest = buildToolCapabilityManifest(tool);
+
+    expect(manifest).toMatchObject({
+      id: "tool:tool-customer-search",
+      sourceId: "tool-customer-search",
+      sourceType: "tool",
+      title: "Search customers",
+      intent: "Use when a user mentions a customer name but not the customer ID.",
+      sideEffects: "read",
+      riskLevel: "low",
+      agentVisibility: "discoverable",
+      agentInvokePolicy: "approval_required",
+    });
+    expect(manifest.inputSemantics).toEqual([
+      expect.objectContaining({
+        name: "keyword",
+        location: "query",
+        required: true,
+        businessMeaning: "Customer name, phone, or external code.",
+      }),
+    ]);
+    expect(manifest.outputSemantics).toEqual([
+      expect.objectContaining({
+        name: "200",
+        businessMeaning: "Matched customers.",
+      }),
+    ]);
+  });
+
+  it("maps an MCP tool schema into argument semantics", () => {
+    const tool: McpProxyTool = {
+      name: "list_orders",
+      description: "List orders for a customer.",
+      inputSchema: {
+        type: "object",
+        required: ["customer_id"],
+        properties: {
+          customer_id: {
+            type: "string",
+            description: "Customer master data ID.",
+          },
+          limit: {
+            type: "integer",
+            description: "Maximum rows.",
+          },
+        },
+      },
+    };
+
+    const manifest = buildMcpToolCapabilityManifest({
+      mcpId: "mcp-crm",
+      serviceName: "CRM MCP",
+      tool,
+    });
+
+    expect(manifest).toMatchObject({
+      id: "mcp:mcp-crm:list_orders",
+      sourceType: "mcp",
+      sourceId: "mcp-crm",
+      title: "list_orders",
+      sideEffects: "unknown",
+      riskLevel: "medium",
+    });
+    expect(manifest.inputSemantics).toEqual([
+      expect.objectContaining({
+        name: "customer_id",
+        location: "argument",
+        required: true,
+        businessMeaning: "Customer master data ID.",
+      }),
+      expect.objectContaining({
+        name: "limit",
+        required: false,
+      }),
+    ]);
+  });
+
+  it("maps a Skill record into a manifest shell", () => {
+    const skill: SkillRecord = {
+      skillId: "skill-report",
+      name: "Quarterly report skill",
+      description: "Prepare quarterly report steps.",
+      status: "published",
+      version: "1.2.0",
+      category: "system",
+    };
+
+    const manifest = buildSkillCapabilityManifest(skill);
+
+    expect(manifest).toMatchObject({
+      id: "skill:skill-report",
+      sourceType: "skill",
+      sourceId: "skill-report",
+      title: "Quarterly report skill",
+      sideEffects: "unknown",
+      riskLevel: "medium",
+      agentVisibility: "discoverable",
+      agentInvokePolicy: "approval_required",
+    });
+  });
+
+  it("maps an Operator detail into a manifest shell with runtime constraints", () => {
+    const operator: OperatorDetail = {
+      operatorId: "op-sync",
+      name: "Sync orders",
+      version: "v3",
+      status: "published",
+      description: "Synchronize orders from ERP.",
+      metadataType: "function",
+      category: "data_process",
+      executeControl: {
+        timeout: 5000,
+        retryPolicy: { maxAttempts: 3 },
+      },
+    };
+
+    const manifest = buildOperatorCapabilityManifest(operator);
+
+    expect(manifest).toMatchObject({
+      id: "operator:op-sync:v3",
+      sourceType: "operator",
+      sourceId: "op-sync",
+      title: "Sync orders",
+      sideEffects: "write",
+      riskLevel: "high",
+      agentInvokePolicy: "approval_required",
+    });
+    expect(manifest.authRequirements).toContain("timeout: 5000ms");
+    expect(manifest.authRequirements).toContain("max retry attempts: 3");
+  });
+
+  it("scores readiness from semantics, examples, policy, and verification", () => {
+    const manifest = buildToolCapabilityManifest({
+      toolId: "tool-ready",
+      name: "Ready tool",
+      description: "Ready for Agent use.",
+      status: "enabled",
+      metadataType: "openapi",
+      useRule: "Use for safe read-only lookup.",
+      ioSpec: {
+        parameters: [{ name: "id", description: "Business object ID." }],
+        responses: { "200": { description: "Business object." } },
+      },
+    });
+
+    const readiness = getCapabilityReadiness({
+      ...manifest,
+      examples: [
+        {
+          title: "Lookup example",
+          input: { id: "A001" },
+          status: "passed",
+        },
+      ],
+      testStatus: "passed",
+      agentVisibility: "callable",
+      agentInvokePolicy: "auto_allowed",
+    });
+
+    expect(readiness.score).toBeGreaterThanOrEqual(80);
+    expect(readiness.missing).toEqual([]);
+  });
+});
+

--- a/src/modules/execution-factory/utils/capability-manifest.ts
+++ b/src/modules/execution-factory/utils/capability-manifest.ts
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type {
+  CapabilityInputSemantic,
+  CapabilityManifest,
+  CapabilityOutputSemantic,
+  CapabilityReadiness,
+} from "@/modules/execution-factory/types/capability-manifest";
+import type { McpProxyTool } from "@/modules/execution-factory/types/mcp";
+import type { OperatorDetail } from "@/modules/execution-factory/types/operator";
+import type { SkillRecord } from "@/modules/execution-factory/types/skill";
+import type { ToolDetail, ToolIoParameter } from "@/modules/execution-factory/types/tool";
+
+type JsonSchemaObject = {
+  type?: string;
+  description?: string;
+  properties?: Record<string, JsonSchemaObject>;
+  required?: string[];
+  examples?: unknown[];
+  example?: unknown;
+};
+
+function asSchemaObject(value: unknown): JsonSchemaObject | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as JsonSchemaObject;
+}
+
+function buildInputFromToolParameter(parameter: ToolIoParameter): CapabilityInputSemantic {
+  return {
+    name: parameter.name,
+    location: parameter.in as CapabilityInputSemantic["location"],
+    dataType: parameter.type,
+    required: parameter.required,
+    businessMeaning: parameter.description,
+    sourceHint: parameter.description ? "schema description" : undefined,
+  };
+}
+
+function buildInputsFromJsonSchema(schema: unknown): CapabilityInputSemantic[] {
+  const schemaObject = asSchemaObject(schema);
+  if (!schemaObject?.properties) {
+    return [];
+  }
+
+  const required = new Set(schemaObject.required ?? []);
+
+  return Object.entries(schemaObject.properties).map(([name, property]) => ({
+    name,
+    location: "argument",
+    dataType: property.type,
+    required: required.has(name),
+    businessMeaning: property.description,
+    examples: property.examples ?? (property.example === undefined ? undefined : [property.example]),
+    sourceHint: property.description ? "schema description" : undefined,
+  }));
+}
+
+function buildToolOutputs(tool: ToolDetail): CapabilityOutputSemantic[] {
+  const responses = tool.ioSpec?.responses;
+  if (!responses) {
+    return [];
+  }
+
+  return Object.entries(responses).map(([statusCode, response]) => ({
+    name: statusCode,
+    businessMeaning: response.description,
+    examples: response.example === undefined ? undefined : [response.example],
+  }));
+}
+
+function inferToolSideEffect(tool: ToolDetail): CapabilityManifest["sideEffects"] {
+  const method = tool.method?.toUpperCase();
+  if (!method || method === "GET" || method === "HEAD" || method === "OPTIONS") {
+    return "read";
+  }
+
+  return "write";
+}
+
+function inferToolRisk(tool: ToolDetail): CapabilityManifest["riskLevel"] {
+  return inferToolSideEffect(tool) === "read" ? "low" : "medium";
+}
+
+export function buildToolCapabilityManifest(tool: ToolDetail): CapabilityManifest {
+  return {
+    id: `tool:${tool.toolId}`,
+    sourceType: "tool",
+    sourceId: tool.toolId,
+    title: tool.name,
+    description: tool.description,
+    status: tool.status,
+    category: tool.metadataType,
+    intent: tool.useRule || tool.description,
+    inputSemantics: tool.ioSpec?.parameters.map(buildInputFromToolParameter) ?? [],
+    outputSemantics: buildToolOutputs(tool),
+    sideEffects: inferToolSideEffect(tool),
+    riskLevel: inferToolRisk(tool),
+    testStatus: "untested",
+    agentVisibility: tool.status === "enabled" ? "discoverable" : "hidden",
+    agentInvokePolicy: "approval_required",
+    updatedAt: tool.updateTime,
+  };
+}
+
+export function buildMcpToolCapabilityManifest({
+  mcpId,
+  serviceName,
+  tool,
+}: {
+  mcpId: string;
+  serviceName?: string;
+  tool: McpProxyTool;
+}): CapabilityManifest {
+  return {
+    id: `mcp:${mcpId}:${tool.name}`,
+    sourceType: "mcp",
+    sourceId: mcpId,
+    sourceName: serviceName,
+    title: tool.name,
+    description: tool.description,
+    status: "discovered",
+    intent: tool.description,
+    inputSemantics: buildInputsFromJsonSchema(tool.inputSchema),
+    outputSemantics: [],
+    sideEffects: "unknown",
+    riskLevel: "medium",
+    testStatus: "untested",
+    agentVisibility: "discoverable",
+    agentInvokePolicy: "approval_required",
+  };
+}
+
+export function buildSkillCapabilityManifest(skill: SkillRecord): CapabilityManifest {
+  return {
+    id: `skill:${skill.skillId}`,
+    sourceType: "skill",
+    sourceId: skill.skillId,
+    title: skill.name,
+    description: skill.description,
+    status: skill.status,
+    category: skill.category,
+    intent: skill.description,
+    inputSemantics: [],
+    outputSemantics: [],
+    sideEffects: "unknown",
+    riskLevel: "medium",
+    testStatus: "untested",
+    agentVisibility: skill.status === "published" ? "discoverable" : "hidden",
+    agentInvokePolicy: "approval_required",
+    updatedAt: skill.updateTime,
+  };
+}
+
+function buildOperatorAuthRequirements(operator: OperatorDetail): string[] {
+  const requirements: string[] = [];
+
+  if (operator.executeControl?.timeout) {
+    requirements.push(`timeout: ${operator.executeControl.timeout}ms`);
+  }
+
+  if (operator.executeControl?.retryPolicy?.maxAttempts) {
+    requirements.push(`max retry attempts: ${operator.executeControl.retryPolicy.maxAttempts}`);
+  }
+
+  return requirements;
+}
+
+export function buildOperatorCapabilityManifest(operator: OperatorDetail): CapabilityManifest {
+  return {
+    id: `operator:${operator.operatorId}:${operator.version}`,
+    sourceType: "operator",
+    sourceId: operator.operatorId,
+    title: operator.name,
+    description: operator.description,
+    status: operator.status,
+    category: operator.category,
+    intent: operator.description,
+    inputSemantics: [],
+    outputSemantics: [],
+    sideEffects: operator.metadataType === "function" ? "write" : "unknown",
+    riskLevel: "high",
+    testStatus: "untested",
+    agentVisibility: operator.status === "published" ? "discoverable" : "hidden",
+    agentInvokePolicy: "approval_required",
+    authRequirements: buildOperatorAuthRequirements(operator),
+    updatedAt: operator.updateTime,
+  };
+}
+
+export function getCapabilityReadiness(manifest: CapabilityManifest): CapabilityReadiness {
+  const missing: string[] = [];
+  let score = 0;
+
+  if (manifest.intent) {
+    score += 20;
+  } else {
+    missing.push("business intent");
+  }
+
+  if ((manifest.inputSemantics ?? []).some((input) => input.businessMeaning)) {
+    score += 20;
+  } else {
+    missing.push("input semantics");
+  }
+
+  if ((manifest.outputSemantics ?? []).some((output) => output.businessMeaning)) {
+    score += 15;
+  } else {
+    missing.push("output semantics");
+  }
+
+  if ((manifest.examples ?? []).some((example) => example.status === "passed")) {
+    score += 20;
+  } else {
+    missing.push("verified example");
+  }
+
+  if (manifest.testStatus === "passed") {
+    score += 15;
+  } else {
+    missing.push("passed verification");
+  }
+
+  if (manifest.agentVisibility === "callable" && manifest.agentInvokePolicy) {
+    score += 10;
+  } else {
+    missing.push("Agent callable policy");
+  }
+
+  return {
+    score,
+    level: score >= 80 ? "high" : score >= 50 ? "medium" : "low",
+    missing,
+  };
+}
+


### PR DESCRIPTION
﻿## 背景

Issue #47 需要把执行工厂能力从后台资源管理进一步抽象为面向 Agent 可理解的能力契约，为后续 HTTP/OpenAPI、MCP、Skill 等能力的语义化治理提供基础。

## 主要改动

- 新增 Agent capability manifest 类型、推断工具和测试。
- 在工具箱工具详情和 MCP 详情中展示 Agent 可用性与就绪度。
- 补充 #47 的实现设计与计划文档。

## 影响范围

- 主要影响执行工厂模块的能力详情展示与 Agent 可用性表达。
- 修改了 `src/modules/execution-factory/scenes/*`、能力契约类型与工具函数，属于模块场景与对外能力表达变化，需要重点 review。
- 未修改模块注册入口、全局 routes 或 runtime 配置。

## 验证方式

- `pnpm exec vitest run src/modules/execution-factory/utils/capability-manifest.test.ts`

## 未完成项或风险

- 当前 PR 提供基础契约与就绪度表达，后续 #55-#58 会以独立 PR 继续补充创建指引、OpenAPI 审阅、敏感度和调试证据。