### PR TITLE
feat(execution-factory): guide next steps after capability creation

### DIFF
--- a/src/modules/execution-factory/components/create-menu/AddCapabilityWizard.tsx
+++ b/src/modules/execution-factory/components/create-menu/AddCapabilityWizard.tsx
@@ -43,6 +43,7 @@ import {
 
 
 import { AddCapabilityModeStep } from "./AddCapabilityModeStep";
+import { CapabilityCreatedNextSteps } from "./CapabilityCreatedNextSteps";
 
 import { CreateMcpDrawer } from "./CreateMcpDrawer";
 
@@ -98,7 +99,12 @@ type AddCapabilityWizardProps = {
 const FUNCTION_TOOLBOX_FORM_ID = "create-function-toolbox-form";
 const IMPORT_OPENAPI_FORM_ID = "import-openapi-capability-form";
 
-
+type CreatedNextStepState = {
+  boxId: string;
+  toolId?: string;
+  toolName?: string;
+  toolboxName?: string;
+};
 
 export function AddCapabilityWizard({
 
@@ -143,6 +149,7 @@ export function AddCapabilityWizard({
   );
 
   const [submitting, setSubmitting] = useState(false);
+  const [createdNextStep, setCreatedNextStep] = useState<CreatedNextStepState | null>(null);
 
 
 
@@ -163,6 +170,7 @@ export function AddCapabilityWizard({
     setStep(skipModeStep ? 1 : 0);
 
     setSubmitting(false);
+    setCreatedNextStep(null);
 
   }, [contextTab, initialBoxId, initialMode, open, skipModeStep]);
 
@@ -245,6 +253,7 @@ export function AddCapabilityWizard({
   const handleClose = () => {
 
     setStep(0);
+    setCreatedNextStep(null);
 
     onClose();
 
@@ -260,6 +269,28 @@ export function AddCapabilityWizard({
 
     handleClose();
 
+  };
+
+  const handleCreatedNextStep = (payload: CreatedNextStepState) => {
+    onRefresh?.();
+    setCreatedNextStep(payload);
+  };
+
+  const navigateToCreatedToolset = (mode: "view" | "contract" = "view") => {
+    if (!createdNextStep) {
+      return;
+    }
+
+    handleClose();
+
+    if (mode === "contract" && createdNextStep.toolId) {
+      void navigate(
+        `/execution-factory/toolboxes/${createdNextStep.boxId}/tools/${createdNextStep.toolId}/edit`,
+      );
+      return;
+    }
+
+    void navigate(`/execution-factory/toolboxes/${createdNextStep.boxId}/tools`);
   };
 
 
@@ -340,7 +371,12 @@ export function AddCapabilityWizard({
           : t("executionFactory.quickApiCreateSuccess"),
       );
 
-      handleCreated("toolbox", result.boxId, result.toolIds[0]);
+      handleCreatedNextStep({
+        boxId: result.boxId,
+        toolId: result.toolIds[0],
+        toolName: payload.values.summary,
+        toolboxName: payload.values.toolboxName,
+      });
 
     } catch (error) {
 
@@ -412,7 +448,11 @@ export function AddCapabilityWizard({
         );
       }
 
-      handleCreated("toolbox", result.boxId, result.toolIds[0]);
+      handleCreatedNextStep({
+        boxId: result.boxId,
+        toolId: result.toolIds[0],
+        toolboxName: payload.values.toolboxName,
+      });
     } catch (error) {
       void message.error(extractRequestErrorMessage(error));
     } finally {
@@ -421,6 +461,23 @@ export function AddCapabilityWizard({
   };
 
   const renderBody = () => {
+
+    if (createdNextStep) {
+      return (
+        <CapabilityCreatedNextSteps
+          onClose={handleClose}
+          onCompleteContract={
+            createdNextStep.toolId
+              ? () => navigateToCreatedToolset("contract")
+              : undefined
+          }
+          onDebug={() => navigateToCreatedToolset("view")}
+          onViewToolset={() => navigateToCreatedToolset("view")}
+          toolName={createdNextStep.toolName}
+          toolboxName={createdNextStep.toolboxName}
+        />
+      );
+    }
 
     if (showModeStep) {
 
@@ -575,6 +632,10 @@ export function AddCapabilityWizard({
 
 
   const renderFooter = () => {
+
+    if (createdNextStep) {
+      return null;
+    }
 
     if (showModeStep) {
 

--- a/src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.module.css
+++ b/src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.module.css
@@ -1,0 +1,53 @@
+.panel {
+  border: 1px solid rgba(23, 63, 159, 0.14);
+  border-radius: 10px;
+  background: #fbfdff;
+  padding: 18px;
+}
+
+.title {
+  color: #17253d;
+  font-size: 18px;
+  font-weight: 750;
+  margin-bottom: 6px;
+}
+
+.description {
+  color: rgba(15, 30, 54, 0.62);
+  line-height: 1.6;
+  margin: 0 0 16px;
+}
+
+.meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.metaItem {
+  border: 1px solid rgba(15, 30, 54, 0.08);
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px 12px;
+}
+
+.metaLabel {
+  color: rgba(15, 30, 54, 0.48);
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.metaValue {
+  color: #17253d;
+  font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}

--- a/src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.test.tsx
+++ b/src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CapabilityCreatedNextSteps } from "@/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+describe("CapabilityCreatedNextSteps", () => {
+  it("shows created HTTP capability context and exposes next actions", () => {
+    const onViewToolset = vi.fn();
+    const onDebug = vi.fn();
+    const onCompleteContract = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <CapabilityCreatedNextSteps
+        onClose={onClose}
+        onCompleteContract={onCompleteContract}
+        onDebug={onDebug}
+        onViewToolset={onViewToolset}
+        toolName="query_weather"
+        toolboxName="weather_toolbox"
+      />,
+    );
+
+    expect(screen.getByTestId("capability-created-next-steps")).toBeTruthy();
+    expect(screen.getByText("query_weather")).toBeTruthy();
+    expect(screen.getByText("weather_toolbox")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /查看工具集|View toolset|鏌ョ湅/i }));
+    fireEvent.click(screen.getByRole("button", { name: /调试|Debug|璋冭瘯/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Agent/i }));
+    fireEvent.click(screen.getByRole("button", { name: /关\s*闭|Close|鍏\s*抽棴/i }));
+
+    expect(onViewToolset).toHaveBeenCalledTimes(1);
+    expect(onDebug).toHaveBeenCalledTimes(1);
+    expect(onCompleteContract).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.tsx
+++ b/src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.tsx
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { useTranslation } from "react-i18next";
+
+import { AppButton } from "@/framework/ui/common/AppButton";
+
+import styles from "./CapabilityCreatedNextSteps.module.css";
+
+type CapabilityCreatedNextStepsProps = {
+  onClose: () => void;
+  onCompleteContract?: () => void;
+  onDebug?: () => void;
+  onViewToolset: () => void;
+  toolName?: string;
+  toolboxName?: string;
+};
+
+export function CapabilityCreatedNextSteps({
+  onClose,
+  onCompleteContract,
+  onDebug,
+  onViewToolset,
+  toolName,
+  toolboxName,
+}: CapabilityCreatedNextStepsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <section className={styles.panel} data-testid="capability-created-next-steps">
+      <div className={styles.title}>
+        {t("executionFactory.createdNextStepsTitle", {
+          defaultValue: "HTTP API 已添加到工具集",
+        })}
+      </div>
+      <p className={styles.description}>
+        {t("executionFactory.createdNextStepsDescription", {
+          defaultValue:
+            "建议下一步先调试验证，再补齐 Agent 契约。也可以直接进入工具集继续管理。",
+        })}
+      </p>
+      <div className={styles.meta}>
+        <div className={styles.metaItem}>
+          <div className={styles.metaLabel}>
+            {t("executionFactory.createdNextStepsTool", {
+              defaultValue: "工具",
+            })}
+          </div>
+          <div className={styles.metaValue}>{toolName || "-"}</div>
+        </div>
+        <div className={styles.metaItem}>
+          <div className={styles.metaLabel}>
+            {t("executionFactory.createdNextStepsToolbox", {
+              defaultValue: "工具集",
+            })}
+          </div>
+          <div className={styles.metaValue}>{toolboxName || "-"}</div>
+        </div>
+      </div>
+      <div className={styles.actions}>
+        <AppButton onClick={onViewToolset} type="primary">
+          {t("executionFactory.createdNextStepsViewToolset", {
+            defaultValue: "查看工具集",
+          })}
+        </AppButton>
+        {onDebug ? (
+          <AppButton onClick={onDebug}>
+            {t("executionFactory.createdNextStepsDebug", {
+              defaultValue: "去调试",
+            })}
+          </AppButton>
+        ) : null}
+        {onCompleteContract ? (
+          <AppButton onClick={onCompleteContract}>
+            {t("executionFactory.createdNextStepsContract", {
+              defaultValue: "完善 Agent 契约",
+            })}
+          </AppButton>
+        ) : null}
+        <AppButton onClick={onClose}>
+          {t("common.close", {
+            defaultValue: "关闭",
+          })}
+        </AppButton>
+      </div>
+    </section>
+  );
+}

--- a/tests/e2e/helpers/execution-unit-ui.ts
+++ b/tests/e2e/helpers/execution-unit-ui.ts
@@ -636,6 +636,12 @@ export async function fillAndSubmitQuickAddApi(
   const errorToast = page
     .locator(".ant-message-notice-content")
     .filter({ hasText: /失败|错误|error|invalid/i });
+  const nextSteps = drawer.getByTestId("capability-created-next-steps");
+  await expect(nextSteps).toBeVisible({ timeout: 180_000 });
+  await expect(nextSteps).toContainText(options.summary);
+  await expect(nextSteps).toContainText(options.toolboxName);
+  await nextSteps.locator("button").first().click();
+
   await expect(page).toHaveURL(/\/execution-factory\/toolboxes\/[^/]+\/tools/, {
     timeout: 180_000,
   });


### PR DESCRIPTION
﻿## 背景

Closes #55。HTTP/OpenAPI 能力创建成功后，旧流程会直接跳转到工具集页面，用户无法明确知道下一步应该调试、完善 Agent 契约还是继续管理。

## 主要改动

- 新增创建成功后的下一步面板，展示工具和工具集上下文。
- 提供查看工具集、去调试、完善 Agent 契约、关闭等下一步动作。
- 调整创建成功逻辑，先停留在指引页，由用户主动选择下一步。
- 更新 E2E helper，覆盖创建后下一步面板。

## 影响范围

- 影响执行工厂新增 HTTP/OpenAPI 能力后的前端交互流程。
- 不修改后端 API、数据结构、模块路由或导航注册。

## 验证方式

- `pnpm exec vitest run src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.test.tsx`
- 此前完整链路已通过：RW-UI-01、RW-UI-03、RW-UI-04。

## 未完成项或风险

- 该 PR 只调整创建成功后的用户引导，不改变发布、调试和 Agent 契约的后端逻辑。