### PR TITLE
feat(data-catalog): align data index with resource config ownership

### DIFF
--- a/src/modules/data-catalog/components/BuildTaskFormPanel.tsx
+++ b/src/modules/data-catalog/components/BuildTaskFormPanel.tsx
@@ -18,9 +18,11 @@ import {
   BuildTaskConflictError,
   createBuildTask,
   listBuildTasks,
-  updateBuildTask,
 } from "@/modules/data-catalog/services/build-task.service";
-import { getCatalogResource } from "@/modules/data-catalog/services/resource.service";
+import {
+  getCatalogResource,
+  updateCatalogResource,
+} from "@/modules/data-catalog/services/resource.service";
 import type {
   BuildMode,
   BuildTask,
@@ -28,6 +30,10 @@ import type {
   EmbeddingModelOption,
   ResourceSchemaField,
 } from "@/modules/data-catalog/types/data-catalog";
+import {
+  applyIndexFormToSchema,
+  indexFormValuesFromResource,
+} from "@/modules/data-catalog/utils/resource-index-config";
 import { listSmallModels } from "@/modules/model-resources/services/small-model.service";
 
 import formStyles from "./BuildTaskFormPanel.module.css";
@@ -119,18 +125,32 @@ export function BuildTaskFormPanel({
     setModelsLoaded(false);
     setSchema(resource.schema);
 
-    if (resource.schema.length === 0) {
-      setSchemaLoading(true);
-      void getCatalogResource(resource.id)
-        .then((detail) => {
-          if (detail?.schema.length) {
-            setSchema(detail.schema);
-          }
-        })
-        .finally(() => setSchemaLoading(false));
-    }
+    const hydrateFromResource = (detail: CatalogResource) => {
+      setSchema(detail.schema);
+      const form = indexFormValuesFromResource(detail);
+      setEmbeddingFields(form.embeddingFields);
+      setBuildKeyFields(form.buildKeyFields);
+      setFulltextFields(form.fulltextFields);
+      if (form.fulltextAnalyzer) {
+        setFulltextAnalyzer(form.fulltextAnalyzer);
+      }
+      return form.embeddingModel;
+    };
 
     void (async () => {
+      let preferredModel = "";
+      setSchemaLoading(true);
+      try {
+        const detail = await getCatalogResource(resource.id);
+        if (detail) {
+          preferredModel = hydrateFromResource(detail) || "";
+        } else if (resource.schema.length > 0) {
+          preferredModel = hydrateFromResource(resource) || "";
+        }
+      } finally {
+        setSchemaLoading(false);
+      }
+
       let existing: BuildTask | null = null;
       try {
         const tasks = await listBuildTasks({ resourceId: resource.id });
@@ -141,11 +161,15 @@ export function BuildTaskFormPanel({
       if (existing) {
         setExistingTask(existing);
         setMode(existing.mode);
-        setEmbeddingFields(existing.embeddingFields);
-        setBuildKeyFields(existing.buildKeyFields);
-        setFulltextFields(existing.fulltextFields);
-        if (existing.fulltextAnalyzer) {
-          setFulltextAnalyzer(existing.fulltextAnalyzer);
+        // 无 resource 配置时，回退展示最近任务快照
+        if (!preferredModel && existing.embeddingFields.length + existing.fulltextFields.length > 0) {
+          setEmbeddingFields(existing.embeddingFields);
+          setBuildKeyFields(existing.buildKeyFields);
+          setFulltextFields(existing.fulltextFields);
+          if (existing.fulltextAnalyzer) {
+            setFulltextAnalyzer(existing.fulltextAnalyzer);
+          }
+          preferredModel = existing.embeddingModel;
         }
       }
 
@@ -164,18 +188,16 @@ export function BuildTaskFormPanel({
           }));
         const list = options.length > 0 ? options : FALLBACK_MODELS;
         setModels(list);
-        const preferred = existing?.embeddingModel;
         setModelId(
-          preferred && list.some((item) => item.id === preferred)
-            ? preferred
+          preferredModel && list.some((item) => item.id === preferredModel)
+            ? preferredModel
             : list[0]?.id,
         );
       } catch {
         setModels(FALLBACK_MODELS);
-        const preferred = existing?.embeddingModel;
         setModelId(
-          preferred && FALLBACK_MODELS.some((item) => item.id === preferred)
-            ? preferred
+          preferredModel && FALLBACK_MODELS.some((item) => item.id === preferredModel)
+            ? preferredModel
             : FALLBACK_MODELS[0].id,
         );
       } finally {
@@ -207,28 +229,42 @@ export function BuildTaskFormPanel({
 
   const submitTask = async () => {
     const useEmbedding = embeddingFields.length > 0 && selectedModel;
-    const payload = {
+    const detail =
+      (await getCatalogResource(resource.id)) ??
+      ({
+        ...resource,
+        schema,
+      } satisfies CatalogResource);
+
+    const { schema: nextSchema, indexConfig } = applyIndexFormToSchema(detail.schema.length ? detail.schema : schema, {
       buildKeyFields,
       embeddingFields,
       embeddingModel: useEmbedding ? selectedModel.id : "",
-      modelDimensions: useEmbedding ? selectedModel.dimensions : 0,
       fulltextFields,
       fulltextAnalyzer: fulltextFields.length > 0 ? fulltextAnalyzer : undefined,
-    };
+    });
 
-    if (isEditable && existingTask) {
-      await updateBuildTask(existingTask.id, payload);
-      message.success(t("dataCatalog.build.edited"));
-      onSubmitted(existingTask);
-      return;
-    }
+    // 先写 resource 索引配置，再创建构建任务（任务只触发执行）。
+    await updateCatalogResource(resource.id, {
+      catalogId: detail.catalogId,
+      category: detail.category,
+      description: detail.description,
+      name: detail.name,
+      sourceIdentifier: detail.sourceIdentifier,
+      schema: nextSchema,
+      indexConfig,
+    });
 
     const task = await createBuildTask({
-      ...payload,
       mode,
       resourceId: resource.id,
+      executeType: mode === "batch" ? "full" : undefined,
     });
-    message.success(t("dataCatalog.build.created", { id: task.id }));
+    message.success(
+      isEditable
+        ? t("dataCatalog.build.edited")
+        : t("dataCatalog.build.created", { id: task.id }),
+    );
     onSubmitted(task);
   };
 

--- a/src/modules/data-catalog/hooks/use-build-task-actions.ts
+++ b/src/modules/data-catalog/hooks/use-build-task-actions.ts
@@ -54,9 +54,10 @@ export function useBuildTaskActions(onRefresh: () => Promise<void> | void) {
 
   const retry = useCallback(
     async (task: BuildTask, executeType: BuildExecuteType = "incremental") => {
+      const reset = executeType === "full";
       const run = async () => {
         try {
-          const next = await retryBuildTask(task.id, executeType);
+          const next = await retryBuildTask(task.id, reset);
           if (next) {
             message.success(t("dataCatalog.task.retried", { id: next.id }));
           }
@@ -66,7 +67,7 @@ export function useBuildTaskActions(onRefresh: () => Promise<void> | void) {
         }
       };
 
-      if (executeType === "full") {
+      if (reset) {
         modal.confirm({
           title: t("dataCatalog.task.rebuildFullConfirmTitle"),
           content: t("dataCatalog.task.rebuildFullConfirmContent"),

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -30,6 +30,16 @@ import type {
   IndexHealthState,
 } from "@/modules/data-catalog/types/data-catalog";
 
+type BackendBuildTaskFieldFeature = {
+  fulltext?: { analyzer?: string };
+  vector?: { dimensions?: number; model_id?: string };
+};
+
+type BackendBuildTaskIndexConfig = {
+  build_key_fields?: string[];
+  features?: Record<string, BackendBuildTaskFieldFeature>;
+};
+
 type BackendBuildTask = {
   build_key_fields?: string | string[];
   create_time?: number;
@@ -40,6 +50,7 @@ type BackendBuildTask = {
   fulltext_analyzer?: string;
   fulltext_fields?: string | string[];
   id: string;
+  index_config?: BackendBuildTaskIndexConfig | null;
   index_health?: { embedding?: string; fulltext?: string; usable?: boolean };
   mode?: string;
   model_dimensions?: number;
@@ -125,15 +136,64 @@ export function embeddingStateOf(task: BuildTask): IndexHealthState {
   );
 }
 
+function snapshotFieldsOf(item: BackendBuildTask) {
+  const snapshot = item.index_config;
+  if (snapshot?.features || snapshot?.build_key_fields) {
+    const embeddingFields: string[] = [];
+    const fulltextFields: string[] = [];
+    let embeddingModel = "";
+    let modelDimensions = 0;
+    let fulltextAnalyzer = "";
+
+    for (const [fieldName, feature] of Object.entries(snapshot.features ?? {})) {
+      if (feature.vector) {
+        embeddingFields.push(fieldName);
+        if (feature.vector.model_id && !embeddingModel) {
+          embeddingModel = feature.vector.model_id;
+        }
+        if (feature.vector.dimensions && !modelDimensions) {
+          modelDimensions = feature.vector.dimensions;
+        }
+      }
+      if (feature.fulltext) {
+        fulltextFields.push(fieldName);
+        if (feature.fulltext.analyzer && !fulltextAnalyzer) {
+          fulltextAnalyzer = feature.fulltext.analyzer;
+        }
+      }
+    }
+
+    return {
+      buildKeyFields: snapshot.build_key_fields ?? [],
+      embeddingFields,
+      embeddingModel,
+      modelDimensions,
+      fulltextFields,
+      fulltextAnalyzer,
+    };
+  }
+
+  // 兼容旧扁平字段（过渡期 / mock）
+  return {
+    buildKeyFields: splitFields(item.build_key_fields),
+    embeddingFields: splitFields(item.embedding_fields),
+    embeddingModel: item.embedding_model ?? "",
+    modelDimensions: item.model_dimensions ?? 0,
+    fulltextFields: splitFields(item.fulltext_fields),
+    fulltextAnalyzer: item.fulltext_analyzer ?? "",
+  };
+}
+
 function mapBuildTask(item: BackendBuildTask): BuildTask {
   const createdAt = item.create_time ?? 0;
   const mode: BuildMode = item.mode === "streaming" ? "streaming" : "batch";
   const status = normalizeStatus(item.status, mode);
+  const snapshot = snapshotFieldsOf(item);
 
   // 已完成但 embedding 没建满（vectorized < synced）= 索引降级：向量化失败/部分失败。
   const synced = item.synced_count ?? 0;
   const vectorized = item.vectorized_count ?? 0;
-  const wantsEmbedding = splitFields(item.embedding_fields).length > 0;
+  const wantsEmbedding = snapshot.embeddingFields.length > 0;
   const embeddingDegraded = wantsEmbedding && status === "succeeded" && vectorized < synced;
 
   // 优先用后端真实 index_health;缺省则按计数兜底,保持与 embeddingDegraded 一致。
@@ -157,13 +217,13 @@ function mapBuildTask(item: BackendBuildTask): BuildTask {
     resourceId: item.resource_id ?? "",
     mode,
     status,
-    embeddingFields: splitFields(item.embedding_fields),
-    buildKeyFields: splitFields(item.build_key_fields),
-    embeddingModel: item.embedding_model ?? "",
+    embeddingFields: snapshot.embeddingFields,
+    buildKeyFields: snapshot.buildKeyFields,
+    embeddingModel: snapshot.embeddingModel,
     embeddingDegraded,
-    modelDimensions: item.model_dimensions ?? 0,
-    fulltextFields: splitFields(item.fulltext_fields),
-    fulltextAnalyzer: item.fulltext_analyzer ?? "",
+    modelDimensions: snapshot.modelDimensions,
+    fulltextFields: snapshot.fulltextFields,
+    fulltextAnalyzer: snapshot.fulltextAnalyzer,
     totalCount: item.total_count ?? 0,
     syncedCount: synced,
     vectorizedCount: vectorized,
@@ -376,18 +436,43 @@ export async function createBuildTask(
     }
 
     const resource = mockResources.find((item) => item.id === input.resourceId);
+    const form = resource
+      ? {
+          buildKeyFields: resource.indexConfig?.buildKeyFields ?? [],
+          embeddingFields:
+            resource.schema
+              .filter((field) =>
+                field.features?.some((feature) => feature.featureType === "vector"),
+              )
+              .map((field) => field.name) ?? [],
+          embeddingModel: resource.indexConfig?.defaultEmbeddingModel ?? "",
+          fulltextFields:
+            resource.schema
+              .filter((field) =>
+                field.features?.some((feature) => feature.featureType === "fulltext"),
+              )
+              .map((field) => field.name) ?? [],
+          fulltextAnalyzer: resource.indexConfig?.defaultFulltextAnalyzer ?? "",
+        }
+      : {
+          buildKeyFields: [],
+          embeddingFields: [],
+          embeddingModel: "",
+          fulltextFields: [],
+          fulltextAnalyzer: "",
+        };
     const createdAt = Date.now();
     const task: BuildTask = {
       id: `bt-${mockSlug(8)}`,
       resourceId: input.resourceId,
       mode: input.mode,
       status: "pending",
-      embeddingFields: input.embeddingFields,
-      buildKeyFields: input.buildKeyFields,
-      embeddingModel: input.embeddingModel,
-      modelDimensions: input.modelDimensions,
-      fulltextFields: input.fulltextFields,
-      fulltextAnalyzer: input.fulltextAnalyzer ?? "",
+      embeddingFields: form.embeddingFields,
+      buildKeyFields: form.buildKeyFields,
+      embeddingModel: form.embeddingModel,
+      modelDimensions: 0,
+      fulltextFields: form.fulltextFields,
+      fulltextAnalyzer: form.fulltextAnalyzer,
       totalCount: resource?.rowCount ?? 0,
       syncedCount: 0,
       vectorizedCount: 0,
@@ -406,18 +491,16 @@ export async function createBuildTask(
     return wait(task);
   }
 
-  // 创建仅返回 {id, resource_id, status: "init"},完整任务体再查一次
+  // 创建仅返回 {id, resource_id, status: "init"},完整任务体再查一次。
+  // 索引配置由服务端从 resource 派生快照，客户端不再传字段配置。
   const response = await http.post<BackendBuildTask>(
     "/vega-backend/v1/build-tasks",
     {
-      build_key_fields: input.buildKeyFields.join(","),
-      embedding_fields: input.embeddingFields.join(","),
-      embedding_model: input.embeddingModel,
-      mode: input.mode,
-      model_dimensions: input.modelDimensions,
       resource_id: input.resourceId,
-      fulltext_fields: input.fulltextFields.join(","),
-      fulltext_analyzer: input.fulltextAnalyzer || undefined,
+      mode: input.mode,
+      ...(input.mode === "batch" && input.executeType
+        ? { execute_type: input.executeType }
+        : {}),
     },
   );
 
@@ -453,46 +536,21 @@ export async function resumeBuildTask(id: string) {
     return;
   }
 
-  // 后端语义:start = 恢复运行(body 可选)
-  await http.post(`/vega-backend/v1/build-tasks/${id}/start`);
+  // 后端语义:start = 恢复运行；默认 reset=false 按游标续跑
+  await http.post(`/vega-backend/v1/build-tasks/${id}/start`, { reset: false });
 }
 
+/**
+ * @deprecated 索引配置归属 resource。请 updateCatalogResource 后再 createBuildTask。
+ * 保留空实现会误导调用方，这里直接抛错。
+ */
 export async function updateBuildTask(
-  id: string,
-  input: BuildTaskUpdateInput,
+  _id: string,
+  _input: BuildTaskUpdateInput,
 ): Promise<void> {
-  if (useMock) {
-    const task = mockBuildTasks.find((item) => item.id === id);
-    if (task) {
-      task.embeddingFields = input.embeddingFields;
-      task.buildKeyFields = input.buildKeyFields;
-      task.embeddingModel = input.embeddingModel;
-      task.modelDimensions = input.modelDimensions;
-      task.fulltextFields = input.fulltextFields;
-      task.fulltextAnalyzer = input.fulltextAnalyzer ?? "";
-      task.status = "pending";
-      task.syncedCount = 0;
-      task.vectorizedCount = 0;
-      task.embeddingDegraded = false;
-      task.indexUsable = true;
-      task.failureDetail = "";
-      task.error = null;
-      emitMockChange();
-      ensureMockTicker();
-    }
-    await wait(undefined, 120);
-    return;
-  }
-
-  // 编辑配置 + 触发 full 重建(后端 drop 旧索引按新 mapping 重建)。仅 batch。
-  await http.put(`/vega-backend/v1/build-tasks/${id}`, {
-    build_key_fields: input.buildKeyFields.join(","),
-    embedding_fields: input.embeddingFields.join(","),
-    embedding_model: input.embeddingModel,
-    model_dimensions: input.modelDimensions,
-    fulltext_fields: input.fulltextFields.join(","),
-    fulltext_analyzer: input.fulltextAnalyzer || undefined,
-  });
+  throw new Error(
+    "Build task index config updates are removed; update the resource index config and create a new build task.",
+  );
 }
 
 export async function deleteBuildTask(
@@ -537,32 +595,39 @@ export async function deleteBuildTask(
 
 export type BuildExecuteType = "incremental" | "full";
 
+/**
+ * 重新 start 任务。
+ * - reset=false：按 synced_mark 增量续跑（对应旧 execute_type=incremental）
+ * - reset=true：忽略游标全量重跑（对应旧 execute_type=full）
+ */
 export async function retryBuildTask(
   id: string,
-  executeType: BuildExecuteType = "incremental",
+  resetOrExecuteType: boolean | BuildExecuteType = false,
 ): Promise<BuildTask | null> {
+  const reset =
+    typeof resetOrExecuteType === "boolean"
+      ? resetOrExecuteType
+      : resetOrExecuteType === "full";
+
   if (useMock) {
     const source = mockBuildTasks.find((item) => item.id === id);
     if (!source) {
       return wait(null);
     }
-    return createBuildTask({
-      buildKeyFields: source.buildKeyFields,
-      embeddingFields: source.embeddingFields,
-      embeddingModel: source.embeddingModel,
-      mode: source.mode,
-      modelDimensions: source.modelDimensions,
-      resourceId: source.resourceId,
-      fulltextFields: source.fulltextFields,
-      fulltextAnalyzer: source.fulltextAnalyzer,
-    });
+    if (reset) {
+      source.syncedCount = 0;
+      source.vectorizedCount = 0;
+    }
+    source.status = source.mode === "streaming" ? "listening" : "running";
+    source.error = null;
+    source.failureDetail = "";
+    source.lastEventAt = Date.now();
+    emitMockChange();
+    ensureMockTicker();
+    return wait(source);
   }
 
-  // 后端没有独立 retry:重新 start(支持 completed/stopped/failed)。
-  // execute_type:incremental 从 build key 游标(synced_mark)续传;full 游标清零全表重灌
-  await http.post(`/vega-backend/v1/build-tasks/${id}/start`, {
-    execute_type: executeType,
-  });
+  await http.post(`/vega-backend/v1/build-tasks/${id}/start`, { reset });
   return getBuildTask(id);
 }
 

--- a/src/modules/data-catalog/services/resource.service.ts
+++ b/src/modules/data-catalog/services/resource.service.ts
@@ -22,6 +22,9 @@ import type {
   CatalogScanRecord,
   ResourceCategory,
   ResourceCreateInput,
+  ResourceFieldFeature,
+  ResourceFeatureType,
+  ResourceIndexConfig,
   ResourceListQuery,
   ResourcePreviewQuery,
   ResourcePreviewResult,
@@ -29,14 +32,89 @@ import type {
   ResourceUpdateInput,
 } from "@/modules/data-catalog/types/data-catalog";
 
+type BackendFieldFeature = {
+  config?: Record<string, unknown>;
+  description?: string;
+  feature_type?: string;
+  is_default?: boolean;
+  is_native?: boolean;
+  ref_property?: string;
+};
+
 type BackendSchemaField = {
   description?: string;
   display_name?: string;
+  features?: BackendFieldFeature[] | null;
   name?: string;
   original_name?: string;
   original_type?: string;
   type?: string;
 };
+
+type BackendIndexConfig = {
+  build_key_fields?: string[];
+  default_embedding_model?: string;
+  default_fulltext_analyzer?: string;
+};
+
+function mapFeatureToBackend(feature: ResourceFieldFeature): BackendFieldFeature {
+  return {
+    feature_type: feature.featureType,
+    description: feature.description,
+    ref_property: feature.refProperty,
+    is_default: feature.isDefault,
+    is_native: feature.isNative,
+    config: feature.config,
+  };
+}
+
+function mapFeatureFromBackend(feature: BackendFieldFeature): ResourceFieldFeature | null {
+  const featureType = feature.feature_type;
+  if (
+    featureType !== "keyword" &&
+    featureType !== "fulltext" &&
+    featureType !== "vector"
+  ) {
+    return null;
+  }
+
+  return {
+    featureType: featureType as ResourceFeatureType,
+    description: feature.description,
+    refProperty: feature.ref_property,
+    isDefault: feature.is_default,
+    isNative: feature.is_native,
+    config: feature.config,
+  };
+}
+
+function mapIndexConfigToBackend(
+  config?: ResourceIndexConfig,
+): BackendIndexConfig | undefined {
+  if (!config) {
+    return undefined;
+  }
+
+  return {
+    build_key_fields: config.buildKeyFields,
+    default_fulltext_analyzer: config.defaultFulltextAnalyzer,
+    default_embedding_model: config.defaultEmbeddingModel,
+  };
+}
+
+function mapIndexConfigFromBackend(
+  config?: BackendIndexConfig | null,
+): ResourceIndexConfig | undefined {
+  if (!config) {
+    return undefined;
+  }
+
+  return {
+    buildKeyFields: config.build_key_fields,
+    defaultFulltextAnalyzer: config.default_fulltext_analyzer,
+    defaultEmbeddingModel: config.default_embedding_model,
+  };
+}
 
 function mapSchemaFieldToBackend(field: ResourceSchemaField): BackendSchemaField {
   const displayName = field.displayName?.trim() || field.name;
@@ -48,6 +126,7 @@ function mapSchemaFieldToBackend(field: ResourceSchemaField): BackendSchemaField
     name: field.name,
     original_name: field.name,
     type: field.type,
+    features: field.features?.map(mapFeatureToBackend),
   };
 }
 
@@ -55,6 +134,9 @@ function mapSchemaField(field: BackendSchemaField): ResourceSchemaField {
   const name = field.name ?? field.original_name ?? field.display_name ?? "";
   const displayName = field.display_name?.trim();
   const description = field.description?.trim();
+  const features = (field.features ?? [])
+    .map(mapFeatureFromBackend)
+    .filter((item): item is ResourceFieldFeature => item !== null);
 
   return {
     name,
@@ -62,6 +144,7 @@ function mapSchemaField(field: BackendSchemaField): ResourceSchemaField {
     displayName:
       displayName && displayName !== name ? displayName : undefined,
     description: description || undefined,
+    features: features.length > 0 ? features : undefined,
   };
 }
 
@@ -71,6 +154,7 @@ type BackendResource = {
   column_count?: number;
   description?: string;
   id: string;
+  index_config?: BackendIndexConfig | null;
   logic_type?: string;
   name: string;
   row_count?: number;
@@ -122,6 +206,7 @@ function mapResource(item: BackendResource): CatalogResource {
     sourceIdentifier: item.source_identifier ?? "",
     description: item.description ?? "",
     schema: (item.schema_definition ?? []).map(mapSchemaField),
+    indexConfig: mapIndexConfigFromBackend(item.index_config),
     // 列表接口不返回 schema_definition,改用后端标量 column_count;详情接口回退到 schema 长度
     columnCount: item.column_count ?? item.schema_definition?.length ?? 0,
     // 顶层 row_count 后端常缺省,实际行数在 source_metadata.properties 里
@@ -220,6 +305,7 @@ export async function createCatalogResource(input: ResourceCreateInput) {
       name: input.name,
       schema_definition:
         input.schema.length > 0 ? input.schema.map(mapSchemaFieldToBackend) : undefined,
+      index_config: mapIndexConfigToBackend(input.indexConfig),
       source_identifier: input.sourceIdentifier,
     },
   );
@@ -261,6 +347,7 @@ export async function updateCatalogResource(
       description: input.description,
       name: input.name,
       schema: input.schema,
+      indexConfig: input.indexConfig ?? current.indexConfig,
       sourceIdentifier: input.sourceIdentifier,
       columnCount: input.schema.length,
       updatedAt,
@@ -278,6 +365,7 @@ export async function updateCatalogResource(
     description: input.description,
     name: input.name,
     schema_definition: input.schema.map(mapSchemaFieldToBackend),
+    index_config: mapIndexConfigToBackend(input.indexConfig),
     source_identifier: input.sourceIdentifier,
   });
 

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -7,13 +7,34 @@
 
 export type ResourceCategory = "dataset" | "logicview" | "table";
 
+/** 字段级索引能力：keyword / fulltext / vector（对齐 Vega feature_type）。 */
+export type ResourceFeatureType = "keyword" | "fulltext" | "vector";
+
+export type ResourceFieldFeature = {
+  config?: Record<string, unknown>;
+  description?: string;
+  featureType: ResourceFeatureType;
+  isDefault?: boolean;
+  isNative?: boolean;
+  refProperty?: string;
+};
+
 export type ResourceSchemaField = {
   /** 业务字段名（后端 display_name） */
   displayName?: string;
   /** 字段说明（后端 description） */
   description?: string;
+  /** 字段级索引 features（全文 / 向量等） */
+  features?: ResourceFieldFeature[];
   name: string;
   type: string;
+};
+
+/** Resource 级默认值与跨字段构建策略（不含字段是否参与索引）。 */
+export type ResourceIndexConfig = {
+  buildKeyFields?: string[];
+  defaultEmbeddingModel?: string;
+  defaultFulltextAnalyzer?: string;
 };
 
 export type CatalogResource = {
@@ -22,6 +43,8 @@ export type CatalogResource = {
   columnCount: number;
   description: string;
   id: string;
+  /** 当前索引配置；列表接口可能缺省，配置页以详情为准 */
+  indexConfig?: ResourceIndexConfig;
   name: string;
   rowCount: number;
   schema: ResourceSchemaField[];
@@ -40,6 +63,7 @@ export type ResourceCreateInput = {
   catalogId: string;
   category: ResourceCategory;
   description: string;
+  indexConfig?: ResourceIndexConfig;
   name: string;
   schema: ResourceSchemaField[];
   sourceIdentifier: string;
@@ -137,19 +161,20 @@ export type BuildTaskPageResult = {
   total: number;
 };
 
+/** 创建任务：索引配置已归属 resource，此处只触发构建。 */
 export type BuildTaskCreateInput = {
-  buildKeyFields: string[];
-  embeddingFields: string[];
-  embeddingModel: string;
-  fulltextAnalyzer?: string;
-  fulltextFields: string[];
+  /** batch only；默认 full。streaming 勿传 unsupported 值。 */
+  executeType?: "full" | "incremental";
   mode: BuildMode;
-  modelDimensions: number;
   resourceId: string;
 };
 
 export type FulltextAnalyzer = "hanlp_index" | "ik_max_word" | "standard";
 
+/**
+ * @deprecated 索引配置改走 resource update；勿再 PUT task 配置。
+ * 保留类型仅用于过渡期 UI 组装 resource 写入载荷。
+ */
 export type BuildTaskUpdateInput = {
   buildKeyFields: string[];
   embeddingFields: string[];
@@ -157,6 +182,11 @@ export type BuildTaskUpdateInput = {
   fulltextAnalyzer?: string;
   fulltextFields: string[];
   modelDimensions: number;
+};
+
+/** start / 重跑：reset=true 忽略游标全量重跑。 */
+export type BuildTaskStartInput = {
+  reset?: boolean;
 };
 
 export type CatalogScanStatus = "failed" | "running" | "succeeded";

--- a/src/modules/data-catalog/utils/resource-index-config.test.ts
+++ b/src/modules/data-catalog/utils/resource-index-config.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyIndexFormToSchema,
+  indexFormValuesFromResource,
+} from "@/modules/data-catalog/utils/resource-index-config";
+
+describe("resource-index-config", () => {
+  it("writes vector/fulltext features and index_config from form values", () => {
+    const result = applyIndexFormToSchema(
+      [
+        { name: "id", type: "string", features: [{ featureType: "keyword" }] },
+        { name: "title", type: "string" },
+        { name: "body", type: "string" },
+      ],
+      {
+        buildKeyFields: ["id"],
+        embeddingFields: ["body"],
+        embeddingModel: "embed-1",
+        fulltextFields: ["title", "body"],
+        fulltextAnalyzer: "ik_max_word",
+      },
+    );
+
+    expect(result.indexConfig).toEqual({
+      buildKeyFields: ["id"],
+      defaultFulltextAnalyzer: "ik_max_word",
+      defaultEmbeddingModel: "embed-1",
+    });
+    expect(result.schema.find((f) => f.name === "id")?.features).toEqual([
+      { featureType: "keyword" },
+    ]);
+    expect(result.schema.find((f) => f.name === "title")?.features).toEqual([
+      { featureType: "fulltext", config: { analyzer: "ik_max_word" } },
+    ]);
+    expect(result.schema.find((f) => f.name === "body")?.features).toEqual([
+      { featureType: "fulltext", config: { analyzer: "ik_max_word" } },
+      { featureType: "vector", config: { embedding_model: "embed-1" } },
+    ]);
+  });
+
+  it("reads form values back from resource features", () => {
+    const values = indexFormValuesFromResource({
+      indexConfig: { buildKeyFields: ["id"], defaultEmbeddingModel: "embed-1" },
+      schema: [
+        {
+          name: "title",
+          type: "string",
+          features: [{ featureType: "fulltext", config: { analyzer: "standard" } }],
+        },
+        {
+          name: "body",
+          type: "string",
+          features: [{ featureType: "vector", config: { embedding_model: "embed-1" } }],
+        },
+      ],
+    });
+
+    expect(values).toEqual({
+      buildKeyFields: ["id"],
+      embeddingFields: ["body"],
+      embeddingModel: "embed-1",
+      fulltextFields: ["title"],
+      fulltextAnalyzer: "standard",
+    });
+  });
+});

--- a/src/modules/data-catalog/utils/resource-index-config.ts
+++ b/src/modules/data-catalog/utils/resource-index-config.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type {
+  ResourceFieldFeature,
+  ResourceIndexConfig,
+  ResourceSchemaField,
+} from "@/modules/data-catalog/types/data-catalog";
+
+export type ResourceIndexFormValues = {
+  buildKeyFields: string[];
+  embeddingFields: string[];
+  embeddingModel: string;
+  fulltextAnalyzer?: string;
+  fulltextFields: string[];
+};
+
+/**
+ * Merge UI field-role selections into schema features + resource index_config.
+ * Preserves unrelated features (e.g. keyword) on each field.
+ */
+export function applyIndexFormToSchema(
+  schema: ResourceSchemaField[],
+  values: ResourceIndexFormValues,
+): { indexConfig: ResourceIndexConfig; schema: ResourceSchemaField[] } {
+  const embeddingSet = new Set(values.embeddingFields);
+  const fulltextSet = new Set(values.fulltextFields);
+
+  const nextSchema = schema.map((field) => {
+    const kept = (field.features ?? []).filter(
+      (feature) => feature.featureType !== "vector" && feature.featureType !== "fulltext",
+    );
+    const features: ResourceFieldFeature[] = [...kept];
+
+    if (fulltextSet.has(field.name)) {
+      features.push({
+        featureType: "fulltext",
+        config: values.fulltextAnalyzer ? { analyzer: values.fulltextAnalyzer } : undefined,
+      });
+    }
+
+    if (embeddingSet.has(field.name)) {
+      features.push({
+        featureType: "vector",
+        config: values.embeddingModel
+          ? { embedding_model: values.embeddingModel }
+          : undefined,
+      });
+    }
+
+    return {
+      ...field,
+      features: features.length > 0 ? features : undefined,
+    };
+  });
+
+  return {
+    schema: nextSchema,
+    indexConfig: {
+      buildKeyFields: values.buildKeyFields,
+      defaultFulltextAnalyzer: values.fulltextAnalyzer || undefined,
+      defaultEmbeddingModel: values.embeddingModel || undefined,
+    },
+  };
+}
+
+/** Derive flat field lists from resource schema features for form/display. */
+export function indexFormValuesFromResource(resource: {
+  indexConfig?: ResourceIndexConfig;
+  schema: ResourceSchemaField[];
+}): ResourceIndexFormValues {
+  const embeddingFields: string[] = [];
+  const fulltextFields: string[] = [];
+  let embeddingModel = resource.indexConfig?.defaultEmbeddingModel ?? "";
+  let fulltextAnalyzer = resource.indexConfig?.defaultFulltextAnalyzer ?? "";
+
+  for (const field of resource.schema) {
+    for (const feature of field.features ?? []) {
+      if (feature.featureType === "vector") {
+        embeddingFields.push(field.name);
+        const model = feature.config?.embedding_model;
+        if (typeof model === "string" && model && !embeddingModel) {
+          embeddingModel = model;
+        }
+      }
+      if (feature.featureType === "fulltext") {
+        fulltextFields.push(field.name);
+        const analyzer = feature.config?.analyzer;
+        if (typeof analyzer === "string" && analyzer && !fulltextAnalyzer) {
+          fulltextAnalyzer = analyzer;
+        }
+      }
+    }
+  }
+
+  return {
+    buildKeyFields: resource.indexConfig?.buildKeyFields ?? [],
+    embeddingFields,
+    embeddingModel,
+    fulltextFields,
+    fulltextAnalyzer: fulltextAnalyzer || undefined,
+  };
+}


### PR DESCRIPTION
﻿## Summary
- Align Studio data-directory「数据索引」with Vega resource index ownership (Foundry #221 / PR #223 / #229).
- Closes https://github.com/openbkn-ai/bkn-studio/issues/137
- Design doc: https://github.com/openbkn-ai/bkn-docs/pull/5

### Changes
- Resource types/services now map `index_config` and schema `features`
- `POST /build-tasks` only sends `resource_id` / `mode` / optional `execute_type`
- Start/retry uses `{ reset }` instead of `execute_type`
- Index form saves resource config first, then creates a build task

## Test plan
- [ ] Configure vector/fulltext/build-key on a resource, save and create batch build
- [ ] Confirm create request body has no legacy index fields
- [ ] Resume with reset=false / full rebuild with reset=true
- [ ] Unit: `resource-index-config.test.ts`
