### PR TITLE
fix(system-admin): 修复日志管理页布局被表格撑开

### DIFF
--- a/eslint.base.mjs
+++ b/eslint.base.mjs
@@ -53,11 +53,15 @@ export function createTypeScriptConfig({ typeChecked }) {
     ...reactPluginConfig,
     rules: {
       ...reactPluginConfig.rules,
-      "@typescript-eslint/no-unsafe-argument": "warn",
-      "@typescript-eslint/no-unsafe-assignment": "warn",
-      "@typescript-eslint/no-unsafe-member-access": "warn",
-      "@typescript-eslint/no-unsafe-return": "warn",
-      "@typescript-eslint/restrict-template-expressions": "warn",
+      ...(typeChecked
+        ? {
+            "@typescript-eslint/no-unsafe-argument": "warn",
+            "@typescript-eslint/no-unsafe-assignment": "warn",
+            "@typescript-eslint/no-unsafe-member-access": "warn",
+            "@typescript-eslint/no-unsafe-return": "warn",
+            "@typescript-eslint/restrict-template-expressions": "warn",
+          }
+        : {}),
     },
   };
 }

--- a/src/modules/system-admin/scenes/AuditLogScene.tsx
+++ b/src/modules/system-admin/scenes/AuditLogScene.tsx
@@ -390,11 +390,11 @@ export function AuditLogScene() {
   return (
     <>
       <section className={[styles.contentSurface, layoutStyles.pageSurface].join(" ")}>
-        <div className={layoutStyles.explorer}>
-          <aside className={layoutStyles.deptPanel}>
+        <div className={[layoutStyles.explorer, layoutStyles.auditExplorer].join(" ")}>
+          <aside className={[layoutStyles.deptPanel, layoutStyles.auditFilterPanel].join(" ")}>
             <div className={layoutStyles.deptPanelHead}>
               <h2 className={layoutStyles.deptPanelTitle}>{t("systemAdmin.audit.title")}</h2>
-              <span className={styles.toolbarMeta}>{t("systemAdmin.audit.description")}</span>
+              <span className={layoutStyles.auditDescription}>{t("systemAdmin.audit.description")}</span>
             </div>
             <Select
               allowClear
@@ -460,7 +460,7 @@ export function AuditLogScene() {
             ) : null}
           </aside>
 
-          <div className={layoutStyles.userPanel}>
+          <div className={[layoutStyles.userPanel, layoutStyles.auditTablePanel].join(" ")}>
             <div className={layoutStyles.userPanelHead}>
               <div className={layoutStyles.userPanelToolbar}>
                 <div className={layoutStyles.userPanelLeading}>
@@ -482,7 +482,7 @@ export function AuditLogScene() {
               />
             ) : null}
 
-            <div className={layoutStyles.tableSection} ref={tableSectionRef}>
+            <div className={[layoutStyles.tableSection, layoutStyles.auditTableSection].join(" ")} ref={tableSectionRef}>
               {loadError ? (
                 <Alert
                   action={

--- a/src/modules/system-admin/scenes/UserManagementScene.module.css
+++ b/src/modules/system-admin/scenes/UserManagementScene.module.css
@@ -24,11 +24,31 @@
 
 .deptPanel {
   display: flex;
+  flex-direction: column;
+  gap: 12px;
   height: 100%;
   padding: 14px 12px 16px;
   border-right: 1px solid var(--admin-color-border, #d9e0ea);
   background: var(--admin-color-surface-muted, #f3f6fa);
   min-height: 0;
+  min-width: 0;
+}
+
+.deptPanelHead {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  flex-shrink: 0;
+}
+
+.deptPanelTitle {
+  margin: 0;
+  color: var(--admin-color-heading, #172033);
+  font-size: var(--admin-font-size-body, 14px);
+  font-weight: var(--admin-font-weight-strong, 600);
+  line-height: 1.5;
+  white-space: normal;
 }
 
 .deptTreeWrap {
@@ -129,6 +149,51 @@
   overflow: hidden;
 }
 
+.auditExplorer {
+  grid-template-columns: 280px minmax(0, 1fr);
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.auditFilterPanel {
+  width: 280px;
+  min-width: 280px;
+  max-width: 280px;
+  overflow: hidden;
+}
+
+.auditDescription {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  color: var(--admin-color-secondary, #4b5563);
+  font-size: var(--admin-font-size-meta, 13px);
+  font-weight: var(--admin-font-weight-regular, 400);
+  line-height: 1.7;
+  overflow-wrap: break-word;
+  white-space: normal;
+}
+
+.auditTablePanel {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.auditTableSection {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.auditTableSection :global(.ant-table-wrapper),
+.auditTableSection :global(.ant-spin-nested-loading),
+.auditTableSection :global(.ant-spin-container),
+.auditTableSection :global(.ant-table-container) {
+  min-width: 0;
+  max-width: 100%;
+}
+
 @media (max-width: 1200px) {
   .explorer {
     grid-template-columns: 1fr;
@@ -139,6 +204,12 @@
     border-bottom: 1px solid var(--admin-color-border, #d9e0ea);
     height: auto;
     max-height: none;
+  }
+
+  .auditFilterPanel {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
   }
 
   .deptTreeWrap {


### PR DESCRIPTION
## 修复内容
- 修复系统管理 / 日志管理页面右侧表格横向撑开整页布局的问题
- 左侧筛选栏改用审计日志专用样式，保持固定宽度
- 表格横向滚动限制在右侧表格容器内部，避免左侧标题和说明被挤压成逐字换行

## 关联 Issue
- Fixes #100

## 验证
- corepack pnpm exec tsc --noEmit