### PR TITLE
fix: hide duplicate user account database errors

### DIFF
--- a/src/modules/system-admin/components/UserFormDrawer.tsx
+++ b/src/modules/system-admin/components/UserFormDrawer.tsx
@@ -10,10 +10,10 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAppServices } from "@/framework/context/use-app-services";
-import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { createUser, getUser, updateUser } from "@/modules/system-admin/services/admin.service";
 import type { AdminDepartment, AdminUser } from "@/modules/system-admin/types/admin";
+import { extractSystemAdminErrorMessage } from "@/modules/system-admin/utils/system-admin-error-message";
 
 import drawerStyles from "@/modules/system-admin/components/UserFormDrawer.module.css";
 import styles from "@/modules/system-admin/scenes/admin.module.css";
@@ -149,35 +149,46 @@ export function UserFormDrawer({
   }, [form, open, user]);
 
   const handleSubmit = () => {
+    if (submitting) {
+      return;
+    }
+
     void form.validateFields().then(async (values) => {
       setSubmitting(true);
       try {
         if (isEdit && user) {
-          await updateUser(user.id, {
-            name: values.name.trim(),
-            email: values.email.trim(),
-            telephone: values.telephone.trim(),
-            enabled: user.enabled,
-            departmentIds: deptIds,
-            roleIds: preservedRoleIds.current,
-          });
+          await updateUser(
+            user.id,
+            {
+              name: values.name.trim(),
+              email: values.email.trim(),
+              telephone: values.telephone.trim(),
+              enabled: user.enabled,
+              departmentIds: deptIds,
+              roleIds: preservedRoleIds.current,
+            },
+            { skipErrorToast: true },
+          );
           message.success(t("systemAdmin.users.toast.userSaved"));
         } else {
-          await createUser({
-            account: values.account.trim(),
-            name: values.name.trim(),
-            email: values.email.trim(),
-            telephone: values.telephone.trim(),
-            password: values.password,
-            departmentIds: deptIds,
-            roleIds: [],
-          });
+          await createUser(
+            {
+              account: values.account.trim(),
+              name: values.name.trim(),
+              email: values.email.trim(),
+              telephone: values.telephone.trim(),
+              password: values.password,
+              departmentIds: deptIds,
+              roleIds: [],
+            },
+            { skipErrorToast: true },
+          );
           message.success(t("systemAdmin.users.toast.userCreated"));
         }
         onSaved();
         onClose();
       } catch (error) {
-        void message.error(extractRequestErrorMessage(error));
+        void message.error(extractSystemAdminErrorMessage(error));
       } finally {
         setSubmitting(false);
       }

--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -112,6 +112,7 @@ export const systemAdminEnUS = {
       invalidToken: "Session expired. Please sign in again.",
       missingToken: "Not signed in.",
       notAdmin: "Your account is not authorized for admin operations.",
+      userAccountDuplicate: "Login name already exists. Please choose another one.",
     },
     users: {
       title: "User Management",

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -111,6 +111,7 @@ export const systemAdminZhCN = {
       invalidToken: "登录已失效，请重新登录。",
       missingToken: "未登录，请先登录。",
       notAdmin: "当前账号无管理权限。",
+      userAccountDuplicate: "登录名已存在，请更换登录名。",
     },
     users: {
       title: "用户管理",

--- a/src/modules/system-admin/services/admin.service.ts
+++ b/src/modules/system-admin/services/admin.service.ts
@@ -397,7 +397,10 @@ export async function listAuditLogs(
 
 // ---- user writes ------------------------------------------------------------
 
-export async function createUser(input: CreateUserInput): Promise<void> {
+export async function createUser(
+  input: CreateUserInput,
+  options?: { skipErrorToast?: boolean },
+): Promise<void> {
   if (useMock) {
     if (users.some((item) => item.account === input.account)) {
       throw new Error(`登录名已存在：${input.account}`);
@@ -421,23 +424,35 @@ export async function createUser(input: CreateUserInput): Promise<void> {
     await wait(undefined);
     return;
   }
-  const created = await http.post<{ id: string }>(`${ADMIN}/users`, {
-    account: input.account,
-    password: input.password,
-    name: input.name,
-    email: input.email,
-    telephone: input.telephone,
-    ...(input.departmentIds.length ? { department_ids: input.departmentIds } : {}),
-  });
+  const created = await http.post<{ id: string }>(
+    `${ADMIN}/users`,
+    {
+      account: input.account,
+      password: input.password,
+      name: input.name,
+      email: input.email,
+      telephone: input.telephone,
+      ...(input.departmentIds.length ? { department_ids: input.departmentIds } : {}),
+    },
+    { skipErrorToast: options?.skipErrorToast },
+  );
   const userId = created.data.id;
   await Promise.all(
     input.roleIds.map((roleId) =>
-      http.post(`${ADMIN}/role-bindings`, { accessor_id: userId, role_id: roleId }),
+      http.post(
+        `${ADMIN}/role-bindings`,
+        { accessor_id: userId, role_id: roleId },
+        { skipErrorToast: options?.skipErrorToast },
+      ),
     ),
   );
 }
 
-export async function syncUserRoleBindings(accessorId: string, roleIds: string[]): Promise<void> {
+export async function syncUserRoleBindings(
+  accessorId: string,
+  roleIds: string[],
+  options?: { skipErrorToast?: boolean },
+): Promise<void> {
   if (useMock) {
     for (const role of roles) {
       const has = role.accessorIds.includes(accessorId);
@@ -451,20 +466,32 @@ export async function syncUserRoleBindings(accessorId: string, roleIds: string[]
   }
   const bound = await http.get<{ role_ids?: string[] }>(`${ADMIN}/role-bindings`, {
     params: { accessor_id: accessorId },
+    skipErrorToast: options?.skipErrorToast,
   });
   const current = new Set(bound.data.role_ids ?? []);
   const want = new Set(roleIds);
   await Promise.all([
     ...[...want].filter((roleId) => !current.has(roleId)).map((roleId) =>
-      http.post(`${ADMIN}/role-bindings`, { accessor_id: accessorId, role_id: roleId }),
+      http.post(
+        `${ADMIN}/role-bindings`,
+        { accessor_id: accessorId, role_id: roleId },
+        { skipErrorToast: options?.skipErrorToast },
+      ),
     ),
     ...[...current].filter((roleId) => !want.has(roleId)).map((roleId) =>
-      http.delete(`${ADMIN}/role-bindings`, { data: { accessor_id: accessorId, role_id: roleId } }),
+      http.delete(`${ADMIN}/role-bindings`, {
+        data: { accessor_id: accessorId, role_id: roleId },
+        skipErrorToast: options?.skipErrorToast,
+      }),
     ),
   ]);
 }
 
-export async function updateUser(id: string, input: UpdateUserInput): Promise<void> {
+export async function updateUser(
+  id: string,
+  input: UpdateUserInput,
+  options?: { skipErrorToast?: boolean },
+): Promise<void> {
   if (useMock) {
     const user = findUser(id);
     if (!user) {
@@ -483,14 +510,18 @@ export async function updateUser(id: string, input: UpdateUserInput): Promise<vo
     return;
   }
   // department_ids 替换语义：始终传当前选择集（含 [] 清空）。
-  await http.put(`${ADMIN}/users/${encodeURIComponent(id)}`, {
-    name: input.name,
-    email: input.email,
-    telephone: input.telephone,
-    enabled: input.enabled,
-    department_ids: input.departmentIds,
-  });
-  await syncUserRoleBindings(id, input.roleIds);
+  await http.put(
+    `${ADMIN}/users/${encodeURIComponent(id)}`,
+    {
+      name: input.name,
+      email: input.email,
+      telephone: input.telephone,
+      enabled: input.enabled,
+      department_ids: input.departmentIds,
+    },
+    { skipErrorToast: options?.skipErrorToast },
+  );
+  await syncUserRoleBindings(id, input.roleIds, options);
 }
 
 export async function deleteUser(id: string): Promise<void> {

--- a/src/modules/system-admin/utils/system-admin-error-message.test.ts
+++ b/src/modules/system-admin/utils/system-admin-error-message.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import i18n from "@/app/locales/i18n";
+import { extractSystemAdminErrorMessage } from "@/modules/system-admin/utils/system-admin-error-message";
+
+describe("extractSystemAdminErrorMessage", () => {
+  it("maps duplicate user account database errors to a business message", () => {
+    const message = extractSystemAdminErrorMessage(
+      new Error("Error 1062 (23000): Duplicate entry 'e' for key 'idx_users_account'"),
+    );
+
+    expect(message).toBe(i18n.t("systemAdmin.errors.userAccountDuplicate"));
+    expect(message).not.toContain("Duplicate entry");
+    expect(message).not.toContain("idx_users_account");
+  });
+});

--- a/src/modules/system-admin/utils/system-admin-error-message.ts
+++ b/src/modules/system-admin/utils/system-admin-error-message.ts
@@ -19,11 +19,24 @@ const KNOWN_SAFE_ADMIN_ERRORS: Record<string, string> = {
   "not authorized for admin operations": "systemAdmin.errors.notAdmin",
 };
 
+function isUserAccountDuplicate(raw: string) {
+  const normalized = raw.toLowerCase();
+  return (
+    normalized.includes("idx_users_account") ||
+    normalized.includes("user account already exists") ||
+    normalized.includes("account already exists") ||
+    raw.includes("登录名已存在")
+  );
+}
+
 export function extractSystemAdminErrorMessage(error: unknown) {
   const raw = extractRequestErrorMessage(error).trim();
   const key = KNOWN_SAFE_ADMIN_ERRORS[raw];
   if (key) {
     return i18n.t(key);
+  }
+  if (isUserAccountDuplicate(raw)) {
+    return i18n.t("systemAdmin.errors.userAccountDuplicate");
   }
   if (raw.startsWith("unknown user id")) {
     return i18n.t("systemAdmin.errors.unknownUser");


### PR DESCRIPTION
## 关联 Issue

- Closes #91

## 变更内容

- 将用户管理中新建/编辑用户的提交错误统一交给表单组件处理，避免全局 toast 与表单 toast 重复弹出。
- 对 MySQL 1062 / `idx_users_account` 等重复登录名错误做业务化映射，提示为“登录名已存在，请更换登录名”。
- 新建/编辑按钮提交中增加防重复提交保护。
- 补充中英文错误文案。
- 增加单测覆盖重复账号数据库错误不再暴露底层错误细节。

## 本地验证

- `npm run license:check` 通过。
- `corepack pnpm exec vitest run src/modules/system-admin/utils/system-admin-error-message.test.ts` 通过。
- 相关文件 ESLint 通过，`--max-warnings 0`。
- `corepack pnpm exec tsc -b --pretty false` 通过。