### PR TITLE
fix(studio): hide experimental execution factory entry

### DIFF
--- a/src/app/shell/navigation/base-navigation.tsx
+++ b/src/app/shell/navigation/base-navigation.tsx
@@ -26,11 +26,6 @@ export const baseConsoleNavigation: ConsoleNavItem[] = [
     icon: <ClusterOutlined />,
   },
   {
-    key: "execution-factory-lab",
-    labelKey: "shell.items.executionFactoryLab",
-    icon: <ExperimentOutlined />,
-  },
-  {
     key: "general-business-knowledge-network",
     labelKey: "shell.items.generalBusinessKnowledgeNetwork",
     icon: <AppstoreOutlined />,


### PR DESCRIPTION
﻿## 背景

Closes #61。执行工厂实验版暂时不对用户开放，继续显示主导航入口会让用户误以为这是正式能力入口。

## 主要改动

- 从基础控制台导航中移除 `execution-factory-lab` 顶层入口。
- 保留正式执行工厂入口不变。

## 影响范围

- 修改 `src/app/shell/navigation/base-navigation.tsx`，属于全局导航入口变化，需要重点 review。
- 该 PR 只隐藏菜单入口，不删除实验版路由或模块代码。

## 验证方式

- `pnpm exec eslint src/app/shell/navigation/base-navigation.tsx`

## 未完成项或风险

- 直接访问实验版路由是否继续可用由现有 route 配置决定，本 PR 不做路由删除。