### PR TITLE
chore(i18n): TraceAI 菜单文案改为 BKN Trace

### DIFF
--- a/src/app/locales/resources/shell/en-US.ts
+++ b/src/app/locales/resources/shell/en-US.ts
@@ -41,7 +41,7 @@ export const shellEnUS = {
       roleManagement: "Role Management",
       authorizationManagement: "Authorizations",
       modelManagement: "Model Configuration",
-      traceai: "TraceAI",
+      traceai: "BKN Trace",
       logManagement: "Log Management",
       apiKeys: "API Key",
       account: "Account",

--- a/src/app/locales/resources/shell/zh-CN.ts
+++ b/src/app/locales/resources/shell/zh-CN.ts
@@ -42,7 +42,7 @@ export const shellZhCN = {
       roleManagement: "角色管理",
       authorizationManagement: "授权管理",
       modelManagement: "模型配置",
-      traceai: "traceai",
+      traceai: "BKN Trace",
       logManagement: "日志管理",
       apiKeys: "API Key",
       account: "个人中心",


### PR DESCRIPTION
## 变更

可观测模块随 openbkn-ai/bkn-foundry#214 由 trace-ai 改名 **bkn-trace**,Studio 侧菜单显示文案同步:

- en-US:`"TraceAI"` → `"BKN Trace"`
- zh-CN:`"traceai"`(原值为漏翻小写)→ `"BKN Trace"`

locale key `traceai` 不动,路由/菜单引用不受影响;纯显示文案,无功能变化。

注:`feat/catalog-sql-tool` 分支同路径文件有同样两行,合 main 时对齐即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)