### PR TITLE
fix(execution-factory): persist quick api debug requests

### DIFF
--- a/src/modules/execution-factory/components/ToolDebugModal.tsx
+++ b/src/modules/execution-factory/components/ToolDebugModal.tsx
@@ -19,6 +19,7 @@ import type {
   ToolIoSpec,
 } from "@/modules/execution-factory/types/tool";
 import { buildDefaultDebugBody } from "@/modules/execution-factory/utils/generate-sample-json";
+import { buildToolDebugRequest } from "@/modules/execution-factory/utils/tool-io";
 
 import styles from "./ToolDebugModal.module.css";
 
@@ -93,7 +94,8 @@ export function ToolDebugModal({
         body = JSON.parse(values.requestBody) as Record<string, unknown>;
       }
 
-      const debugResult = await debugTool(boxId, record.toolId, { body });
+      const debugRequest = buildToolDebugRequest(body, ioSpec);
+      const debugResult = await debugTool(boxId, record.toolId, debugRequest);
       setResult(debugResult);
       onRunComplete?.({
         id: `${Date.now()}`,
@@ -102,7 +104,7 @@ export function ToolDebugModal({
         durationMs: debugResult.durationMs,
         error: debugResult.error,
         body: debugResult.body,
-        requestBody: body,
+        requestBody: debugRequest,
       });
     } catch (caughtError) {
       setError(extractRequestErrorMessage(caughtError));

--- a/src/modules/execution-factory/services/quick-api.service.test.ts
+++ b/src/modules/execution-factory/services/quick-api.service.test.ts
@@ -126,7 +126,7 @@ describe("registerQuickApi", () => {
     ).rejects.toThrow("Tool creation was not persisted");
   });
 
-  it("does not return a navigable result when the created toolbox is missing from list", async () => {
+  it("returns a navigable result when detail is readable even if toolbox list lags", async () => {
     vi.mocked(listToolboxes).mockResolvedValue({
       items: [],
       page: 1,
@@ -140,6 +140,6 @@ describe("registerQuickApi", () => {
         serviceUrl: "http://127.0.0.1:8095",
         toolboxName: "Quick API Box",
       }),
-    ).rejects.toThrow("Toolbox creation was not persisted");
+    ).resolves.toEqual({ boxId: "box-1", toolIds: ["tool-1"] });
   });
 });

--- a/src/modules/execution-factory/services/quick-api.service.ts
+++ b/src/modules/execution-factory/services/quick-api.service.ts
@@ -75,14 +75,11 @@ async function confirmQuickApiPersistence(input: {
     toolboxVisible = Boolean(toolbox);
 
     if (toolboxVisible && input.toolboxName?.trim()) {
-      const list = await listToolboxes({
+      void listToolboxes({
         keyword: input.toolboxName.trim(),
         page: 1,
         pageSize: 100,
       }).catch(() => null);
-      toolboxVisible = Boolean(
-        list?.items.some((item) => item.boxId === input.boxId),
-      );
     }
 
     if (toolboxVisible) {

--- a/src/modules/execution-factory/services/tool.service.ts
+++ b/src/modules/execution-factory/services/tool.service.ts
@@ -473,7 +473,11 @@ export async function debugTool(
     status_code?: number;
   }>(
     `${API_PREFIX}/tool-box/${boxId}/tool/${toolId}/debug`,
-    { body: input.body },
+    {
+      body: input.body,
+      header: input.header,
+      query: input.query,
+    },
     { headers: getBusinessDomainHeaders() },
   );
 

--- a/src/modules/execution-factory/types/tool.ts
+++ b/src/modules/execution-factory/types/tool.ts
@@ -114,7 +114,9 @@ export type ToolCreateResult = {
 };
 
 export type ToolDebugInput = {
+  header?: Record<string, unknown>;
   body?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 };
 
 export type ToolDebugResult = {

--- a/src/modules/execution-factory/utils/tool-io.test.ts
+++ b/src/modules/execution-factory/utils/tool-io.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildToolDebugRequest } from "@/modules/execution-factory/utils/tool-io";
+
+describe("buildToolDebugRequest", () => {
+  it("splits flat debug input by OpenAPI parameter location", () => {
+    expect(
+      buildToolDebugRequest(
+        {
+          accept: "application/json",
+          customerId: "1001",
+          region: "CN",
+          "x-demo-source": "openbkn-manual",
+        },
+        {
+          parameters: [
+            { in: "query", name: "customerId", type: "string" },
+            { in: "query", name: "region", type: "string" },
+            { in: "header", name: "accept", type: "string" },
+            { in: "header", name: "x-demo-source", type: "string" },
+          ],
+        },
+      ),
+    ).toEqual({
+      header: {
+        accept: "application/json",
+        "x-demo-source": "openbkn-manual",
+      },
+      query: {
+        customerId: "1001",
+        region: "CN",
+      },
+    });
+  });
+
+  it("preserves explicit query/header/body debug payloads", () => {
+    expect(
+      buildToolDebugRequest({
+        body: { city: "Beijing" },
+        header: { accept: "application/json" },
+        query: { region: "CN" },
+      }),
+    ).toEqual({
+      body: { city: "Beijing" },
+      header: { accept: "application/json" },
+      query: { region: "CN" },
+    });
+  });
+
+  it("keeps unknown flat fields in the request body", () => {
+    expect(
+      buildToolDebugRequest(
+        { city: "Beijing", traceId: "debug-1" },
+        { parameters: [{ in: "query", name: "city", type: "string" }] },
+      ),
+    ).toEqual({
+      body: { traceId: "debug-1" },
+      query: { city: "Beijing" },
+    });
+  });
+});

--- a/src/modules/execution-factory/utils/tool-io.ts
+++ b/src/modules/execution-factory/utils/tool-io.ts
@@ -5,7 +5,11 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import type { ToolIoParameter, ToolIoSpec } from "@/modules/execution-factory/types/tool";
+import type {
+  ToolDebugInput,
+  ToolIoParameter,
+  ToolIoSpec,
+} from "@/modules/execution-factory/types/tool";
 
 export { buildDefaultDebugBody } from "@/modules/execution-factory/utils/generate-sample-json";
 
@@ -80,5 +84,67 @@ export function parseToolIoSpec(metadata?: ApiSpecMetadata): ToolIoSpec | undefi
     requestBodyExample: firstRequestContent?.example,
     requestBodySchema: firstRequestContent?.schema,
     responses,
+  };
+}
+
+function pickRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function hasStructuredDebugPayload(input: Record<string, unknown>) {
+  return "query" in input || "header" in input || "body" in input;
+}
+
+export function buildToolDebugRequest(
+  input?: Record<string, unknown>,
+  ioSpec?: ToolIoSpec,
+): ToolDebugInput {
+  if (!input) {
+    return {};
+  }
+
+  if (hasStructuredDebugPayload(input)) {
+    return {
+      body: pickRecord(input.body),
+      header: pickRecord(input.header),
+      query: pickRecord(input.query),
+    };
+  }
+
+  const body: Record<string, unknown> = {};
+  const header: Record<string, unknown> = {};
+  const query: Record<string, unknown> = {};
+  const consumedKeys = new Set<string>();
+
+  for (const parameter of ioSpec?.parameters ?? []) {
+    if (!(parameter.name in input)) {
+      continue;
+    }
+
+    consumedKeys.add(parameter.name);
+
+    if (parameter.in === "header") {
+      header[parameter.name] = input[parameter.name];
+    } else if (parameter.in === "query" || parameter.in === "path") {
+      query[parameter.name] = input[parameter.name];
+    } else {
+      body[parameter.name] = input[parameter.name];
+    }
+  }
+
+  for (const [key, value] of Object.entries(input)) {
+    if (!consumedKeys.has(key)) {
+      body[key] = value;
+    }
+  }
+
+  return {
+    ...(Object.keys(body).length > 0 ? { body } : {}),
+    ...(Object.keys(header).length > 0 ? { header } : {}),
+    ...(Object.keys(query).length > 0 ? { query } : {}),
   };
 }


### PR DESCRIPTION
## ??

Closes #85.

???? HTTP API ??????????????????????????????????????????? `Toolbox creation was not persisted`????? OpenAPI/HTTP ?????????????????? `body`??? query/header ???????????????????

## ????

- ???? API ??????????????????????????????????????
- ?? `buildToolDebugRequest`????? IO ??????????? `query`?`header`?`body`?
- ??????????????? `query/header/body` ?????
- ??????????????? HTTP ???????

## ????

- ???? / ???? / HTTP API ????????????
- ???? / ???? / ????????????
- ????????????????????????????

## ????

- [x] `pnpm vitest run src/modules/execution-factory/services/quick-api.service.test.ts src/modules/execution-factory/utils/tool-io.test.ts`
  - 2 files passed, 6 tests passed
- [x] `pnpm test -- --run`
  - 39 files passed, 143 tests passed
- [x] `pnpm lint`
  - ????????????? lint ??????? PR ????????
    - `src/modules/data-catalog/components/CatalogDetailPanel.tsx`: unused `setSearchParams`
    - `src/modules/data-connect/services/data-connect.service.ts`: unused `DataConnectRecord`
    - `src/modules/knowledge-network/services/action-type-tool.service.ts`: unused imports
    - `src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx`: unused `UserOutlined`
- [x] `pnpm build`
  - ????????????? TypeScript ??????
    - `src/modules/data-catalog/scenes/IndexBuildListScene.tsx`: duplicate object property
    - `src/modules/knowledge-network/components/object-type/ObjectTypePropertyTable.tsx`: table sorter type mismatch
    - `src/modules/system-admin/components/UserFormDrawer.tsx`: `TreeSelect` unsupported `mode` prop
    - `src/modules/execution-factory/services/import-openapi.service.test.ts`: existing `ToolboxRecord` fixture type mismatch

## ????????

- ?? `lint` ? `build` ?????????? PR ??????????????
- ?????????? `query/header/body` ?????????? PR ??????????????
