### PR TITLE
ci: fix trivy action version

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: aquasecurity/trivy-action@0.28.0
+      - uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
## 变更内容

- 修复主线 `security-scan` 中 Trivy Action 版本不可解析的问题。
- 将 `aquasecurity/trivy-action@0.28.0` 改为已存在的 `aquasecurity/trivy-action@v0.36.0`。

## 失败原因

主线运行 https://github.com/openbkn-ai/bkn-studio/actions/runs/29234294297 失败不是因为漏洞命中，而是 GitHub 无法解析 `aquasecurity/trivy-action@0.28.0`：

`Unable to resolve action aquasecurity/trivy-action@0.28.0, unable to find version 0.28.0`

## 本地验证

- `npm run license:check` 通过。
- `git diff --check .github/workflows/security-scan.yml` 通过。