### PR TITLE
fix(execution-factory): resolve relative OpenAPI server URLs

### DIFF
--- a/docs/superpowers/specs/2026-07-08-openapi-relative-server-url-import-design.md
+++ b/docs/superpowers/specs/2026-07-08-openapi-relative-server-url-import-design.md
@@ -1,0 +1,145 @@
+# OpenAPI Relative Server URL Import Design
+
+## Issue
+
+GitHub issue: #80 `bug(execution-factory): OpenAPI import accepts relative servers URL then fails on save`
+
+## Problem
+
+The OpenAPI import drawer can fetch and validate a public OpenAPI 3.x document such as:
+
+```text
+https://petstore3.swagger.io/api/v3/openapi.json
+```
+
+The document validates successfully and endpoint preview works. However, its first server is relative:
+
+```json
+{
+  "servers": [{ "url": "/api/v3" }]
+}
+```
+
+The UI currently fills the Service URL with `/api/v3`. The backend registration path requires a full HTTP(S) service URL, so the final save fails with a generic URL-format error. This is confusing because users already saw "OpenAPI document validated successfully".
+
+## User Story
+
+As a user importing an OpenAPI interface set from a URL, I want the system to resolve relative `servers.url` values against the OpenAPI document URL when possible, so I can import public OpenAPI documents without manually editing JSON.
+
+As a user importing by paste or file upload, I want a clear prompt when `servers.url` is relative, so I know that I must provide the absolute service URL before saving.
+
+## Design Goals
+
+- Preserve OpenAPI structural validation: relative `servers.url` is legal OpenAPI and should not make the document invalid.
+- Add import-time service URL validation because the Execution Factory runtime requires an absolute callable base URL.
+- Resolve relative server URLs only when the OpenAPI document source URL is known.
+- Show field-level, actionable guidance before submit.
+- Avoid backend API changes.
+
+## Proposed Data Flow
+
+### 1. Track OpenAPI Document Source
+
+`OpenApiSpecInput` already supports paste, file upload, and URL fetch. Extend its `onChange` contract or add a second callback so consumers can know the source:
+
+```ts
+type OpenApiSpecSource =
+  | { kind: "paste" }
+  | { kind: "file"; fileName?: string }
+  | { kind: "url"; url: string };
+```
+
+`ImportOpenApiCapabilityForm` stores this source in local state next to `openapiSpec`.
+
+### 2. Analyze Server URL Intent
+
+Add a utility near `metadata-content.ts`, or a small dedicated helper:
+
+```ts
+type ResolvedOpenApiServerUrl =
+  | { ok: true; url: string; source: "absolute" | "resolved-relative" }
+  | { ok: false; reason: string; relativeUrl?: string };
+```
+
+Rules:
+
+- If `servers[0].url` is absolute `http://` or `https://`, return it unchanged.
+- If it starts with `/` and source is URL, resolve with the source origin:
+  - source: `https://petstore3.swagger.io/api/v3/openapi.json`
+  - server: `/api/v3`
+  - result: `https://petstore3.swagger.io/api/v3`
+- If it is relative without leading slash, resolve against the source document directory:
+  - source: `https://example.com/docs/openapi.json`
+  - server: `../api`
+  - result: `https://example.com/api`
+- If source is paste or file and server is relative, do not guess. Return a validation warning that asks the user to fill Service URL manually.
+- If no valid server exists, keep existing structural validation behavior for missing/empty servers.
+
+### 3. Fill Service URL Before Submit
+
+When `analysis.ok`:
+
+- Use the resolver to compute the callable service URL.
+- If resolver succeeds, set `serviceUrl` to the resolved absolute URL.
+- If resolver fails because the server is relative and source is unknown, keep the service field editable and set a field warning/error:
+  - "The OpenAPI server `/api/v3` is relative. Please enter a full service URL, for example `https://example.com/api/v3`."
+
+### 4. Submit Guard
+
+Before calling `onSubmit`, validate the final `serviceUrl`:
+
+- Must be absolute HTTP(S).
+- If invalid, set the `serviceUrl` field error and scroll/focus it.
+- Do not let the request reach backend with `/api/v3`.
+
+This prevents the generic backend URL-format toast from being the first feedback.
+
+### 5. User Feedback
+
+When a relative server URL is resolved from URL source, show a calm informational hint:
+
+```text
+Detected relative OpenAPI server /api/v3 and resolved it to https://petstore3.swagger.io/api/v3.
+```
+
+When manual input is required:
+
+```text
+This OpenAPI document uses a relative server URL /api/v3. Enter the full service URL before importing.
+```
+
+Use the same subtle blue-gray information style as the Execution Factory import and debug panels. Avoid red until the user tries to submit without a valid URL.
+
+## Files
+
+Likely files to update:
+
+- `src/modules/execution-factory/components/OpenApiSpecInput.tsx`
+- `src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx`
+- `src/modules/execution-factory/utils/metadata-content.ts`
+- `src/modules/execution-factory/locales/zh-CN.ts`
+- `src/modules/execution-factory/locales/en-US.ts`
+- `src/modules/execution-factory/utils/metadata-content.test.ts`
+- A component or E2E test for URL import with Petstore-style relative server.
+
+## Test Plan
+
+Unit tests:
+
+- Absolute server URL remains unchanged.
+- URL source plus `/api/v3` resolves to origin + path.
+- URL source plus `../api` resolves relative to the document URL directory.
+- Paste/file source plus `/api/v3` returns a manual-input warning.
+- Submit guard rejects `/api/v3` with a service URL field error.
+
+E2E/component tests:
+
+- In OpenAPI import URL mode, fill `https://petstore3.swagger.io/api/v3/openapi.json`.
+- After fetch, Service URL is `https://petstore3.swagger.io/api/v3`.
+- Endpoint preview still shows operations.
+- Import submit no longer fails because of `/api/v3`.
+
+## Risks
+
+- Some OpenAPI documents intentionally use relative servers for deployment portability. Resolving relative URLs should only happen when the source URL is known and should remain editable.
+- External network availability can make E2E flaky. Prefer component tests with mocked fetch for CI; keep live Petstore URL as manual verification or optional E2E.

