### PR TITLE
fix(knowledge-network): 修复关系映射预览和重复规则校验

### DIFF
--- a/src/modules/knowledge-network/components/relation-type/RelationMappingPreview.module.css
+++ b/src/modules/knowledge-network/components/relation-type/RelationMappingPreview.module.css
@@ -6,46 +6,39 @@
  */
 
 .previewBox {
-  background: #f5f5f5;
-  border: 1px solid #e5e5e5;
-  border-radius: 4px;
+  background: #f7f9fc;
+  border: 1px solid #d9e2f0;
+  border-radius: 2px;
   margin: 16px 0 24px;
   min-height: 160px;
-  padding: 24px 32px;
+  padding: 26px 32px;
 }
 
 .previewCanvas {
   align-items: center;
   display: flex;
-  gap: 24px;
+  gap: 14px;
   justify-content: center;
   min-height: 112px;
-}
-
-.previewColumn {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  min-width: 88px;
 }
 
 .previewNode {
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  min-width: 112px;
 }
 
 .previewNodeIcon {
   align-items: center;
-  border-radius: 4px;
+  border-radius: 2px;
   color: #fff;
   display: inline-flex;
-  font-size: 16px;
-  height: 32px;
+  font-size: 18px;
+  height: 40px;
   justify-content: center;
-  width: 32px;
+  width: 40px;
 }
 
 .previewNodeLabel {
@@ -58,23 +51,13 @@
   white-space: nowrap;
 }
 
