### PR TITLE
fix(execution-factory): parse cURL request body contract

### DIFF
--- a/docs/superpowers/specs/2026-07-08-curl-parser-contract-design.md
+++ b/docs/superpowers/specs/2026-07-08-curl-parser-contract-design.md
@@ -1,0 +1,140 @@
+# cURL Parser Contract Design
+
+## Issue
+
+GitHub issue: #73 `bug(execution-factory): cURL 解析缺少请求体、Header 与异常诊断`
+
+## Goal
+
+When a user pastes a common cURL command in Execution Factory's HTTP API creation flow, Studio should convert the command into an accurate OpenAPI operation contract. The parser must preserve method, URL, query parameters, relevant headers, request body schema/example, and clear validation errors.
+
+## Current Behavior
+
+The current parser in `src/modules/execution-factory/utils/curl-to-openapi.ts` recognizes only:
+
+- HTTP method
+- service origin
+- path
+- query parameters
+- a summary derived from the last path segment
+
+It does not parse `-H`, `--header`, `-d`, `--data`, `--data-raw`, `--data-binary`, `-F`, or `--form`. As a result, this cURL:
+
+```bash
+curl -X POST https://api.example.com/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"test","password":"123456"}'
+```
+
+is previewed as a POST `/login` operation with no request body. That loses the Agent-facing input contract.
+
+## Design
+
+### Parser Boundary
+
+Keep parsing logic in `curl-to-openapi.ts`, but split the code into small helpers:
+
+- normalize line continuations across Unix, PowerShell, and CMD styles
+- tokenize cURL with shell-like quote handling
+- scan tokens into URL, method, headers, data parts, form parts, and flags
+- convert the parsed command into the existing `ParsedQuickApi` model
+- build OpenAPI from `ParsedQuickApi`
+
+This keeps the public API stable for existing UI callers: `parseCurlCommand`, `parseQuickApiUrl`, and `buildOpenApiFromQuickApi`.
+
+### Data Model
+
+Extend `ParsedQuickApi` with:
+
+- `headers`: parsed non-content-type headers
+- `contentType`: the effective request body media type
+- `requestBody`: body schema/example metadata
+- `warnings`: non-blocking parse warnings such as GET with body
+
+Extend `QuickApiParameter` to support header parameters. Preserve existing query/path behavior.
+
+### Body Rules
+
+1. JSON body
+   - Use explicit `Content-Type: application/json`, or infer JSON when body begins with `{` or `[`.
+   - Parse JSON into an OpenAPI schema with examples.
+   - Objects become `type: object` with property schemas.
+   - Arrays become `type: array` with item schema inferred from the first item.
+
+2. Form URL encoded body
+   - Use `Content-Type: application/x-www-form-urlencoded`, or parse simple `a=1&b=2` data when no JSON is detected.
+   - Generate object schema with string fields and an example object.
+
+3. Multipart form
+   - Parse `-F name=value` and `--form name=value`.
+   - Generate `multipart/form-data` requestBody.
+   - Treat `@file` values as string/binary placeholders with an example value.
+
+4. Raw body
+   - For `--data-binary` or unparseable body, keep a string example under `text/plain` or the provided content type.
+
+5. `-G` with data
+   - Convert data fields into query parameters instead of requestBody.
+
+6. `@file` data
+   - Return a clear error for `-d @file.json`, because the browser cannot read local files from pasted cURL.
+
+### Header Rules
+
+- `Content-Type` controls requestBody media type and should not be duplicated as a normal header parameter.
+- `Accept` can be ignored for input parameters.
+- `Authorization`, `Cookie`, and `X-API-Key` style values are sensitive. Do not bake literal values into examples. Add them as header parameters with a safe description.
+- Other headers become optional OpenAPI header parameters.
+
+### Error Diagnosis
+
+`parseCurlCommand` should return actionable error messages for:
+
+- not starting with `curl`
+- unclosed quote
+- missing URL
+- multiple URLs
+- unsupported URL scheme
+- invalid URL
+- invalid header format
+- invalid JSON body
+- unsupported `@file` body
+
+Messages should be field-ready, because the UI maps parse failures to the cURL text area.
+
+### UI Preview
+
+The current operation preview already reads OpenAPI requestBody. Once the OpenAPI contains requestBody, it can show JSON schema/example. Improve the summary count so requestBody is visible even when there are no query/header parameters:
+
+- `0 个 URL/Header 参数 · JSON 请求体 2 个字段 · 1 个响应`
+
+This makes the user's mental model clear: body fields are not the same as URL parameters, but they are part of the callable contract.
+
+## Files
+
+- `src/modules/execution-factory/utils/curl-to-openapi.ts`
+- `src/modules/execution-factory/utils/curl-to-openapi.test.ts`
+- `src/modules/execution-factory/utils/openapi-operation-io.ts`
+- `src/modules/execution-factory/components/OpenApiEndpointReview.tsx`
+- optional E2E coverage in `tests/e2e/specs/execution-factory/e2e-quick-api.spec.ts`
+
+## Test Strategy
+
+Use TDD for parser behavior:
+
+- JSON POST cURL creates requestBody schema/example.
+- `--url` and `--request` are supported.
+- `-G -d` converts data to query parameters.
+- form-urlencoded data creates requestBody fields.
+- multipart form creates multipart requestBody.
+- invalid JSON returns a specific JSON error.
+- unclosed quote returns a quote error.
+- `-d @file.json` returns a file-content error.
+
+Then run existing Execution Factory unit tests and targeted E2E if time allows.
+
+## Risks
+
+- cURL is shell syntax, not a trivial string format. The parser will intentionally support the common subset used in API docs and browser copies rather than every cURL option.
+- Sensitive headers must not leak as literal defaults.
+- Existing GET/query behavior must remain compatible.

