### PR TITLE
feat(deploy): redirect gateway root to /studio

### DIFF
--- a/deploy/charts/bkn-studio/templates/ingress.yaml
+++ b/deploy/charts/bkn-studio/templates/ingress.yaml
@@ -15,8 +15,9 @@ spec:
   rules:
     - http:
         paths:
-          {{- /* studio adds ONLY /studio; /api, /oauth2, /.well-known, /userinfo
-                 stay on the gateway ingress that routes to bkn-safe. */}}
+          {{- /* studio adds /studio (plus, optionally, an Exact / below);
+                 /api, /oauth2, /.well-known, /userinfo stay on the gateway
+                 ingress that routes to bkn-safe. */}}
           - path: {{ .Values.ingress.path }}
             pathType: ImplementationSpecific
             backend:
@@ -24,4 +25,14 @@ spec:
                 name: {{ .Values.image.name }}
                 port:
                   number: {{ .Values.service.port }}
+          {{- if .Values.ingress.rootRedirect }}
+          {{- /* Exact / only — studio's nginx 302s it to /studio/. */}}
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: {{ .Values.image.name }}
+                port:
+                  number: {{ .Values.service.port }}
+          {{- end }}
 {{- end }}

--- a/deploy/charts/bkn-studio/values.yaml
+++ b/deploy/charts/bkn-studio/values.yaml
@@ -23,13 +23,19 @@ auth:
   enabled: true
 
 # studio is a static SPA. The gateway ingress already routes /api, /oauth2,
-# /.well-known and /userinfo to bkn-safe — studio contributes ONLY /studio.
+# /.well-known and /userinfo to bkn-safe — studio contributes /studio plus an
+# optional Exact-/ rule (rootRedirect) so the bare host lands in the studio.
 ingress:
   enabled: true
   ingressClass: class-443
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
   path: /studio
+  # Also claim the bare root (Exact /) and hand it to studio's nginx, which
+  # 302s / -> /studio/ — so https://<gateway>/ lands in the studio shell.
+  # Exact match only: /api, /oauth2 and every other gateway path are untouched.
+  # Set false if another ingress on this gateway already owns /.
+  rootRedirect: true
 
 resources:
   requests:

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -189,12 +189,14 @@ cmd_cluster() {
     cat >&2 <<EOF
 
 [install] done (no-auth). studio served at  https://<gateway-host>/studio
+          (bare https://<gateway-host>/ redirects there)
 [install] OAuth gate OFF — no login, runs as default local-admin. No bkn-safe needed.
 EOF
   else
     cat >&2 <<EOF
 
 [install] done. studio served at  https://<gateway-host>/studio
+          (bare https://<gateway-host>/ redirects there)
 [install] same gateway as /api + /oauth2 → same-origin; OAuth callback
           https://<gateway-host>/studio/callback is already seeded by bkn-safe
           (accessAddress-derived). No callback registration needed.
@@ -213,6 +215,9 @@ server {
     listen 80;
     server_name _;
     root /usr/share/nginx/html;
+
+    # Relative redirects — no scheme/host baked in, so an https front stays https.
+    absolute_redirect off;
 
     gzip on;
     gzip_types text/css application/javascript application/json image/svg+xml;

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -7,6 +7,11 @@ server {
 
     root /usr/share/nginx/html;
 
+    # Relative Location headers: this server sits behind a TLS-terminating
+    # gateway, so an absolute redirect would be built from the plain-HTTP
+    # backend request and downgrade https -> http.
+    absolute_redirect off;
+
     gzip on;
     gzip_types text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;


### PR DESCRIPTION
## What

- Cluster chart: new `ingress.rootRedirect` value (default **on**) adds an **Exact `/`** path to the studio ingress. Bare `https://<gateway>/` now lands in the studio shell via the container nginx's `302 /studio/`.
- `absolute_redirect off` in both nginx confs (baked image conf + `install.sh` local-mode generated conf), so the 302 `Location` is relative and an https front is not downgraded to http (backend only sees plain HTTP behind the TLS-terminating gateway).
- `install.sh` cluster done-message mentions the root redirect.

## Why

Fresh installs left `https://<host>/` on whatever claimed the gateway root (on Foundry: `sandbox-control-plane`'s Prefix `/` catch-all returning a JSON info blob). Users landing on the bare host should reach studio.

`Exact` match only steals the bare root — `/api`, `/oauth2`, sandbox's `/docs`, `/openapi.json` and all other gateway paths are untouched. Opt out with `--set ingress.rootRedirect=false` if another ingress must own `/`.

## Verified

- `helm template` renders both toggle states; `helm lint` clean.
- Live on the Parallels VM foundry (k3s, arm64): `https://10.211.55.4/` → `302 /studio/` (relative Location, https preserved) → SPA 200; OAuth login chain intact; sandbox paths unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)