### PR TITLE
feat(execution-factory): surface debug evidence in Agent contract

### DIFF
--- a/docs/prototypes/execution-factory-http-agent-ui.html
+++ b/docs/prototypes/execution-factory-http-agent-ui.html
@@ -1,0 +1,1031 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>执行工厂 HTTP Agent UI 原型</title>
+  <style>
+    :root {
+      --blue: #173f9f;
+      --blue-2: #2457d6;
+      --ink: #071832;
+      --muted: #60708a;
+      --line: #dfe6f2;
+      --soft: #f5f8fc;
+      --panel: #ffffff;
+      --green: #18a058;
+      --amber: #d98500;
+      --red: #d93025;
+      --shadow: 0 10px 28px rgba(28, 47, 85, .12);
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: #eef3f9;
+      font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    .app {
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      min-height: 100vh;
+    }
+
+    .side {
+      background: #fff;
+      border-right: 1px solid var(--line);
+      padding: 18px 16px;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-weight: 800;
+      color: var(--blue);
+      margin-bottom: 28px;
+      font-size: 20px;
+    }
+
+    .mark {
+      width: 34px;
+      height: 34px;
+      border: 2px solid var(--blue);
+      border-radius: 8px;
+      position: relative;
+    }
+
+    .mark:before,
+    .mark:after {
+      content: "";
+      position: absolute;
+      inset: 7px;
+      border: 1px solid #66a3ff;
+      transform: rotate(45deg);
+    }
+
+    .nav-group {
+      color: #50617c;
+      margin: 18px 0 8px;
+      font-weight: 650;
+    }
+
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      height: 40px;
+      padding: 0 12px;
+      border-radius: 7px;
+      color: #243653;
+    }
+
+    .nav-item.active {
+      background: #eaf1ff;
+      color: var(--blue);
+      border: 1px solid #b8ccff;
+      font-weight: 700;
+    }
+
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .main {
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .topbar {
+      height: 64px;
+      background: #fff;
+      border-bottom: 1px solid var(--line);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 28px;
+    }
+
+    .crumb {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-weight: 650;
+      color: #53647c;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      height: 26px;
+      padding: 0 10px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: #f7faff;
+      color: #49617f;
+      font-size: 12px;
+      font-weight: 650;
+    }
+
+    .user {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 14px;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: #fff;
+    }
+
+    .avatar {
+      width: 30px;
+      height: 30px;
+      border-radius: 50%;
+      background: var(--blue-2);
+    }
+
+    .content {
+      padding: 26px 28px 60px;
+    }
+
+    .page-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 24px;
+      margin-bottom: 22px;
+    }
+
+    h1, h2, h3 {
+      margin: 0;
+      line-height: 1.25;
+    }
+
+    h1 { font-size: 28px; }
+    h2 { font-size: 20px; }
+    h3 { font-size: 16px; }
+
+    .sub {
+      color: var(--muted);
+      margin-top: 8px;
+      max-width: 820px;
+    }
+
+    .actions {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      border: 1px solid var(--line);
+      background: #fff;
+      color: #1f3150;
+      border-radius: 8px;
+      height: 36px;
+      padding: 0 15px;
+      font-weight: 650;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      white-space: nowrap;
+    }
+
+    .btn.primary {
+      background: var(--blue);
+      color: #fff;
+      border-color: var(--blue);
+      box-shadow: 0 6px 14px rgba(23, 63, 159, .22);
+    }
+
+    .btn.ghost {
+      background: #f8fbff;
+    }
+
+    .toolbar {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-bottom: 16px;
+    }
+
+    .select, .input {
+      height: 34px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+      padding: 0 12px;
+      color: #42536f;
+      min-width: 130px;
+    }
+
+    .input.search { min-width: 280px; }
+
+    .tabs {
+      display: flex;
+      gap: 22px;
+      border-bottom: 1px solid var(--line);
+      margin: 8px 0 18px;
+    }
+
+    .tab {
+      padding: 11px 0;
+      color: #31415c;
+      font-weight: 650;
+    }
+
+    .tab.active {
+      color: var(--blue);
+      border-bottom: 2px solid var(--blue);
+    }
+
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(280px, 1fr));
+      gap: 16px;
+    }
+
+    .card {
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+      min-height: 210px;
+      box-shadow: 0 2px 10px rgba(20, 39, 70, .04);
+    }
+
+    .card-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 10px;
+    }
+
+    .type {
+      display: inline-flex;
+      align-items: center;
+      height: 22px;
+      padding: 0 7px;
+      border-radius: 5px;
+      background: #eaf1ff;
+      color: var(--blue);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      height: 24px;
+      padding: 0 8px;
+      border-radius: 7px;
+      font-size: 12px;
+      font-weight: 650;
+      background: #eefbf4;
+      color: var(--green);
+      border: 1px solid #a9e6c5;
+    }
+
+    .status.draft {
+      background: #eef5ff;
+      color: #1f60d1;
+      border-color: #b8d2ff;
+    }
+
+    .muted { color: var(--muted); }
+
+    .metric-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 8px;
+      margin: 16px 0;
+    }
+
+    .metric {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 9px;
+      background: #fbfdff;
+    }
+
+    .metric strong {
+      display: block;
+      font-size: 16px;
+      margin-bottom: 2px;
+    }
+
+    .bar {
+      height: 7px;
+      border-radius: 99px;
+      background: #dce5f5;
+      overflow: hidden;
+      margin-top: 8px;
+    }
+
+    .bar span {
+      display: block;
+      height: 100%;
+      background: var(--blue-2);
+    }
+
+    .card-foot {
+      border-top: 1px solid var(--line);
+      padding-top: 12px;
+      display: flex;
+      justify-content: space-between;
+      color: #70809b;
+      font-size: 12px;
+    }
+
+    .section {
+      margin-top: 28px;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .section-title {
+      padding: 16px 18px;
+      border-bottom: 1px solid var(--line);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 14px;
+    }
+
+    .section-body { padding: 18px; }
+
+    .split {
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) 360px;
+      gap: 18px;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 14px;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    .field.full { grid-column: 1 / -1; }
+
+    label {
+      font-weight: 650;
+      color: #253653;
+    }
+
+    textarea, input, select {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 11px;
+      font: inherit;
+      color: #17253d;
+      background: #fff;
+    }
+
+    textarea { min-height: 92px; resize: vertical; }
+
+    .hint {
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .preview {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fbfdff;
+      padding: 14px;
+    }
+
+    .preview h3 { margin-bottom: 12px; }
+
+    .kv {
+      display: grid;
+      grid-template-columns: 86px 1fr;
+      gap: 8px;
+      margin: 8px 0;
+      color: #31415c;
+    }
+
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .tag {
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 999px;
+      padding: 3px 9px;
+      font-size: 12px;
+      color: #455670;
+    }
+
+    .tag.green { color: var(--green); background: #effbf4; border-color: #bde9cc; }
+    .tag.amber { color: var(--amber); background: #fff8e8; border-color: #f2d59b; }
+    .tag.red { color: var(--red); background: #fff0ee; border-color: #f2b8b5; }
+    .tag.blue { color: var(--blue); background: #eef4ff; border-color: #c6d7ff; }
+
+    .drawer {
+      margin-top: 28px;
+      display: grid;
+      grid-template-columns: 1fr 620px;
+      gap: 18px;
+    }
+
+    .scrim {
+      border: 1px dashed #b7c4d9;
+      border-radius: 8px;
+      background: rgba(20, 31, 52, .04);
+      min-height: 680px;
+      padding: 22px;
+      color: #6a7891;
+    }
+
+    .drawer-panel {
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .drawer-head {
+      height: 60px;
+      padding: 0 18px;
+      border-bottom: 1px solid var(--line);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .steps {
+      display: flex;
+      gap: 10px;
+      margin-bottom: 18px;
+    }
+
+    .step {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      color: #6f7f97;
+      font-weight: 650;
+    }
+
+    .step b {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: #edf2fa;
+      color: #5b6e8d;
+      font-size: 12px;
+    }
+
+    .step.active { color: var(--blue); }
+    .step.active b { background: var(--blue); color: #fff; }
+
+    .drawer-body {
+      padding: 18px;
+      max-height: 780px;
+      overflow: auto;
+    }
+
+    .mini-tabs {
+      display: flex;
+      gap: 18px;
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 14px;
+    }
+
+    .mini-tabs span {
+      padding: 9px 0;
+      font-weight: 650;
+    }
+
+    .mini-tabs .active {
+      color: var(--blue);
+      border-bottom: 2px solid var(--blue);
+    }
+
+    .notice {
+      border: 1px solid #b8d2ff;
+      background: #f3f7ff;
+      border-radius: 8px;
+      padding: 12px 14px;
+      margin: 12px 0;
+      color: #28456f;
+    }
+
+    .success {
+      border-color: #a9e6c5;
+      background: #f0fbf5;
+      color: #145c36;
+    }
+
+    .table {
+      width: 100%;
+      border-collapse: collapse;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .table th,
+    .table td {
+      border-bottom: 1px solid var(--line);
+      padding: 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .table th {
+      background: #f8fbff;
+      color: #40516c;
+      font-weight: 700;
+    }
+
+    .table tr:last-child td { border-bottom: 0; }
+
+    .detail-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      margin-bottom: 18px;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 18px;
+    }
+
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+      margin-bottom: 18px;
+    }
+
+    .summary {
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+    }
+
+    .summary strong {
+      display: block;
+      font-size: 22px;
+      margin: 4px 0;
+    }
+
+    .contract-grid {
+      display: grid;
+      grid-template-columns: 1fr 320px;
+      gap: 18px;
+    }
+
+    .checklist {
+      display: grid;
+      gap: 9px;
+      color: #40516c;
+    }
+
+    .check {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 8px;
+    }
+
+    .code {
+      font-family: Consolas, "SFMono-Regular", monospace;
+      background: #f7f9fc;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px;
+      white-space: pre-wrap;
+      color: #1f304d;
+    }
+
+    @media (max-width: 1200px) {
+      .cards { grid-template-columns: repeat(2, minmax(260px, 1fr)); }
+      .split, .contract-grid { grid-template-columns: 1fr; }
+      .drawer { grid-template-columns: 1fr; }
+      .scrim { min-height: 180px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside class="side">
+      <div class="brand"><span class="mark"></span><span>OpenBKN</span></div>
+      <div class="nav-group">领域业务知识网络</div>
+      <div class="nav-item"><span class="dot"></span>知识网络</div>
+      <div class="nav-group">执行工厂</div>
+      <div class="nav-item active"><span class="dot"></span>能力管理</div>
+      <div class="nav-item"><span class="dot"></span>能力市场</div>
+      <div class="nav-item"><span class="dot"></span>沙箱运行时管理</div>
+      <div class="nav-group">模型管理</div>
+      <div class="nav-item"><span class="dot"></span>模型配置</div>
+      <div class="nav-item"><span class="dot"></span>模型统计</div>
+      <div class="nav-group">系统管理</div>
+      <div class="nav-item"><span class="dot"></span>用户管理</div>
+    </aside>
+
+    <main class="main">
+      <header class="topbar">
+        <div class="crumb">执行工厂 <span>/</span> <span class="pill">能力管理</span></div>
+        <div class="user"><span class="avatar"></span><div><b>Local Admin</b><br><span class="muted">admin</span></div></div>
+      </header>
+
+      <div class="content">
+        <section class="page-head">
+          <div>
+            <h1>能力管理</h1>
+            <p class="sub">为智能体配置可调用的能力：工具集接入 HTTP 接口、MCP 服务连接外部协议工具、Skill 包导入可复用技能。配置、验证并发布后，即可在对话与流程编排中调用。</p>
+          </div>
+          <div class="actions">
+            <button class="btn primary">+ 添加能力</button>
+            <button class="btn">导入</button>
+          </div>
+        </section>
+
+        <section class="toolbar">
+          <select class="select"><option>全部来源</option><option>系统内置</option><option>自定义</option></select>
+          <select class="select"><option>全部类型</option><option>HTTP</option><option>Function</option><option>MCP</option><option>Skill</option></select>
+          <select class="select"><option>全部状态</option><option>已发布</option><option>未发布</option></select>
+          <input class="input search" placeholder="搜索能力名称或描述" />
+        </section>
+
+        <nav class="tabs">
+          <span class="tab active">工具集</span>
+          <span class="tab">MCP 服务</span>
+          <span class="tab">Skill 包</span>
+        </nav>
+
+        <section class="cards">
+          <article class="card">
+            <div class="card-head">
+              <span class="type">OpenAPI</span>
+              <span class="status">已发布</span>
+            </div>
+            <h3>查询天气</h3>
+            <p class="muted">根据城市查询实时天气。</p>
+            <div class="metric-row">
+              <div class="metric"><strong>75%</strong><span class="muted">Agent Ready</span><div class="bar"><span style="width:75%"></span></div></div>
+              <div class="metric"><strong>低</strong><span class="muted">风险</span></div>
+              <div class="metric"><strong>通过</strong><span class="muted">验证</span></div>
+            </div>
+            <div class="tags">
+              <span class="tag green">Agent 可调用</span>
+              <span class="tag amber">调用前确认</span>
+              <span class="tag blue">GET /weather</span>
+            </div>
+            <div class="card-foot"><span>1 个工具</span><span>更新：2026/07/07</span></div>
+          </article>
+
+          <article class="card">
+            <div class="card-head">
+              <span class="type">OpenAPI</span>
+              <span class="status draft">未发布</span>
+            </div>
+            <h3>订单查询工具集</h3>
+            <p class="muted">ERP 订单查询接口集合。</p>
+            <div class="metric-row">
+              <div class="metric"><strong>40%</strong><span class="muted">Agent Ready</span><div class="bar"><span style="width:40%"></span></div></div>
+              <div class="metric"><strong>中</strong><span class="muted">风险</span></div>
+              <div class="metric"><strong>未测</strong><span class="muted">验证</span></div>
+            </div>
+            <div class="tags">
+              <span class="tag">缺少输出语义</span>
+              <span class="tag">缺少成功示例</span>
+            </div>
+            <div class="card-foot"><span>8 个工具</span><span>更新：2026/07/07</span></div>
+          </article>
+
+          <article class="card">
+            <div class="card-head">
+              <span class="type">Function</span>
+              <span class="status draft">未发布</span>
+            </div>
+            <h3>运算工具箱</h3>
+            <p class="muted">用于简单数学计算的函数工具。</p>
+            <div class="metric-row">
+              <div class="metric"><strong>55%</strong><span class="muted">Agent Ready</span><div class="bar"><span style="width:55%"></span></div></div>
+              <div class="metric"><strong>低</strong><span class="muted">风险</span></div>
+              <div class="metric"><strong>通过</strong><span class="muted">验证</span></div>
+            </div>
+            <div class="tags">
+              <span class="tag blue">函数</span>
+              <span class="tag">待发布</span>
+            </div>
+            <div class="card-foot"><span>5 个工具</span><span>更新：2026/07/06</span></div>
+          </article>
+        </section>
+
+        <section class="section">
+          <div class="section-title">
+            <div>
+              <h2>添加能力菜单</h2>
+              <div class="muted">在现有按钮上优化文案和分组，降低选择成本。</div>
+            </div>
+            <button class="btn primary">+ 添加能力</button>
+          </div>
+          <div class="section-body">
+            <div class="preview" style="max-width: 360px">
+              <h3>HTTP / API</h3>
+              <p><b>添加 HTTP API</b><br><span class="muted">从 cURL、URL 或表单快速创建单个工具。</span></p>
+              <p><b>导入 OpenAPI</b><br><span class="muted">从 OpenAPI 文档批量生成工具集和工具。</span></p>
+              <h3 style="margin-top: 18px">MCP</h3>
+              <p><b>注册 MCP 服务</b><br><span class="muted">连接 SSE 或 Streamable HTTP MCP 服务。</span></p>
+              <h3 style="margin-top: 18px">Skill</h3>
+              <p><b>导入 Skill 包</b><br><span class="muted">上传 ZIP 或 SKILL.md，沉淀可复用技能。</span></p>
+            </div>
+          </div>
+        </section>
+
+        <section class="drawer">
+          <div class="scrim">
+            <h2>当前能力管理页</h2>
+            <p>点击“添加 HTTP API”后，沿用现有右侧抽屉交互。抽屉内部改为三段式轻量表单，右侧固定显示接口预览和 Agent Ready。</p>
+          </div>
+          <div class="drawer-panel">
+            <div class="drawer-head">
+              <h2>添加 HTTP API</h2>
+              <button class="btn primary">保存并完成</button>
+            </div>
+            <div class="drawer-body">
+              <div class="steps">
+                <span class="step active"><b>1</b>接口来源</span>
+                <span class="step active"><b>2</b>工具信息</span>
+                <span class="step"><b>3</b>工具集</span>
+              </div>
+              <div class="split">
+                <div>
+                  <div class="mini-tabs"><span class="active">粘贴 cURL</span><span>填表单</span></div>
+                  <div class="field full">
+                    <label>cURL 命令</label>
+                    <textarea>curl -X GET "http://host.docker.internal:8080/proxy/uapis/weather?city=北京"</textarea>
+                    <span class="hint">从浏览器或接口文档复制 cURL，系统会解析方法、地址与参数。</span>
+                  </div>
+                  <button class="btn ghost" style="margin: 12px 0">识别接口信息</button>
+                  <div class="notice success">识别成功：已解析 GET、服务地址、路径与 1 个 query 参数。</div>
+
+                  <div class="form-grid">
+                    <div class="field">
+                      <label>工具名称 *</label>
+                      <input value="query_weather" />
+                    </div>
+                    <div class="field">
+                      <label>一句话说明 *</label>
+                      <input value="根据城市查询实时天气" />
+                    </div>
+                    <div class="field full">
+                      <label>业务意图</label>
+                      <textarea>当用户询问某个城市的实时天气时使用，不适合查询历史天气。</textarea>
+                    </div>
+                    <div class="field">
+                      <label>放入工具集</label>
+                      <select><option>新建工具集</option><option>加入已有工具集</option></select>
+                    </div>
+                    <div class="field">
+                      <label>工具集名称 *</label>
+                      <input value="weather_toolbox" />
+                    </div>
+                    <div class="field full">
+                      <label>工具集描述</label>
+                      <input value="天气查询相关 HTTP 工具" />
+                    </div>
+                  </div>
+                </div>
+                <aside class="preview">
+                  <h3>接口预览</h3>
+                  <div class="kv"><span>方法</span><b>GET</b></div>
+                  <div class="kv"><span>服务地址</span><b>http://host.docker.internal:8080</b></div>
+                  <div class="kv"><span>路径</span><b>/proxy/uapis/weather</b></div>
+                  <div class="kv"><span>入参</span><b>city query string</b></div>
+                  <div class="kv"><span>响应</span><b>200 object</b></div>
+                  <hr style="border:0;border-top:1px solid var(--line);margin:14px 0">
+                  <h3>Agent Ready</h3>
+                  <div class="bar"><span style="width:45%"></span></div>
+                  <p><b>45%</b></p>
+                  <div class="tags">
+                    <span class="tag green">已识别接口结构</span>
+                    <span class="tag green">已填写工具名称</span>
+                    <span class="tag">缺少参数语义</span>
+                    <span class="tag">缺少输出语义</span>
+                    <span class="tag">缺少成功示例</span>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-title">
+            <div>
+              <h2>导入 OpenAPI</h2>
+              <div class="muted">批量导入时重点不是堆字段，而是先让用户选择接口、识别风险、设置默认 Agent 策略。</div>
+            </div>
+            <button class="btn primary">导入 2 个接口</button>
+          </div>
+          <div class="section-body">
+            <div class="split">
+              <div>
+                <div class="steps">
+                  <span class="step active"><b>1</b>文档来源</span>
+                  <span class="step active"><b>2</b>选择接口</span>
+                  <span class="step"><b>3</b>工具集设置</span>
+                </div>
+                <div class="mini-tabs"><span class="active">粘贴内容</span><span>上传文件</span><span>从 URL 获取</span></div>
+                <div class="code">openapi: 3.0.3
+info:
+  title: Weather API
+paths:
+  /weather:
+    get:
+      summary: 查询天气</div>
+                <div class="notice success">解析成功：OpenAPI 3.0.3 · 发现 6 个接口 · 服务地址已识别。</div>
+                <table class="table">
+                  <thead>
+                    <tr><th>选择</th><th>方法</th><th>路径</th><th>说明</th><th>风险</th><th>结构</th></tr>
+                  </thead>
+                  <tbody>
+                    <tr><td>☑</td><td>GET</td><td>/weather</td><td>查询天气</td><td><span class="tag green">低</span></td><td>1 入参</td></tr>
+                    <tr><td>☑</td><td>GET</td><td>/weather/history</td><td>查询历史天气</td><td><span class="tag green">低</span></td><td>2 入参</td></tr>
+                    <tr><td>☐</td><td>POST</td><td>/weather/alert</td><td>创建天气提醒</td><td><span class="tag amber">中</span></td><td>3 入参</td></tr>
+                    <tr><td>☐</td><td>DELETE</td><td>/weather/alert/{id}</td><td>删除天气提醒</td><td><span class="tag red">高</span></td><td>1 入参</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <aside class="preview">
+                <h3>工具集设置</h3>
+                <div class="field"><label>工具集名称 *</label><input value="Weather API 工具集"></div>
+                <div class="field"><label>工具集描述</label><textarea>天气查询与提醒相关接口。</textarea></div>
+                <div class="field"><label>分类</label><select><option>数据查询</option></select></div>
+                <h3 style="margin-top:16px">默认 Agent 策略</h3>
+                <div class="field"><label>Agent 可见性</label><select><option>可发现</option><option>不可见</option><option>可调用</option></select></div>
+                <div class="field"><label>调用策略</label><select><option>调用前确认</option><option>仅人工调用</option><option>允许自动调用</option></select></div>
+                <div class="field"><label>写操作默认策略</label><select><option>必须人工确认</option><option>禁止 Agent 调用</option></select></div>
+              </aside>
+            </div>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-title">
+            <div>
+              <h2>HTTP 工具详情页</h2>
+              <div class="muted">详情页负责补齐 Agent 契约，不把创建流程做重。</div>
+            </div>
+            <div class="actions"><button class="btn">调试</button><button class="btn primary">保存</button></div>
+          </div>
+          <div class="section-body">
+            <div class="detail-head">
+              <div>
+                <h2>查询天气</h2>
+                <p class="muted">HTTP / OpenAPI · GET /proxy/uapis/weather</p>
+              </div>
+              <div class="tags">
+                <span class="tag blue">未发布</span>
+                <span class="tag green">Agent 可发现</span>
+                <span class="tag amber">调用前确认</span>
+                <span class="tag green">Agent Ready 65%</span>
+              </div>
+            </div>
+
+            <div class="tabs">
+              <span class="tab">概览</span>
+              <span class="tab active">契约</span>
+              <span class="tab">调试</span>
+              <span class="tab">发布</span>
+            </div>
+
+            <div class="contract-grid">
+              <div>
+                <div class="form-grid">
+                  <div class="field full">
+                    <label>业务意图</label>
+                    <textarea>当用户询问某个城市的实时天气时使用。</textarea>
+                  </div>
+                  <div class="field full">
+                    <label>适用场景</label>
+                    <input value="查询实时天气；查询城市天气概况" />
+                  </div>
+                  <div class="field full">
+                    <label>不适用场景</label>
+                    <input value="查询历史天气；查询空气质量详情" />
+                  </div>
+                </div>
+
+                <h3 style="margin:18px 0 10px">输入语义</h3>
+                <table class="table">
+                  <thead><tr><th>参数名</th><th>位置</th><th>类型</th><th>必填</th><th>业务含义</th><th>示例</th></tr></thead>
+                  <tbody><tr><td>city</td><td>query</td><td>string</td><td>是</td><td>城市名称，如北京、上海</td><td>北京</td></tr></tbody>
+                </table>
+
+                <h3 style="margin:18px 0 10px">输出语义</h3>
+                <table class="table">
+                  <thead><tr><th>字段路径</th><th>类型</th><th>业务含义</th><th>示例</th></tr></thead>
+                  <tbody>
+                    <tr><td>weather</td><td>string</td><td>天气现象</td><td>晴</td></tr>
+                    <tr><td>temperature</td><td>number</td><td>当前温度，单位摄氏度</td><td>26</td></tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <aside class="preview">
+                <h3>Agent 可用性</h3>
+                <div class="bar"><span style="width:65%"></span></div>
+                <p><b>65%</b></p>
+                <div class="field"><label>副作用</label><select><option>只读</option><option>写入</option><option>外部动作</option></select></div>
+                <div class="field"><label>风险等级</label><select><option>低</option><option>中</option><option>高</option></select></div>
+                <div class="field"><label>Agent 可见性</label><select><option>可发现</option><option>不可见</option><option>可调用</option></select></div>
+                <div class="field"><label>调用策略</label><select><option>调用前确认</option><option>仅人工调用</option><option>允许自动调用</option></select></div>
+                <h3 style="margin-top:16px">待完善</h3>
+                <div class="checklist">
+                  <div class="check"><span>成功验证示例</span><span class="tag amber">缺少</span></div>
+                  <div class="check"><span>发布状态</span><span class="tag">未发布</span></div>
+                  <div class="check"><span>输出语义</span><span class="tag green">已填写</span></div>
+                </div>
+              </aside>
+            </div>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-title">
+            <div>
+              <h2>调试与发布</h2>
+              <div class="muted">调试成功要能沉淀为 Agent 示例；发布时区分资源发布和 Agent 可用策略。</div>
+            </div>
+          </div>
+          <div class="section-body">
+            <div class="split">
+              <div class="preview">
+                <h3>调试</h3>
+                <div class="field"><label>city</label><input value="北京" /></div>
+                <button class="btn primary" style="margin:12px 0">运行调试</button>
+                <div class="notice success">调试成功 · 128ms</div>
+                <div class="code">{
+  "weather": "晴",
+  "temperature": 26
+}</div>
+                <button class="btn" style="margin-top:12px">保存为成功示例</button>
+              </div>
+              <div class="preview">
+                <h3>发布与 Agent 治理</h3>
+                <div class="summary-grid" style="grid-template-columns:1fr 1fr">
+                  <div class="summary"><span class="muted">资源状态</span><strong>未发布</strong></div>
+                  <div class="summary"><span class="muted">Agent 状态</span><strong>可发现</strong></div>
+                </div>
+                <div class="checklist">
+                  <div class="check"><span>接口结构完整</span><span class="tag green">通过</span></div>
+                  <div class="check"><span>业务意图</span><span class="tag green">通过</span></div>
+                  <div class="check"><span>输入语义</span><span class="tag green">通过</span></div>
+                  <div class="check"><span>输出语义</span><span class="tag green">通过</span></div>
+                  <div class="check"><span>成功验证示例</span><span class="tag amber">建议补齐</span></div>
+                </div>
+                <div class="actions" style="margin-top:16px">
+                  <button class="btn">保存策略</button>
+                  <button class="btn primary">发布并保持 Agent 可发现</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-07-07-http-agent-ux-followups.md
+++ b/docs/superpowers/plans/2026-07-07-http-agent-ux-followups.md
@@ -1,0 +1,126 @@
+# HTTP Agent UX Follow-ups Implementation Design
+
+## Linked Issues
+
+- #55 `ux(execution-factory): guide next steps after HTTP capability creation`
+- #56 `ux(execution-factory): preview and select OpenAPI endpoints before import`
+- #57 `enhancement(execution-factory): include data sensitivity in Agent risk review`
+- #58 `enhancement(execution-factory): persist debug success examples into Agent contract`
+
+## Goal
+
+Improve the HTTP/OpenAPI capability onboarding experience from a real user mental model:
+
+1. I created a tool and need a clear next step.
+2. I imported an OpenAPI document and need to know which endpoints become tools.
+3. I need Agent risk to reflect data sensitivity, not only HTTP method.
+4. I need successful debug results to become Agent evidence.
+
+## Scope for This Iteration
+
+### Implement Now
+
+- Add a success guidance surface after quick HTTP API creation with actions:
+  - view created tool/toolset;
+  - debug/verify next;
+  - complete Agent contract.
+- Add an OpenAPI endpoint review panel in the import form:
+  - method;
+  - path;
+  - summary;
+  - inferred risk;
+  - input/response count.
+- Add front-end data sensitivity inference and display in the HTTP Agent contract:
+  - normal;
+  - possible_sensitive;
+  - high_sensitive.
+- Add tests for data sensitivity inference and OpenAPI endpoint review rendering.
+- Extend E2E coverage to verify the new UI guidance appears in the real cURL/OpenAPI flows.
+
+### Document/Prepare But Do Not Persist Yet
+
+- #58 backend persistence of debug examples is not implemented in this iteration.
+- The current implementation keeps session-level successful debug runs as Agent evidence.
+- Durable examples need either a backend contract metadata field or a new example API. That should be a backend-supported follow-up before claiming cross-refresh persistence.
+
+## User Experience Design
+
+### #55 Creation Success Guidance
+
+After a quick HTTP API is successfully created, the user sees a lightweight result panel instead of only a toast:
+
+```text
+HTTP API added to toolset
+
+Tool: query_weather
+Toolset: weather_toolbox
+
+Recommended next steps
+[View toolset] [Debug now] [Complete Agent contract]
+```
+
+This preserves the fast creation flow but makes the next action explicit.
+
+### #56 OpenAPI Endpoint Review
+
+When the OpenAPI document validates, show an endpoint list below the validation message:
+
+```text
+Endpoint review
+
+GET    /weather          Query weather        low risk      1 input · 1 response
+POST   /weather/alert    Create alert         medium risk   3 inputs · 1 response
+DELETE /weather/{id}     Delete alert         high risk     1 input · 1 response
+```
+
+First iteration is review-only. Selection can come in the next slice if backend import supports partial import.
+
+### #57 Data Sensitivity
+
+Risk currently infers side effects from HTTP method:
+
+- GET -> read/low risk;
+- POST/PUT/PATCH -> write/medium risk;
+- DELETE -> write/high risk.
+
+This is necessary but not sufficient. Add sensitivity inference from title, path, description, and semantic text:
+
+- `log`, `audit`, `trace` -> possible_sensitive.
+- `user`, `customer`, `order`, `finance`, `invoice`, `credential`, `token`, `secret`, `password` -> high_sensitive.
+- otherwise normal.
+
+The contract panel displays:
+
+```text
+Data sensitivity: possible_sensitive
+```
+
+This helps prevent the UX from saying "safe" for sensitive GET tools.
+
+### #58 Debug Evidence
+
+The current #47 implementation already converts the latest successful debug run into a session-level passed example. This iteration clarifies the UI copy:
+
+```text
+Latest successful debug is used as a session Agent example.
+```
+
+Durable persistence remains a follow-up until backend storage is available.
+
+## Test Plan
+
+- Unit:
+  - sensitivity inference returns possible/high sensitivity for log/user/order/finance endpoints.
+  - endpoint review extracts method/path/summary/risk/counts from OpenAPI.
+  - contract panel displays sensitivity.
+- E2E:
+  - quick cURL weather flow shows next-step guidance and still debugs successfully.
+  - OpenAPI import flow shows endpoint review and still imports successfully.
+  - log cURL flow displays sensitivity hint when opening the Agent contract.
+
+## Non-goals
+
+- No database migration.
+- No OpenAPI partial import submit.
+- No durable debug example API.
+- No MCP/Skill UI changes.

--- a/docs/superpowers/plans/2026-07-07-issue-47-http-agent-ui-design.md
+++ b/docs/superpowers/plans/2026-07-07-issue-47-http-agent-ui-design.md
@@ -1,0 +1,183 @@
+# Issue 47 HTTP Agent UI Implementation Design
+
+## Goal
+
+Evolve the existing Execution Factory HTTP experience into an Agent-readable capability workflow without rebuilding the underlying resource model. The first implementation focuses on HTTP/OpenAPI tools only. MCP and Skill keep their current flows and will receive separate designs later.
+
+## Product Principle
+
+The UI should generate as much as possible from cURL, URL, and OpenAPI documents, then ask the user to confirm or fill only the business semantics and governance decisions that cannot be inferred reliably.
+
+Automatically generated:
+
+- HTTP method, server URL, path, parameters, request body, responses.
+- Initial tool name, description, toolbox name, and toolbox description when OpenAPI provides metadata.
+- Initial side effect and risk hints from HTTP method and path naming.
+- Agent readiness score and missing items.
+
+User confirmed or filled:
+
+- Business intent.
+- Use cases and anti-use cases.
+- Input and output business meanings.
+- Verification example after debug.
+- Agent visibility and invoke policy.
+- Risk override when business context differs from HTTP method inference.
+
+## Scope
+
+### In Scope
+
+- Add a lightweight HTTP Agent contract UI that displays and edits Agent-oriented fields around a `CapabilityManifest`.
+- Reorganize HTTP tool detail into a clearer structure: overview, contract, debug, and publish sections.
+- Keep quick HTTP creation lightweight: source, tool metadata, toolbox placement.
+- Make OpenAPI import clearer by emphasizing parsed endpoint selection and default Agent policy in UI copy and layout.
+- Surface Agent readiness, missing items, risk, verification, visibility, and invoke policy in HTTP tool contexts.
+- Preserve existing tool, toolbox, debug, import, export, and publish services.
+
+### Out of Scope
+
+- No new Agent runtime, planner, or autonomous invocation engine.
+- No backend database schema migration.
+- No MCP or Skill contract editor in this issue.
+- No LLM-generated semantic descriptions.
+- No multi-environment credential management.
+- No replacement of existing execution-factory routes.
+
+## UI Architecture
+
+### Existing Surfaces Kept
+
+- `ExecutionUnitListScene` remains the ability management entry.
+- `AddCapabilityWizard` remains the add-capability drawer.
+- `QuickAddApiForm` remains the single HTTP API creation form.
+- `ImportOpenApiCapabilityForm` remains the full OpenAPI import form.
+- `ToolboxToolsScene` remains the toolbox detail and tool list page.
+- `ToolDetailScene` remains the dedicated tool edit page.
+
+### New/Changed UI Units
+
+1. `HttpCapabilityContractPanel`
+   - Focused display/edit component for business intent, use cases, input/output semantics, risk, visibility, and invoke policy.
+   - It consumes a `CapabilityManifest`.
+   - First version is front-end-only and uses existing manifest inference plus local form controls.
+
+2. `HttpCapabilityOverviewPanel`
+   - Compact summary for method/path/status/readiness/risk/test state.
+   - Used near the top of the HTTP tool detail view.
+
+3. `ToolDetailScene` tab layout
+   - Tabs: overview, contract, debug, publish.
+   - Existing form fields move into the overview/contract sections without changing service payload shape.
+
+4. Quick HTTP copy/layout refinement
+   - Keep current cURL/form tabs.
+   - Keep OpenAPI IO preview.
+   - Make Agent readiness preview and missing items visible next to generated interface preview.
+
+## Data Model Strategy
+
+Use the existing `CapabilityManifest` as the front-end contract:
+
+```ts
+type CapabilityManifest = {
+  id: string;
+  sourceType: "tool" | "mcp" | "skill" | "operator";
+  sourceId: string;
+  title: string;
+  description?: string;
+  intent?: string;
+  useCases?: string[];
+  antiUseCases?: string[];
+  inputSemantics?: CapabilityInputSemantic[];
+  outputSemantics?: CapabilityOutputSemantic[];
+  examples?: CapabilityExample[];
+  sideEffects?: CapabilitySideEffect;
+  riskLevel?: CapabilityRiskLevel;
+  testStatus?: CapabilityTestStatus;
+  agentVisibility?: AgentVisibility;
+  agentInvokePolicy?: AgentInvokePolicy;
+};
+```
+
+First version does not persist all manifest fields independently. It maps:
+
+- `title` from tool name.
+- `description` from tool description.
+- `intent` from use rule or description.
+- input/output semantics from OpenAPI IO schema.
+- side effect and risk from HTTP method.
+- test status from debug/example state when available in session.
+- visibility and invoke policy from inferred defaults.
+
+When backend support is added later, the same component can submit the full manifest payload.
+
+## Interaction Design
+
+### Quick Add HTTP API
+
+The quick add drawer remains a low-friction creation path:
+
+1. Interface source: cURL or form.
+2. Tool metadata: name, one-line description, business intent.
+3. Toolbox placement: existing or new toolbox.
+
+The right side preview should show:
+
+- Method, server URL, path.
+- Input and response preview.
+- Agent readiness score.
+- Missing semantic items.
+
+Validation must stay field-local. If cURL parsing or backend URL validation fails, the error is shown on cURL/server URL rather than only as a toast.
+
+### Import OpenAPI
+
+The OpenAPI import form focuses on batch clarity:
+
+- Parse document from paste/file/URL.
+- Show document title/version/server/endpoint count.
+- Show a selectable endpoint list with method, path, summary, risk, and IO count.
+- Apply default Agent policy to imported tools.
+
+The first implementation can keep backend import behavior unchanged while improving preview and policy copy.
+
+### HTTP Tool Detail
+
+The detail page becomes the main place to complete Agent readiness:
+
+- Overview: current technical and governance summary.
+- Contract: business intent, use cases, input/output semantics, risk, visibility, invoke policy.
+- Debug: run existing debug and optionally save a passed example in session.
+- Publish: distinguish resource publish state from Agent availability.
+
+## Testing Strategy
+
+1. Unit tests for manifest inference remain in `capability-manifest.test.ts`.
+2. New component tests verify:
+   - HTTP contract panel renders intent, input semantics, output semantics, risk, visibility, invoke policy.
+   - Missing readiness items are visible when semantics or examples are incomplete.
+   - Read-only inferred fields remain visible even before backend persistence exists.
+3. Existing execution factory tests must continue to pass.
+4. Manual QA should cover:
+   - Add HTTP API from cURL.
+   - Import OpenAPI.
+   - Open tool detail.
+   - Review contract.
+   - Debug with sample input.
+   - Confirm publish/Agent policy separation.
+
+## Rollout Plan
+
+1. Add component tests for the HTTP contract UI.
+2. Implement `HttpCapabilityContractPanel`.
+3. Wire the panel into `ToolDetailScene`.
+4. Refine quick HTTP/OpenAPI texts only where needed.
+5. Run targeted execution-factory tests and lint.
+6. Keep MCP/Skill untouched except shared manifest types already present.
+
+## Risks
+
+- If too many fields are required during creation, users will abandon the flow. Mitigation: keep creation lightweight and move semantics to detail.
+- If Agent policy appears equivalent to publish status, users may accidentally overexpose tools. Mitigation: separate resource status and Agent status visually.
+- If inferred semantics look authoritative, users may skip review. Mitigation: show missing/derived hints and ask for business confirmation.

--- a/src/modules/execution-factory/components/HttpCapabilityContractPanel.module.css
+++ b/src/modules/execution-factory/components/HttpCapabilityContractPanel.module.css
@@ -1,0 +1,113 @@
+.panel {
+  display: grid;
+  gap: 16px;
+}
+
+.section {
+  border: 1px solid #dfe6f2;
+  border-radius: 8px;
+  background: #fff;
+  padding: 16px;
+}
+
+.sectionTitle {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.sectionTitle h3 {
+  font-size: 16px;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.intent {
+  color: #233653;
+  margin: 0;
+}
+
+.muted {
+  color: #60708a;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 16px;
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid #e6edf7;
+  padding: 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.table th {
+  background: #f7faff;
+  color: #40516c;
+  font-weight: 700;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.policyGrid {
+  display: grid;
+  gap: 10px;
+}
+
+.readiness {
+  border: 1px solid #dfe6f2;
+  border-radius: 8px;
+  background: #f8fbff;
+  padding: 14px;
+}
+
+.score {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.scoreValue {
+  color: #173f9f;
+  font-size: 26px;
+  font-weight: 800;
+}
+
+.bar {
+  background: #dce5f5;
+  border-radius: 999px;
+  height: 8px;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.barFill {
+  background: #2457d6;
+  height: 100%;
+}
+
+@media (max-width: 1100px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/modules/execution-factory/components/HttpCapabilityContractPanel.test.tsx
+++ b/src/modules/execution-factory/components/HttpCapabilityContractPanel.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HttpCapabilityContractPanel } from "@/modules/execution-factory/components/HttpCapabilityContractPanel";
+import type { CapabilityManifest } from "@/modules/execution-factory/types/capability-manifest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+describe("HttpCapabilityContractPanel", () => {
+  it("shows inferred HTTP semantics and Agent governance in one contract surface", () => {
+    const manifest: CapabilityManifest = {
+      id: "tool:query-weather",
+      sourceId: "query-weather",
+      sourceType: "tool",
+      title: "Query weather",
+      description: "Query realtime weather by city.",
+      status: "enabled",
+      intent: "Use when a user asks for realtime weather in a city.",
+      inputSemantics: [
+        {
+          name: "city",
+          location: "query",
+          dataType: "string",
+          required: true,
+          businessMeaning: "City name such as Beijing or Shanghai.",
+          examples: ["Beijing"],
+        },
+      ],
+      outputSemantics: [
+        {
+          name: "200",
+          dataType: "object",
+          businessMeaning: "Realtime weather result.",
+          examples: [{ weather: "sunny", temperature: 26 }],
+        },
+      ],
+      sideEffects: "read",
+      riskLevel: "low",
+      testStatus: "untested",
+      agentVisibility: "discoverable",
+      agentInvokePolicy: "approval_required",
+    };
+
+    render(<HttpCapabilityContractPanel manifest={manifest} />);
+
+    expect(screen.getByText("Use when a user asks for realtime weather in a city.")).toBeTruthy();
+    expect(screen.getByText("city")).toBeTruthy();
+    expect(screen.getByText("query")).toBeTruthy();
+    expect(screen.getByText("City name such as Beijing or Shanghai.")).toBeTruthy();
+    expect(screen.getByText("Realtime weather result.")).toBeTruthy();
+    expect(screen.getByText("Risk: low")).toBeTruthy();
+    expect(screen.getByText("Agent: discoverable")).toBeTruthy();
+    expect(screen.getByText("Invoke: approval_required")).toBeTruthy();
+    expect(screen.getByText("Missing: verified example")).toBeTruthy();
+  });
+});

--- a/src/modules/execution-factory/components/HttpCapabilityContractPanel.tsx
+++ b/src/modules/execution-factory/components/HttpCapabilityContractPanel.tsx
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { Tag } from "antd";
+import { useTranslation } from "react-i18next";
+
+import type {
+  CapabilityInputSemantic,
+  CapabilityManifest,
+  CapabilityOutputSemantic,
+} from "@/modules/execution-factory/types/capability-manifest";
+import { getCapabilityReadiness } from "@/modules/execution-factory/utils/capability-manifest";
+
+import styles from "./HttpCapabilityContractPanel.module.css";
+
+type HttpCapabilityContractPanelProps = {
+  manifest: CapabilityManifest;
+};
+
+function formatValue(value: unknown) {
+  if (value === undefined || value === null || value === "") {
+    return "-";
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
+
+function formatExamples(examples?: unknown[]) {
+  if (!examples?.length) {
+    return "-";
+  }
+
+  return examples.slice(0, 2).map(formatValue).join(", ");
+}
+
+function missingLabel(item: string) {
+  return `Missing: ${item}`;
+}
+
+function InputSemanticsTable({ items }: { items: CapabilityInputSemantic[] }) {
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Location</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Business meaning</th>
+            <th>Example</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={`${item.location ?? "argument"}:${item.name}`}>
+              <td>{item.name}</td>
+              <td>{item.location ?? "argument"}</td>
+              <td>{item.dataType ?? "-"}</td>
+              <td>{item.required ? "Yes" : "No"}</td>
+              <td>{item.businessMeaning ?? "-"}</td>
+              <td>{formatExamples(item.examples)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function OutputSemanticsTable({ items }: { items: CapabilityOutputSemantic[] }) {
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Path</th>
+            <th>Type</th>
+            <th>Business meaning</th>
+            <th>Example</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={`${item.path ?? item.name}:${item.dataType ?? ""}`}>
+              <td>{item.name}</td>
+              <td>{item.path ?? "-"}</td>
+              <td>{item.dataType ?? "-"}</td>
+              <td>{item.businessMeaning ?? "-"}</td>
+              <td>{formatExamples(item.examples)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function HttpCapabilityContractPanel({ manifest }: HttpCapabilityContractPanelProps) {
+  const { t } = useTranslation();
+  const readiness = getCapabilityReadiness(manifest);
+  const inputs = manifest.inputSemantics ?? [];
+  const outputs = manifest.outputSemantics ?? [];
+  const sideEffects = manifest.sideEffects ?? "unknown";
+  const riskLevel = manifest.riskLevel ?? "medium";
+  const dataSensitivity = manifest.dataSensitivity ?? "normal";
+  const agentVisibility = manifest.agentVisibility ?? "hidden";
+  const invokePolicy = manifest.agentInvokePolicy ?? "manual_only";
+
+  return (
+    <section className={styles.panel} data-testid="http-capability-contract-panel">
+      <div className={styles.grid}>
+        <div className={styles.panel}>
+          <section className={styles.section}>
+            <div className={styles.sectionTitle}>
+              <h3>
+                {t("executionFactory.httpContract.intentTitle", {
+                  defaultValue: "Business intent",
+                })}
+              </h3>
+            </div>
+            <p className={styles.intent}>
+              {manifest.intent ||
+                manifest.description ||
+                t("executionFactory.httpContract.emptyIntent", {
+                  defaultValue: "Describe when people or agents should use this capability.",
+                })}
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <div className={styles.sectionTitle}>
+              <h3>
+                {t("executionFactory.httpContract.inputTitle", {
+                  defaultValue: "Input semantics",
+                })}
+              </h3>
+              <Tag>{inputs.length}</Tag>
+            </div>
+            {inputs.length > 0 ? (
+              <InputSemanticsTable items={inputs} />
+            ) : (
+              <p className={styles.muted}>
+                {t("executionFactory.httpContract.emptyInputs", {
+                  defaultValue: "No input parameters were detected.",
+                })}
+              </p>
+            )}
+          </section>
+
+          <section className={styles.section}>
+            <div className={styles.sectionTitle}>
+              <h3>
+                {t("executionFactory.httpContract.outputTitle", {
+                  defaultValue: "Output semantics",
+                })}
+              </h3>
+              <Tag>{outputs.length}</Tag>
+            </div>
+            {outputs.length > 0 ? (
+              <OutputSemanticsTable items={outputs} />
+            ) : (
+              <p className={styles.muted}>
+                {t("executionFactory.httpContract.emptyOutputs", {
+                  defaultValue: "No response fields were detected.",
+                })}
+              </p>
+            )}
+          </section>
+        </div>
+
+        <aside className={styles.readiness}>
+          <div className={styles.score}>
+            <span className={styles.scoreValue}>{readiness.score}%</span>
+            <span className={styles.muted}>
+              {t("executionFactory.httpContract.agentReady", {
+                defaultValue: "Agent Ready",
+              })}
+            </span>
+          </div>
+          <div className={styles.bar}>
+            <div className={styles.barFill} style={{ width: `${readiness.score}%` }} />
+          </div>
+
+          <div className={styles.policyGrid}>
+            <Tag>{`Side effect: ${sideEffects}`}</Tag>
+            <Tag>{`Risk: ${riskLevel}`}</Tag>
+            <Tag>{`Data sensitivity: ${dataSensitivity}`}</Tag>
+            <Tag>{`Agent: ${agentVisibility}`}</Tag>
+            <Tag>{`Invoke: ${invokePolicy}`}</Tag>
+            <Tag>{`Verification: ${manifest.testStatus ?? "untested"}`}</Tag>
+          </div>
+
+          {readiness.missing.length > 0 ? (
+            <>
+              <div className={styles.sectionTitle} style={{ marginTop: 16 }}>
+                <h3>
+                  {t("executionFactory.httpContract.missingTitle", {
+                    defaultValue: "Missing items",
+                  })}
+                </h3>
+              </div>
+              <div className={styles.tags}>
+                {readiness.missing.map((item) => (
+                  <Tag key={item}>{missingLabel(item)}</Tag>
+                ))}
+              </div>
+            </>
+          ) : (
+            <p className={styles.muted}>
+              {t("executionFactory.httpContract.ready", {
+                defaultValue: "This capability has enough semantics for Agent review.",
+              })}
+            </p>
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/src/modules/execution-factory/scenes/ToolDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/ToolDetailScene.tsx
@@ -5,8 +5,8 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Alert, Collapse, Form, Input, Spin } from "antd";
-import { useEffect, useState } from "react";
+import { Alert, Collapse, Form, Input, Spin, Tabs, Tag } from "antd";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
@@ -17,6 +17,7 @@ import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { CrudFormPage } from "@/framework/scaffold/CrudFormPage";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { FunctionDefinitionFields } from "@/modules/execution-factory/components/FunctionDefinitionFields";
+import { HttpCapabilityContractPanel } from "@/modules/execution-factory/components/HttpCapabilityContractPanel";
 import { OpenApiSpecInput } from "@/modules/execution-factory/components/OpenApiSpecInput";
 import { ToolDebugModal } from "@/modules/execution-factory/components/ToolDebugModal";
 import { ToolGlobalParameterFields } from "@/modules/execution-factory/components/ToolGlobalParameterFields";
@@ -27,11 +28,13 @@ import {
 } from "@/modules/execution-factory/services/tool.service";
 import type {
   ToolGlobalParameter,
+  ToolDetail,
   ToolIoSpec,
   ToolMetadataType,
   ToolRunLogEntry,
 } from "@/modules/execution-factory/types/tool";
 import type { FunctionParameterDef } from "@/modules/execution-factory/types/function-input";
+import { buildToolCapabilityManifest } from "@/modules/execution-factory/utils/capability-manifest";
 import { validateOpenApiDocumentText } from "@/modules/execution-factory/utils/metadata-content";
 
 import styles from "./UnitFormScene.module.css";
@@ -56,6 +59,7 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
   const [loadError, setLoadError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [metadataType, setMetadataType] = useState<ToolMetadataType>("openapi");
+  const [toolDetail, setToolDetail] = useState<ToolDetail | null>(null);
   const [ioSpec, setIoSpec] = useState<ToolIoSpec | undefined>();
   const [debugOpen, setDebugOpen] = useState(false);
   const [sessionLogs, setSessionLogs] = useState<ToolRunLogEntry[]>([]);
@@ -70,6 +74,7 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
       try {
         const record = await getToolDetail(boxId, toolId);
         const type = record.metadataType ?? "openapi";
+        setToolDetail(record);
         setMetadataType(type);
         setIoSpec(record.ioSpec);
         form.setFieldsValue({
@@ -91,6 +96,7 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
             : undefined,
         });
       } catch (error) {
+        setToolDetail(null);
         setLoadError(extractRequestErrorMessage(error));
       } finally {
         setLoading(false);
@@ -153,6 +159,38 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
     setSessionLogs((current) => [entry, ...current].slice(0, 20));
   };
 
+  const capabilityManifest = useMemo(() => {
+    if (!toolDetail) {
+      return null;
+    }
+
+    const manifest = buildToolCapabilityManifest(toolDetail);
+    const latestLog = sessionLogs[0];
+
+    if (!latestLog) {
+      return manifest;
+    }
+
+    return {
+      ...manifest,
+      examples: latestLog.error
+        ? manifest.examples
+        : [
+            {
+              title: t("executionFactory.httpContract.latestDebugExample", {
+                defaultValue: "Latest successful debug",
+              }),
+              input: latestLog.requestBody ?? {},
+              expectedOutputSummary: JSON.stringify(latestLog.body ?? {}),
+              status: "passed" as const,
+              verifiedAt: latestLog.timestamp,
+            },
+            ...(manifest.examples ?? []),
+          ],
+      testStatus: latestLog.error ? ("failed" as const) : ("passed" as const),
+    };
+  }, [sessionLogs, t, toolDetail]);
+
   const functionInput =
     metadataType === "function"
       ? { inputs: functionInputs, outputs: functionOutputs }
@@ -174,49 +212,142 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
         {!loading && !loadError ? (
           <div className={styles.formSurface}>
             <Form form={form} layout="vertical">
-              <Form.Item
-                label={t("executionFactory.toolName")}
-                name="name"
-                rules={[{ required: true, message: t("common.required") }]}
-              >
-                <Input />
-              </Form.Item>
-              <Form.Item label={t("common.description")} name="description">
-                <Input.TextArea rows={3} />
-              </Form.Item>
-              <Form.Item label={t("executionFactory.useRule")} name="useRule">
-                <Input.TextArea rows={2} />
-              </Form.Item>
-              {metadataType === "openapi" ? (
-                <Form.Item
-                  label={t("executionFactory.openapiSpec")}
-                  name="openapiSpec"
-                  rules={[{ required: true, message: t("common.required") }]}
-                >
-                  <OpenApiSpecInput rows={14} />
-                </Form.Item>
-              ) : (
-                <FunctionDefinitionFields />
-              )}
-              <Collapse
-                ghost
+              <Tabs
                 items={[
                   {
-                    key: "globalParameters",
-                    label: t("executionFactory.globalParametersTitle"),
-                    children: <ToolGlobalParameterFields />,
+                    key: "overview",
+                    label: t("executionFactory.httpContract.tabs.overview", {
+                      defaultValue: "概览",
+                    }),
+                    children: (
+                      <>
+                        <Form.Item
+                          label={t("executionFactory.toolName")}
+                          name="name"
+                          rules={[{ required: true, message: t("common.required") }]}
+                        >
+                          <Input />
+                        </Form.Item>
+                        <Form.Item label={t("common.description")} name="description">
+                          <Input.TextArea rows={3} />
+                        </Form.Item>
+                        <Form.Item label={t("executionFactory.useRule")} name="useRule">
+                          <Input.TextArea rows={2} />
+                        </Form.Item>
+                        {metadataType === "openapi" ? (
+                          <Form.Item
+                            label={t("executionFactory.openapiSpec")}
+                            name="openapiSpec"
+                            rules={[{ required: true, message: t("common.required") }]}
+                          >
+                            <OpenApiSpecInput rows={14} />
+                          </Form.Item>
+                        ) : (
+                          <FunctionDefinitionFields />
+                        )}
+                        <Collapse
+                          ghost
+                          items={[
+                            {
+                              key: "globalParameters",
+                              label: t("executionFactory.globalParametersTitle"),
+                              children: <ToolGlobalParameterFields />,
+                            },
+                          ]}
+                        />
+                      </>
+                    ),
+                  },
+                  ...(metadataType === "openapi"
+                    ? [
+                        {
+                          key: "contract",
+                          label: t("executionFactory.httpContract.tabs.contract", {
+                            defaultValue: "契约",
+                          }),
+                          children: capabilityManifest ? (
+                            <HttpCapabilityContractPanel manifest={capabilityManifest} />
+                          ) : (
+                            <Alert
+                              message={t("executionFactory.httpContract.noManifest", {
+                                defaultValue: "暂无可展示的能力契约。",
+                              })}
+                              showIcon
+                              type="info"
+                            />
+                          ),
+                        },
+                      ]
+                    : []),
+                  {
+                    key: "debug",
+                    label: t("executionFactory.httpContract.tabs.debug", {
+                      defaultValue: "调试",
+                    }),
+                    children: (
+                      <section style={{ marginTop: 8 }}>
+                        <Alert
+                          message={t("executionFactory.httpContract.debugHint", {
+                            defaultValue:
+                              "运行调试后，最近一次成功结果会作为本会话的 Agent 验证示例展示在契约中。",
+                          })}
+                          showIcon
+                          style={{ marginBottom: 16 }}
+                          type="info"
+                        />
+                        <ToolIoPanel
+                          functionInput={functionInput}
+                          ioSpec={ioSpec}
+                          runLogs={sessionLogs}
+                        />
+                      </section>
+                    ),
+                  },
+                  {
+                    key: "publish",
+                    label: t("executionFactory.httpContract.tabs.publish", {
+                      defaultValue: "发布",
+                    }),
+                    children: (
+                      <section style={{ display: "grid", gap: 12, marginTop: 8 }}>
+                        <Alert
+                          message={t("executionFactory.httpContract.publishHint", {
+                            defaultValue:
+                              "资源发布状态与 Agent 可用状态需要分开判断。已发布不代表 Agent 可以自动调用。",
+                          })}
+                          showIcon
+                          type="info"
+                        />
+                        <div>
+                          <Tag>
+                            {t("executionFactory.httpContract.resourceStatus", {
+                              defaultValue: "资源状态",
+                            })}
+                            : {toolDetail?.status ?? "-"}
+                          </Tag>
+                          {capabilityManifest ? (
+                            <>
+                              <Tag>
+                                Agent: {capabilityManifest.agentVisibility ?? "hidden"}
+                              </Tag>
+                              <Tag>
+                                Invoke: {capabilityManifest.agentInvokePolicy ?? "manual_only"}
+                              </Tag>
+                              <Tag>
+                                Risk: {capabilityManifest.riskLevel ?? "medium"}
+                              </Tag>
+                              <Tag>
+                                Verification: {capabilityManifest.testStatus ?? "untested"}
+                              </Tag>
+                            </>
+                          ) : null}
+                        </div>
+                      </section>
+                    ),
                   },
                 ]}
               />
             </Form>
-            <section style={{ marginTop: 24 }}>
-              <h3 style={{ marginBottom: 12 }}>{t("executionFactory.toolboxInputOutputTitle")}</h3>
-              <ToolIoPanel
-                functionInput={functionInput}
-                ioSpec={ioSpec}
-                runLogs={sessionLogs}
-              />
-            </section>
             <div className={styles.formActions}>
               <AppButton onClick={handleBack}>{t("common.cancel")}</AppButton>
               <PermissionGate permissions="execution-factory:tool:debug">


### PR DESCRIPTION
﻿## 背景

Refs #58。完整的 #58 需要后端持久化调试 evidence、脱敏治理和重新验证。本 PR 先交付前端/会话级闭环：调试成功后，当前页面的 Agent 契约能展示最近一次成功示例和验证状态。

## 主要改动

- 新增 HTTP capability contract 面板，集中展示 intent、输入/输出语义、治理信息、风险和就绪度。
- 工具详情页改为概览、契约、调试、发布分区，降低编辑页的信息拥挤度。
- 调试成功后把当前会话的请求/响应作为 Agent 契约示例展示，并标记 testStatus。
- 补充 HTML 原型和实现设计文档。

## 影响范围

- 基于 #65 / feature/57-agent-data-sensitivity。
- 影响工具详情页的信息架构与 HTTP/OpenAPI 工具的契约展示。
- 不新增后端 API，不持久化 evidence，不改变实际工具调用路径。

## 验证方式

- `pnpm exec vitest run src/modules/execution-factory/components/HttpCapabilityContractPanel.test.tsx`
- 此前完整链路已通过：RW-UI-01、RW-UI-03、RW-UI-04。

## 未完成项或风险

- This PR does not close #58。
- 仍缺后端 evidence 数据模型、保存/查询/删除/重新验证 API、脱敏策略和跨刷新持久展示。