-.previewLinks {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 28px;
-  max-width: 280px;
-  min-width: 160px;
-  padding-top: 8px;
-}
-
 .previewLink {
-  background: linear-gradient(90deg, #91caff 0%, #91caff 100%);
+  background: #91caff;
   border-radius: 999px;
   display: block;
   height: 2px;
   position: relative;
-  width: 100%;
+  width: min(18vw, 220px);
 }
 
 .previewLink::after {
@@ -86,4 +69,42 @@
   right: -2px;
   top: 50%;
   transform: translateY(-50%);
+}
+
+.previewBridge {
+  align-items: center;
+  background: #eaf3ff;
+  border: 1px solid #bfdbff;
+  border-radius: 2px;
+  color: #1d6fe8;
+  display: inline-flex;
+  font-size: 18px;
+  height: 40px;
+  justify-content: center;
+  width: 40px;
+}
+
+.previewBridgeNode {
+  align-items: center;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 112px;
+}
+
+.previewBridgeLabel {
+  color: rgba(0, 0, 0, 0.65);
+  font-size: 12px;
+  line-height: 1.4;
+  max-width: 120px;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.previewBridgeResource {
+  background: #ecfdf3;
+  border-color: #b7ebc6;
+  color: #16a34a;
 }

--- a/src/modules/knowledge-network/components/relation-type/RelationMappingPreview.tsx
+++ b/src/modules/knowledge-network/components/relation-type/RelationMappingPreview.tsx
@@ -5,7 +5,13 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { EnvironmentOutlined, UserOutlined } from "@ant-design/icons";
+import {
+  ApartmentOutlined,
+  DatabaseOutlined,
+  LinkOutlined,
+  NodeIndexOutlined,
+} from "@ant-design/icons";
+import type { ReactNode } from "react";
 
 import { renderResourceIcon } from "@/modules/knowledge-network/components/shared/ResourceIconSelect";
 import type { KnowledgeNetworkObjectTypeRecord } from "@/modules/knowledge-network/types/knowledge-network";
@@ -13,74 +19,57 @@ import type { KnowledgeNetworkObjectTypeRecord } from "@/modules/knowledge-netwo
 import styles from "./RelationMappingPreview.module.css";
 
 type RelationMappingPreviewProps = {
-  propertyMappingCount: number;
+  bridgeLabel: string;
+  mappingMode: "direct" | "resource";
   sourceObject?: KnowledgeNetworkObjectTypeRecord;
   targetObject?: KnowledgeNetworkObjectTypeRecord;
 };
 
 export function RelationMappingPreview({
-  propertyMappingCount,
+  bridgeLabel,
+  mappingMode,
   sourceObject,
   targetObject,
 }: RelationMappingPreviewProps) {
-  const leftNodeCount = Math.max(1, Math.min(3, propertyMappingCount || 1));
-  const rightNodeCount = Math.max(1, Math.min(2, propertyMappingCount || 1));
-
   return (
     <div aria-hidden className={styles.previewBox}>
       <div className={styles.previewCanvas}>
-        <div className={styles.previewColumn}>
-          {Array.from({ length: leftNodeCount }).map((_, index) => (
-            <div className={styles.previewNode} key={`source-${index}`}>
-              <span
-                className={styles.previewNodeIcon}
-                style={{
-                  backgroundColor:
-                    index === 0 && sourceObject?.color ? sourceObject.color : "#3A93FF",
-                }}
-              >
-                {index === 0 && sourceObject?.icon ? (
-                  renderResourceIcon(sourceObject.icon)
-                ) : (
-                  <EnvironmentOutlined />
-                )}
-              </span>
-              {index === 0 && sourceObject ? (
-                <span className={styles.previewNodeLabel}>{sourceObject.name}</span>
-              ) : null}
-            </div>
-          ))}
-        </div>
-
-        <div className={styles.previewLinks}>
-          {Array.from({ length: Math.max(leftNodeCount, rightNodeCount) }).map((_, index) => (
-            <span className={styles.previewLink} key={`link-${index}`} />
-          ))}
-        </div>
-
-        <div className={styles.previewColumn}>
-          {Array.from({ length: rightNodeCount }).map((_, index) => (
-            <div className={styles.previewNode} key={`target-${index}`}>
-              <span
-                className={styles.previewNodeIcon}
-                style={{
-                  backgroundColor:
-                    index === 0 && targetObject?.color ? targetObject.color : "#3A93FF",
-                }}
-              >
-                {index === 0 && targetObject?.icon ? (
-                  renderResourceIcon(targetObject.icon)
-                ) : (
-                  <UserOutlined />
-                )}
-              </span>
-              {index === 0 && targetObject ? (
-                <span className={styles.previewNodeLabel}>{targetObject.name}</span>
-              ) : null}
-            </div>
-          ))}
-        </div>
+        <PreviewObjectNode fallbackIcon={<ApartmentOutlined />} object={sourceObject} />
+        <span className={styles.previewLink} />
+        <span className={styles.previewBridgeNode}>
+          <span
+            className={`${styles.previewBridge} ${
+              mappingMode === "resource" ? styles.previewBridgeResource : ""
+            }`}
+          >
+            {mappingMode === "resource" ? <DatabaseOutlined /> : <LinkOutlined />}
+          </span>
+          <span className={styles.previewBridgeLabel}>{bridgeLabel}</span>
+        </span>
+        <span className={styles.previewLink} />
+        <PreviewObjectNode fallbackIcon={<NodeIndexOutlined />} object={targetObject} />
       </div>
+    </div>
+  );
+}
+
+type PreviewObjectNodeProps = {
+  fallbackIcon: ReactNode;
+  object?: KnowledgeNetworkObjectTypeRecord;
+};
+
+function PreviewObjectNode({ fallbackIcon, object }: PreviewObjectNodeProps) {
+  return (
+    <div className={styles.previewNode}>
+      <span
+        className={styles.previewNodeIcon}
+        style={{
+          backgroundColor: object?.color ? object.color : "#3A93FF",
+        }}
+      >
+        {object?.icon ? renderResourceIcon(object.icon) : fallbackIcon}
+      </span>
+      {object ? <span className={styles.previewNodeLabel}>{object.name}</span> : null}
     </div>
   );
 }

--- a/src/modules/knowledge-network/components/relation-type/RelationTypeMappingEditor.tsx
+++ b/src/modules/knowledge-network/components/relation-type/RelationTypeMappingEditor.tsx
@@ -65,7 +65,9 @@ export function RelationTypeMappingEditor({
       mappingModeField={mappingModeField}
       objectTypes={objectTypes}
       onMappingModeChange={handleMappingModeChange}
-      resourceName={value.mappingRules.backingDataSourceName}
+      resourceName={
+        value.mappingRules.backingDataSourceName || value.mappingRules.backingDataSourceId
+      }
       sourceObjectTypeId={value.mappingRules.sourceObjectTypeId}
       targetObjectTypeId={value.mappingRules.targetObjectTypeId}
     >

--- a/src/modules/knowledge-network/components/relation-type/RelationTypeMappingEditor.tsx
+++ b/src/modules/knowledge-network/components/relation-type/RelationTypeMappingEditor.tsx
@@ -7,14 +7,11 @@
 
 /* eslint-disable react-refresh/only-export-components */
 
-import { useMemo } from "react";
-
 import type { KnowledgeNetworkObjectTypeRecord } from "@/modules/knowledge-network/types/knowledge-network";
 
 import { RelationTypeResourceMappingRules } from "./RelationTypeResourceMappingRules";
 import { RelationTypeDirectMappingRules } from "./RelationTypeDirectMappingRules";
 import {
-  countValidResourceMappings,
   resetMappingRulesForMode,
   type RelationTypeMappingFormValues,
 } from "./mapping-utils";
@@ -44,16 +41,6 @@ export function RelationTypeMappingEditor({
   value,
   onChange,
 }: RelationTypeMappingEditorProps) {
-  const mappingSummaryCount = useMemo(() => {
-    if (value.mappingMode === "resource") {
-      return countValidResourceMappings(value.mappingRules.resourceMappings);
-    }
-
-    return value.mappingRules.propertyMappings.filter(
-      (item) => item.sourcePropertyName && item.targetPropertyName,
-    ).length;
-  }, [value.mappingMode, value.mappingRules.resourceMappings, value.mappingRules.propertyMappings]);
-
   const handleMappingModeChange = (mode: "direct" | "resource") => {
     if (mode === value.mappingMode) {
       return;
@@ -78,7 +65,7 @@ export function RelationTypeMappingEditor({
       mappingModeField={mappingModeField}
       objectTypes={objectTypes}
       onMappingModeChange={handleMappingModeChange}
-      propertyMappingCount={mappingSummaryCount}
+      resourceName={value.mappingRules.backingDataSourceName}
       sourceObjectTypeId={value.mappingRules.sourceObjectTypeId}
       targetObjectTypeId={value.mappingRules.targetObjectTypeId}
     >

--- a/src/modules/knowledge-network/components/relation-type/RelationTypeMappingShell.tsx
+++ b/src/modules/knowledge-network/components/relation-type/RelationTypeMappingShell.tsx
@@ -20,7 +20,7 @@ type RelationTypeMappingShellProps = {
   mappingMode: "direct" | "resource";
   mappingModeField?: boolean;
   objectTypes: KnowledgeNetworkObjectTypeRecord[];
-  propertyMappingCount: number;
+  resourceName?: string;
   sourceObjectTypeId: string;
   targetObjectTypeId: string;
   onMappingModeChange: (mode: "direct" | "resource") => void;
@@ -31,7 +31,7 @@ export function RelationTypeMappingShell({
   mappingMode,
   mappingModeField = true,
   objectTypes,
-  propertyMappingCount,
+  resourceName,
   sourceObjectTypeId,
   targetObjectTypeId,
   onMappingModeChange,
@@ -76,7 +76,12 @@ export function RelationTypeMappingShell({
       ) : null}
 
       <RelationMappingPreview
-        propertyMappingCount={propertyMappingCount}
+        bridgeLabel={
+          mappingMode === "resource"
+            ? resourceName || t("knowledgeNetwork.relationTypePreviewResource")
+            : t("knowledgeNetwork.relationTypePreviewPropertyLink")
+        }
+        mappingMode={mappingMode}
         sourceObject={sourceObject}
         targetObject={targetObject}
       />

--- a/src/modules/knowledge-network/components/relation-type/mapping-utils.ts
+++ b/src/modules/knowledge-network/components/relation-type/mapping-utils.ts
@@ -79,6 +79,10 @@ export function countValidResourceMappings(
   ).length;
 }
 
+function hasDuplicateValues(values: string[]): boolean {
+  return new Set(values).size !== values.length;
+}
+
 export function normalizeRelationTypeMappingValues(
   value: RelationTypeMappingFormValues,
 ): RelationTypeMappingFormValues {
@@ -151,6 +155,14 @@ export function validateRelationTypeMappingValues(
       return t("knowledgeNetwork.relationTypePropertyMappingRequired");
     }
 
+    const mappingKeys = validMappings.map(
+      (item) => `${item.sourcePropertyName}::${item.targetPropertyName}`,
+    );
+
+    if (hasDuplicateValues(mappingKeys)) {
+      return t("knowledgeNetwork.relationTypeDuplicatePropertyMapping");
+    }
+
     return null;
   }
 
@@ -160,6 +172,22 @@ export function validateRelationTypeMappingValues(
 
   if (countValidResourceMappings(mappingRules.resourceMappings) === 0) {
     return t("knowledgeNetwork.relationTypeResourceMappingRequired");
+  }
+
+  const validResourceMappings = mappingRules.resourceMappings.filter(
+    (item) =>
+      item.sourceObjectPropertyName &&
+      item.resourceSourcePropertyName &&
+      item.resourceTargetPropertyName &&
+      item.targetObjectPropertyName,
+  );
+  const resourceMappingKeys = validResourceMappings.map(
+    (item) =>
+      `${item.sourceObjectPropertyName}::${item.resourceSourcePropertyName}::${item.resourceTargetPropertyName}::${item.targetObjectPropertyName}`,
+  );
+
+  if (hasDuplicateValues(resourceMappingKeys)) {
+    return t("knowledgeNetwork.relationTypeDuplicateResourceMapping");
   }
 
   return null;

--- a/src/modules/knowledge-network/locales/en-US/relation-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/relation-type.ts
@@ -38,6 +38,10 @@ export const relationtypePart = {
     relationTypeDetailTitle: "Relation type detail",
     relationTypeDirectMapping: "Direct mapping",
     relationTypeDirectMappingOption: "Connect object type properties directly",
+    relationTypeDuplicatePropertyMapping:
+      "Duplicate property mappings exist. Adjust them before saving.",
+    relationTypeDuplicateResourceMapping:
+      "Duplicate resource mappings exist. Adjust them before saving.",
     relationTypeEditDescription: "Edit relation type basics and mapping rules.",
     relationTypeEditTitle: "Edit relation type",
     relationTypeEmptyValue: "—",

--- a/src/modules/knowledge-network/locales/en-US/relation-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/relation-type.ts
@@ -55,6 +55,8 @@ export const relationtypePart = {
     relationTypeMappingObjectRow: "Object type",
     relationTypeMappingPending:
       "Full mapping rules will be migrated in the next phase. This page currently hosts the entry and basic information.",
+    relationTypePreviewPropertyLink: "Property link",
+    relationTypePreviewResource: "Data resource",
     relationTypeMappingPropertyRow: "Data property",
     relationTypeMappingSourcePoint: "Source",
     relationTypeMappingSourcePropertyPlaceholder: "Select a source property",

--- a/src/modules/knowledge-network/locales/zh-CN/relation-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/relation-type.ts
@@ -32,6 +32,8 @@ export const relationtypePart = {
     relationTypeDetailTitle: "关系类详情",
     relationTypeDirectMapping: "直接映射",
     relationTypeDirectMappingOption: "对象类属性与对象类属性直接连接",
+    relationTypeDuplicatePropertyMapping: "存在重复的属性映射，请调整后保存。",
+    relationTypeDuplicateResourceMapping: "存在重复的资源映射，请调整后保存。",
     relationTypeEditDescription: "编辑关系类基础信息与映射规则。",
     relationTypeEditTitle: "编辑关系类",
     relationTypeEmptyValue: "—",

--- a/src/modules/knowledge-network/locales/zh-CN/relation-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/relation-type.ts
@@ -49,6 +49,8 @@ export const relationtypePart = {
     relationTypeMappingObjectRow: "对象类",
     relationTypeMappingPending:
       "完整映射规则将在下一阶段迁入，当前页面先承载入口与基础信息。",
+    relationTypePreviewPropertyLink: "属性连接",
+    relationTypePreviewResource: "数据资源",
     relationTypeMappingPropertyRow: "数据属性",
     relationTypeMappingSourcePoint: "起点",
     relationTypeMappingSourcePropertyPlaceholder: "请选择起点属性",


### PR DESCRIPTION
## 修复内容

- 修复 #54：关系类映射配置中的预览区域不再按映射条数动态渲染连线，改为静态业务示意图，避免“资源映射数量”和“预览连线数量”不一致造成误解。
- 修复 #54：资源映射模式下，中间节点展示已选择的数据资源名称；未选择时展示“数据资源”占位。
- 修复 #53：保存关系映射前增加重复规则校验。
  - 直接映射：同一个“起点属性 + 终点属性”组合只能出现一次。
  - 资源映射：同一个“起点对象属性 + 资源起点字段 + 资源终点字段 + 终点对象属性”组合只能出现一次。
- 补充重复映射校验的中英文提示文案。

## 验证

- corepack pnpm exec tsc --noEmit

Fixes #53
Fixes #54