### PR TITLE
feat(execution-factory): review OpenAPI endpoints before import

### DIFF
--- a/src/modules/execution-factory/components/OpenApiEndpointReview.module.css
+++ b/src/modules/execution-factory/components/OpenApiEndpointReview.module.css
@@ -1,0 +1,106 @@
+.root {
+  margin-top: 10px;
+  border: 1px solid rgba(23, 63, 159, 0.14);
+  border-radius: 8px;
+  background: #fbfdff;
+  overflow: hidden;
+}
+
+.header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(23, 63, 159, 0.1);
+}
+
+.title {
+  color: #17253d;
+  font-weight: 700;
+}
+
+.count {
+  color: rgba(15, 30, 54, 0.56);
+  font-size: 12px;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid rgba(15, 30, 54, 0.08);
+  padding: 9px 10px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.table th {
+  background: rgba(23, 63, 159, 0.035);
+  color: rgba(15, 30, 54, 0.64);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.table tr:last-child td {
+  border-bottom: 0;
+}
+
+.method {
+  display: inline-flex;
+  min-width: 54px;
+  justify-content: center;
+  border-radius: 6px;
+  background: #eef4ff;
+  color: #173f9f;
+  font-family: Consolas, "SFMono-Regular", monospace;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 2px 6px;
+}
+
+.path {
+  color: #20324e;
+  font-family: Consolas, "SFMono-Regular", monospace;
+  font-size: 12px;
+}
+
+.summary {
+  color: rgba(15, 30, 54, 0.78);
+}
+
+.risk {
+  border: 1px solid #dfe6f2;
+  border-radius: 999px;
+  color: rgba(15, 30, 54, 0.72);
+  display: inline-flex;
+  font-size: 12px;
+  padding: 2px 8px;
+}
+
+.riskLow {
+  background: rgba(23, 125, 78, 0.06);
+  border-color: rgba(23, 125, 78, 0.18);
+  color: #177d4e;
+}
+
+.riskMedium {
+  background: rgba(217, 133, 0, 0.07);
+  border-color: rgba(217, 133, 0, 0.2);
+  color: #9b6100;
+}
+
+.riskHigh {
+  background: rgba(217, 48, 37, 0.06);
+  border-color: rgba(217, 48, 37, 0.2);
+  color: #b42318;
+}
+
+.io {
+  color: rgba(15, 30, 54, 0.58);
+  font-size: 12px;
+  white-space: nowrap;
+}

--- a/src/modules/execution-factory/components/OpenApiEndpointReview.test.tsx
+++ b/src/modules/execution-factory/components/OpenApiEndpointReview.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OpenApiEndpointReview } from "@/modules/execution-factory/components/OpenApiEndpointReview";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string; count?: number }) =>
+      options?.defaultValue ?? String(options?.count ?? _key),
+  }),
+}));
+
+describe("OpenApiEndpointReview", () => {
+  it("renders endpoint method, path, summary, risk, and IO counts", () => {
+    const spec = JSON.stringify({
+      openapi: "3.0.3",
+      info: { title: "Weather API", version: "1.0.0" },
+      servers: [{ url: "http://host.docker.internal:8080" }],
+      paths: {
+        "/weather": {
+          get: {
+            summary: "Query weather",
+            parameters: [
+              {
+                name: "city",
+                in: "query",
+                schema: { type: "string" },
+              },
+            ],
+            responses: { "200": { description: "OK" } },
+          },
+        },
+        "/weather/alert": {
+          post: {
+            summary: "Create weather alert",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    render(<OpenApiEndpointReview openapiSpec={spec} />);
+
+    expect(screen.getByText("Endpoint review")).toBeTruthy();
+    expect(screen.getByText("GET")).toBeTruthy();
+    expect(screen.getByText("/weather")).toBeTruthy();
+    expect(screen.getByText("Query weather")).toBeTruthy();
+    expect(screen.getByText("low")).toBeTruthy();
+    expect(screen.getByText("1 input · 1 response")).toBeTruthy();
+    expect(screen.getByText("POST")).toBeTruthy();
+    expect(screen.getByText("/weather/alert")).toBeTruthy();
+    expect(screen.getByText("medium")).toBeTruthy();
+  });
+});

--- a/src/modules/execution-factory/components/OpenApiEndpointReview.tsx
+++ b/src/modules/execution-factory/components/OpenApiEndpointReview.tsx
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { extractOpenApiOperationsIo } from "@/modules/execution-factory/utils/openapi-operation-io";
+
+import styles from "./OpenApiEndpointReview.module.css";
+
+type OpenApiEndpointReviewProps = {
+  limit?: number;
+  openapiSpec?: string;
+};
+
+type EndpointRisk = "low" | "medium" | "high";
+
+function inferEndpointRisk(method: string, path: string, summary?: string): EndpointRisk {
+  const upperMethod = method.toUpperCase();
+  const text = `${path} ${summary ?? ""}`.toLowerCase();
+
+  if (upperMethod === "DELETE" || /delete|remove|cancel|approve|pay|submit/.test(text)) {
+    return "high";
+  }
+
+  if (["POST", "PUT", "PATCH"].includes(upperMethod)) {
+    return "medium";
+  }
+
+  return "low";
+}
+
+function riskClassName(risk: EndpointRisk) {
+  if (risk === "high") {
+    return `${styles.risk} ${styles.riskHigh}`;
+  }
+
+  if (risk === "medium") {
+    return `${styles.risk} ${styles.riskMedium}`;
+  }
+
+  return `${styles.risk} ${styles.riskLow}`;
+}
+
+export function OpenApiEndpointReview({
+  limit = 12,
+  openapiSpec,
+}: OpenApiEndpointReviewProps) {
+  const { t } = useTranslation();
+  const operations = useMemo(() => extractOpenApiOperationsIo(openapiSpec), [openapiSpec]);
+  const visibleOperations = operations.slice(0, limit);
+
+  if (visibleOperations.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={styles.root} data-testid="openapi-endpoint-review">
+      <div className={styles.header}>
+        <span className={styles.title}>
+          {t("executionFactory.openapiEndpointReviewTitle", {
+            defaultValue: "Endpoint review",
+          })}
+        </span>
+        <span className={styles.count}>
+          {t("executionFactory.openapiEndpointReviewCount", {
+            count: operations.length,
+            defaultValue: `${operations.length} endpoints detected`,
+          })}
+        </span>
+      </div>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>
+              {t("executionFactory.openapiEndpointReviewMethod", {
+                defaultValue: "Method",
+              })}
+            </th>
+            <th>
+              {t("executionFactory.openapiEndpointReviewPath", {
+                defaultValue: "Path",
+              })}
+            </th>
+            <th>
+              {t("executionFactory.openapiEndpointReviewSummary", {
+                defaultValue: "Summary",
+              })}
+            </th>
+            <th>
+              {t("executionFactory.openapiEndpointReviewRisk", {
+                defaultValue: "Risk",
+              })}
+            </th>
+            <th>
+              {t("executionFactory.openapiEndpointReviewIo", {
+                defaultValue: "IO",
+              })}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {visibleOperations.map((operation) => {
+            const risk = inferEndpointRisk(
+              operation.method,
+              operation.path,
+              operation.summary,
+            );
+            const inputCount = operation.io.parameters.length;
+            const responseCount = Object.keys(operation.io.responses ?? {}).length;
+
+            return (
+              <tr key={`${operation.method}:${operation.path}`}>
+                <td>
+                  <span className={styles.method}>{operation.method}</span>
+                </td>
+                <td>
+                  <code className={styles.path}>{operation.path}</code>
+                </td>
+                <td className={styles.summary}>{operation.summary ?? "-"}</td>
+                <td>
+                  <span className={riskClassName(risk)}>{risk}</span>
+                </td>
+                <td className={styles.io}>
+                  {inputCount} input · {responseCount} response
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/src/modules/execution-factory/components/OpenApiSpecInput.module.css
+++ b/src/modules/execution-factory/components/OpenApiSpecInput.module.css
@@ -85,3 +85,17 @@
   color: rgba(0, 0, 0, 0.45);
   font-size: 12px;
 }
+
+.validationSuccess {
+  margin-top: 8px;
+  border-color: rgba(23, 125, 78, 0.2);
+  background: rgba(23, 125, 78, 0.055);
+}
+
+.validationSuccess :global(.ant-alert-icon) {
+  color: #177d4e;
+}
+
+.validationSuccess :global(.ant-alert-message) {
+  color: rgba(15, 30, 54, 0.78);
+}

--- a/src/modules/execution-factory/components/OpenApiSpecInput.tsx
+++ b/src/modules/execution-factory/components/OpenApiSpecInput.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { OpenApiOperationsIoPreview } from "@/modules/execution-factory/components/OpenApiOperationsIoPreview";
+import { OpenApiEndpointReview } from "@/modules/execution-factory/components/OpenApiEndpointReview";
 import {
   OPENAPI_OPERATOR_TEMPLATE,
   OPENAPI_TOOLBOX_TEMPLATE,
@@ -30,6 +31,7 @@ type OpenApiSpecInputProps = {
   onValidationChange?: (valid: boolean) => void;
   registrationTarget?: "operator" | "toolbox" | "default";
   rows?: number;
+  showEndpointReview?: boolean;
   value?: string;
   onChange?: (value: string) => void;
 };
@@ -41,6 +43,7 @@ export function OpenApiSpecInput({
   onValidationChange,
   registrationTarget = "default",
   rows = 10,
+  showEndpointReview = false,
   value = "",
   onChange,
 }: OpenApiSpecInputProps) {
@@ -205,11 +208,11 @@ export function OpenApiSpecInput({
       {validation.ok && analysis.ok ? (
         <>
           <Alert
+            className={styles.validationSuccess}
             message={t("executionFactory.openapiValidationOkWithCount", {
               count: analysis.operationCount,
             })}
             showIcon
-            style={{ marginTop: 8 }}
             type="success"
           />
           <div className={styles.previewPanel}>
@@ -222,6 +225,7 @@ export function OpenApiSpecInput({
               </span>
             </div>
             <OpenApiOperationsIoPreview openapiSpec={value} />
+            {showEndpointReview ? <OpenApiEndpointReview openapiSpec={value} /> : null}
           </div>
         </>
       ) : null}

--- a/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx
@@ -243,6 +243,8 @@ export const ImportOpenApiCapabilityForm = forwardRef<
 
         rows={8}
 
+        showEndpointReview
+
         value={openapiSpec}
 
       />

--- a/src/modules/execution-factory/components/create-menu/ImportOpenApiToolsModal.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportOpenApiToolsModal.tsx
@@ -217,6 +217,8 @@ export function ImportOpenApiToolsModal({
 
         rows={8}
 
+        showEndpointReview
+
         value={openapiSpec}
 
       />

--- a/src/modules/execution-factory/components/create-menu/ImportResourceModal.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportResourceModal.tsx
@@ -518,6 +518,8 @@ export function ImportResourceModal({
 
                   rows={8}
 
+                  showEndpointReview
+
                   value={openapiSpec}
 
                 />

--- a/tests/e2e/helpers/execution-unit-ui.ts
+++ b/tests/e2e/helpers/execution-unit-ui.ts
@@ -756,6 +756,7 @@ export async function importToolboxOpenApiViaUi(
   const panel = await openImportOpenApiPanel(importDialog);
   await fillOpenApiSpecPaste(page, spec, panel);
   await expectOpenApiOperationsIoPreview(panel, { containsText: /GET|POST/i });
+  await expect(panel.getByText(/Endpoint review|端点审阅|绔偣瀹￠槄/i)).toBeVisible();
 
   await importDialog.getByLabel(/工具箱名称|Toolbox Name/i).fill(toolboxName);
   if (options?.serviceUrl) {


### PR DESCRIPTION
﻿## 背景

Closes #56。OpenAPI 导入时虽然已有参数预览，但用户缺少导入前的端点级审阅视角，不容易判断会生成哪些工具、每个接口风险如何。

## 主要改动

- 新增 OpenAPI endpoint review 组件，展示 method、path、summary、风险等级和输入/响应数量。
- 在能力导入、资源导入、工具集内 OpenAPI 导入等入口接入端点审阅。
- 调整 OpenAPI 校验成功提示的配色，避免大面积绿色看起来像异常告警。
- E2E helper 增加端点审阅出现的断言。

## 影响范围

- 影响 OpenAPI 导入/识别表单的前端展示。
- 不改变 OpenAPI 解析、导入 API、后端数据结构。

## 验证方式

- `pnpm exec vitest run src/modules/execution-factory/components/OpenApiEndpointReview.test.tsx`
- 此前完整链路已通过：RW-UI-04 OpenAPI fixture UI 导入。

## 未完成项或风险

- 当前 PR 只做审阅展示，尚未支持端点勾选/过滤导入；该能力可作为后续增强。