--- a/src/modules/execution-factory/components/OpenApiOperationsIoPreview.module.css
+++ b/src/modules/execution-factory/components/OpenApiOperationsIoPreview.module.css
@@ -2,6 +2,23 @@
   margin-top: 8px;
 }
 
+.root :global(.ant-collapse) {
+  border-color: var(--color-interface-panel-border);
+  background: var(--color-interface-panel-bg);
+}
+
+.root :global(.ant-collapse-item) {
+  border-color: var(--color-interface-panel-border);
+}
+
+.root :global(.ant-collapse-content) {
+  border-color: var(--color-interface-panel-border);
+}
+
+.root :global(.ant-collapse-header) {
+  background: var(--color-interface-panel-bg);
+}
+
 .hint {
   margin-bottom: 8px;
   color: rgba(0, 0, 0, 0.55);
@@ -27,13 +44,13 @@
 }
 
 .ioMeta {
-  color: rgba(0, 0, 0, 0.45);
+  color: var(--color-interface-panel-muted);
   font-size: 12px;
 }
 
 .more {
   margin-top: 8px;
-  color: rgba(0, 0, 0, 0.45);
+  color: var(--color-interface-panel-muted);
   font-size: 12px;
 }
 

--- a/src/modules/execution-factory/components/OpenApiSpecInput.module.css
+++ b/src/modules/execution-factory/components/OpenApiSpecInput.module.css
@@ -55,9 +55,9 @@
 .previewPanel {
   margin-top: 8px;
   padding: 10px 12px;
-  border: 1px solid rgba(18, 110, 227, 0.15);
+  border: 1px solid var(--color-interface-panel-border);
   border-radius: 8px;
-  background: rgba(18, 110, 227, 0.04);
+  background: var(--color-interface-panel-bg);
 }
 
 .previewMeta {
@@ -82,18 +82,18 @@
 
 .previewMore {
   margin-top: 6px;
-  color: rgba(0, 0, 0, 0.45);
+  color: var(--color-interface-panel-muted);
   font-size: 12px;
 }
 
 .validationSuccess {
   margin-top: 8px;
-  border-color: rgba(23, 125, 78, 0.2);
-  background: rgba(23, 125, 78, 0.055);
+  border-color: var(--color-interface-panel-border);
+  background: var(--color-interface-panel-bg);
 }
 
 .validationSuccess :global(.ant-alert-icon) {
-  color: #177d4e;
+  color: var(--color-interface-success-dot);
 }
 
 .validationSuccess :global(.ant-alert-message) {

--- a/src/modules/execution-factory/components/OpenApiSpecInput.tsx
+++ b/src/modules/execution-factory/components/OpenApiSpecInput.tsx
@@ -20,6 +20,7 @@ import {
 import {
   analyzeOpenApiDocumentText,
   extractOpenApiMetadataHints,
+  type OpenApiSpecSource,
   validateOpenApiDocumentText,
 } from "@/modules/execution-factory/utils/metadata-content";
 import { triggerBrowserDownload } from "@/modules/execution-factory/utils/download-file";
@@ -33,7 +34,7 @@ type OpenApiSpecInputProps = {
   rows?: number;
   showEndpointReview?: boolean;
   value?: string;
-  onChange?: (value: string) => void;
+  onChange?: (value: string, source?: OpenApiSpecSource) => void;
 };
 
 type InputMode = "paste" | "file" | "url";
@@ -65,13 +66,13 @@ export function OpenApiSpecInput({
   }, [onMetadataHints, onValidationChange, validation.ok, value]);
 
   const handlePasteChange = (nextValue: string) => {
-    onChange?.(nextValue);
+    onChange?.(nextValue, { kind: "paste" });
   };
 
   const readFileText = async (file: File) => {
     const text = await file.text();
     setFetchError(null);
-    onChange?.(text);
+    onChange?.(text, { kind: "file", fileName: file.name });
   };
 
   const uploadProps: UploadProps = {
@@ -101,7 +102,7 @@ export function OpenApiSpecInput({
       }
 
       const text = await response.text();
-      onChange?.(text);
+      onChange?.(text, { kind: "url", url: trimmed });
       setMode("paste");
     } catch (error) {
       setFetchError(error instanceof Error ? error.message : String(error));

--- a/src/modules/execution-factory/components/ToolDebugModal.module.css
+++ b/src/modules/execution-factory/components/ToolDebugModal.module.css
@@ -6,13 +6,13 @@
 }
 
 .resultPanelSuccess {
-  border: 1px solid rgba(21, 94, 117, 0.18);
-  background: #f8fafc;
+  border: 1px solid var(--color-interface-panel-border);
+  background: var(--color-interface-panel-bg);
 }
 
 .resultPanelWarning {
-  border: 1px solid rgba(180, 83, 9, 0.24);
-  background: #fffaf3;
+  border: 1px solid var(--color-interface-warning-border);
+  background: var(--color-interface-warning-bg);
 }
 
 .resultHeader {
@@ -32,13 +32,13 @@
 }
 
 .statusDotSuccess {
-  background: #0f9f6e;
-  box-shadow: 0 0 0 3px rgba(15, 159, 110, 0.12);
+  background: var(--color-interface-success-dot);
+  box-shadow: 0 0 0 3px var(--color-interface-success-ring);
 }
 
 .statusDotWarning {
-  background: #d97706;
-  box-shadow: 0 0 0 3px rgba(217, 119, 6, 0.14);
+  background: var(--color-interface-warning-dot);
+  box-shadow: 0 0 0 3px var(--color-interface-warning-ring);
 }
 
 .resultTitle {
@@ -47,14 +47,14 @@
 }
 
 .resultMeta {
-  color: rgba(15, 30, 54, 0.52);
+  color: var(--color-interface-panel-muted);
   font-size: 12px;
   margin-left: auto;
 }
 
 .resultCode {
-  background: #ffffff;
-  color: #182235;
+  background: var(--color-interface-code-bg);
+  color: var(--color-interface-code-text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
   font-size: 12px;
   line-height: 1.58;

--- a/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.test.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ImportOpenApiCapabilityForm } from "@/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm";
+
+const petstoreSpec = JSON.stringify({
+  openapi: "3.0.4",
+  info: { title: "Swagger Petstore", version: "1.0.0" },
+  servers: [{ url: "/api/v3" }],
+  paths: {
+    "/pet": {
+      put: {
+        summary: "Update a pet",
+        responses: { "200": { description: "OK" } },
+      },
+    },
+  },
+});
+
+const translate = (key: string, options?: Record<string, unknown>) => {
+  const labels: Record<string, string> = {
+    "common.description": "Description",
+    "common.required": "Required",
+    "executionFactory.businessIntro.importOpenApiTop": "Import OpenAPI.",
+    "executionFactory.businessIntro.toolboxPlacementSection": "Toolbox placement.",
+    "executionFactory.importOpenApiCapabilityPreview": `OpenAPI ${options?.version} with ${options?.count} endpoint(s)`,
+    "executionFactory.importOpenApiRelativeServerResolved": `Detected relative OpenAPI server ${options?.relativeUrl} and resolved it to ${options?.serviceUrl}.`,
+    "executionFactory.quickApiToolboxExisting": "Existing toolset",
+    "executionFactory.quickApiToolboxNew": "New toolset",
+    "executionFactory.quickApiToolboxTarget": "Add to toolset",
+    "executionFactory.serviceUrl": "Service URL",
+    "executionFactory.toolboxName": "Toolbox name",
+    "executionFactory.useRule": "Use rule",
+  };
+
+  return labels[key] ?? key;
+};
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    matches: false,
+    media: query,
+    onchange: null,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  })),
+});
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: {
+    init: vi.fn(),
+    type: "3rdParty",
+  },
+  useTranslation: () => ({
+    t: translate,
+  }),
+}));
+
+vi.mock("@/modules/execution-factory/services/toolbox.service", () => ({
+  listToolboxes: vi.fn(async () => ({ items: [] })),
+}));
+
+vi.mock("@/modules/execution-factory/components/CapabilityBusinessIntro", () => ({
+  CapabilityBusinessIntro: ({ messageKey }: { messageKey: string }) => <p>{messageKey}</p>,
+  ToolboxPlacementIntro: () => null,
+}));
+
+vi.mock("@/modules/execution-factory/components/CapabilityCategoryFields", () => ({
+  CapabilityCategoryFields: () => null,
+}));
+
+vi.mock("@/modules/execution-factory/components/OperatorSyncPublishFields", () => ({
+  OperatorSyncPublishFields: () => null,
+}));
+
+vi.mock("@/modules/execution-factory/components/OpenApiSpecInput", () => ({
+  OpenApiSpecInput: ({
+    onChange,
+  }: {
+    onChange?: (value: string, source?: { kind: "url"; url: string }) => void;
+  }) => (
+    <button
+      onClick={() =>
+        onChange?.(petstoreSpec, {
+          kind: "url",
+          url: "https://petstore3.swagger.io/api/v3/openapi.json",
+        })
+      }
+      type="button"
+    >
+      Load Petstore OpenAPI
+    </button>
+  ),
+}));
+
+describe("ImportOpenApiCapabilityForm", () => {
+  it("resolves a relative server URL from the fetched OpenAPI document URL", async () => {
+    render(<ImportOpenApiCapabilityForm formId="import-openapi" onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Load Petstore OpenAPI" }));
+
+    expect(await screen.findByDisplayValue("https://petstore3.swagger.io/api/v3")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Detected relative OpenAPI server /api/v3 and resolved it to https://petstore3.swagger.io/api/v3.",
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.test.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.test.tsx
@@ -111,6 +111,7 @@ describe("ImportOpenApiCapabilityForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "Load Petstore OpenAPI" }));
 
     expect(await screen.findByDisplayValue("https://petstore3.swagger.io/api/v3")).toBeTruthy();
+    expect(screen.getByDisplayValue("Swagger_Petstore")).toBeTruthy();
     expect(
       screen.getByText(
         "Detected relative OpenAPI server /api/v3 and resolved it to https://petstore3.swagger.io/api/v3.",

--- a/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx
@@ -36,10 +36,13 @@ import {
   analyzeOpenApiDocumentText,
 
   extractOpenApiMetadataHints,
+  normalizeGeneratedCapabilityName,
   resolveOpenApiServiceUrl,
   type OpenApiSpecSource,
 
 } from "@/modules/execution-factory/utils/metadata-content";
+
+import styles from "./create-menu.module.css";
 
 
 
@@ -206,7 +209,8 @@ export const ImportOpenApiCapabilityForm = forwardRef<
 
         form.setFieldsValue({
 
-          toolboxName: hints.title?.trim() || form.getFieldValue("toolboxName"),
+          toolboxName:
+            normalizeGeneratedCapabilityName(hints.title) || form.getFieldValue("toolboxName"),
 
           toolboxDescription: hints.description ?? form.getFieldValue("toolboxDescription"),
 
@@ -312,6 +316,8 @@ export const ImportOpenApiCapabilityForm = forwardRef<
       {analysis.ok ? (
 
         <Alert
+
+          className={styles.interfaceSuccessAlert}
 
           message={t("executionFactory.importOpenApiCapabilityPreview", {
 

--- a/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx
@@ -36,6 +36,8 @@ import {
   analyzeOpenApiDocumentText,
 
   extractOpenApiMetadataHints,
+  resolveOpenApiServiceUrl,
+  type OpenApiSpecSource,
 
 } from "@/modules/execution-factory/utils/metadata-content";
 
@@ -96,6 +98,7 @@ export const ImportOpenApiCapabilityForm = forwardRef<
   const [form] = Form.useForm<ImportOpenApiCapabilityFormValues>();
 
   const [openapiSpec, setOpenApiSpec] = useState("");
+  const [openapiSource, setOpenApiSource] = useState<OpenApiSpecSource>({ kind: "paste" });
 
   const [parseHint, setParseHint] = useState<string | null>(null);
 
@@ -158,6 +161,10 @@ export const ImportOpenApiCapabilityForm = forwardRef<
 
 
   const analysis = useMemo(() => analyzeOpenApiDocumentText(openapiSpec), [openapiSpec]);
+  const resolvedServiceUrl = useMemo(
+    () => (analysis.ok ? resolveOpenApiServiceUrl(openapiSpec, openapiSource) : undefined),
+    [analysis, openapiSource, openapiSpec],
+  );
 
 
 
@@ -175,11 +182,21 @@ export const ImportOpenApiCapabilityForm = forwardRef<
 
     if (analysis.ok) {
 
-      setParseHint(
+      const nextParseHint =
+        resolvedServiceUrl?.ok && resolvedServiceUrl.source === "resolved-relative"
+          ? t("executionFactory.importOpenApiRelativeServerResolved", {
+              relativeUrl: analysis.serverUrl,
+              serviceUrl: resolvedServiceUrl.url,
+            })
+          : resolvedServiceUrl && !resolvedServiceUrl.ok && resolvedServiceUrl.relativeUrl
+            ? t("executionFactory.importOpenApiRelativeServerManual", {
+                relativeUrl: resolvedServiceUrl.relativeUrl,
+              })
+            : t("executionFactory.importOpenApiCapabilityParsed", {
+                count: analysis.operationCount,
+              });
 
-        t("executionFactory.importOpenApiCapabilityParsed", { count: analysis.operationCount }),
-
-      );
+      setParseHint(nextParseHint);
 
 
 
@@ -193,10 +210,24 @@ export const ImportOpenApiCapabilityForm = forwardRef<
 
           toolboxDescription: hints.description ?? form.getFieldValue("toolboxDescription"),
 
-          serviceUrl: analysis.serverUrl ?? form.getFieldValue("serviceUrl"),
+          serviceUrl:
+            resolvedServiceUrl?.ok
+              ? resolvedServiceUrl.url
+              : analysis.serverUrl ?? form.getFieldValue("serviceUrl"),
 
         });
 
+      }
+
+      form.setFieldsValue({
+        serviceUrl:
+          resolvedServiceUrl?.ok
+            ? resolvedServiceUrl.url
+            : analysis.serverUrl ?? form.getFieldValue("serviceUrl"),
+      });
+
+      if (resolvedServiceUrl?.ok) {
+        form.setFields([{ name: "serviceUrl", errors: [] }]);
       }
 
       return;
@@ -207,7 +238,7 @@ export const ImportOpenApiCapabilityForm = forwardRef<
 
     setParseHint(t("executionFactory.importOpenApiCapabilityFileReady"));
 
-  }, [analysis, form, initialBoxId, openapiSpec, t]);
+  }, [analysis, form, initialBoxId, openapiSpec, resolvedServiceUrl, t]);
 
 
 
@@ -221,9 +252,23 @@ export const ImportOpenApiCapabilityForm = forwardRef<
 
     }
 
+    const serviceUrl = values.serviceUrl?.trim();
+    if (!serviceUrl || !/^https?:\/\//i.test(serviceUrl)) {
+      const message =
+        resolvedServiceUrl && !resolvedServiceUrl.ok && resolvedServiceUrl.relativeUrl
+          ? t("executionFactory.importOpenApiRelativeServerManual", {
+              relativeUrl: resolvedServiceUrl.relativeUrl,
+            })
+          : t("executionFactory.importOpenApiServiceUrlRequired");
+      form.setFields([{ name: "serviceUrl", errors: [message] }]);
+      form.scrollToField("serviceUrl", { behavior: "smooth", focus: true });
+      setParseHint(message);
+      return;
+    }
 
 
-    onSubmit({ openapiSpec, values });
+
+    onSubmit({ openapiSpec, values: { ...values, serviceUrl } });
 
   };
 
@@ -237,7 +282,12 @@ export const ImportOpenApiCapabilityForm = forwardRef<
 
       <OpenApiSpecInput
 
-        onChange={setOpenApiSpec}
+        onChange={(value, source) => {
+          setOpenApiSpec(value);
+          if (source) {
+            setOpenApiSource(source);
+          }
+        }}
 
         registrationTarget="toolbox"
 
@@ -286,6 +336,12 @@ export const ImportOpenApiCapabilityForm = forwardRef<
       <Form.Item label={t("executionFactory.useRule")} name="useRule">
 
         <Input.TextArea rows={2} />
+
+      </Form.Item>
+
+      <Form.Item label={t("executionFactory.serviceUrl")} name="serviceUrl">
+
+        <Input placeholder="https://api.example.com" />
 
       </Form.Item>
 
@@ -360,13 +416,6 @@ export const ImportOpenApiCapabilityForm = forwardRef<
                 <Input.TextArea rows={2} />
 
               </Form.Item>
-
-              <Form.Item label={t("executionFactory.serviceUrl")} name="serviceUrl">
-
-                <Input placeholder="https://api.example.com" />
-
-              </Form.Item>
-
               <CapabilityCategoryFields />
 
             </>

--- a/src/modules/execution-factory/components/create-menu/create-menu.module.css
+++ b/src/modules/execution-factory/components/create-menu/create-menu.module.css
@@ -98,6 +98,19 @@
   margin-bottom: 12px;
 }
 
+.interfaceSuccessAlert {
+  border-color: var(--color-interface-panel-border);
+  background: var(--color-interface-panel-bg);
+}
+
+.interfaceSuccessAlert :global(.ant-alert-icon) {
+  color: var(--color-interface-success-dot);
+}
+
+.interfaceSuccessAlert :global(.ant-alert-message) {
+  color: rgba(15, 30, 54, 0.78);
+}
+
 .businessIntro {
   border-left: 3px solid #1677ff;
   background: rgba(15, 30, 54, 0.03);

--- a/src/modules/execution-factory/locales/en-US.ts
+++ b/src/modules/execution-factory/locales/en-US.ts
@@ -129,6 +129,12 @@ export const executionFactoryEnUS = {
     importOpenApiCapabilitySuccess: "Imported {{count}} tool(s) successfully",
     importOpenApiCapabilityPartial: "Imported {{success}} tool(s), {{failed}} failed",
     importOpenApiCapabilityParsed: "Detected {{count}} endpoint(s). Confirm the toolset and import.",
+    importOpenApiRelativeServerResolved:
+      "Detected relative OpenAPI server {{relativeUrl}} and resolved it to {{serviceUrl}}.",
+    importOpenApiServiceUrlRequired:
+      "Please enter a full HTTP(S) service URL before importing.",
+    importOpenApiRelativeServerManual:
+      "This OpenAPI document uses a relative server URL {{relativeUrl}}. Enter the full service URL before importing.",
     importOpenApiCapabilityFileReady: "File ready. It will be parsed and imported on save.",
     importOpenApiCapabilityPreview: "OpenAPI {{version}} · {{count}} endpoint(s)",
     addCapabilityFunctionTitle: "Write a function",

--- a/src/modules/execution-factory/locales/zh-CN.ts
+++ b/src/modules/execution-factory/locales/zh-CN.ts
@@ -128,6 +128,11 @@ export const executionFactoryZhCN = {
     importOpenApiCapabilitySuccess: "已成功导入 {{count}} 个工具",
     importOpenApiCapabilityPartial: "已导入 {{success}} 个工具，{{failed}} 个失败",
     importOpenApiCapabilityParsed: "已识别 {{count}} 个接口，请确认工具集后导入。",
+    importOpenApiRelativeServerResolved:
+      "检测到 OpenAPI 相对服务地址 {{relativeUrl}}，已解析为 {{serviceUrl}}。",
+    importOpenApiServiceUrlRequired: "导入前请填写完整的 HTTP(S) 服务地址。",
+    importOpenApiRelativeServerManual:
+      "当前 OpenAPI 文档使用相对服务地址 {{relativeUrl}}，请填写完整服务地址后再导入。",
     importOpenApiCapabilityFileReady: "文件已就绪，保存后将解析并导入接口。",
     importOpenApiCapabilityPreview: "OpenAPI {{version}} · 共 {{count}} 个接口",
     addCapabilityFunctionTitle: "写个小函数",

--- a/src/modules/execution-factory/utils/metadata-content.test.ts
+++ b/src/modules/execution-factory/utils/metadata-content.test.ts
@@ -11,6 +11,7 @@ import {
   analyzeOpenApiDocumentText,
   buildOpenApiDocumentFromMetadata,
   parseOpenApiDataPayload,
+  resolveOpenApiServiceUrl,
   validateOpenApiDocumentText,
 } from "@/modules/execution-factory/utils/metadata-content";
 
@@ -125,6 +126,57 @@ describe("metadata-content OpenAPI helpers", () => {
         path: "/weather",
         summary: "查询天气",
       });
+    }
+  });
+
+  it("resolves a root-relative server URL against an OpenAPI document URL", () => {
+    const spec = JSON.stringify({
+      openapi: "3.0.4",
+      info: { title: "Swagger Petstore", version: "1.0.0" },
+      servers: [{ url: "/api/v3" }],
+      paths: {
+        "/pet": {
+          put: {
+            summary: "Update a pet",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const resolved = resolveOpenApiServiceUrl(spec, {
+      kind: "url",
+      url: "https://petstore3.swagger.io/api/v3/openapi.json",
+    });
+
+    expect(resolved).toEqual({
+      ok: true,
+      source: "resolved-relative",
+      url: "https://petstore3.swagger.io/api/v3",
+    });
+  });
+
+  it("requires a manual service URL for relative servers from pasted OpenAPI documents", () => {
+    const spec = JSON.stringify({
+      openapi: "3.0.4",
+      info: { title: "Swagger Petstore", version: "1.0.0" },
+      servers: [{ url: "/api/v3" }],
+      paths: {
+        "/pet": {
+          put: {
+            summary: "Update a pet",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const resolved = resolveOpenApiServiceUrl(spec, { kind: "paste" });
+
+    expect(resolved.ok).toBe(false);
+    if (!resolved.ok) {
+      expect(resolved.relativeUrl).toBe("/api/v3");
+      expect(resolved.reason).toContain("/api/v3");
     }
   });
 

--- a/src/modules/execution-factory/utils/metadata-content.ts
+++ b/src/modules/execution-factory/utils/metadata-content.ts
@@ -75,6 +75,16 @@ export type ResolvedOpenApiServiceUrl =
   | { ok: true; source: "absolute" | "resolved-relative"; url: string }
   | { ok: false; reason: string; relativeUrl?: string };
 
+export function normalizeGeneratedCapabilityName(value?: string): string | undefined {
+  const normalized = value
+    ?.trim()
+    .replace(/[^\u4e00-\u9fa5A-Za-z0-9_]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return normalized || undefined;
+}
+
 function isFullOpenApiDocument(value: unknown): value is Record<string, unknown> {
   return (
     typeof value === "object" &&

--- a/src/modules/execution-factory/utils/metadata-content.ts
+++ b/src/modules/execution-factory/utils/metadata-content.ts
@@ -66,6 +66,15 @@ export type OpenApiDocumentAnalysis =
     }
   | { ok: false; reason: string };
 
+export type OpenApiSpecSource =
+  | { kind: "paste" }
+  | { kind: "file"; fileName?: string }
+  | { kind: "url"; url: string };
+
+export type ResolvedOpenApiServiceUrl =
+  | { ok: true; source: "absolute" | "resolved-relative"; url: string }
+  | { ok: false; reason: string; relativeUrl?: string };
+
 function isFullOpenApiDocument(value: unknown): value is Record<string, unknown> {
   return (
     typeof value === "object" &&
@@ -371,6 +380,47 @@ export function buildOpenApiDocumentFromMetadata(metadata: BackendMetadata): str
   }
 
   return JSON.stringify(document, null, 2);
+}
+
+export function resolveOpenApiServiceUrl(
+  openapiSpec: string,
+  source?: OpenApiSpecSource,
+): ResolvedOpenApiServiceUrl {
+  const analysis = analyzeOpenApiDocumentText(openapiSpec);
+
+  if (!analysis.ok) {
+    return { ok: false, reason: analysis.reason };
+  }
+
+  const serverUrl = analysis.serverUrl?.trim();
+  if (!serverUrl) {
+    return { ok: false, reason: "servers[0].url 不能为空。" };
+  }
+
+  if (/^https?:\/\//i.test(serverUrl)) {
+    return { ok: true, source: "absolute", url: serverUrl };
+  }
+
+  if (source?.kind === "url") {
+    try {
+      const resolved = new URL(serverUrl, source.url);
+      if (/^https?:$/i.test(resolved.protocol)) {
+        return {
+          ok: true,
+          source: "resolved-relative",
+          url: resolved.toString().replace(/\/$/, ""),
+        };
+      }
+    } catch {
+      // Fall through to the manual input message below.
+    }
+  }
+
+  return {
+    ok: false,
+    relativeUrl: serverUrl,
+    reason: `OpenAPI servers[0].url 是相对路径 ${serverUrl}，请填写完整服务地址。`,
+  };
 }
 
 export function serializeOpenApiSpec(metadata?: BackendMetadata): string | undefined {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -31,6 +31,19 @@
   --color-error-text: #b91c1c;
   --color-error-border: #fecaca;
 
+  /* Interface debugging and schema review */
+  --color-interface-panel-bg: #f8fafc;
+  --color-interface-panel-border: rgba(21, 94, 117, 0.18);
+  --color-interface-panel-muted: rgba(15, 30, 54, 0.52);
+  --color-interface-code-bg: #ffffff;
+  --color-interface-code-text: #182235;
+  --color-interface-success-dot: #0f9f6e;
+  --color-interface-success-ring: rgba(15, 159, 110, 0.12);
+  --color-interface-warning-bg: #fffaf3;
+  --color-interface-warning-border: rgba(180, 83, 9, 0.24);
+  --color-interface-warning-dot: #d97706;
+  --color-interface-warning-ring: rgba(217, 119, 6, 0.14);
+
   /* Shadow */
   --shadow-card: 0 4px 16px rgba(15, 23, 42, 0.06);
   --shadow-dropdown: 0 12px 32px rgba(15, 23, 42, 0.14);


### PR DESCRIPTION
## 背景

Closes #80。

公开 OpenAPI 文档可能使用相对 `servers[0].url`，例如 Petstore 3.0 的 `/api/v3`。此前从 URL 拉取并校验成功后，导入表单会把相对路径作为服务地址提交，后端 URL 校验失败，用户只能看到泛化的“URL格式错误”。

## 主要改动

- 记录 OpenAPI 内容来源：粘贴、文件、URL。
- 新增 `resolveOpenApiServiceUrl`，当 OpenAPI 从 URL 拉取时，将相对 server 地址按文档 URL 自动解析为完整 HTTP(S) 服务地址。
- 对粘贴/文件导入中的相对 server 地址给出明确提示，并在提交前定位到服务地址字段。
- 将 OpenAPI 导入表单里的服务地址字段前置，避免既有工具集导入时看不到需要确认的地址。
- 补充单元测试与组件测试覆盖 Petstore 相对 server URL 场景。
- 补充实现设计文档。

## 影响范围

- 仅影响执行工厂 OpenAPI 3.0 导入链路。
- 不修改模块注册、路由、导航或后端接口协议。
- `OpenApiSpecInput.onChange` 增加可选 source 参数，已有单参数调用保持兼容。

## 验证方式

已通过：

```bash
pnpm vitest run src/modules/execution-factory/utils/metadata-content.test.ts src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.test.tsx
pnpm exec eslint src/modules/execution-factory/utils/metadata-content.ts src/modules/execution-factory/utils/metadata-content.test.ts src/modules/execution-factory/components/OpenApiSpecInput.tsx src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.test.tsx src/modules/execution-factory/locales/en-US.ts src/modules/execution-factory/locales/zh-CN.ts
pnpm test:execution-factory
pnpm test -- --run
git diff --check origin/main...HEAD
```

仓库现有阻塞，非本 PR 引入：

- `pnpm lint` 失败于 data-connect / knowledge-network / system-admin 的未使用导入等既有问题。
- `pnpm build` 失败于 data-connect / knowledge-network / system-admin 的既有 TypeScript 错误。

## 未完成项或风险

- 文件上传或粘贴 OpenAPI 且 server 为相对路径时，仍需要用户手动补全完整服务地址，这是因为缺少可用于解析的原始文档 URL。
- 远端 OpenAPI URL 拉取是否可用仍受浏览器 CORS 和网络可达性影响。