### PR TITLE
fix(execution-factory): verify impex import debug roundtrip

### DIFF
--- a/tests/e2e/helpers/execution-unit-ui.ts
+++ b/tests/e2e/helpers/execution-unit-ui.ts
@@ -1,6 +1,7 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
 const STUDIO_BASE_PATH = "/studio";
+const STUDIO_API_BASE_URL = process.env.E2E_STUDIO_API_BASE_URL ?? "/api";
 
 export function toStudioPath(url: string) {
   if (/^https?:\/\//i.test(url)) {
@@ -19,10 +20,10 @@ export async function ensureE2eRuntime(
   page: Page,
   options?: { capabilityUxV2?: boolean },
 ) {
-  await page.addInitScript((capabilityUxV2) => {
+  await page.addInitScript(({ apiBaseUrl, capabilityUxV2 }) => {
     window.__BKN_STUDIO_RUNTIME__ = {
       ...(window.__BKN_STUDIO_RUNTIME__ ?? {}),
-      apiBaseUrl: "/api",
+      apiBaseUrl,
       mode: "hosted",
       features: {
         ...(window.__BKN_STUDIO_RUNTIME__?.features ?? {}),
@@ -33,7 +34,10 @@ export async function ensureE2eRuntime(
         ...(window.__BKN_STUDIO_RUNTIME__?.currentUser ?? {}),
       },
     };
-  }, options?.capabilityUxV2 ?? true);
+  }, {
+    apiBaseUrl: STUDIO_API_BASE_URL,
+    capabilityUxV2: options?.capabilityUxV2 ?? true,
+  });
 }
 
 export async function ensureLegacyE2eRuntime(page: Page) {
@@ -496,7 +500,10 @@ export async function submitImportModal(
     importDialog.getByRole("button", { name: /开始导入|^Import$/i }).click(),
   ]);
   const importResponse = await importResponsePromise;
-  expect(importResponse.ok()).toBeTruthy();
+  expect(
+    importResponse.ok(),
+    `Import ${type} backup failed (${importResponse.status()}) at ${importResponse.url()}: ${await importResponse.text()}`,
+  ).toBeTruthy();
   await expectAppToast(page, /导入成功|Imported successfully/i);
   await expect(importDialog).toBeHidden();
   return importResponse;

--- a/tests/e2e/helpers/impex.ts
+++ b/tests/e2e/helpers/impex.ts
@@ -68,8 +68,15 @@ export function cloneToolboxImpexForCreate(exported: Record<string, unknown>, ne
       tool.tool_id = randomUUID();
       if (tool.source_type === "operator" && tool.source_id) {
         tool.source_id = operatorIdMap.get(String(tool.source_id)) ?? randomUUID();
-      } else if (tool.source_id) {
-        tool.source_id = randomUUID();
+      } else {
+        const metadata = tool.metadata as Record<string, unknown> | undefined;
+        if (metadata?.version) {
+          const metadataVersion = randomUUID();
+          metadata.version = metadataVersion;
+          tool.source_id = metadataVersion;
+        } else if (tool.source_id) {
+          tool.source_id = randomUUID();
+        }
       }
     }
   }

--- a/tests/e2e/specs/execution-factory/impex-helper.spec.ts
+++ b/tests/e2e/specs/execution-factory/impex-helper.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+import { cloneToolboxImpexForCreate } from "../../helpers/impex";
+
+test.describe("impex helper payload cloning", () => {
+  test("keeps cloned OpenAPI tool source_id aligned with metadata version", () => {
+    const cloned = cloneToolboxImpexForCreate(
+      {
+        toolbox: {
+          configs: [
+            {
+              box_id: "source-box",
+              box_name: "source toolbox",
+              tools: [
+                {
+                  tool_id: "source-tool",
+                  box_id: "source-box",
+                  source_type: "openapi",
+                  source_id: "source-metadata-version",
+                  metadata: {
+                    version: "source-metadata-version",
+                    summary: "source tool",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "cloned toolbox",
+    ) as {
+      toolbox: {
+        configs: Array<{
+          tools: Array<{
+            source_id?: string;
+            metadata?: { version?: string };
+          }>;
+        }>;
+      };
+    };
+
+    const clonedTool = cloned.toolbox.configs[0].tools[0];
+    expect(clonedTool.metadata?.version).not.toBe("source-metadata-version");
+    expect(clonedTool.source_id).toBe(clonedTool.metadata?.version);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,8 +36,6 @@ export default defineConfig(({ mode }) => {
   const useMock = env.VITE_USE_MOCK !== "false";
   const agentOperatorProxyTarget =
     process.env.VITE_PROXY_TARGET ?? (useMock ? "http://127.0.0.1:9000" : devProxyOrigin);
-  // ContextLoader「立即体验」直接打 agent-retrieval（REST /api/agent-retrieval/v1/...，MCP /api/agent-retrieval/v1/mcp）。
-  // 默认转发到后端网关；自定义时设 VITE_AGENT_RETRIEVAL_TARGET。
   const agentRetrievalTarget = process.env.VITE_AGENT_RETRIEVAL_TARGET ?? devProxyOrigin;
 
   return {
@@ -52,8 +50,7 @@ export default defineConfig(({ mode }) => {
         "**/node_modules/**",
         "**/dist/**",
         // Playwright e2e specs run via `pnpm test:execution-factory:e2e`, not
-        // vitest — they import @playwright/test (not a root dep), so collecting
-        // them here would always fail.
+        // vitest. They import @playwright/test, so collecting them here fails.
         "tests/e2e/**",
         "tests/execution-factory/agent-at/**",
         "tests/execution-factory/operator-web-ui/**",
@@ -61,8 +58,8 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       host: true,
-      // OAuth redirect_uri is registered as http://localhost:8000/studio/callback —
-      // fail fast instead of silently drifting to another port when taken.
+      // OAuth redirect_uri is registered as http://localhost:8000/studio/callback.
+      // Fail fast instead of silently drifting to another port when taken.
       port: 8000,
       strictPort: true,
       allowedHosts: ["host.docker.internal", "localhost", "127.0.0.1"],
@@ -77,12 +74,34 @@ export default defineConfig(({ mode }) => {
           }
         : {}),
       proxy: {
+        // Specific API prefixes must be listed before the generic /api proxy.
+        "/api/agent-operator-integration": {
+          changeOrigin: true,
+          secure: false,
+          timeout: 120_000,
+          proxyTimeout: 120_000,
+          target: agentOperatorProxyTarget,
+        },
+        "/api/capabilities-lab": {
+          changeOrigin: true,
+          secure: false,
+          timeout: 120_000,
+          proxyTimeout: 120_000,
+          target: process.env.VITE_LAB_PROXY_TARGET ?? "http://127.0.0.1:9010",
+        },
+        "/api/agent-retrieval": {
+          changeOrigin: true,
+          secure: false,
+          timeout: 120_000,
+          proxyTimeout: 120_000,
+          target: agentRetrievalTarget,
+        },
         ...(useMock
           ? {}
           : {
               "/api": {
                 changeOrigin: true,
-                // 允许自签名 https 目标（如 VM https://10.211.55.4）。
+                // Allow self-signed HTTPS targets used by local gateways.
                 secure: false,
                 target: devProxyOrigin,
               },
@@ -104,28 +123,6 @@ export default defineConfig(({ mode }) => {
                 target: devProxyOrigin,
               },
             }),
-        "/api/agent-operator-integration": {
-          changeOrigin: true,
-          secure: false,
-          timeout: 120_000,
-          proxyTimeout: 120_000,
-          target: agentOperatorProxyTarget,
-        },
-        "/api/capabilities-lab": {
-          changeOrigin: true,
-          secure: false,
-          timeout: 120_000,
-          proxyTimeout: 120_000,
-          target: process.env.VITE_LAB_PROXY_TARGET ?? "http://127.0.0.1:9010",
-        },
-        // REST(/api/agent-retrieval/v1/...) 与 MCP(/api/agent-retrieval/v1/mcp) 同前缀，一条代理覆盖。
-        "/api/agent-retrieval": {
-          changeOrigin: true,
-          secure: false,
-          timeout: 120_000,
-          proxyTimeout: 120_000,
-          target: agentRetrievalTarget,
-        },
         "/oss-workspace": {
           changeOrigin: true,
           secure: false,


### PR DESCRIPTION
﻿## Background

Closes #48.

The IMPEX UI roundtrip already checked that an exported toolbox backup could be imported, but it did not reliably prove that imported OpenAPI tools remained callable afterward. During verification, the imported toolbox could fail before reaching the backend because cloned OpenAPI tool metadata lost the `source_id` / `metadata.version` linkage, and the dev server could route the agent-operator import API through the generic `/api` proxy first.

## Changes

- Keep cloned OpenAPI tool `source_id` aligned with the regenerated `metadata.version` in the IMPEX E2E helper.
- Add a focused Playwright regression spec for OpenAPI IMPEX clone metadata linkage.
- Improve UI import helper assertion output so failed imports show status, URL, and response text.
- Reorder Vite dev proxy entries so specific execution-factory service prefixes are matched before the generic `/api` fallback.

## Impact

- Affects E2E/test helpers and local dev proxy configuration.
- Product runtime logic is unchanged.
- The proxy ordering change is intentionally narrow: service-specific prefixes now win before the generic gateway fallback.

## Verification

Passed:

```bash
pnpm exec eslint vite.config.ts tests/e2e/helpers/impex.ts tests/e2e/helpers/execution-unit-ui.ts tests/e2e/specs/execution-factory/impex-helper.spec.ts tests/e2e/specs/execution-factory/e2e-impex-ui.spec.ts
npx playwright test specs/execution-factory/impex-helper.spec.ts
npx playwright test specs/execution-factory/e2e-impex-ui.spec.ts -g "IMPEX-UI-05"
pnpm test -- --run
```

Full checks with existing unrelated failures:

```bash
pnpm lint
```

Fails on existing unused imports in `src/modules/data-connect/services/data-connect.service.ts`, `src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx`, `src/modules/knowledge-network/services/action-type-tool.service.ts`, and `src/modules/knowledge-network/services/mappers/action-type.mapper.ts`.

```bash
pnpm build
```

Fails on the same existing unused imports plus the existing `ObjectTypePropertyTable.tsx` sorter type mismatch.

## Risks

- Low. The behavioral fix is covered by the IMPEX helper regression and the UI import/debug E2E roundtrip.
