### PR TITLE
fix(data-directory): stop auto-selecting first catalog on root entry

### DIFF
--- a/src/modules/data-catalog/pages/DataCatalogPage.tsx
+++ b/src/modules/data-catalog/pages/DataCatalogPage.tsx
@@ -20,11 +20,12 @@ export function DataCatalogPage({ selectionType }: DataCatalogPageProps) {
     selectionType === "catalog" && routeCatalogId
       ? ({ id: routeCatalogId, type: "catalog" } as const)
       : null;
+  const suppressAutoSelect = selectionType !== "catalog";
 
   return (
     <DataCatalogScene
       selection={selection}
-      suppressAutoSelect={false}
+      suppressAutoSelect={suppressAutoSelect}
     />
   );
 }


### PR DESCRIPTION
## Summary\n- stop auto-selecting the first catalog when entering the data directory root route\n- keep explicit catalog selection only for /data-directory/catalog/:catalogId\n- make the data directory menu return to the root entry state instead of jumping to a stale physical source\n\n## Validation\n- ./node_modules/.bin/tsc.cmd -p tsconfig.json --noEmit --pretty false