### PR TITLE
fix(execution-factory): align HTTP tool lifecycle experience

### DIFF
--- a/docs/superpowers/plans/2026-07-10-execution-factory-http-tool-lifecycle-ui.md
+++ b/docs/superpowers/plans/2026-07-10-execution-factory-http-tool-lifecycle-ui.md
@@ -1,0 +1,94 @@
+# Execution Factory HTTP Tool Lifecycle UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align HTTP API tool edit/view experience with the guided create experience so the same tool keeps a stable lifecycle UI.
+
+**Architecture:** Add a focused shared section component for HTTP tool lifecycle layout and use it in the existing tool detail scene. Keep data loading, saving, debug, and route contracts unchanged.
+
+**Tech Stack:** React, TypeScript, Ant Design, Vitest, Testing Library, Vite.
+
+---
+
+### Task 1: Add Shared HTTP Tool Lifecycle Layout
+
+**Files:**
+- Create: `src/modules/execution-factory/components/HttpToolLifecyclePanel.tsx`
+- Create: `src/modules/execution-factory/components/HttpToolLifecyclePanel.module.css`
+- Create: `src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Create a component test that renders basic fields, IO preview before advanced configuration, and the OpenAPI advanced section.
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```powershell
+node_modules\.bin\vitest.cmd run src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx
+```
+
+Expected: fail because the component does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+The component accepts React nodes for business fields, IO preview, and advanced configuration. It owns only layout and copy, not data mutation.
+
+- [ ] **Step 4: Run test and verify pass**
+
+Run the same Vitest command. Expected: pass.
+
+### Task 2: Use The Layout In Tool Detail Scene
+
+**Files:**
+- Modify: `src/modules/execution-factory/scenes/ToolDetailScene.tsx`
+- Modify: `src/modules/execution-factory/locales/en-US.ts`
+- Modify: `src/modules/execution-factory/locales/zh-CN.ts`
+
+- [ ] **Step 1: Move business fields into lifecycle summary**
+
+Keep `name`, `description`, and `useRule` as the first section.
+
+- [ ] **Step 2: Move IO preview before advanced configuration**
+
+Render `ToolIoPanel` before raw OpenAPI/global parameters.
+
+- [ ] **Step 3: Place raw OpenAPI/global parameters in advanced configuration**
+
+For OpenAPI tools, show raw OpenAPI inside an advanced collapsible section. For function tools, show function definition in the same advanced section.
+
+- [ ] **Step 4: Preserve debug and save behavior**
+
+Do not change `updateTool`, `ToolDebugModal`, or navigation logic.
+
+### Task 3: Verify
+
+**Files:**
+- Test: `src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx`
+- Existing tests: quick API creation and IO utilities
+
+- [ ] **Step 1: Run targeted tests**
+
+```powershell
+node_modules\.bin\vitest.cmd run src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx src/modules/execution-factory/components/create-menu/CapabilityCreatedNextSteps.test.tsx src/modules/execution-factory/utils/tool-io.test.ts
+```
+
+- [ ] **Step 2: Start local service**
+
+Use the existing local Vite service if running. Otherwise start it with:
+
+```powershell
+pnpm dev --host 127.0.0.1
+```
+
+- [ ] **Step 3: Manual verification URL**
+
+Open:
+
+```text
+http://127.0.0.1:5173/studio/execution-factory/units?activeTab=toolbox
+```
+
+Verify HTTP API create -> save -> edit keeps the same business-first structure.
+

--- a/docs/superpowers/specs/2026-07-10-execution-factory-http-tool-lifecycle-ui-design.md
+++ b/docs/superpowers/specs/2026-07-10-execution-factory-http-tool-lifecycle-ui-design.md
@@ -1,0 +1,87 @@
+# Execution Factory HTTP Tool Lifecycle UI Design
+
+## Issue
+
+GitHub issue: https://github.com/openbkn-ai/bkn-studio/issues/90
+
+## Problem
+
+Execution Factory currently gives users a polished guided flow when creating HTTP API tools, but a different raw configuration page when they later view or edit the same tool. This breaks the user's mental model:
+
+- Creation is business-oriented: cURL/form input, generated API preview, toolbox placement, and next actions.
+- Editing is configuration-oriented: raw OpenAPI, global parameters, and IO/debug blocks.
+- The same resource feels like a different product after saving.
+
+For an enterprise product, the same capability should keep a stable information architecture across create, view, edit, debug, and publish.
+
+## First Phase Scope
+
+Only HTTP API / Tool lifecycle continuity is in scope for this phase.
+
+In scope:
+
+- Align HTTP API tool edit UI with the creation UI structure.
+- Keep generated IO preview visible in a predictable place.
+- Keep raw OpenAPI and global parameters available as advanced configuration.
+- Preserve existing debug and save behavior.
+- Improve wording and layout so the screen feels like a professional capability management surface.
+
+Out of scope for this phase:
+
+- Rewriting MCP, Skill, Toolbox, or Operator pages.
+- Backend schema changes.
+- Changing publish or marketplace logic.
+
+## Desired User Mental Model
+
+The user should think:
+
+1. "This is the same HTTP API tool I created."
+2. "The important business fields are still at the top."
+3. "I can verify its request and response shape without reading raw OpenAPI."
+4. "If I need low-level control, I can open Advanced configuration."
+5. "Debug, save, and return actions are predictable."
+
+## UI Structure
+
+The HTTP API tool surface should use these sections:
+
+1. Capability summary
+   - Tool name
+   - Description
+   - Usage rules
+   - Metadata type shown as read-only context
+
+2. Interface preview
+   - Request parameters
+   - Request body
+   - Response examples
+   - Recent debug results if available
+
+3. Advanced configuration
+   - Raw OpenAPI spec
+   - Global parameters
+   - Function definition for function tools
+
+4. Actions
+   - Back/cancel
+   - Debug
+   - Save
+
+## Design Principles
+
+- Same information order across create and edit.
+- Read-only or disabled state should come from mode, not a separate user journey.
+- Advanced/raw configuration should not be the first thing users see.
+- Status and success colors should be restrained and consistent with the current UI token style.
+- Existing APIs and route behavior should remain stable.
+
+## Acceptance Criteria
+
+- Editing an HTTP API tool starts with business fields and IO preview, not raw OpenAPI.
+- Raw OpenAPI is still available under an advanced section.
+- Global parameters remain available under advanced configuration.
+- Debug action remains available from the edit page.
+- Existing tests for quick API creation still pass.
+- A new component-level test verifies the HTTP tool lifecycle layout order.
+

--- a/src/modules/execution-factory/components/HttpToolLifecyclePanel.module.css
+++ b/src/modules/execution-factory/components/HttpToolLifecyclePanel.module.css
@@ -1,0 +1,45 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section {
+  border: 1px solid #dbe5f2;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 18px;
+}
+
+.sectionHeader {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.sectionTitle {
+  color: #0f172a;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+  margin: 0;
+}
+
+.sectionDesc {
+  color: #64748b;
+  font-size: 13px;
+  line-height: 20px;
+  margin: 4px 0 0;
+}
+
+.metadataTag {
+  flex: 0 0 auto;
+}
+
+.advanced {
+  border-color: #e2e8f0;
+  background: #fbfdff;
+}
+

--- a/src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx
+++ b/src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HttpToolLifecyclePanel } from "@/modules/execution-factory/components/HttpToolLifecyclePanel";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("HttpToolLifecyclePanel", () => {
+  it("keeps business fields and IO preview before advanced raw configuration", () => {
+    render(
+      <HttpToolLifecyclePanel
+        advancedConfig={<div>raw openapi spec</div>}
+        businessFields={<div>business summary fields</div>}
+        ioPreview={<div>request and response preview</div>}
+        metadataTypeLabel="OpenAPI"
+      />,
+    );
+
+    const business = screen.getByText("business summary fields");
+    const ioPreview = screen.getByText("request and response preview");
+    const advanced = screen.getByText("raw openapi spec");
+
+    expect(screen.getByText("executionFactory.httpToolLifecycleSummaryTitle")).toBeTruthy();
+    expect(screen.getByText("executionFactory.httpToolLifecyclePreviewTitle")).toBeTruthy();
+    expect(screen.getByText("executionFactory.httpToolLifecycleAdvancedTitle")).toBeTruthy();
+    expect(screen.getByText("OpenAPI")).toBeTruthy();
+    expect(business.compareDocumentPosition(ioPreview) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(ioPreview.compareDocumentPosition(advanced) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/src/modules/execution-factory/components/HttpToolLifecyclePanel.tsx
+++ b/src/modules/execution-factory/components/HttpToolLifecyclePanel.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ReactNode } from "react";
+import { Tag } from "antd";
+import { useTranslation } from "react-i18next";
+
+import styles from "./HttpToolLifecyclePanel.module.css";
+
+type HttpToolLifecyclePanelProps = {
+  advancedConfig?: ReactNode;
+  businessFields: ReactNode;
+  debugWorkbench?: ReactNode;
+  ioPreview: ReactNode;
+  metadataTypeLabel: string;
+};
+
+export function HttpToolLifecyclePanel({
+  advancedConfig,
+  businessFields,
+  debugWorkbench,
+  ioPreview,
+  metadataTypeLabel,
+}: HttpToolLifecyclePanelProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.panel}>
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <h3 className={styles.sectionTitle}>
+              {t("executionFactory.httpToolLifecycleSummaryTitle")}
+            </h3>
+            <p className={styles.sectionDesc}>
+              {t("executionFactory.httpToolLifecycleSummaryDesc")}
+            </p>
+          </div>
+          <Tag className={styles.metadataTag}>{metadataTypeLabel}</Tag>
+        </div>
+        {businessFields}
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <h3 className={styles.sectionTitle}>
+              {t("executionFactory.httpToolLifecyclePreviewTitle")}
+            </h3>
+            <p className={styles.sectionDesc}>
+              {t("executionFactory.httpToolLifecyclePreviewDesc")}
+            </p>
+          </div>
+        </div>
+        {ioPreview}
+      </section>
+
+      {debugWorkbench ? debugWorkbench : null}
+
+      {advancedConfig ? (
+        <section className={`${styles.section} ${styles.advanced}`}>
+          <div className={styles.sectionHeader}>
+            <div>
+              <h3 className={styles.sectionTitle}>
+                {t("executionFactory.httpToolLifecycleAdvancedTitle")}
+              </h3>
+              <p className={styles.sectionDesc}>
+                {t("executionFactory.httpToolLifecycleAdvancedDesc")}
+              </p>
+            </div>
+          </div>
+          {advancedConfig}
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/modules/execution-factory/components/ToolDebugModal.tsx
+++ b/src/modules/execution-factory/components/ToolDebugModal.tsx
@@ -19,6 +19,7 @@ import type {
   ToolIoSpec,
 } from "@/modules/execution-factory/types/tool";
 import { buildDefaultDebugBody } from "@/modules/execution-factory/utils/generate-sample-json";
+import { buildToolDebugRequest } from "@/modules/execution-factory/utils/tool-io";
 
 import styles from "./ToolDebugModal.module.css";
 
@@ -93,7 +94,8 @@ export function ToolDebugModal({
         body = JSON.parse(values.requestBody) as Record<string, unknown>;
       }
 
-      const debugResult = await debugTool(boxId, record.toolId, { body });
+      const debugRequest = buildToolDebugRequest(body, ioSpec);
+      const debugResult = await debugTool(boxId, record.toolId, debugRequest);
       setResult(debugResult);
       onRunComplete?.({
         id: `${Date.now()}`,
@@ -102,7 +104,7 @@ export function ToolDebugModal({
         durationMs: debugResult.durationMs,
         error: debugResult.error,
         body: debugResult.body,
-        requestBody: body,
+        requestBody: debugRequest,
       });
     } catch (caughtError) {
       setError(extractRequestErrorMessage(caughtError));

--- a/src/modules/execution-factory/components/ToolDebugPanel.module.css
+++ b/src/modules/execution-factory/components/ToolDebugPanel.module.css
@@ -1,0 +1,126 @@
+.panel {
+  border: 1px solid #dbe5f2;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 18px;
+}
+
+.header {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.title {
+  color: #0f172a;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+  margin: 0;
+}
+
+.desc {
+  color: #64748b;
+  font-size: 13px;
+  line-height: 20px;
+  margin: 4px 0 0;
+}
+
+.content {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.requestCard,
+.resultCard {
+  min-width: 0;
+}
+
+.resultEmpty {
+  align-items: center;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  color: #64748b;
+  display: flex;
+  font-size: 13px;
+  justify-content: center;
+  min-height: 190px;
+  padding: 16px;
+  text-align: center;
+}
+
+.resultPanelSuccess,
+.resultPanelWarning {
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.resultPanelSuccess {
+  border: 1px solid var(--color-interface-panel-border);
+  background: var(--color-interface-panel-bg);
+}
+
+.resultPanelWarning {
+  border: 1px solid var(--color-interface-warning-border);
+  background: var(--color-interface-warning-bg);
+}
+
+.resultHeader {
+  align-items: center;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+}
+
+.statusDotSuccess,
+.statusDotWarning {
+  border-radius: 999px;
+  display: inline-flex;
+  height: 9px;
+  width: 9px;
+}
+
+.statusDotSuccess {
+  background: var(--color-interface-success-dot);
+  box-shadow: 0 0 0 3px var(--color-interface-success-ring);
+}
+
+.statusDotWarning {
+  background: var(--color-interface-warning-dot);
+  box-shadow: 0 0 0 3px var(--color-interface-warning-ring);
+}
+
+.resultTitle {
+  color: #17253d;
+  font-weight: 650;
+}
+
+.resultMeta {
+  color: var(--color-interface-panel-muted);
+  font-size: 12px;
+  margin-left: auto;
+}
+
+.resultCode {
+  background: var(--color-interface-code-bg);
+  color: var(--color-interface-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.58;
+  margin: 0;
+  max-height: 280px;
+  overflow: auto;
+  padding: 14px 16px;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 1100px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/src/modules/execution-factory/components/ToolDebugPanel.test.tsx
+++ b/src/modules/execution-factory/components/ToolDebugPanel.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ToolDebugPanel } from "@/modules/execution-factory/components/ToolDebugPanel";
+import { debugTool } from "@/modules/execution-factory/services/tool.service";
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: {
+    type: "3rdParty",
+    init: vi.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/framework/request/error-message", () => ({
+  extractRequestErrorMessage: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+vi.mock("@/modules/execution-factory/services/tool.service", () => ({
+  debugTool: vi.fn(),
+}));
+
+describe("ToolDebugPanel", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it("runs debug inline and reports the result without opening a modal", async () => {
+    vi.mocked(debugTool).mockResolvedValue({
+      statusCode: 200,
+      durationMs: 12,
+      body: { ok: true },
+    });
+    const onRunComplete = vi.fn();
+
+    render(
+      <ToolDebugPanel
+        boxId="box-1"
+        onRunComplete={onRunComplete}
+        record={{ toolId: "tool-1", name: "Search", status: "enabled" }}
+      />,
+    );
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "executionFactory.runDebug" }));
+
+    await waitFor(() => {
+      expect(debugTool).toHaveBeenCalledWith("box-1", "tool-1", {});
+    });
+    expect(await screen.findByTestId("tool-debug-inline-result")).toBeTruthy();
+    expect(onRunComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/execution-factory/components/ToolDebugPanel.tsx
+++ b/src/modules/execution-factory/components/ToolDebugPanel.tsx
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { Alert, Form, Input } from "antd";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { extractRequestErrorMessage } from "@/framework/request/error-message";
+import { AppButton } from "@/framework/ui/common/AppButton";
+import { debugTool } from "@/modules/execution-factory/services/tool.service";
+import type { FunctionInputPayload } from "@/modules/execution-factory/types/function-input";
+import type {
+  ToolDebugResult,
+  ToolIoSpec,
+  ToolRecord,
+  ToolRunLogEntry,
+} from "@/modules/execution-factory/types/tool";
+import { buildDefaultDebugBody } from "@/modules/execution-factory/utils/generate-sample-json";
+import { buildToolDebugRequest } from "@/modules/execution-factory/utils/tool-io";
+
+import styles from "./ToolDebugPanel.module.css";
+
+type ToolDebugPanelProps = {
+  boxId: string;
+  defaultRequestBody?: string;
+  functionInput?: FunctionInputPayload;
+  ioSpec?: ToolIoSpec;
+  onRunComplete?: (entry: ToolRunLogEntry) => void;
+  record: ToolRecord | null;
+};
+
+type DebugFormValues = {
+  requestBody?: string;
+};
+
+export function ToolDebugPanel({
+  boxId,
+  defaultRequestBody,
+  functionInput,
+  ioSpec,
+  onRunComplete,
+  record,
+}: ToolDebugPanelProps) {
+  const { t } = useTranslation();
+  const [form] = Form.useForm<DebugFormValues>();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ToolDebugResult | null>(null);
+
+  const generatedBody = useMemo(
+    () =>
+      defaultRequestBody ??
+      buildDefaultDebugBody({
+        ioSpec,
+        functionInput,
+      }),
+    [defaultRequestBody, functionInput, ioSpec],
+  );
+
+  useEffect(() => {
+    form.setFieldsValue({
+      requestBody: generatedBody,
+    });
+  }, [form, generatedBody]);
+
+  const handleDebug = async () => {
+    if (!record) {
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const values = await form.validateFields();
+      let body: Record<string, unknown> | undefined;
+
+      if (values.requestBody?.trim()) {
+        body = JSON.parse(values.requestBody) as Record<string, unknown>;
+      }
+
+      const debugRequest = buildToolDebugRequest(body, ioSpec);
+      const debugResult = await debugTool(boxId, record.toolId, debugRequest);
+      setResult(debugResult);
+      onRunComplete?.({
+        id: `${Date.now()}`,
+        timestamp: Date.now(),
+        statusCode: debugResult.statusCode,
+        durationMs: debugResult.durationMs,
+        error: debugResult.error,
+        body: debugResult.body,
+        requestBody: debugRequest,
+      });
+    } catch (caughtError) {
+      setError(extractRequestErrorMessage(caughtError));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className={styles.panel}>
+      <div className={styles.header}>
+        <div>
+          <h3 className={styles.title}>{t("executionFactory.toolDebugWorkbenchTitle")}</h3>
+          <p className={styles.desc}>{t("executionFactory.toolDebugWorkbenchDesc")}</p>
+        </div>
+        <AppButton
+          disabled={!record}
+          loading={submitting}
+          onClick={() => {
+            void handleDebug();
+          }}
+          type="primary"
+        >
+          {t("executionFactory.runDebug")}
+        </AppButton>
+      </div>
+      {record ? (
+        <p className={styles.desc}>
+          {record.name} ({record.toolId})
+        </p>
+      ) : null}
+      <div className={styles.content}>
+        <div className={styles.requestCard}>
+          <Form form={form} layout="vertical">
+            <Form.Item label={t("executionFactory.debugRequestBody")} name="requestBody">
+              <Input.TextArea placeholder="{}" rows={9} />
+            </Form.Item>
+          </Form>
+          {error ? <Alert message={error} showIcon type="error" /> : null}
+        </div>
+        <div className={styles.resultCard}>
+          {result ? (
+            <section
+              className={result.error ? styles.resultPanelWarning : styles.resultPanelSuccess}
+              data-testid="tool-debug-inline-result"
+            >
+              <div className={styles.resultHeader}>
+                <span className={result.error ? styles.statusDotWarning : styles.statusDotSuccess} />
+                <span className={styles.resultTitle}>
+                  {t("executionFactory.debugResultTitle")}
+                </span>
+                <span className={styles.resultMeta}>
+                  HTTP {result.statusCode || "-"}
+                  {typeof result.durationMs === "number" ? ` · ${result.durationMs} ms` : ""}
+                </span>
+              </div>
+              <pre className={styles.resultCode}>{JSON.stringify(result, null, 2)}</pre>
+            </section>
+          ) : (
+            <div className={styles.resultEmpty}>
+              {t("executionFactory.toolDebugWorkbenchEmpty")}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/modules/execution-factory/components/create-menu/AddCapabilityWizard.tsx
+++ b/src/modules/execution-factory/components/create-menu/AddCapabilityWizard.tsx
@@ -335,6 +335,8 @@ export function AddCapabilityWizard({
 
       summary?: string;
 
+      description?: string;
+
       operatorSync?: import("@/modules/execution-factory/types/operator-sync").OperatorSyncPublishInput;
 
     };
@@ -364,6 +366,7 @@ export function AddCapabilityWizard({
         operatorSync: payload.values.operatorSync,
 
         toolName: payload.values.summary,
+        toolDescription: payload.values.description,
 
       });
 

--- a/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.tsx
@@ -25,8 +25,6 @@ import { CapabilityCategoryFields } from "@/modules/execution-factory/components
 
 import { OpenApiSpecInput } from "@/modules/execution-factory/components/OpenApiSpecInput";
 
-import { OperatorSyncPublishFields } from "@/modules/execution-factory/components/OperatorSyncPublishFields";
-
 import { listToolboxes } from "@/modules/execution-factory/services/toolbox.service";
 
 import type { OperatorSyncPublishInput } from "@/modules/execution-factory/types/operator-sync";
@@ -109,9 +107,6 @@ export const ImportOpenApiCapabilityForm = forwardRef<
   const [toolboxOptions, setToolboxOptions] = useState<Array<{ label: string; value: string }>>([]);
 
   const toolboxMode = Form.useWatch("toolboxMode", form) ?? (initialBoxId ? "existing" : "new");
-
-  const toolboxName = Form.useWatch("toolboxName", form) as string | undefined;
-
 
 
   useImperativeHandle(ref, () => ({
@@ -353,10 +348,6 @@ export const ImportOpenApiCapabilityForm = forwardRef<
         <Input placeholder="https://api.example.com" />
 
       </Form.Item>
-
-
-
-      <OperatorSyncPublishFields defaultOperatorName={toolboxName} />
 
 
 

--- a/src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx
+++ b/src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx
@@ -22,7 +22,6 @@ import {
   ToolboxPlacementIntro,
 } from "@/modules/execution-factory/components/CapabilityBusinessIntro";
 import { CapabilityCategoryFields } from "@/modules/execution-factory/components/CapabilityCategoryFields";
-import { OperatorSyncPublishFields } from "@/modules/execution-factory/components/OperatorSyncPublishFields";
 import { listToolboxes } from "@/modules/execution-factory/services/toolbox.service";
 import type { OperatorSyncPublishInput } from "@/modules/execution-factory/types/operator-sync";
 
@@ -81,7 +80,6 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
   const [parseHint, setParseHint] = useState<string | null>(null);
   const [toolboxOptions, setToolboxOptions] = useState<Array<{ label: string; value: string }>>([]);
   const toolboxMode = Form.useWatch("toolboxMode", form) ?? (initialBoxId ? "existing" : "new");
-  const summary = Form.useWatch("summary", form) as string | undefined;
   const watchedValues = Form.useWatch([], form) as QuickAddApiFormValues | undefined;
 
   const previewSpec = useMemo(() => {
@@ -278,6 +276,7 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
       {previewValidation.ok && previewSpec ? (
         <div style={{ marginBottom: 16 }}>
           <Alert
+            className={styles.interfaceSuccessAlert}
             message={t("executionFactory.quickApiIoPreviewTitle")}
             showIcon
             style={{ marginBottom: 8 }}
@@ -286,8 +285,6 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
           <OpenApiOperationsIoPreview limit={1} openapiSpec={previewSpec} />
         </div>
       ) : null}
-
-      <OperatorSyncPublishFields defaultOperatorName={summary} />
 
       {!initialBoxId ? (
         <>

--- a/src/modules/execution-factory/locales/en-US.ts
+++ b/src/modules/execution-factory/locales/en-US.ts
@@ -166,7 +166,7 @@ export const executionFactoryEnUS = {
     backToCapabilities: "← Back to toolsets / MCP / skills",
     advancedOperatorEntry: "Operator dev",
     advancedOperatorBanner:
-      "Operator list and debug. For everyday HTTP APIs, use Add API under Toolsets and enable Sync as operator.",
+      "Operator list and debug. For everyday HTTP APIs, use Add API under Toolsets; register an operator separately when orchestration metadata is needed.",
     quickApiTabCurl: "Paste cURL",
     quickApiTabForm: "Simple form",
     quickApiCurlLabel: "cURL command",
@@ -387,7 +387,7 @@ export const executionFactoryEnUS = {
       "After creating a function toolbox, configure each tool with code, inputs, and outputs under View Tools.",
     toolboxEditFlowHint: "Editing updates toolbox metadata without replacing the registered spec.",
     functionToolCreateHint:
-      "Provide function code plus input and output parameters. After saving, use the tool IDE for debugging and advanced edits.",
+      "Provide function code plus input and output parameters. After saving, use the tool configuration page for debugging and advanced edits.",
     createToolboxFunctionNextStep:
       "After creation you will be guided to the tools page to add your first function tool.",
     serviceUrl: "Service URL",
@@ -547,16 +547,29 @@ export const executionFactoryEnUS = {
     parameterName: "Name",
     parameterType: "Type",
     parameterDescription: "Description",
-    globalParametersTitle: "Global parameters",
+    globalParametersTitle: "Additional parameters",
     globalParameterName: "Name",
     globalParameterDescription: "Description",
     globalParameterIn: "In",
     globalParameterType: "Type",
     globalParameterRequired: "Required",
     globalParameterValue: "Value (JSON)",
-    toolDetailTitle: "Tool IDE",
-    toolDetailDescription: "Edit tool metadata, OpenAPI spec, or function code.",
-    openToolIde: "Open IDE",
+    toolDetailTitle: "Tool configuration",
+    toolDetailDescription: "Edit tool information, interface configuration, usage rules, and debug settings.",
+    httpToolLifecycleSummaryTitle: "Capability information",
+    httpToolLifecycleSummaryDesc:
+      "Keep the business name, description, and usage rules clear for people and agents.",
+    httpToolLifecyclePreviewTitle: "Interface preview",
+    httpToolLifecyclePreviewDesc:
+      "Review generated request parameters, request body, responses, and debug results before publishing.",
+    httpToolLifecycleAdvancedTitle: "Advanced configuration",
+    httpToolLifecycleAdvancedDesc:
+      "Raw OpenAPI, function definition, and global parameters are kept here for low-level control.",
+    toolDebugWorkbenchTitle: "Debug validation",
+    toolDebugWorkbenchDesc:
+      "Run the current tool in place, review the response, then continue editing without losing context.",
+    toolDebugWorkbenchEmpty: "Run debug to see status, duration, response body, and error details here.",
+    openToolIde: "Edit configuration",
     importResourceTitle: {
       operator: "Import Operator",
       toolbox: "Import Toolbox",

--- a/src/modules/execution-factory/locales/zh-CN.ts
+++ b/src/modules/execution-factory/locales/zh-CN.ts
@@ -135,6 +135,14 @@ export const executionFactoryZhCN = {
       "当前 OpenAPI 文档使用相对服务地址 {{relativeUrl}}，请填写完整服务地址后再导入。",
     importOpenApiCapabilityFileReady: "文件已就绪，保存后将解析并导入接口。",
     importOpenApiCapabilityPreview: "OpenAPI {{version}} · 共 {{count}} 个接口",
+    createdNextStepsTitle: "HTTP API 已添加到工具集",
+    createdNextStepsDescription:
+      "建议下一步先调试验证，再补齐工具说明与使用规则。也可以直接进入工具集继续管理。",
+    createdNextStepsTool: "工具",
+    createdNextStepsToolbox: "工具集",
+    createdNextStepsViewToolset: "查看工具集",
+    createdNextStepsDebug: "去调试",
+    createdNextStepsEditTool: "编辑工具信息",
     addCapabilityFunctionTitle: "写个小函数",
     addCapabilityFunctionDesc: "创建函数型工具集，在线编写逻辑",
     addCapabilityMcpTitle: "MCP 服务",
@@ -154,7 +162,7 @@ export const executionFactoryZhCN = {
     backToCapabilities: "← 返回工具集 / MCP / Skill",
     advancedOperatorEntry: "算子开发",
     advancedOperatorBanner:
-      "算子列表与调试入口。日常 HTTP 接口请在「工具集」添加 API，并勾选「同步发布为算子」即可一并注册。",
+      "算子列表与调试入口。日常 HTTP 接口请在「工具集」添加 API；需要流程编排算子时，可从算子入口单独注册。",
     quickApiTabCurl: "粘贴 cURL",
     quickApiTabForm: "填表单",
     quickApiCurlLabel: "cURL 命令",
@@ -373,7 +381,7 @@ export const executionFactoryZhCN = {
       "函数工具箱创建后，请在「查看工具详情」中为每个工具配置函数代码、入参和出参。",
     toolboxEditFlowHint: "编辑操作仅更新工具箱元数据，不会替换已注册的规范。",
     functionToolCreateHint:
-      "请填写函数代码、入参和出参。保存后可在工具 IDE 中继续调试与编辑。",
+      "请填写函数代码、入参和出参。保存后可在工具配置页继续调试与编辑。",
     createToolboxFunctionNextStep:
       "创建完成后将引导您进入工具管理页，添加第一个函数工具。",
     serviceUrl: "服务地址",
@@ -532,16 +540,29 @@ export const executionFactoryZhCN = {
     parameterName: "参数名",
     parameterType: "参数类型",
     parameterDescription: "参数描述",
-    globalParametersTitle: "全局参数",
+    globalParametersTitle: "附加参数",
     globalParameterName: "参数名",
     globalParameterDescription: "参数描述",
     globalParameterIn: "参数位置",
     globalParameterType: "参数类型",
     globalParameterRequired: "必填",
     globalParameterValue: "参数值 (JSON)",
-    toolDetailTitle: "工具 IDE",
-    toolDetailDescription: "编辑工具元数据、OpenAPI 规范或函数代码。",
-    openToolIde: "打开 IDE",
+    toolDetailTitle: "工具配置",
+    toolDetailDescription: "编辑工具信息、接口配置、使用规则与调试设置。",
+    httpToolLifecycleSummaryTitle: "能力信息",
+    httpToolLifecycleSummaryDesc:
+      "保持业务名称、描述和使用规则清晰，方便人员和智能体理解。",
+    httpToolLifecyclePreviewTitle: "接口预览",
+    httpToolLifecyclePreviewDesc:
+      "发布前核对生成的请求参数、请求体、响应和调试结果。",
+    httpToolLifecycleAdvancedTitle: "高级配置",
+    httpToolLifecycleAdvancedDesc:
+      "原始 OpenAPI、函数定义和全局参数保留在这里，用于底层配置。",
+    toolDebugWorkbenchTitle: "调试验证",
+    toolDebugWorkbenchDesc:
+      "在当前页面运行工具，查看响应结果，再继续编辑配置，避免丢失上下文。",
+    toolDebugWorkbenchEmpty: "运行调试后，这里会显示状态码、耗时、响应体和错误详情。",
+    openToolIde: "编辑配置",
     importResourceTitle: {
       operator: "导入算子",
       toolbox: "导入工具箱",

--- a/src/modules/execution-factory/scenes/ToolDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/ToolDetailScene.tsx
@@ -5,8 +5,8 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Alert, Collapse, Form, Input, Spin } from "antd";
-import { useEffect, useState } from "react";
+import { Alert, Form, Input, Spin } from "antd";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
@@ -17,9 +17,8 @@ import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { CrudFormPage } from "@/framework/scaffold/CrudFormPage";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { FunctionDefinitionFields } from "@/modules/execution-factory/components/FunctionDefinitionFields";
-import { OpenApiSpecInput } from "@/modules/execution-factory/components/OpenApiSpecInput";
-import { ToolDebugModal } from "@/modules/execution-factory/components/ToolDebugModal";
-import { ToolGlobalParameterFields } from "@/modules/execution-factory/components/ToolGlobalParameterFields";
+import { HttpToolLifecyclePanel } from "@/modules/execution-factory/components/HttpToolLifecyclePanel";
+import { ToolDebugPanel } from "@/modules/execution-factory/components/ToolDebugPanel";
 import { ToolIoPanel } from "@/modules/execution-factory/components/ToolIoPanel";
 import {
   getToolDetail,
@@ -58,8 +57,8 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
   const [submitting, setSubmitting] = useState(false);
   const [metadataType, setMetadataType] = useState<ToolMetadataType>("openapi");
   const [ioSpec, setIoSpec] = useState<ToolIoSpec | undefined>();
-  const [debugOpen, setDebugOpen] = useState(false);
   const [sessionLogs, setSessionLogs] = useState<ToolRunLogEntry[]>([]);
+  const debugSectionRef = useRef<HTMLDivElement | null>(null);
   const functionInputs = Form.useWatch("functionInputs", form);
   const functionOutputs = Form.useWatch("functionOutputs", form);
 
@@ -101,7 +100,7 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
 
   useEffect(() => {
     if (!loading && !loadError && searchParams.get("focus") === "debug") {
-      setDebugOpen(true);
+      debugSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   }, [loadError, loading, searchParams]);
 
@@ -181,53 +180,83 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
         {!loading && !loadError ? (
           <div className={styles.formSurface}>
             <Form form={form} layout="vertical">
-              <Form.Item
-                label={t("executionFactory.toolName")}
-                name="name"
-                rules={[{ required: true, message: t("common.required") }]}
-              >
+              <HttpToolLifecyclePanel
+                advancedConfig={
+                  metadataType === "function" ? <FunctionDefinitionFields /> : undefined
+                }
+                businessFields={
+                  <>
+                    <Form.Item
+                      label={t("executionFactory.toolName")}
+                      name="name"
+                      rules={[{ required: true, message: t("common.required") }]}
+                    >
+                      <Input />
+                    </Form.Item>
+                    <Form.Item label={t("common.description")} name="description">
+                      <Input.TextArea rows={3} />
+                    </Form.Item>
+                    <Form.Item label={t("executionFactory.useRule")} name="useRule">
+                      <Input.TextArea rows={2} />
+                    </Form.Item>
+                  </>
+                }
+                debugWorkbench={
+                  <div ref={debugSectionRef}>
+                    <ToolDebugPanel
+                      boxId={boxId}
+                      functionInput={functionInput}
+                      ioSpec={ioSpec}
+                      onRunComplete={handleDebugRunComplete}
+                      record={{
+                        toolId,
+                        name: form.getFieldValue("name") ?? toolId,
+                        status: "enabled",
+                      }}
+                    />
+                  </div>
+                }
+                ioPreview={
+                  <ToolIoPanel
+                    functionInput={functionInput}
+                    ioSpec={ioSpec}
+                    runLogs={sessionLogs}
+                  />
+                }
+                metadataTypeLabel={t(`executionFactory.metadataTypes.${metadataType}`)}
+              />
+              {metadataType === "openapi" ? (
+                <Form.Item hidden name="openapiSpec">
+                  <Input />
+                </Form.Item>
+              ) : null}
+              <Form.Item hidden name={["globalParameters", "name"]}>
                 <Input />
               </Form.Item>
-              <Form.Item label={t("common.description")} name="description">
-                <Input.TextArea rows={3} />
+              <Form.Item hidden name={["globalParameters", "description"]}>
+                <Input />
               </Form.Item>
-              <Form.Item label={t("executionFactory.useRule")} name="useRule">
-                <Input.TextArea rows={2} />
+              <Form.Item hidden name={["globalParameters", "in"]}>
+                <Input />
               </Form.Item>
-              {metadataType === "openapi" ? (
-                <Form.Item
-                  label={t("executionFactory.openapiSpec")}
-                  name="openapiSpec"
-                  rules={[{ required: true, message: t("common.required") }]}
-                >
-                  <OpenApiSpecInput rows={14} />
-                </Form.Item>
-              ) : (
-                <FunctionDefinitionFields />
-              )}
-              <Collapse
-                ghost
-                items={[
-                  {
-                    key: "globalParameters",
-                    label: t("executionFactory.globalParametersTitle"),
-                    children: <ToolGlobalParameterFields />,
-                  },
-                ]}
-              />
+              <Form.Item hidden name={["globalParameters", "type"]}>
+                <Input />
+              </Form.Item>
+              <Form.Item hidden name={["globalParameters", "value"]}>
+                <Input />
+              </Form.Item>
             </Form>
-            <section style={{ marginTop: 24 }}>
-              <h3 style={{ marginBottom: 12 }}>{t("executionFactory.toolboxInputOutputTitle")}</h3>
-              <ToolIoPanel
-                functionInput={functionInput}
-                ioSpec={ioSpec}
-                runLogs={sessionLogs}
-              />
-            </section>
             <div className={styles.formActions}>
               <AppButton onClick={handleBack}>{t("common.cancel")}</AppButton>
               <PermissionGate permissions="execution-factory:tool:debug">
-                <AppButton onClick={() => setDebugOpen(true)}>
+                <AppButton
+                  onClick={() =>
+                    debugSectionRef.current?.scrollIntoView({
+                      behavior: "smooth",
+                      block: "start",
+                    })
+                  }
+                >
                   {t("executionFactory.debug")}
                 </AppButton>
               </PermissionGate>
@@ -238,26 +267,6 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
           </div>
         ) : null}
       </CrudFormPage>
-      <ToolDebugModal
-        boxId={boxId}
-        functionInput={
-          metadataType === "function"
-            ? {
-                inputs: functionInputs,
-                outputs: functionOutputs,
-              }
-            : undefined
-        }
-        ioSpec={ioSpec}
-        onClose={() => setDebugOpen(false)}
-        onRunComplete={handleDebugRunComplete}
-        open={debugOpen}
-        record={{
-          toolId,
-          name: form.getFieldValue("name") ?? toolId,
-          status: "enabled",
-        }}
-      />
     </PermissionGate>
   );
 }

--- a/src/modules/execution-factory/services/import-openapi.service.test.ts
+++ b/src/modules/execution-factory/services/import-openapi.service.test.ts
@@ -42,18 +42,15 @@ describe("registerOpenApiImport", () => {
     vi.clearAllMocks();
     vi.mocked(createToolbox).mockResolvedValue({
       boxId: "box-1",
-      id: "box-1",
       name: "Swagger_Petstore_OpenAPI_3_0",
       description: "Petstore",
       metadataType: "openapi",
-      source: "custom",
       status: "offline",
-      category: "other_category",
+      categoryType: "other_category",
+      categoryName: "other_category",
       toolCount: 0,
-      creator: "admin",
-      updatedBy: "admin",
-      createdAt: "",
-      updatedAt: "",
+      createUser: "admin",
+      updateUser: "admin",
     });
     vi.mocked(importOpenApiTools).mockResolvedValue({
       successIds: ["tool-1"],

--- a/src/modules/execution-factory/services/quick-api.service.test.ts
+++ b/src/modules/execution-factory/services/quick-api.service.test.ts
@@ -126,7 +126,7 @@ describe("registerQuickApi", () => {
     ).rejects.toThrow("Tool creation was not persisted");
   });
 
-  it("does not return a navigable result when the created toolbox is missing from list", async () => {
+  it("returns a navigable result when detail is readable even if toolbox list lags", async () => {
     vi.mocked(listToolboxes).mockResolvedValue({
       items: [],
       page: 1,
@@ -140,6 +140,6 @@ describe("registerQuickApi", () => {
         serviceUrl: "http://127.0.0.1:8095",
         toolboxName: "Quick API Box",
       }),
-    ).rejects.toThrow("Toolbox creation was not persisted");
+    ).resolves.toEqual({ boxId: "box-1", toolIds: ["tool-1"] });
   });
 });

--- a/src/modules/execution-factory/services/quick-api.service.test.ts
+++ b/src/modules/execution-factory/services/quick-api.service.test.ts
@@ -95,10 +95,20 @@ describe("registerQuickApi", () => {
       registerQuickApi({
         openapiSpec,
         serviceUrl: "http://127.0.0.1:8095",
+        toolDescription: "Health check endpoint",
+        toolName: "health_check",
         toolboxName: "Quick API Box",
       }),
     ).resolves.toEqual({ boxId: "box-1", toolIds: ["tool-1"] });
 
+    expect(createTool).toHaveBeenCalledWith(
+      "box-1",
+      expect.objectContaining({
+        description: "Health check endpoint",
+        name: "health_check",
+        openapiSpec,
+      }),
+    );
     expect(listToolboxes).toHaveBeenCalledWith(
       expect.objectContaining({ keyword: "Quick API Box" }),
     );

--- a/src/modules/execution-factory/services/quick-api.service.ts
+++ b/src/modules/execution-factory/services/quick-api.service.ts
@@ -75,14 +75,11 @@ async function confirmQuickApiPersistence(input: {
     toolboxVisible = Boolean(toolbox);
 
     if (toolboxVisible && input.toolboxName?.trim()) {
-      const list = await listToolboxes({
+      void listToolboxes({
         keyword: input.toolboxName.trim(),
         page: 1,
         pageSize: 100,
       }).catch(() => null);
-      toolboxVisible = Boolean(
-        list?.items.some((item) => item.boxId === input.boxId),
-      );
     }
 
     if (toolboxVisible) {

--- a/src/modules/execution-factory/services/quick-api.service.ts
+++ b/src/modules/execution-factory/services/quick-api.service.ts
@@ -38,6 +38,7 @@ export type RegisterQuickApiInput = {
   operatorSync?: OperatorSyncPublishInput;
 
   toolName?: string;
+  toolDescription?: string;
 
 };
 
@@ -219,6 +220,10 @@ export async function registerQuickApi(
   const result = await createTool(boxId, {
 
     metadataType: "openapi",
+
+    name: input.toolName,
+
+    description: input.toolDescription,
 
     openapiSpec: input.openapiSpec,
 

--- a/src/modules/execution-factory/services/tool.service.test.ts
+++ b/src/modules/execution-factory/services/tool.service.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createTool,
+  getToolDetail,
+  importOpenApiTools,
+  listTools,
+} from "@/modules/execution-factory/services/tool.service";
+
+describe("tool.service mock persistence", () => {
+  it("keeps created HTTP tool metadata available when reopened for editing", async () => {
+    const boxId = `box-${Date.now()}`;
+    const openapiSpec = JSON.stringify({
+      openapi: "3.0.3",
+      info: { title: "HTTPBin Get", version: "1.0.0" },
+      servers: [{ url: "https://httpbin.org" }],
+      paths: {
+        "/get": {
+          get: {
+            summary: "httpbin_get",
+            parameters: [
+              { name: "customerId", in: "query", schema: { type: "string", example: "1001" } },
+              { name: "x-demo-source", in: "header", schema: { type: "string", example: "openbkn" } },
+            ],
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const result = await createTool(boxId, {
+      metadataType: "openapi",
+      name: "httpbin_get",
+      description: "HTTPBin GET test",
+      openapiSpec,
+    });
+    const detail = await getToolDetail(boxId, result.successIds[0]!);
+
+    expect(detail.name).toBe("httpbin_get");
+    expect(detail.description).toBe("HTTPBin GET test");
+    expect(detail.openapiSpec).toBe(openapiSpec);
+    expect(detail.ioSpec?.parameters.map((item) => [item.name, item.in])).toEqual([
+      ["customerId", "query"],
+      ["x-demo-source", "header"],
+    ]);
+  });
+
+  it("splits a multi-operation OpenAPI document into separate mock tools", async () => {
+    const boxId = `box-multi-${Date.now()}`;
+    const openapiSpec = JSON.stringify({
+      openapi: "3.0.3",
+      info: { title: "Mini Petstore", version: "1.0.0" },
+      servers: [{ url: "https://petstore3.swagger.io/api/v3" }],
+      paths: {
+        "/pet": {
+          put: {
+            summary: "updatePet",
+            description: "Update an existing pet",
+            parameters: [{ name: "traceId", in: "header", schema: { type: "string" } }],
+            responses: { "200": { description: "OK" } },
+          },
+          post: {
+            summary: "addPet",
+            description: "Add a new pet",
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: { type: "object" },
+                },
+              },
+            },
+            responses: { "200": { description: "OK" } },
+          },
+        },
+        "/pet/findByStatus": {
+          get: {
+            summary: "findPetsByStatus",
+            parameters: [{ name: "status", in: "query", schema: { type: "string" } }],
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const result = await importOpenApiTools(boxId, openapiSpec, "Petstore test rules");
+    const tools = await listTools(boxId, { page: 1, pageSize: 100 });
+    const firstDetail = await getToolDetail(boxId, result.successIds[0]!);
+
+    expect(result.successCount).toBe(3);
+    expect(tools.items.map((item) => item.name)).toEqual([
+      "updatePet",
+      "addPet",
+      "findPetsByStatus",
+    ]);
+    expect(firstDetail.name).toBe("updatePet");
+    expect(firstDetail.path).toBe("/pet");
+    expect(firstDetail.method).toBe("PUT");
+    expect(firstDetail.useRule).toBe("Petstore test rules");
+    expect(firstDetail.ioSpec?.parameters).toEqual([
+      { name: "traceId", in: "header", required: false, type: "string" },
+    ]);
+  });
+
+  it("keeps all operations when importing a Petstore-sized OpenAPI document", async () => {
+    const boxId = `box-petstore-sized-${Date.now()}`;
+    const paths = Object.fromEntries(
+      Array.from({ length: 19 }, (_, index) => [
+        `/petstore/resource-${index + 1}`,
+        {
+          get: {
+            summary: `petstoreResource${index + 1}`,
+            parameters: [
+              { name: "limit", in: "query", schema: { type: "integer" } },
+            ],
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      ]),
+    );
+    const openapiSpec = JSON.stringify({
+      openapi: "3.0.3",
+      info: { title: "Swagger Petstore", version: "1.0.0" },
+      servers: [{ url: "https://petstore3.swagger.io/api/v3" }],
+      paths,
+    });
+
+    const result = await importOpenApiTools(boxId, openapiSpec);
+    const tools = await listTools(boxId, { page: 1, pageSize: 100 });
+    const lastDetail = await getToolDetail(boxId, result.successIds[18]!);
+
+    expect(result.successCount).toBe(19);
+    expect(tools.total).toBe(19);
+    expect(tools.items).toHaveLength(19);
+    expect(tools.items[0]?.name).toBe("petstoreResource1");
+    expect(tools.items[18]?.name).toBe("petstoreResource19");
+    expect(lastDetail.path).toBe("/petstore/resource-19");
+    expect(lastDetail.method).toBe("GET");
+    expect(lastDetail.ioSpec?.parameters[0]?.name).toBe("limit");
+  });
+});

--- a/src/modules/execution-factory/services/tool.service.ts
+++ b/src/modules/execution-factory/services/tool.service.ts
@@ -23,10 +23,12 @@ import type {
 } from "@/modules/execution-factory/types/tool";
 import {
   mapFunctionContent,
+  normalizeGeneratedCapabilityName,
   parseOpenApiDataPayload,
   serializeOpenApiSpec,
 } from "@/modules/execution-factory/utils/metadata-content";
 import { normalizeTimestamp } from "@/modules/execution-factory/utils/format-timestamp";
+import { extractOpenApiOperationsIo } from "@/modules/execution-factory/utils/openapi-operation-io";
 import { parseToolIoSpec } from "@/modules/execution-factory/utils/tool-io";
 import type { ToolGlobalParameter } from "@/modules/execution-factory/types/tool";
 
@@ -77,8 +79,26 @@ type BackendToolListResponse = {
 const API_PREFIX = "/agent-operator-integration/v1";
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 const DEFAULT_BUSINESS_DOMAIN = "bd_public";
+const HTTP_METHODS = new Set([
+  "delete",
+  "get",
+  "head",
+  "options",
+  "patch",
+  "post",
+  "put",
+]);
 
-const mockToolsByBox: Record<string, ToolRecord[]> = {
+type MockOpenApiOperation = {
+  description?: string;
+  method: string;
+  name: string;
+  openapiSpec: string;
+  path: string;
+  serverUrl?: string;
+};
+
+const mockToolsByBox: Record<string, ToolDetail[]> = {
   tb_context_loader: [
     {
       toolId: "tool_search",
@@ -227,6 +247,99 @@ function getMockTools(boxId: string) {
   return mockToolsByBox[boxId] ?? [];
 }
 
+function parseMockOpenApiIo(openapiSpec?: string) {
+  return extractOpenApiOperationsIo(openapiSpec)[0]?.io;
+}
+
+function extractMockOpenApiOperations(openapiSpec?: string): MockOpenApiOperation[] {
+  if (!openapiSpec?.trim()) {
+    return [];
+  }
+
+  try {
+    const document = JSON.parse(openapiSpec) as Record<string, unknown>;
+    const paths = document.paths;
+    if (!paths || typeof paths !== "object" || Array.isArray(paths)) {
+      return [];
+    }
+
+    const serverUrl = Array.isArray(document.servers)
+      ? ((document.servers[0] as { url?: unknown } | undefined)?.url as string | undefined)
+      : undefined;
+    const operations: MockOpenApiOperation[] = [];
+
+    for (const [path, pathItem] of Object.entries(paths as Record<string, unknown>)) {
+      if (!pathItem || typeof pathItem !== "object" || Array.isArray(pathItem)) {
+        continue;
+      }
+
+      for (const [method, operation] of Object.entries(pathItem as Record<string, unknown>)) {
+        if (!HTTP_METHODS.has(method.toLowerCase())) {
+          continue;
+        }
+
+        if (!operation || typeof operation !== "object" || Array.isArray(operation)) {
+          continue;
+        }
+
+        const operationRecord = operation as Record<string, unknown>;
+        const summary =
+          typeof operationRecord.summary === "string" ? operationRecord.summary : undefined;
+        const description =
+          typeof operationRecord.description === "string"
+            ? operationRecord.description
+            : summary;
+        const name =
+          normalizeGeneratedCapabilityName(summary) ??
+          normalizeGeneratedCapabilityName(`${method}_${path}`) ??
+          "api_tool";
+        const singleOperationDocument = {
+          ...document,
+          paths: {
+            [path]: {
+              [method]: operationRecord,
+            },
+          },
+        };
+
+        operations.push({
+          description,
+          method: method.toUpperCase(),
+          name,
+          openapiSpec: JSON.stringify(singleOperationDocument),
+          path,
+          serverUrl,
+        });
+      }
+    }
+
+    return operations;
+  } catch {
+    return [];
+  }
+}
+
+function buildMockToolDetail(toolId: string, input: ToolCreateInput): ToolDetail {
+  const operation = extractMockOpenApiOperations(input.openapiSpec)[0];
+
+  return {
+    toolId,
+    name: input.name ?? operation?.name ?? `Tool ${toolId}`,
+    description: input.description ?? operation?.description,
+    status: "disabled",
+    metadataType: input.metadataType,
+    useRule: input.useRule,
+    method: operation?.method,
+    path: operation?.path,
+    serverUrl: operation?.serverUrl,
+    updateTime: Date.now(),
+    openapiSpec: input.openapiSpec,
+    functionInput: input.functionInput,
+    globalParameters: input.globalParameters,
+    ioSpec: input.metadataType === "openapi" ? parseMockOpenApiIo(input.openapiSpec) : undefined,
+  };
+}
+
 function filterMockTools(boxId: string, query: ToolListQuery) {
   const keyword = query.keyword?.trim().toLowerCase();
 
@@ -321,11 +434,14 @@ export async function getToolDetail(boxId: string, toolId: string): Promise<Tool
 
     return {
       ...record,
-      openapiSpec: record.metadataType === "openapi" ? '{"openapi":"3.0.3"}' : undefined,
+      openapiSpec:
+        record.openapiSpec ??
+        (record.metadataType === "openapi" ? '{"openapi":"3.0.3"}' : undefined),
       functionInput:
-        record.metadataType === "function"
+        record.functionInput ??
+        (record.metadataType === "function"
           ? { code: "def handler(event):\n    return event\n", script_type: "python" }
-          : undefined,
+          : undefined),
     };
   }
 
@@ -343,14 +459,7 @@ export async function createTool(
 ): Promise<ToolCreateResult> {
   if (useMock) {
     const toolId = `tool_${Date.now()}`;
-    const record: ToolRecord = {
-      toolId,
-      name: `Tool ${toolId}`,
-      status: "disabled",
-      metadataType: input.metadataType,
-      useRule: input.useRule,
-      updateTime: Date.now(),
-    };
+    const record = buildMockToolDetail(toolId, input);
     mockToolsByBox[boxId] = [record, ...getMockTools(boxId)];
     return {
       successIds: [toolId],
@@ -385,6 +494,38 @@ export async function importOpenApiTools(
   openapiSpec: string,
   useRule?: string,
 ): Promise<ToolCreateResult> {
+  if (useMock) {
+    const operations = extractMockOpenApiOperations(openapiSpec);
+
+    if (operations.length <= 1) {
+      return createTool(boxId, {
+        metadataType: "openapi",
+        openapiSpec,
+        useRule,
+      });
+    }
+
+    const now = Date.now();
+    const records = operations.map((operation, index) =>
+      buildMockToolDetail(`tool_${now}_${index}`, {
+        metadataType: "openapi",
+        name: operation.name,
+        description: operation.description,
+        openapiSpec: operation.openapiSpec,
+        useRule,
+      }),
+    );
+
+    mockToolsByBox[boxId] = [...records, ...getMockTools(boxId)];
+
+    return {
+      successIds: records.map((record) => record.toolId),
+      successCount: records.length,
+      failureCount: 0,
+      failures: [],
+    };
+  }
+
   return createTool(boxId, {
     metadataType: "openapi",
     openapiSpec,
@@ -398,6 +539,7 @@ export async function updateTool(
   input: ToolEditInput,
 ): Promise<void> {
   if (useMock) {
+    const metadataType = input.metadataType;
     mockToolsByBox[boxId] = getMockTools(boxId).map((item) =>
       item.toolId === toolId
         ? {
@@ -405,6 +547,14 @@ export async function updateTool(
             name: input.name,
             description: input.description,
             useRule: input.useRule,
+            metadataType: metadataType ?? item.metadataType,
+            openapiSpec: input.openapiSpec ?? item.openapiSpec,
+            functionInput: input.functionInput ?? item.functionInput,
+            globalParameters: input.globalParameters ?? item.globalParameters,
+            ioSpec:
+              metadataType === "openapi" && input.openapiSpec
+                ? parseMockOpenApiIo(input.openapiSpec)
+                : item.ioSpec,
             updateTime: Date.now(),
           }
         : item,

--- a/src/modules/execution-factory/services/tool.service.ts
+++ b/src/modules/execution-factory/services/tool.service.ts
@@ -473,7 +473,11 @@ export async function debugTool(
     status_code?: number;
   }>(
     `${API_PREFIX}/tool-box/${boxId}/tool/${toolId}/debug`,
-    { body: input.body },
+    {
+      body: input.body,
+      header: input.header,
+      query: input.query,
+    },
     { headers: getBusinessDomainHeaders() },
   );
 

--- a/src/modules/execution-factory/types/tool.ts
+++ b/src/modules/execution-factory/types/tool.ts
@@ -114,7 +114,9 @@ export type ToolCreateResult = {
 };
 
 export type ToolDebugInput = {
+  header?: Record<string, unknown>;
   body?: Record<string, unknown>;
+  query?: Record<string, unknown>;
 };
 
 export type ToolDebugResult = {

--- a/src/modules/execution-factory/types/tool.ts
+++ b/src/modules/execution-factory/types/tool.ts
@@ -81,6 +81,8 @@ export type ToolListResult = {
 };
 
 export type ToolCreateInput = {
+  name?: string;
+  description?: string;
   metadataType: ToolMetadataType;
   openapiSpec?: string;
   functionInput?: FunctionInputPayload;

--- a/src/modules/execution-factory/utils/curl-to-openapi.test.ts
+++ b/src/modules/execution-factory/utils/curl-to-openapi.test.ts
@@ -92,6 +92,44 @@ describe("curl-to-openapi", () => {
     });
   });
 
+  it("turns curl headers into header parameters except content type", () => {
+    const result = parseCurlCommand(`curl -X GET "https://httpbin.org/get?customerId=1001&region=CN" \
+  -H "accept: application/json" \
+  -H "x-demo-source: openbkn-manual"`);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.queryParams.map((item) => [item.name, item.in, item.example])).toEqual([
+      ["customerId", "query", "1001"],
+      ["region", "query", "CN"],
+      ["accept", "header", "application/json"],
+      ["x-demo-source", "header", "openbkn-manual"],
+    ]);
+
+    const spec = JSON.parse(buildOpenApiFromQuickApi(result.value)) as {
+      paths: {
+        "/get": {
+          get: {
+            parameters?: Array<{ in?: string; name?: string; schema?: { example?: unknown } }>;
+          };
+        };
+      };
+    };
+
+    expect(spec.paths["/get"].get.parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          in: "header",
+          name: "x-demo-source",
+          schema: expect.objectContaining({ example: "openbkn-manual" }),
+        }),
+      ]),
+    );
+  });
+
   it("turns -G data fields into query parameters", () => {
     const result = parseCurlCommand(
       `curl -G --data-urlencode "city=北京" --data "unit=c" https://api.example.com/weather`,

