### PR TITLE
fix(execution-factory): soften debug result success palette

### DIFF
--- a/src/modules/execution-factory/components/ToolDebugModal.module.css
+++ b/src/modules/execution-factory/components/ToolDebugModal.module.css
@@ -1,0 +1,66 @@
+.resultPanelSuccess,
+.resultPanelWarning {
+  border-radius: 10px;
+  margin-top: 16px;
+  overflow: hidden;
+}
+
+.resultPanelSuccess {
+  border: 1px solid rgba(21, 94, 117, 0.18);
+  background: #f8fafc;
+}
+
+.resultPanelWarning {
+  border: 1px solid rgba(180, 83, 9, 0.24);
+  background: #fffaf3;
+}
+
+.resultHeader {
+  align-items: center;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+}
+
+.statusDotSuccess,
+.statusDotWarning {
+  border-radius: 999px;
+  display: inline-flex;
+  height: 9px;
+  width: 9px;
+}
+
+.statusDotSuccess {
+  background: #0f9f6e;
+  box-shadow: 0 0 0 3px rgba(15, 159, 110, 0.12);
+}
+
+.statusDotWarning {
+  background: #d97706;
+  box-shadow: 0 0 0 3px rgba(217, 119, 6, 0.14);
+}
+
+.resultTitle {
+  color: #17253d;
+  font-weight: 650;
+}
+
+.resultMeta {
+  color: rgba(15, 30, 54, 0.52);
+  font-size: 12px;
+  margin-left: auto;
+}
+
+.resultCode {
+  background: #ffffff;
+  color: #182235;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.58;
+  margin: 0;
+  max-height: 280px;
+  overflow: auto;
+  padding: 14px 16px;
+  white-space: pre-wrap;
+}

--- a/src/modules/execution-factory/components/ToolDebugModal.tsx
+++ b/src/modules/execution-factory/components/ToolDebugModal.tsx
@@ -20,6 +20,8 @@ import type {
 } from "@/modules/execution-factory/types/tool";
 import { buildDefaultDebugBody } from "@/modules/execution-factory/utils/generate-sample-json";
 
+import styles from "./ToolDebugModal.module.css";
+
 type ToolDebugModalProps = {
   boxId: string;
   defaultRequestBody?: string;
@@ -135,16 +137,20 @@ export function ToolDebugModal({
       </Form>
       {error ? <Alert message={error} showIcon style={{ marginBottom: 16 }} type="error" /> : null}
       {result ? (
-        <Alert
-          description={
-            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
-              {JSON.stringify(result, null, 2)}
-            </pre>
-          }
-          message={t("executionFactory.debugResultTitle")}
-          showIcon
-          type={result.error ? "warning" : "success"}
-        />
+        <section
+          className={result.error ? styles.resultPanelWarning : styles.resultPanelSuccess}
+          data-testid="tool-debug-result"
+        >
+          <div className={styles.resultHeader}>
+            <span className={result.error ? styles.statusDotWarning : styles.statusDotSuccess} />
+            <span className={styles.resultTitle}>{t("executionFactory.debugResultTitle")}</span>
+            <span className={styles.resultMeta}>
+              HTTP {result.statusCode || "-"}
+              {typeof result.durationMs === "number" ? ` · ${result.durationMs} ms` : ""}
+            </span>
+          </div>
+          <pre className={styles.resultCode}>{JSON.stringify(result, null, 2)}</pre>
+        </section>
       ) : null}
     </Modal>
   );


### PR DESCRIPTION
﻿## 背景

Closes #60。接口调试成功结果使用大面积绿色背景，视觉上容易被误认为异常或告警块。

## 主要改动

- 将工具调试结果从 AntD 大面积 success Alert 改为中性响应面板。
- 只用小面积状态点表达成功/警告状态。
- 在结果头部展示 HTTP status 和耗时。
- 响应体使用白底代码区，提升 JSON 可读性。

## 影响范围

- 仅影响 HTTP tool 调试弹窗的结果展示。
- 不改变调试 API、请求体、响应结构或 Agent 契约逻辑。

## 验证方式

- `pnpm exec eslint src/modules/execution-factory/components/ToolDebugModal.tsx`
- 手工验证：天气工具调试成功后结果不再显示大面积绿色背景。

## 未完成项或风险

- MCP/Function/Operator 的调试结果面板仍使用原样式，可在后续统一视觉规范时一起收敛。