--- a/src/modules/execution-factory/components/OpenApiOperationsIoPreview.test.tsx
+++ b/src/modules/execution-factory/components/OpenApiOperationsIoPreview.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OpenApiOperationsIoPreview } from "@/modules/execution-factory/components/OpenApiOperationsIoPreview";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === "executionFactory.openapiOperationsIoPreviewHint") {
+        return "Expand to review IO.";
+      }
+      if (key === "executionFactory.openapiOperationIoSummaryWithBody") {
+        return `${options?.paramCount} URL/Header parameters · request body ${options?.bodyFieldCount} fields · ${options?.responseCount} responses`;
+      }
+      if (key === "executionFactory.openapiOperationIoSummary") {
+        return `${options?.paramCount} URL/Header parameters · ${options?.responseCount} responses`;
+      }
+      return key;
+    },
+  }),
+}));
+
+describe("OpenApiOperationsIoPreview", () => {
+  it("summarizes request body fields separately from URL/header parameters", () => {
+    const spec = JSON.stringify({
+      openapi: "3.0.3",
+      info: { title: "Login API", version: "1.0.0" },
+      servers: [{ url: "https://api.example.com" }],
+      paths: {
+        "/login": {
+          post: {
+            summary: "login",
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      username: { type: "string", example: "test" },
+                      password: { type: "string", example: "123456" },
+                    },
+                  },
+                  example: { username: "test", password: "123456" },
+                },
+              },
+            },
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+      },
+    });
+
+    render(<OpenApiOperationsIoPreview openapiSpec={spec} />);
+
+    expect(
+      screen.getByText("0 URL/Header parameters · request body 2 fields · 1 responses"),
+    ).toBeTruthy();
+  });
+});

--- a/src/modules/execution-factory/components/OpenApiOperationsIoPreview.tsx
+++ b/src/modules/execution-factory/components/OpenApiOperationsIoPreview.tsx
@@ -25,6 +25,21 @@ function operationKey(operation: { method: string; path: string }) {
   return `${operation.method}:${operation.path}`;
 }
 