--- a/src/modules/execution-factory/utils/curl-to-openapi.ts
+++ b/src/modules/execution-factory/utils/curl-to-openapi.ts
@@ -467,6 +467,24 @@ function addDataAsQueryParams(scan: CurlScan, queryParams: QuickApiParameter[]) 
   }
 }
 
+function addHeaderParams(scan: CurlScan, queryParams: QuickApiParameter[]) {
+  const skippedHeaders = new Set(["content-type", "content-length"]);
+
+  for (const header of scan.headers) {
+    if (skippedHeaders.has(header.name.toLowerCase())) {
+      continue;
+    }
+
+    queryParams.push({
+      name: header.name,
+      in: "header",
+      required: false,
+      type: "string",
+      example: header.value,
+    });
+  }
+}
+
 export function parseCurlCommand(raw: string): ParseCurlResult {
   const normalized = normalizeCurlInput(raw);
   const tokenized = tokenizeCurl(normalized);
@@ -513,6 +531,7 @@ export function parseCurlCommand(raw: string): ParseCurlResult {
   const queryParams: QuickApiParameter[] = [];
   addQueryParamsFromUrl(parsedUrl, queryParams);
   addDataAsQueryParams(scan, queryParams);
+  addHeaderParams(scan, queryParams);
 
   const lastSegment = path.split("/").filter(Boolean).pop() ?? "api";
   const summary = decodeURIComponent(lastSegment).replace(/[-_]/g, " ");

--- a/src/modules/execution-factory/utils/tool-io.test.ts
+++ b/src/modules/execution-factory/utils/tool-io.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildToolDebugRequest } from "@/modules/execution-factory/utils/tool-io";
+
+describe("buildToolDebugRequest", () => {
+  it("splits flat debug input by OpenAPI parameter location", () => {
+    expect(
+      buildToolDebugRequest(
+        {
+          accept: "application/json",
+          customerId: "1001",
+          region: "CN",
+          "x-demo-source": "openbkn-manual",
+        },
+        {
+          parameters: [
+            { in: "query", name: "customerId", type: "string" },
+            { in: "query", name: "region", type: "string" },
+            { in: "header", name: "accept", type: "string" },
+            { in: "header", name: "x-demo-source", type: "string" },
+          ],
+        },
+      ),
+    ).toEqual({
+      header: {
+        accept: "application/json",
+        "x-demo-source": "openbkn-manual",
+      },
+      query: {
+        customerId: "1001",
+        region: "CN",
+      },
+    });
+  });
+
+  it("preserves explicit query/header/body debug payloads", () => {
+    expect(
+      buildToolDebugRequest({
+        body: { city: "Beijing" },
+        header: { accept: "application/json" },
+        query: { region: "CN" },
+      }),
+    ).toEqual({
+      body: { city: "Beijing" },
+      header: { accept: "application/json" },
+      query: { region: "CN" },
+    });
+  });
+
+  it("keeps unknown flat fields in the request body", () => {
+    expect(
+      buildToolDebugRequest(
+        { city: "Beijing", traceId: "debug-1" },
+        { parameters: [{ in: "query", name: "city", type: "string" }] },
+      ),
+    ).toEqual({
+      body: { traceId: "debug-1" },
+      query: { city: "Beijing" },
+    });
+  });
+});

--- a/src/modules/execution-factory/utils/tool-io.ts
+++ b/src/modules/execution-factory/utils/tool-io.ts
@@ -5,7 +5,11 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import type { ToolIoParameter, ToolIoSpec } from "@/modules/execution-factory/types/tool";
+import type {
+  ToolDebugInput,
+  ToolIoParameter,
+  ToolIoSpec,
+} from "@/modules/execution-factory/types/tool";
 
 export { buildDefaultDebugBody } from "@/modules/execution-factory/utils/generate-sample-json";
 
@@ -80,5 +84,67 @@ export function parseToolIoSpec(metadata?: ApiSpecMetadata): ToolIoSpec | undefi
     requestBodyExample: firstRequestContent?.example,
     requestBodySchema: firstRequestContent?.schema,
     responses,
+  };
+}
+
+function pickRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function hasStructuredDebugPayload(input: Record<string, unknown>) {
+  return "query" in input || "header" in input || "body" in input;
+}
+
+export function buildToolDebugRequest(
+  input?: Record<string, unknown>,
+  ioSpec?: ToolIoSpec,
+): ToolDebugInput {
+  if (!input) {
+    return {};
+  }
+
+  if (hasStructuredDebugPayload(input)) {
+    return {
+      body: pickRecord(input.body),
+      header: pickRecord(input.header),
+      query: pickRecord(input.query),
+    };
+  }
+
+  const body: Record<string, unknown> = {};
+  const header: Record<string, unknown> = {};
+  const query: Record<string, unknown> = {};
+  const consumedKeys = new Set<string>();
+
+  for (const parameter of ioSpec?.parameters ?? []) {
+    if (!(parameter.name in input)) {
+      continue;
+    }
+
+    consumedKeys.add(parameter.name);
+
+    if (parameter.in === "header") {
+      header[parameter.name] = input[parameter.name];
+    } else if (parameter.in === "query" || parameter.in === "path") {
+      query[parameter.name] = input[parameter.name];
+    } else {
+      body[parameter.name] = input[parameter.name];
+    }
+  }
+
+  for (const [key, value] of Object.entries(input)) {
+    if (!consumedKeys.has(key)) {
+      body[key] = value;
+    }
+  }
+
+  return {
+    ...(Object.keys(body).length > 0 ? { body } : {}),
+    ...(Object.keys(header).length > 0 ? { header } : {}),
+    ...(Object.keys(query).length > 0 ? { query } : {}),
   };
 }


