### PR TITLE
fix(execution-factory): require publish before toolbox export

### DIFF
--- a/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx
+++ b/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx
@@ -49,14 +49,18 @@ function pushMenuAction(
   onAction: ExecutionUnitCardMenuProps["onAction"],
   action: ExecutionUnitCardAction,
   item: ExecutionUnitCardItem,
-  options?: { danger?: boolean },
+  options?: { danger?: boolean; disabled?: boolean; disabledReason?: string },
 ) {
   menuItems?.push({
     key,
     danger: options?.danger,
-    label,
+    disabled: options?.disabled,
+    label: options?.disabledReason ? <span title={options.disabledReason}>{label}</span> : label,
     onClick: ({ domEvent }) => {
       domEvent.stopPropagation();
+      if (options?.disabled) {
+        return;
+      }
       onAction(action, item);
     },
   });
@@ -191,6 +195,7 @@ export function ExecutionUnitCardMenu({
   }
 
   if (activeTab === "operator" || activeTab === "toolbox" || activeTab === "mcp") {
+    const exportDisabled = activeTab === "toolbox" && item.status !== "published";
     pushMenuAction(
       menuItems,
       "export",
@@ -198,6 +203,12 @@ export function ExecutionUnitCardMenu({
       onAction,
       "export",
       item,
+      exportDisabled
+        ? {
+            disabled: true,
+            disabledReason: t("executionFactory.exportDisabledUntilPublished"),
+          }
+        : undefined,
     );
   }
 

--- a/src/modules/execution-factory/locales/en-US.ts
+++ b/src/modules/execution-factory/locales/en-US.ts
@@ -319,6 +319,7 @@ export const executionFactoryEnUS = {
     createMcpDrawerTitle: "New MCP",
     editMcpDrawerTitle: "Edit MCP",
     exportSuccess: "Export completed",
+    exportDisabledUntilPublished: "Publish before exporting a backup",
     downloadSuccess: "Download completed",
     updateSkillPackageTitle: "Update Skill package: {{name}}",
     skillPackageUpdateSuccess: "Skill package updated",

--- a/src/modules/execution-factory/locales/zh-CN.ts
+++ b/src/modules/execution-factory/locales/zh-CN.ts
@@ -315,6 +315,7 @@ export const executionFactoryZhCN = {
     createMcpDrawerTitle: "新建 MCP",
     editMcpDrawerTitle: "编辑 MCP",
     exportSuccess: "导出成功",
+    exportDisabledUntilPublished: "发布后可导出备份",
     downloadSuccess: "下载成功",
     updateSkillPackageTitle: "更新 Skill 包：{{name}}",
     skillPackageUpdateSuccess: "Skill 包更新成功",

--- a/tests/e2e/specs/execution-factory/e2e-impex-ui.spec.ts
+++ b/tests/e2e/specs/execution-factory/e2e-impex-ui.spec.ts
@@ -11,7 +11,10 @@ import {
   buildImpexImportName,
 } from "../../helpers/impex";
 import {
+  debugToolFromToolsPage,
+  executionUnitCard,
   exportFromCardMenu,
+  gotoToolboxToolsPage,
   gotoUnitsTab,
   importBackupFileViaUi,
 } from "../../helpers/execution-unit-ui";
@@ -134,9 +137,31 @@ test.describe("Execution Factory — Impex UI E2E flows", () => {
   test("IMPEX-UI-03: export toolbox backup from card menu", async ({ page, request }) => {
     const toolbox = await createToolboxViaApi(request, buildToolboxName("ui_export"));
     createdBoxIds.push(toolbox.boxId);
+    await createToolViaApi(request, toolbox.boxId, buildToolboxName("ui_export_tool"));
+    await publishToolboxViaApi(request, toolbox.boxId);
 
     await gotoUnitsTab(page, "toolbox");
     await exportFromCardMenu(page, toolbox.name, "toolbox");
+  });
+
+  test("IMPEX-UI-03b: unpublished toolbox export action is disabled with guidance", async ({
+    page,
+    request,
+  }) => {
+    const toolbox = await createToolboxViaApi(request, buildToolboxName("ui_export_draft"));
+    createdBoxIds.push(toolbox.boxId);
+
+    await gotoUnitsTab(page, "toolbox");
+    const card = executionUnitCard(page, toolbox.name);
+    await card.getByRole("button", { name: /更多操作|More/i }).click();
+    const menu = page.getByRole("menu").last();
+    await expect(menu).toBeVisible();
+    const exportItem = menu.getByRole("menuitem", { name: /导出|Export/i });
+    await expect(exportItem).toHaveAttribute("aria-disabled", "true");
+    await expect(exportItem.locator("[title]").first()).toHaveAttribute(
+      "title",
+      /发布后可导出备份|Publish before exporting a backup/i,
+    );
   });
 
   test("IMPEX-UI-04: export MCP backup from card menu", async ({ page, request }) => {
@@ -161,6 +186,7 @@ test.describe("Execution Factory — Impex UI E2E flows", () => {
   }) => {
     const toolbox = await createToolboxViaApi(request, buildToolboxName("ui_roundtrip"));
     createdBoxIds.push(toolbox.boxId);
+    await createToolViaApi(request, toolbox.boxId, buildToolboxName("ui_roundtrip_tool"));
     await publishToolboxViaApi(request, toolbox.boxId);
 
     const exported = (await exportToolboxViaApi(request, toolbox.boxId)) as Record<string, unknown>;
@@ -184,6 +210,25 @@ test.describe("Execution Factory — Impex UI E2E flows", () => {
     expect(imported?.box_id).toBeTruthy();
     if (imported?.box_id) {
       createdBoxIds.push(imported.box_id);
+      const tools = await request.get(
+        apiUrl(`/tool-box/${imported.box_id}/tools/list?page=1&page_size=20`),
+        { headers: { "x-business-domain": "bd_public" } },
+      );
+      expect(tools.ok()).toBeTruthy();
+      const toolsBody = (await tools.json()) as {
+        data?: Array<{ tool_id: string; tool_name?: string; name?: string }>;
+        tools?: Array<{ tool_id: string; tool_name?: string; name?: string }>;
+      };
+      const firstTool = (toolsBody.tools ?? toolsBody.data ?? [])[0];
+      const toolName = firstTool?.tool_name ?? firstTool?.name ?? "";
+      expect(toolName).toBeTruthy();
+
+      await gotoToolboxToolsPage(page, imported.box_id, importName);
+      const debugResponse = await debugToolFromToolsPage(page, imported.box_id, {
+        toolName,
+        fromListItem: true,
+      });
+      expect(debugResponse.ok()).toBeTruthy();
     }
   });
 });


### PR DESCRIPTION
﻿## 背景

Closes #62。未发布工具箱没有稳定发布物，直接导出备份容易生成不可用或不可验证的包。

## 主要改动

- 未发布工具箱卡片菜单中的导出入口禁用。
- 禁用态通过 title 提示“发布后可导出备份”。
- 已发布工具箱导出前补充工具创建，保证备份包可验证。
- UI 回归测试覆盖未发布禁用、已发布导出/导入/调试回环。

## 影响范围

- 影响执行工厂工具箱卡片菜单导出行为。
- 修改了执行工厂 locales 和 E2E 测试。
- 不修改后端 impex/export API。

## 验证方式

- `pnpm exec eslint src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx tests/e2e/specs/execution-factory/e2e-impex-ui.spec.ts`

## 未完成项或风险

- 当前只在前端禁用未发布工具箱导出；如果后端也需要强约束，可后续补充 API 校验。