### PR TITLE
fix(ci): keep SWR pushes on Docker manifest list

### DIFF
--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -126,7 +126,15 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ steps.gate.outputs.publish == 'true' }}
+          # Huawei SWR rejects an OCI image index ("Invalid image, fail to parse
+          # 'manifest.json'"), so the multi-arch manifest must stay in the legacy
+          # Docker format. BuildKit v0.31 made OCI media types the default for all
+          # image exports, and setup-buildx-action pulls the floating
+          # moby/buildkit:buildx-stable-1 tag, which moved to v0.31.2 on
+          # 2026-07-16 — pinning the exporter is what keeps SWR pushes working.
+          # `outputs` replaces `push:` here: the two would each add an image
+          # exporter.
+          outputs: type=image,oci-mediatypes=false,push=${{ steps.gate.outputs.publish == 'true' }}
           provenance: false
           sbom: false
           tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
## 问题

自 2026-07-17 起，所有 `release-studio` 发布构建推 SWR 全挂：

```
ERROR: failed to push swr.cn-east-3.myhuaweicloud.com/openbkn-ai/bkn-studio:<tag>:
unknown: Invalid image, fail to parse 'manifest.json'
```

`main` 和 PR 分支的 dispatch 都中招（run [29545507650](https://github.com/openbkn-ai/bkn-studio/actions/runs/29545507650)、[29546617569](https://github.com/openbkn-ai/bkn-studio/actions/runs/29546617569)）。GHCR 那份每次都推成功，只有 SWR 拒。**代码没有任何改动导致这个问题。**

## 根因

BuildKit v0.31.0 changelog：

> All image results now default to using OCI media types. Previously this was applied based on whether annotations or attestations were needed. `oci-mediatypes=false` can be used for legacy Docker media types. This change raises the compatibility version of BuildKit v0.31.0 to 30. (moby/buildkit#6824)

`setup-buildx-action` 拉的是浮动 tag `moby/buildkit:buildx-stable-1`，每个 job 现拉（日志里 `pulling image moby/buildkit:buildx-stable-1` ~2s，未走缓存）。该 tag **2026-07-16 16:20 UTC 从 v0.30.0 挪到 v0.31.2**（`buildx-stable-1` 与 `v0.31.2` 的 digest 同为 `sha256:2f5adac4ecd1…`）。v0.31.0/v0.31.1 六月就发了，但浮动 tag 一直压在 v0.30.0，所以 v0.31 的行为变更是 07-16 一次性突然生效的。

buildx CLI 两边都是 v0.35.0，光看 buildx 版本看不出来。

实测 GHCR 上新旧镜像的 manifest：

| BuildKit | mediaType | SWR |
|---|---|---|
| v0.30.0（07-16 成功） | `application/vnd.docker.distribution.manifest.list.v2+json` | 收 |
| v0.31.2（07-17 失败） | `application/vnd.oci.image.index.v1+json` | 拒 |

## 改了什么

`outputs: type=image,oci-mediatypes=false,push=…`，让 exporter 回到 Docker manifest list。`outputs` 取代原来的 `push:` —— 两者并存会各加一个 image exporter。

**多架构保留。** 没有改成「SWR 只推 amd64」，因为 arm64 集群正是从 SWR 拉 arm64 镜像（`k3s ctr images pull swr…`），砍掉 arm64 会直接打断那条路。也没有 pin BuildKit 版本 —— 那等于永久冻在旧版本。

## 验证

- YAML 解析通过；`push` 键已移除，`outputs` 生效。
- 待 dispatch 验证 SWR 推送恢复，并确认 manifest mediaType 回到 `manifest.list.v2+json`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)