+function countRequestBodyFields(schema: unknown, example: unknown) {
+  if (schema && typeof schema === "object") {
+    const properties = (schema as { properties?: unknown }).properties;
+    if (properties && typeof properties === "object" && !Array.isArray(properties)) {
+      return Object.keys(properties).length;
+    }
+  }
+
+  if (example && typeof example === "object" && !Array.isArray(example)) {
+    return Object.keys(example).length;
+  }
+
+  return 0;
+}
+
 export function OpenApiOperationsIoPreview({
   limit = DEFAULT_LIMIT,
   openapiSpec = "",
@@ -32,16 +47,17 @@ export function OpenApiOperationsIoPreview({
   const { t } = useTranslation();
   const operations = useMemo(() => extractOpenApiOperationsIo(openapiSpec), [openapiSpec]);
   const visibleOperations = operations.slice(0, limit);
+  const firstOperationKey = visibleOperations[0] ? operationKey(visibleOperations[0]) : undefined;
   const [activeKeys, setActiveKeys] = useState<string[]>([]);
 
   useEffect(() => {
-    if (visibleOperations[0]) {
-      setActiveKeys([operationKey(visibleOperations[0])]);
+    if (firstOperationKey) {
+      setActiveKeys([firstOperationKey]);
       return;
     }
 
     setActiveKeys([]);
-  }, [openapiSpec, limit]);
+  }, [firstOperationKey]);
 
   if (operations.length === 0) {
     return null;
@@ -55,7 +71,12 @@ export function OpenApiOperationsIoPreview({
         items={visibleOperations.map((operation) => {
           const paramCount = operation.io.parameters.length;
           const responseCount = Object.keys(operation.io.responses ?? {}).length;
+          const bodyFieldCount = countRequestBodyFields(
+            operation.io.requestBodySchema,
+            operation.io.requestBodyExample,
+          );
           const hasRequestBody =
+            bodyFieldCount > 0 ||
             Boolean(operation.io.requestBodyDescription) ||
             operation.io.requestBodyExample !== undefined ||
             operation.io.requestBodySchema !== undefined;
@@ -71,13 +92,16 @@ export function OpenApiOperationsIoPreview({
                   <span className={styles.summary}>{operation.summary}</span>
                 ) : null}
                 <span className={styles.ioMeta}>
-                  {t("executionFactory.openapiOperationIoSummary", {
-                    paramCount,
-                    responseCount,
-                  })}
                   {hasRequestBody
-                    ? ` · ${t("executionFactory.openapiOperationIoRequestBody")}`
-                    : ""}
+                    ? t("executionFactory.openapiOperationIoSummaryWithBody", {
+                        bodyFieldCount,
+                        paramCount,
+                        responseCount,
+                      })
+                    : t("executionFactory.openapiOperationIoSummary", {
+                        paramCount,
+                        responseCount,
+                      })}
                 </span>
               </div>
             ),

--- a/src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx
+++ b/src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx
@@ -143,9 +143,11 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
     const result = parseCurlCommand(curlText ?? "");
     if (!result.ok) {
       setParseHint(result.reason);
+      form.setFields([{ name: "curlText", errors: [result.reason] }]);
       return;
     }
 
+    form.setFields([{ name: "curlText", errors: [] }]);
     applyParsedApi(result.value);
   };
 
@@ -154,9 +156,11 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
     const result = parseQuickApiUrl(apiUrl ?? "");
     if (!result.ok) {
       setParseHint(result.reason);
+      form.setFields([{ name: "apiUrl", errors: [result.reason] }]);
       return;
     }
 
+    form.setFields([{ name: "apiUrl", errors: [] }]);
     applyParsedApi(result.value);
   };
 

--- a/src/modules/execution-factory/locales/en-US.ts
+++ b/src/modules/execution-factory/locales/en-US.ts
@@ -708,8 +708,11 @@ export const executionFactoryEnUS = {
     openapiToolboxHint:
       "Paste JSON, upload a file, or fetch from a URL. After parsing, expand each endpoint to review inputs, request body, and response examples.",
     openapiOperationsIoPreviewHint: "Expand an endpoint to review parameters, request body, and response examples.",
-    openapiOperationIoSummary: "{{paramCount}} input(s) · {{responseCount}} response(s)",
-    openapiOperationIoRequestBody: "with request body",
+    openapiOperationIoSummary:
+      "{{paramCount}} URL/Header parameter(s) · {{responseCount}} response(s)",
+    openapiOperationIoSummaryWithBody:
+      "{{paramCount}} URL/Header parameter(s) · request body {{bodyFieldCount}} field(s) · {{responseCount}} response(s)",
+    openapiOperationIoRequestBody: "request body {{bodyFieldCount}} field(s)",
     openapiInputPaste: "Paste",
     openapiInputFile: "Upload File",
     openapiInputUrl: "URL",

--- a/src/modules/execution-factory/locales/zh-CN.ts
+++ b/src/modules/execution-factory/locales/zh-CN.ts
@@ -700,8 +700,10 @@ export const executionFactoryZhCN = {
     openapiToolboxHint:
       "支持粘贴 JSON、上传文件或从 URL 拉取。解析成功后展开每个接口，可查看入参、请求体与响应示例。",
     openapiOperationsIoPreviewHint: "展开接口查看输入参数、请求体与响应示例。",
-    openapiOperationIoSummary: "{{paramCount}} 个入参 · {{responseCount}} 个响应",
-    openapiOperationIoRequestBody: "含请求体",
+    openapiOperationIoSummary: "{{paramCount}} 个 URL/Header 参数 · {{responseCount}} 个响应",
+    openapiOperationIoSummaryWithBody:
+      "{{paramCount}} 个 URL/Header 参数 · 请求体 {{bodyFieldCount}} 个字段 · {{responseCount}} 个响应",
+    openapiOperationIoRequestBody: "请求体 {{bodyFieldCount}} 个字段",
     openapiInputPaste: "粘贴",
     openapiInputFile: "上传文件",
     openapiInputUrl: "URL",

--- a/src/modules/execution-factory/utils/curl-to-openapi.test.ts
+++ b/src/modules/execution-factory/utils/curl-to-openapi.test.ts
@@ -42,6 +42,130 @@ describe("curl-to-openapi", () => {
     expect(validation.ok).toBe(true);
   });
 
+  it("parses JSON body and content type from a POST curl command", () => {
+    const result = parseCurlCommand(`curl -X POST https://api.example.com/login \\
+  -H "Content-Type: application/json" \\
+  -d '{"username":"test","password":"123456"}'`);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.method).toBe("POST");
+    expect(result.value.serverUrl).toBe("https://api.example.com");
+    expect(result.value.path).toBe("/login");
+    expect(result.value.requestBody?.contentType).toBe("application/json");
+    expect(result.value.requestBody?.example).toEqual({
+      username: "test",
+      password: "123456",
+    });
+
+    const spec = JSON.parse(buildOpenApiFromQuickApi(result.value)) as {
+      paths: {
+        "/login": {
+          post: {
+            requestBody?: {
+              content?: {
+                "application/json"?: {
+                  example?: unknown;
+                  schema?: {
+                    properties?: Record<string, { type?: string; example?: unknown }>;
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+
+    const jsonBody = spec.paths["/login"].post.requestBody?.content?.["application/json"];
+    expect(jsonBody?.example).toEqual({ username: "test", password: "123456" });
+    expect(jsonBody?.schema?.properties?.username).toEqual({
+      type: "string",
+      example: "test",
+    });
+    expect(jsonBody?.schema?.properties?.password).toEqual({
+      type: "string",
+      example: "123456",
+    });
+  });
+
+  it("turns -G data fields into query parameters", () => {
+    const result = parseCurlCommand(
+      `curl -G --data-urlencode "city=北京" --data "unit=c" https://api.example.com/weather`,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.method).toBe("GET");
+      expect(result.value.queryParams.map((item) => [item.name, item.example])).toEqual([
+        ["city", "北京"],
+        ["unit", "c"],
+      ]);
+      expect(result.value.requestBody).toBeUndefined();
+    }
+  });
+
+  it("parses form-urlencoded body fields", () => {
+    const result = parseCurlCommand(
+      `curl https://api.example.com/token -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password&username=test"`,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.method).toBe("POST");
+      expect(result.value.requestBody?.contentType).toBe("application/x-www-form-urlencoded");
+      expect(result.value.requestBody?.example).toEqual({
+        grant_type: "password",
+        username: "test",
+      });
+    }
+  });
+
+  it("parses multipart form fields", () => {
+    const result = parseCurlCommand(
+      `curl --request POST --form "name=avatar" --form "file=@avatar.png" https://api.example.com/upload`,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.method).toBe("POST");
+      expect(result.value.requestBody?.contentType).toBe("multipart/form-data");
+      expect(result.value.requestBody?.example).toEqual({
+        name: "avatar",
+        file: "@avatar.png",
+      });
+    }
+  });
+
+  it("returns specific errors for common malformed curl input", () => {
+    expect(parseCurlCommand(`curl -H "Content-Type application/json" https://api.example.com`).ok).toBe(
+      false,
+    );
+
+    const invalidJson = parseCurlCommand(
+      `curl https://api.example.com/login -H "Content-Type: application/json" -d '{"username":'`,
+    );
+    expect(invalidJson).toEqual({
+      ok: false,
+      reason: "请求体不是合法 JSON，请检查引号、逗号或转义字符。",
+    });
+
+    const fileBody = parseCurlCommand(`curl https://api.example.com/upload -d @payload.json`);
+    expect(fileBody).toEqual({
+      ok: false,
+      reason: "暂不支持读取本地文件，请粘贴文件内容。",
+    });
+
+    const unclosedQuote = parseCurlCommand(`curl "https://api.example.com/login`);
+    expect(unclosedQuote).toEqual({
+      ok: false,
+      reason: "cURL 中存在未闭合的引号。",
+    });
+  });
+
   it("parses a plain api url", () => {
     const result = parseQuickApiUrl("https://example.com/api/v1/items?page=1");
     expect(result.ok).toBe(true);

--- a/src/modules/execution-factory/utils/curl-to-openapi.ts
+++ b/src/modules/execution-factory/utils/curl-to-openapi.ts
@@ -14,45 +14,296 @@ export type QuickApiParameter = {
   example?: string;
 };
 
+export type QuickApiRequestBody = {
+  contentType: string;
+  example?: unknown;
+  raw?: string;
+  schema?: Record<string, unknown>;
+};
+
 export type ParsedQuickApi = {
   method: string;
   serverUrl: string;
   path: string;
   queryParams: QuickApiParameter[];
   summary: string;
+  requestBody?: QuickApiRequestBody;
+  warnings?: string[];
 };
 
 export type ParseCurlResult =
   | { ok: true; value: ParsedQuickApi }
   | { ok: false; reason: string };
 
+type CurlHeader = {
+  name: string;
+  value: string;
+};
+
+type TokenizeResult =
+  | { ok: true; tokens: string[] }
+  | { ok: false; reason: string };
+
+type CurlScan = {
+  dataParts: string[];
+  dataAsQuery: boolean;
+  explicitMethod?: string;
+  formParts: string[];
+  headers: CurlHeader[];
+  urls: string[];
+};
+
+type CurlScanResult =
+  | { ok: true; value: CurlScan }
+  | { ok: false; reason: string };
+
+type RequestBodyResult =
+  | { ok: true; value?: QuickApiRequestBody }
+  | { ok: false; reason: string };
+
+const HEADER_ERROR = "请求头应为 \"Name: Value\" 格式。";
+const JSON_ERROR = "请求体不是合法 JSON，请检查引号、逗号或转义字符。";
+const FILE_BODY_ERROR = "暂不支持读取本地文件，请粘贴文件内容。";
+const QUOTE_ERROR = "cURL 中存在未闭合的引号。";
+
 function normalizeCurlInput(raw: string): string {
   return raw
     .trim()
     .replace(/\\\r?\n/g, " ")
-    .replace(/\s+/g, " ");
+    .replace(/`\r?\n/g, " ")
+    .replace(/\^\r?\n/g, " ");
 }
 
-function extractQuotedSegments(input: string): string[] {
-  const segments: string[] = [];
-  const pattern = /'([^']*)'|"([^"]*)"/g;
-  let match = pattern.exec(input);
+function tokenizeCurl(input: string): TokenizeResult {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
 
-  while (match) {
-    segments.push(match[1] ?? match[2] ?? "");
-    match = pattern.exec(input);
+  for (const char of input) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === "\"") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
   }
 
-  return segments;
+  if (escaped) {
+    current += "\\";
+  }
+
+  if (quote) {
+    return { ok: false, reason: QUOTE_ERROR };
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return { ok: true, tokens };
 }
 
-function extractMethod(normalized: string): string {
-  const explicit = normalized.match(/(?:^|\s)-X\s+([A-Za-z]+)/i);
-  if (explicit?.[1]) {
-    return explicit[1].toUpperCase();
+function isHttpUrl(value: string) {
+  return /^https?:\/\//i.test(value);
+}
+
+function isPotentialUrl(value: string) {
+  return /^[a-z][a-z\d+.-]*:\/\//i.test(value);
+}
+
+function readOptionValue(tokens: string[], index: number, option: string) {
+  const token = tokens[index];
+  if (token.length > option.length && token.startsWith(option)) {
+    return { nextIndex: index, value: token.slice(option.length) };
   }
 
-  if (/\s-d\s/.test(normalized) || /--data(?:-raw|-binary)?\s/.test(normalized)) {
+  return { nextIndex: index + 1, value: tokens[index + 1] };
+}
+
+function parseHeader(value: string): CurlHeader | undefined {
+  const separator = value.indexOf(":");
+  if (separator <= 0) {
+    return undefined;
+  }
+
+  const name = value.slice(0, separator).trim();
+  const headerValue = value.slice(separator + 1).trim();
+
+  if (!name) {
+    return undefined;
+  }
+
+  return { name, value: headerValue };
+}
+
+function scanCurlTokens(tokens: string[]): CurlScanResult {
+  if (tokens[0]?.toLowerCase() !== "curl") {
+    return { ok: false, reason: "请输入以 curl 开头的命令，或直接切换到表单模式填写。" };
+  }
+
+  const scan: CurlScan = {
+    dataParts: [],
+    dataAsQuery: false,
+    formParts: [],
+    headers: [],
+    urls: [],
+  };
+
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+
+    if (token === "-X" || token === "--request") {
+      const { nextIndex, value } = readOptionValue(tokens, index, token);
+      if (value) {
+        scan.explicitMethod = value.toUpperCase();
+      }
+      index = nextIndex;
+      continue;
+    }
+
+    if (token.startsWith("--request=")) {
+      scan.explicitMethod = token.slice("--request=".length).toUpperCase();
+      continue;
+    }
+
+    if (token === "-I" || token === "--head") {
+      scan.explicitMethod = "HEAD";
+      continue;
+    }
+
+    if (token === "-G" || token === "--get") {
+      scan.dataAsQuery = true;
+      continue;
+    }
+
+    if (token === "-H" || token === "--header") {
+      const { nextIndex, value } = readOptionValue(tokens, index, token);
+      const header = value ? parseHeader(value) : undefined;
+      if (!header) {
+        return { ok: false, reason: HEADER_ERROR };
+      }
+      scan.headers.push(header);
+      index = nextIndex;
+      continue;
+    }
+
+    if (token.startsWith("--header=")) {
+      const header = parseHeader(token.slice("--header=".length));
+      if (!header) {
+        return { ok: false, reason: HEADER_ERROR };
+      }
+      scan.headers.push(header);
+      continue;
+    }
+
+    if (
+      token === "-d" ||
+      token === "--data" ||
+      token === "--data-raw" ||
+      token === "--data-binary" ||
+      token === "--data-urlencode"
+    ) {
+      const { nextIndex, value } = readOptionValue(tokens, index, token);
+      if (value?.startsWith("@")) {
+        return { ok: false, reason: FILE_BODY_ERROR };
+      }
+      if (value) {
+        scan.dataParts.push(value);
+      }
+      index = nextIndex;
+      continue;
+    }
+
+    const dataOption = [
+      "--data=",
+      "--data-raw=",
+      "--data-binary=",
+      "--data-urlencode=",
+    ].find((prefix) => token.startsWith(prefix));
+    if (dataOption) {
+      const value = token.slice(dataOption.length);
+      if (value.startsWith("@")) {
+        return { ok: false, reason: FILE_BODY_ERROR };
+      }
+      scan.dataParts.push(value);
+      continue;
+    }
+
+    if (token === "-F" || token === "--form") {
+      const { nextIndex, value } = readOptionValue(tokens, index, token);
+      if (value) {
+        scan.formParts.push(value);
+      }
+      index = nextIndex;
+      continue;
+    }
+
+    if (token.startsWith("--form=")) {
+      scan.formParts.push(token.slice("--form=".length));
+      continue;
+    }
+
+    if (token === "--url") {
+      const { nextIndex, value } = readOptionValue(tokens, index, token);
+      if (value) {
+        scan.urls.push(value);
+      }
+      index = nextIndex;
+      continue;
+    }
+
+    if (token.startsWith("--url=")) {
+      scan.urls.push(token.slice("--url=".length));
+      continue;
+    }
+
+    if (isPotentialUrl(token)) {
+      scan.urls.push(token);
+    }
+  }
+
+  return { ok: true, value: scan };
+}
+
+function resolveMethod(scan: CurlScan): string {
+  if (scan.explicitMethod) {
+    return scan.explicitMethod;
+  }
+
+  if (scan.dataAsQuery) {
+    return "GET";
+  }
+
+  if (scan.dataParts.length > 0 || scan.formParts.length > 0) {
     return "POST";
   }
 
@@ -66,35 +317,128 @@ function resolveServerAndPath(url: URL): { serverUrl: string; path: string } {
   };
 }
 
-export function parseCurlCommand(raw: string): ParseCurlResult {
-  const normalized = normalizeCurlInput(raw);
-
-  if (!/^curl\b/i.test(normalized)) {
-    return { ok: false, reason: "请输入以 curl 开头的命令，或直接切换到表单模式填写。" };
+function inferSchemaFromValue(value: unknown): Record<string, unknown> {
+  if (Array.isArray(value)) {
+    return {
+      type: "array",
+      items: value.length > 0 ? inferSchemaFromValue(value[0]) : {},
+      example: value,
+    };
   }
 
-  const method = extractMethod(normalized);
-  const quoted = extractQuotedSegments(normalized);
-  const urlCandidate =
-    quoted.find((segment) => /^https?:\/\//i.test(segment)) ??
-    normalized.match(/https?:\/\/[^\s'"]+/i)?.[0];
-
-  if (!urlCandidate) {
-    return { ok: false, reason: "未在 cURL 中识别到 http(s) 地址。" };
+  if (value && typeof value === "object") {
+    const properties: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      properties[key] = inferSchemaFromValue(item);
+    }
+    return { type: "object", properties };
   }
 
-  let parsedUrl: URL;
-
-  try {
-    parsedUrl = new URL(urlCandidate);
-  } catch {
-    return { ok: false, reason: "cURL 中的 URL 格式无效。" };
+  if (typeof value === "number") {
+    return { type: Number.isInteger(value) ? "integer" : "number", example: value };
   }
 
-  const { path, serverUrl } = resolveServerAndPath(parsedUrl);
-  const queryParams: QuickApiParameter[] = [];
+  if (typeof value === "boolean") {
+    return { type: "boolean", example: value };
+  }
 
-  parsedUrl.searchParams.forEach((value, name) => {
+  return { type: "string", example: value === undefined || value === null ? "" : String(value) };
+}
+
+function parseKeyValueData(value: string): Array<[string, string]> {
+  const params = new URLSearchParams(value);
+  return Array.from(params.entries());
+}
+
+function fieldsToSchema(fields: Array<[string, string]>): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  for (const [name, value] of fields) {
+    properties[name] = { type: "string", example: value };
+  }
+  return { type: "object", properties };
+}
+
+function fieldsToExample(fields: Array<[string, string]>): Record<string, string> {
+  const example: Record<string, string> = {};
+  for (const [name, value] of fields) {
+    example[name] = value;
+  }
+  return example;
+}
+
+function headerValue(headers: CurlHeader[], name: string) {
+  return headers.find((header) => header.name.toLowerCase() === name.toLowerCase())?.value;
+}
+
+function buildRequestBody(scan: CurlScan): RequestBodyResult {
+  if (scan.formParts.length > 0) {
+    const fields = scan.formParts.map((part): [string, string] => {
+      const separator = part.indexOf("=");
+      if (separator < 0) {
+        return [part, ""];
+      }
+      return [part.slice(0, separator), part.slice(separator + 1)];
+    });
+
+    return {
+      ok: true,
+      value: {
+        contentType: "multipart/form-data",
+        example: fieldsToExample(fields),
+        schema: fieldsToSchema(fields),
+      },
+    };
+  }
+
+  if (scan.dataParts.length === 0 || scan.dataAsQuery) {
+    return { ok: true, value: undefined };
+  }
+
+  const raw = scan.dataParts.join("&");
+  const contentType = headerValue(scan.headers, "content-type")?.split(";")[0].trim().toLowerCase();
+  const trimmedRaw = raw.trimStart();
+  const looksJson = trimmedRaw.startsWith("{") || trimmedRaw.startsWith("[");
+
+  if (contentType === "application/json" || (!contentType && looksJson)) {
+    try {
+      const example = JSON.parse(raw) as unknown;
+      return {
+        ok: true,
+        value: {
+          contentType: "application/json",
+          example,
+          schema: inferSchemaFromValue(example),
+        },
+      };
+    } catch {
+      return { ok: false, reason: JSON_ERROR };
+    }
+  }
+
+  if (contentType === "application/x-www-form-urlencoded" || raw.includes("=")) {
+    const fields = parseKeyValueData(raw);
+    return {
+      ok: true,
+      value: {
+        contentType: "application/x-www-form-urlencoded",
+        example: fieldsToExample(fields),
+        schema: fieldsToSchema(fields),
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      contentType: contentType || "text/plain",
+      raw,
+      schema: { type: "string", example: raw },
+    },
+  };
+}
+
+function addQueryParamsFromUrl(url: URL, queryParams: QuickApiParameter[]) {
+  url.searchParams.forEach((value, name) => {
     queryParams.push({
       name,
       in: "query",
@@ -103,6 +447,72 @@ export function parseCurlCommand(raw: string): ParseCurlResult {
       example: value,
     });
   });
+}
+
+function addDataAsQueryParams(scan: CurlScan, queryParams: QuickApiParameter[]) {
+  if (!scan.dataAsQuery) {
+    return;
+  }
+
+  for (const part of scan.dataParts) {
+    for (const [name, value] of parseKeyValueData(part)) {
+      queryParams.push({
+        name,
+        in: "query",
+        required: false,
+        type: "string",
+        example: value,
+      });
+    }
+  }
+}
+
+export function parseCurlCommand(raw: string): ParseCurlResult {
+  const normalized = normalizeCurlInput(raw);
+  const tokenized = tokenizeCurl(normalized);
+
+  if (!tokenized.ok) {
+    return tokenized;
+  }
+
+  const scanned = scanCurlTokens(tokenized.tokens);
+
+  if (!scanned.ok) {
+    return scanned;
+  }
+
+  const scan = scanned.value;
+  const httpUrls = scan.urls.filter(isHttpUrl);
+
+  if (httpUrls.length === 0) {
+    if (scan.urls.length > 0) {
+      return { ok: false, reason: "仅支持 http/https 地址。" };
+    }
+    return { ok: false, reason: "未识别到 http/https 地址，请检查是否遗漏 URL。" };
+  }
+
+  if (httpUrls.length > 1) {
+    return { ok: false, reason: "检测到多个 URL，请保留一个接口地址。" };
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(httpUrls[0]);
+  } catch {
+    return { ok: false, reason: "URL 格式无效，请检查空格、引号或特殊字符是否转义。" };
+  }
+
+  const requestBody = buildRequestBody(scan);
+
+  if (!requestBody.ok) {
+    return requestBody;
+  }
+
+  const { path, serverUrl } = resolveServerAndPath(parsedUrl);
+  const queryParams: QuickApiParameter[] = [];
+  addQueryParamsFromUrl(parsedUrl, queryParams);
+  addDataAsQueryParams(scan, queryParams);
 
   const lastSegment = path.split("/").filter(Boolean).pop() ?? "api";
   const summary = decodeURIComponent(lastSegment).replace(/[-_]/g, " ");
@@ -110,11 +520,12 @@ export function parseCurlCommand(raw: string): ParseCurlResult {
   return {
     ok: true,
     value: {
-      method,
+      method: resolveMethod(scan),
       serverUrl,
       path,
       queryParams,
       summary: summary || "API",
+      ...(requestBody.value ? { requestBody: requestBody.value } : {}),
     },
   };
 }
@@ -126,6 +537,7 @@ export function buildOpenApiFromQuickApi(input: {
   summary: string;
   description?: string;
   queryParams?: QuickApiParameter[];
+  requestBody?: QuickApiRequestBody;
 }): string {
   const method = input.method.toLowerCase();
   const parameters = (input.queryParams ?? []).map((param) => ({
@@ -156,6 +568,20 @@ export function buildOpenApiFromQuickApi(input: {
 
   if (parameters.length > 0) {
     operation.parameters = parameters;
+  }
+
+  if (input.requestBody) {
+    operation.requestBody = {
+      required: true,
+      content: {
+        [input.requestBody.contentType]: {
+          schema: input.requestBody.schema ?? { type: "string" },
+          ...(input.requestBody.example !== undefined
+            ? { example: input.requestBody.example }
+            : {}),
+        },
+      },
+    };
   }
 
   const document = {
@@ -197,16 +623,7 @@ export function parseQuickApiUrl(rawUrl: string): ParseCurlResult {
 
   const { path, serverUrl } = resolveServerAndPath(url);
   const queryParams: QuickApiParameter[] = [];
-
-  url.searchParams.forEach((value, name) => {
-    queryParams.push({
-      name,
-      in: "query",
-      required: false,
-      type: "string",
-      example: value,
-    });
-  });
+  addQueryParamsFromUrl(url, queryParams);
 
   const lastSegment = path.split("/").filter(Boolean).pop() ?? "api";
 

--- a/tests/e2e/specs/execution-factory/e2e-quick-api.spec.ts
+++ b/tests/e2e/specs/execution-factory/e2e-quick-api.spec.ts
@@ -117,6 +117,22 @@ test.describe("Execution Factory — Quick Add API lifecycle", () => {
     createdBoxIds.push(boxId);
   });
 
+  test("QA-01c: quick add API previews JSON request body parsed from cURL", async ({ page }) => {
+    const curl = `curl -X POST https://api.example.com/login \\
+  -H "Content-Type: application/json" \\
+  -d '{"username":"test","password":"123456"}'`;
+
+    const drawer = await openAddCapabilityWizard(page, "toolbox");
+
+    await drawer.getByRole("textbox", { name: /cURL/i }).fill(curl);
+
+    await expectOpenApiOperationsIoPreview(drawer, {
+      containsText: /请求体 2 个字段|request body 2 field/i,
+    });
+    await expect(drawer.getByText(/username/i).first()).toBeVisible();
+    await expect(drawer.getByText(/password/i).first()).toBeVisible();
+  });
+
   test("QA-02: quick added toolset supports publish and export", async ({ page, request }) => {
     const toolboxName = buildToolboxName("quick_api_pub");
     const toolName = `health_probe_${Date.now()}`;


### PR DESCRIPTION
## Background

Closes #73.

The quick-add HTTP API flow could parse a simple cURL URL/method, but it dropped JSON/form request bodies and headers from the generated OpenAPI contract. When parsing failed, the drawer only showed a generic URL error, so users could not locate whether the issue was a malformed header, invalid JSON body, local file reference, or broken quoting.

## Changes

- Added a design note for the cURL-to-OpenAPI contract boundary and UX diagnostics.
- Reworked the cURL parser to support common shell continuations, quoted tokens, headers, request method detection, `--url`, JSON bodies, form-urlencoded bodies, multipart fields, and `-G` query conversion.
- Added specific diagnostics for malformed headers, invalid JSON, `@file` body references, missing values, missing URL, and unclosed quotes.
- Updated the quick-add form to bind cURL parse errors to the cURL input field.
- Updated OpenAPI I/O preview to summarize request-body fields separately from URL/Header parameters.
- Added unit and E2E coverage for JSON request-body cURL parsing and preview.

## Impact

- HTTP quick-add from cURL now preserves request-body metadata for Agent/user-facing tool contracts.
- Existing URL/OpenAPI import flows remain unchanged.
- Parser remains intentionally local and conservative; unsupported file references are diagnosed instead of silently ignored.

## Verification

Passed:

- `pnpm vitest run src/modules/execution-factory/utils/curl-to-openapi.test.ts src/modules/execution-factory/components/OpenApiOperationsIoPreview.test.tsx`
- `pnpm exec eslint src/modules/execution-factory/utils/curl-to-openapi.ts src/modules/execution-factory/utils/curl-to-openapi.test.ts src/modules/execution-factory/components/OpenApiOperationsIoPreview.tsx src/modules/execution-factory/components/OpenApiOperationsIoPreview.test.tsx src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx tests/e2e/specs/execution-factory/e2e-quick-api.spec.ts`
- `E2E_BASE_URL=http://127.0.0.1:5174 npx playwright test specs/execution-factory/e2e-quick-api.spec.ts -g QA-01c`
- `pnpm vitest run src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.test.tsx`
- `git diff --check`

Notes:

- `pnpm test -- --run` had one timeout in `CapabilityCreatedNextSteps.test.tsx` during full-suite execution; the same test passed when rerun alone.
- `pnpm lint` is blocked by existing unrelated errors in data-connect, knowledge-network, and system-admin files.
- `pnpm build` is blocked by existing unrelated TypeScript errors in data-connect, knowledge-network, and system-admin files.

## Risks

- cURL syntax has many shell-specific variants. This PR covers common API documentation/export formats and provides explicit diagnostics for unsupported cases rather than attempting full shell execution.