### PR TITLE
fix(system-admin): enforce three-admin role conflicts

### DIFF
--- a/src/modules/system-admin/components/UserRolesDrawer.tsx
+++ b/src/modules/system-admin/components/UserRolesDrawer.tsx
@@ -21,6 +21,7 @@ import {
   isAssignableRole,
   isSuperAdminRole,
   isThreeAdminRole,
+  threeAdminConflictLabels,
 } from "@/modules/system-admin/utils/role-catalog";
 
 import drawerStyles from "@/modules/system-admin/components/UserFormDrawer.module.css";
@@ -79,6 +80,8 @@ export function UserRolesDrawer({ onClose, onSaved, open, roles, user }: UserRol
   const hasControlledSuperAdmin = controlledRoles.some(isSuperAdminRole);
   const canConfigureAssignableRoles = !hasControlledSuperAdmin;
   const hasDutyConflict = hasThreeAdminConflict(selectedRoles);
+  const dutyConflictRoles = useMemo(() => threeAdminConflictLabels(selectedRoles), [selectedRoles]);
+  const dutyConflictText = dutyConflictRoles.join(" + ");
 
   const filteredBusinessRoles = useMemo(
     () => businessRoles.filter((role) => matchesRoleKeyword(role, roleSearch)),
@@ -114,6 +117,9 @@ export function UserRolesDrawer({ onClose, onSaved, open, roles, user }: UserRol
   };
 
   const handleSubmit = () => {
+    if (hasDutyConflict && canConfigureAssignableRoles) {
+      return;
+    }
     setSubmitting(true);
     void syncUserRoleBindings(user.id, roleIds)
       .then(() => {
@@ -158,7 +164,7 @@ export function UserRolesDrawer({ onClose, onSaved, open, roles, user }: UserRol
           <div className={drawerStyles.footerActions}>
             <AppButton onClick={onClose}>{t("common.cancel")}</AppButton>
             {canConfigureAssignableRoles ? (
-              <AppButton loading={submitting} onClick={handleSubmit} type="primary">
+              <AppButton disabled={hasDutyConflict} loading={submitting} onClick={handleSubmit} type="primary">
                 {t("common.save")}
               </AppButton>
             ) : null}
@@ -201,7 +207,9 @@ export function UserRolesDrawer({ onClose, onSaved, open, roles, user }: UserRol
                   message={t("systemAdmin.users.drawer.threeAdminConflictTitle")}
                   showIcon
                   type="warning"
-                  description={t("systemAdmin.users.drawer.threeAdminConflictDesc")}
+                  description={t("systemAdmin.users.drawer.threeAdminConflictDesc", {
+                    roles: dutyConflictText,
+                  })}
                 />
               ) : null}
               {roles.length > 6 ? (

--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -218,7 +218,7 @@ export const systemAdminEnUS = {
         roleExclusiveHint: "Three-admin roles separate system operations, security authorization, and audit oversight. Use business roles for business-building permissions.",
         superAdminControlledHint: "This account holds the controlled super_admin role and already has full platform permissions; do not add business or three-admin roles here.",
         threeAdminConflictTitle: "Three-admin duty conflict",
-        threeAdminConflictDesc: "A normal account should not hold multiple three-admin roles. Confirm this is temporary or controlled.",
+        threeAdminConflictDesc: "Current combination: {{roles}}. An account cannot hold multiple three-admin roles. Remove the conflicting role before saving.",
         rolesHint: "Pick the roles this user holds, which decide their permissions.",
         roleSearchPlaceholder: "Search by role name or description",
         rolesSelected: "{{count}} role(s) selected",

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -217,7 +217,7 @@ export const systemAdminZhCN = {
         roleExclusiveHint: "三员角色用于系统运维、安全授权和审计监督；业务建设能力请授予业务角色。",
         superAdminControlledHint: "该账号持有 super_admin 受控角色，已拥有平台全量权限；不需要再叠加业务角色或三员角色。",
         threeAdminConflictTitle: "存在三员职责冲突",
-        threeAdminConflictDesc: "同一普通账号不建议同时拥有多个三员角色。请确认这是临时应急或受控配置。",
+        threeAdminConflictDesc: "当前组合：{{roles}}。同一账号不允许同时拥有多个三员角色，请取消冲突角色后再保存。",
         rolesHint: "选择该用户拥有的角色，决定其权限。",
         roleSearchPlaceholder: "搜索角色名称或描述",
         rolesSelected: "已选择 {{count}} 个角色",

--- a/src/modules/system-admin/utils/role-catalog.test.ts
+++ b/src/modules/system-admin/utils/role-catalog.test.ts
@@ -12,6 +12,7 @@ import {
   hasThreeAdminConflict,
   isAssignableRole,
   resolveBuiltinRoleKey,
+  threeAdminConflictLabels,
 } from "@/modules/system-admin/utils/role-catalog";
 
 describe("role-catalog", () => {
@@ -38,5 +39,12 @@ describe("role-catalog", () => {
   it("detects multiple three-admin roles on the same account", () => {
     expect(hasThreeAdminConflict([{ name: "admin" }, { name: "security" }])).toBe(true);
     expect(hasThreeAdminConflict([{ name: "audit" }, { name: "normal_user" }])).toBe(false);
+    expect(hasThreeAdminConflict([{ name: "admin" }, { name: "legacy_system_role", source: "system" }])).toBe(
+      false,
+    );
+    expect(threeAdminConflictLabels([{ name: "admin" }, { name: "security" }])).toEqual([
+      "系统管理员",
+      "安全管理员",
+    ]);
   });
 });

--- a/src/modules/system-admin/utils/role-catalog.ts
+++ b/src/modules/system-admin/utils/role-catalog.ts
@@ -52,7 +52,7 @@ export function getRoleDutyCategory(role: Pick<AdminRole, "name" | "source">): R
   if (builtinKey) {
     return BUILTIN_ROLE_META[builtinKey].category;
   }
-  return role.source === "system" ? "three-admin" : "custom";
+  return "custom";
 }
 
 export function isSuperAdminRole(role: Pick<AdminRole, "name">): boolean {
@@ -69,4 +69,13 @@ export function isAssignableRole(role: Pick<AdminRole, "name">): boolean {
 
 export function hasThreeAdminConflict(roles: Pick<AdminRole, "name" | "source">[]): boolean {
   return roles.filter(isThreeAdminRole).length > 1;
+}
+
+export function threeAdminConflictLabels(roles: Pick<AdminRole, "name" | "source">[]): string[] {
+  return roles
+    .filter(isThreeAdminRole)
+    .map((role) => {
+      const builtinKey = resolveBuiltinRoleKey(role);
+      return builtinKey ? BUILTIN_ROLE_META[builtinKey].label : role.name;
+    });
 }

--- a/tests/e2e/specs/smoke/system-admin-roles.spec.ts
+++ b/tests/e2e/specs/smoke/system-admin-roles.spec.ts
@@ -45,6 +45,7 @@ test.describe("system-admin role system", () => {
     await drawer.getByText("security", { exact: true }).click();
 
     await expect(drawer.getByText("存在三员职责冲突")).toBeVisible();
-    await expect(drawer.getByText("同一普通账号不建议同时拥有多个三员角色")).toBeVisible();
+    await expect(drawer.getByText("同一账号不允许同时拥有多个三员角色")).toBeVisible();
+    await expect(drawer.getByRole("button").last()).toBeDisabled();
   });
 });


### PR DESCRIPTION
## 关联 Issue

Refs #141
Refs #147

## 修复内容

- 用户管理配置角色时，如果同一账号选择多个三员角色，展示具体冲突组合。
- 存在三员职责冲突时禁用保存，并在提交函数中再次拦截。
- super_admin 继续作为受控角色，不进入普通角色配置。
- 三员角色识别只匹配明确的 admin/security/audit，避免遗留 system 角色被误判。

## 验证

- npm run test -- role-catalog
- npm run build