### PR DESCRIPTION
## 背景

- Refs #85
- Closes #90
- 执行工厂 HTTP API 工具创建后的查看/编辑体验与新建流程不一致：工具名称、描述、参数预览和调试入口在创建后再进入编辑页时容易丢失或表现不连续。
- Petstore 等完整 OpenAPI 文档导入场景在本地 mock 下会把多个 operation 误当成 1 个工具，导致手工复测时 19 个接口只显示 1 个工具。

## 主要改动

- 新增 HTTP 工具生命周期布局组件，将编辑页调整为「能力信息 / 接口预览 / 调试验证」的连续体验。
- 新增内联工具调试面板，替代编辑页里突兀的调试弹窗。
- 修复快速 HTTP API 创建后名称、描述、OpenAPI、参数预览的持久化与回读。
- 修复 cURL header 参数解析，保留 query/header 参数用于预览和调试。
- 修复本地 mock 的 OpenAPI 批量导入逻辑：按 path + method 拆分为多个工具，并保留 method/path/serverUrl/ioSpec。
- 隐藏快速创建和 OpenAPI 导入流程中的「同步发布为算子」入口，并调整相关提示文案。
- 补充实现设计文档与回归测试。

## 影响范围

- 主要影响执行工厂的 HTTP API 工具创建、导入、查看、编辑和调试体验。
- 修改了 execution-factory 模块的 `locales`，用于新增/调整中文和英文文案。
- 修改了 execution-factory 模块的 `scenes/ToolDetailScene.tsx`，用于工具编辑页布局和调试交互。
- 未修改 `navigation.tsx`、`routes.tsx`、`module.manifest.ts`。
- 未改动后端 API 契约；真实后端调用仍走原有 create/import/debug 接口。

