### PR TITLE
fix(execution-factory): paginate imported toolbox tools

### DIFF
--- a/src/modules/execution-factory/components/create-menu/McpToolImportedSection.tsx
+++ b/src/modules/execution-factory/components/create-menu/McpToolImportedSection.tsx
@@ -22,6 +22,8 @@ type McpToolImportedSectionProps = {
   onChange?: (value: McpToolConfigInput[]) => void;
 };
 
+const TOOL_PAGE_SIZE = 100;
+
 export function McpToolImportedSection({ value = [], onChange }: McpToolImportedSectionProps) {
   const { t } = useTranslation();
   const [toolboxes, setToolboxes] = useState<ToolboxRecord[]>([]);
@@ -61,20 +63,44 @@ export function McpToolImportedSection({ value = [], onChange }: McpToolImported
     setLoadingTools(true);
     setLoadError(null);
 
+    let cancelled = false;
+
     void (async () => {
       try {
-        const result = await listTools(boxId, {
-          page: 1,
-          pageSize: 200,
-        });
-        setTools(result.items);
+        const allTools: ToolRecord[] = [];
+        let page = 1;
+        let total = 0;
+        let received = 0;
+
+        do {
+          const result = await listTools(boxId, {
+            page,
+            pageSize: TOOL_PAGE_SIZE,
+          });
+          allTools.push(...result.items);
+          total = result.total;
+          received = result.items.length;
+          page += 1;
+        } while (allTools.length < total && received > 0);
+
+        if (!cancelled) {
+          setTools(allTools);
+        }
       } catch (error) {
-        setTools([]);
-        setLoadError(extractRequestErrorMessage(error));
+        if (!cancelled) {
+          setTools([]);
+          setLoadError(extractRequestErrorMessage(error));
+        }
       } finally {
-        setLoadingTools(false);
+        if (!cancelled) {
+          setLoadingTools(false);
+        }
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [boxId]);
 
   const selectedRowKeys = useMemo(


### PR DESCRIPTION
## 背景

工具箱工具导入页面固定请求 `page_size=200`，但执行工厂接口限制单页最多 100 条，因此请求会返回 400。

关联：openbkn-ai/bkn-foundry#233

## 改动

- 将单页请求大小调整为 100。
- 根据接口返回的总数自动请求后续页并合并工具列表。
- 工具箱切换或组件卸载时取消旧请求的状态更新，避免旧请求覆盖当前工具箱数据。

## 验证

- `pnpm lint`：通过（仓库已有 4 条 warning，无 error）
- `pnpm test:execution-factory`：29 个测试文件、95 个测试全部通过
