### PR TITLE
fix(system-admin): keep department panel visible when empty

### DIFF
--- a/src/modules/system-admin/components/DepartmentNavTree.tsx
+++ b/src/modules/system-admin/components/DepartmentNavTree.tsx
@@ -387,7 +387,9 @@ export function DepartmentNavTree({
           </div>
         ) : debouncedDeptSearch ? (
           <p className={navStyles.emptySearch}>{t("systemAdmin.users.deptNode.searchEmpty")}</p>
-        ) : null}
+        ) : (
+          <p className={navStyles.emptySearch}>{t("systemAdmin.users.emptyDepts")}</p>
+        )}
       </div>
     </BusinessTreePanel>
   );

--- a/src/modules/system-admin/scenes/UserManagementScene.tsx
+++ b/src/modules/system-admin/scenes/UserManagementScene.tsx
@@ -578,79 +578,75 @@ export function UserManagementScene() {
         <div className={layoutStyles.explorer}>
           <aside className={layoutStyles.deptPanel}>
             <div className={layoutStyles.deptTreeWrap}>
-              {departments.length ? (
-                <DepartmentNavTree
-                  departments={departments}
-                  headerPrimaryAction={
-                    <PermissionGate permissions="admin-dept:create">
-                      <AppButton
-                        icon={<PlusOutlined />}
-                        onClick={() =>
-                          setDeptDrawer({
-                            department: null,
-                            open: true,
-                            presetParentId: selectedDeptId ?? undefined,
-                          })
-                        }
-                        size="small"
-                        type="primary"
-                      >
-                        {selectedDepartment
-                          ? t("systemAdmin.users.actions.addChild")
-                          : t("systemAdmin.users.createDept")}
-                      </AppButton>
-                    </PermissionGate>
-                  }
-                  headerSecondaryActions={
-                    selectedDepartment ? (
-                      <div className={layoutStyles.deptActionRowSecondary}>
-                        <PermissionGate permissions="admin-dept:edit">
-                          <AppButton
-                            className={styles.actionLink}
-                            onClick={() => setDeptDrawer({ department: selectedDepartment, open: true })}
-                            size="small"
-                            type="link"
-                          >
-                            {t("systemAdmin.users.actions.edit")}
-                          </AppButton>
-                        </PermissionGate>
-                        <PermissionGate permissions="admin-dept:members">
-                          <AppButton
-                            className={styles.actionLink}
-                            onClick={() => setMembersDept(selectedDepartment)}
-                            size="small"
-                            type="link"
-                          >
-                            {t("systemAdmin.users.actions.members")}
-                          </AppButton>
-                        </PermissionGate>
-                        <PermissionGate permissions="admin-dept:delete">
-                          <AppButton
-                            className={[styles.actionLink, styles.actionDanger].join(" ")}
-                            onClick={() => handleDeleteDept(selectedDepartment)}
-                            size="small"
-                            type="link"
-                          >
-                            {t("systemAdmin.users.actions.delete")}
-                          </AppButton>
-                        </PermissionGate>
-                      </div>
-                    ) : null
-                  }
-                  onAddChild={(parentId) =>
-                    setDeptDrawer({ department: null, open: true, presetParentId: parentId })
-                  }
-                  onDelete={handleDeleteDept}
-                  onEdit={(dept) => setDeptDrawer({ department: dept, open: true })}
-                  onMembers={setMembersDept}
-                  onReparent={handleReparent}
-                  onSelect={handleSelectDept}
-                  selectedDeptId={selectedDeptId}
-                  totalUserCount={totalAllUsers}
-                />
-              ) : (
-                <p className={styles.mutedText}>{t("systemAdmin.users.emptyDepts")}</p>
-              )}
+              <DepartmentNavTree
+                departments={departments}
+                headerPrimaryAction={
+                  <PermissionGate permissions="admin-dept:create">
+                    <AppButton
+                      icon={<PlusOutlined />}
+                      onClick={() =>
+                        setDeptDrawer({
+                          department: null,
+                          open: true,
+                          presetParentId: selectedDeptId ?? undefined,
+                        })
+                      }
+                      size="small"
+                      type="primary"
+                    >
+                      {selectedDepartment
+                        ? t("systemAdmin.users.actions.addChild")
+                        : t("systemAdmin.users.createDept")}
+                    </AppButton>
+                  </PermissionGate>
+                }
+                headerSecondaryActions={
+                  selectedDepartment ? (
+                    <div className={layoutStyles.deptActionRowSecondary}>
+                      <PermissionGate permissions="admin-dept:edit">
+                        <AppButton
+                          className={styles.actionLink}
+                          onClick={() => setDeptDrawer({ department: selectedDepartment, open: true })}
+                          size="small"
+                          type="link"
+                        >
+                          {t("systemAdmin.users.actions.edit")}
+                        </AppButton>
+                      </PermissionGate>
+                      <PermissionGate permissions="admin-dept:members">
+                        <AppButton
+                          className={styles.actionLink}
+                          onClick={() => setMembersDept(selectedDepartment)}
+                          size="small"
+                          type="link"
+                        >
+                          {t("systemAdmin.users.actions.members")}
+                        </AppButton>
+                      </PermissionGate>
+                      <PermissionGate permissions="admin-dept:delete">
+                        <AppButton
+                          className={[styles.actionLink, styles.actionDanger].join(" ")}
+                          onClick={() => handleDeleteDept(selectedDepartment)}
+                          size="small"
+                          type="link"
+                        >
+                          {t("systemAdmin.users.actions.delete")}
+                        </AppButton>
+                      </PermissionGate>
+                    </div>
+                  ) : null
+                }
+                onAddChild={(parentId) =>
+                  setDeptDrawer({ department: null, open: true, presetParentId: parentId })
+                }
+                onDelete={handleDeleteDept}
+                onEdit={(dept) => setDeptDrawer({ department: dept, open: true })}
+                onMembers={setMembersDept}
+                onReparent={handleReparent}
+                onSelect={handleSelectDept}
+                selectedDeptId={selectedDeptId}
+                totalUserCount={totalAllUsers}
+              />
             </div>
           </aside>
 


### PR DESCRIPTION
## Summary

- Always render the department navigation panel on the user management page, even when the department list is empty.
- Move the empty-department message inside the full tree panel so the title, search, all-users scope, and create-department action remain available.

## Validation

- corepack pnpm exec eslint src/modules/system-admin/scenes/UserManagementScene.tsx src/modules/system-admin/components/DepartmentNavTree.tsx
- git diff --check

Closes #111