## 验证方式

- [x] `corepack pnpm test -- --run`，42 个测试文件、149 个测试通过。
- [x] `node_modules\\.bin\\vitest.cmd run src/modules/execution-factory/services/import-openapi.service.test.ts src/modules/execution-factory/services/tool.service.test.ts src/modules/execution-factory/services/quick-api.service.test.ts src/modules/execution-factory/components/create-menu/ImportOpenApiCapabilityForm.test.tsx src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx src/modules/execution-factory/components/ToolDebugPanel.test.tsx`
- [x] `node_modules\\.bin\\tsc.cmd --noEmit --pretty false`
- [x] Targeted ESLint for changed execution-factory TS/TSX files.
- [x] `git diff --check`
- [x] Confirmed `https://petstore3.swagger.io/api/v3/openapi.json` currently has 19 operations and added Petstore-sized import regression coverage.

## 未完成项或风险点

- `corepack pnpm lint` 当前失败，但失败项来自本 PR 未触碰的既有模块：`data-catalog`、`data-connect`、`knowledge-network`、`system-admin` 等 unused imports / hook warnings。
- `corepack pnpm build` 当前失败，但本 PR 相关的执行工厂类型错误已修复；剩余失败来自未触碰模块的既有 TS 错误，例如 `data-catalog`、`knowledge-network`、`system-admin`。
- 已在 PR 中保留底层 operator sync 类型和服务兼容能力，只隐藏当前创建流入口。