### PR TITLE
fix(model-resources): show quota switch for platform admins

### DIFF
--- a/src/modules/model-resources/components/models/LargeModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/LargeModelListPanel.tsx
@@ -26,6 +26,7 @@ import {
   LlmMonitorDrawer,
 } from "@/modules/model-resources/components/models/ModelModals";
 import { ModelListToolbar } from "@/modules/model-resources/components/models/ModelListToolbar";
+import { getMyPermissions } from "@/modules/model-resources/services/authorization.service";
 import {
   deleteLlmModels,
   getLlmItemPermissions,
@@ -34,6 +35,7 @@ import {
   testLlmModel,
 } from "@/modules/model-resources/services/llm.service";
 import type { LlmModel } from "@/modules/model-resources/types/llm";
+import { hasModelResourcesAdminRole } from "@/modules/model-resources/utils/admin-access";
 import { getLlmModelTypeLabel } from "@/modules/model-resources/utils/llm-labels";
 import {
   formatNumberWithCommas,
@@ -78,8 +80,13 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
   const [guideOpen, setGuideOpen] = useState(false);
   const [monitorOpen, setMonitorOpen] = useState(false);
   const [authorizeRecord, setAuthorizeRecord] = useState<LlmModel | null>(null);
+  /** `/me/permissions`.is_admin — covers super_admin without literal role `"admin"`. */
+  const [meIsAdmin, setMeIsAdmin] = useState(false);
 
-  const showQuotaColumns = !isAdmin && !runtimeConfig.currentUser.roles.includes("admin");
+  const effectiveAdmin =
+    isAdmin || meIsAdmin || hasModelResourcesAdminRole(runtimeConfig.currentUser.roles);
+  // Admins manage quotas via the form switch + quotas page; non-admins see usage columns.
+  const showQuotaColumns = !effectiveAdmin;
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -115,6 +122,24 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
   useEffect(() => {
     void loadData();
   }, [loadData]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void getMyPermissions()
+      .then((me) => {
+        if (!cancelled) {
+          setMeIsAdmin(me.isAdmin);
+        }
+      })
+      .catch(() => {
+        // Keep role-based fallback when /me/permissions is unavailable.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const sortMenuItems = useMemo(
     () => [
@@ -183,9 +208,9 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
     }
   };
 
-  // 真实管理员判定：roles 含 admin，或该项 operations 含 modify（getMyPermissions().isAdmin 会下发全量操作）。
+  // 真实管理员：prop / roles(含 super_admin) / me.isAdmin，或该项 operations 含 modify。
   const canModify = (record: LlmModel) =>
-    isAdmin || runtimeConfig.currentUser.roles.includes("admin") || Boolean(record.operations?.includes("modify"));
+    effectiveAdmin || Boolean(record.operations?.includes("modify"));
   const canSetDefault = (record: LlmModel) => canModify(record) && !record.default;
   const canUnsetDefault = (record: LlmModel) => canModify(record) && Boolean(record.default);
 
@@ -607,7 +632,7 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
         }}
         open={formOpen}
         record={activeRecord}
-        showQuotaField={isAdmin || runtimeConfig.currentUser.roles.includes("admin")}
+        showQuotaField={effectiveAdmin}
       />
       <LlmApiGuideDrawer
         onClose={() => {

--- a/src/modules/model-resources/utils/admin-access.test.ts
+++ b/src/modules/model-resources/utils/admin-access.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { hasModelResourcesAdminRole } from "@/modules/model-resources/utils/admin-access";
+
+describe("hasModelResourcesAdminRole", () => {
+  it("accepts admin and super_admin role keys", () => {
+    expect(hasModelResourcesAdminRole(["admin"])).toBe(true);
+    expect(hasModelResourcesAdminRole(["super_admin"])).toBe(true);
+    expect(hasModelResourcesAdminRole(["normal_user", "super_admin"])).toBe(true);
+  });
+
+  it("accepts Chinese role display names from /me", () => {
+    expect(hasModelResourcesAdminRole(["系统管理员"])).toBe(true);
+    expect(hasModelResourcesAdminRole(["超级管理员"])).toBe(true);
+  });
+
+  it("rejects non-admin roles and empty input", () => {
+    expect(hasModelResourcesAdminRole(["security"])).toBe(false);
+    expect(hasModelResourcesAdminRole([])).toBe(false);
+    expect(hasModelResourcesAdminRole(null)).toBe(false);
+    expect(hasModelResourcesAdminRole(undefined)).toBe(false);
+  });
+});

--- a/src/modules/model-resources/utils/admin-access.ts
+++ b/src/modules/model-resources/utils/admin-access.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/** Role names that unlock model-resources admin-only UI (e.g. quota switch). */
+const ADMIN_ROLE_KEYS = new Set([
+  "admin",
+  "super_admin",
+  "系统管理员",
+  "超级管理员",
+]);
+
+/**
+ * Whether the caller's role list implies platform/system admin for UI gating.
+ * Prefer pairing with `/me/permissions`.is_admin when available — role strings
+ * alone miss accounts that are admin by identity but not listed as `"admin"`.
+ */
+export function hasModelResourcesAdminRole(roles: string[] | undefined | null): boolean {
+  if (!roles?.length) {
+    return false;
+  }
+
+  return roles.some((role) => ADMIN_ROLE_KEYS.has(role));
+}


### PR DESCRIPTION
## Summary
- Fixes https://github.com/openbkn-ai/bkn-studio/issues/110: Administrator / `super_admin` could edit large models, but the quota toggle stayed hidden because the UI only checked `roles.includes('admin')`.
- Approach: resolve `effectiveAdmin` from bkn-safe `me/permissions` `is_admin`, plus `admin` / `super_admin` (and Chinese aliases) role fallbacks; use it for `showQuotaField` / related admin UI gating.

## Test plan
- [ ] Log in as Administrator (`super_admin`)
- [ ] Open 模型管理 -> 模型配置, create/edit a large model
- [ ] Confirm the quota switch is visible at the bottom of the modal
- [ ] Enable quota, save, then open 配额管理 and confirm the model appears for limit settings
- [ ] Log in as a non-admin editor with `modify` only and confirm the quota switch stays hidden

Made with [Cursor](https://cursor.com)