### PR TITLE
fix(model-resources): show quota switch for platform admins

### DIFF
--- a/src/modules/model-resources/components/models/LargeModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/LargeModelListPanel.tsx
@@ -27,6 +27,7 @@ import {
   LlmMonitorDrawer,
 } from "@/modules/model-resources/components/models/ModelModals";
 import { ModelListToolbar } from "@/modules/model-resources/components/models/ModelListToolbar";
+import { getMyPermissions } from "@/modules/model-resources/services/authorization.service";
 import {
   deleteLlmModels,
   getLlmItemPermissions,
@@ -35,6 +36,7 @@ import {
   testLlmModel,
 } from "@/modules/model-resources/services/llm.service";
 import type { LlmModel } from "@/modules/model-resources/types/llm";
+import { hasModelResourcesAdminRole } from "@/modules/model-resources/utils/admin-access";
 import { getLlmModelTypeLabel } from "@/modules/model-resources/utils/llm-labels";
 import {
   formatNumberWithCommas,
@@ -79,9 +81,12 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
   const [guideOpen, setGuideOpen] = useState(false);
   const [monitorOpen, setMonitorOpen] = useState(false);
   const [authorizeRecord, setAuthorizeRecord] = useState<LlmModel | null>(null);
+  /** `/me/permissions`.is_admin — covers super_admin without literal role `"admin"`. */
+  const [meIsAdmin, setMeIsAdmin] = useState(false);
 
   const userRoles = runtimeConfig.currentUser.roles;
   const userPermissions = runtimeConfig.currentUser.permissions;
+  const effectiveAdmin = isAdmin || meIsAdmin || hasModelResourcesAdminRole(userRoles);
   const canManageLargeModel = hasPermissions({
     currentPermissions: userPermissions,
     mode: "any",
@@ -101,8 +106,7 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
       "large_model:modify",
     ],
   });
-  const isPlatformAdmin = isAdmin || userRoles.includes("admin") || userRoles.includes("super_admin");
-  const showQuotaField = isPlatformAdmin || canManageLargeModel || canManageQuota;
+  const showQuotaField = effectiveAdmin || canManageLargeModel || canManageQuota;
   const showQuotaColumns = !showQuotaField;
 
   const loadData = useCallback(async () => {
@@ -139,6 +143,24 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
   useEffect(() => {
     void loadData();
   }, [loadData]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void getMyPermissions()
+      .then((me) => {
+        if (!cancelled) {
+          setMeIsAdmin(me.isAdmin);
+        }
+      })
+      .catch(() => {
+        // Keep role-based fallback when /me/permissions is unavailable.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const sortMenuItems = useMemo(
     () => [
@@ -207,9 +229,9 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
     }
   };
 
-  // 真实管理员判定：roles 含 admin，或该项 operations 含 modify（getMyPermissions().isAdmin 会下发全量操作）。
+  // 真实管理员：prop / roles(含 super_admin) / me.isAdmin，或该项 operations 含 modify。
   const canModify = (record: LlmModel) =>
-    isPlatformAdmin || Boolean(record.operations?.includes("modify"));
+    effectiveAdmin || Boolean(record.operations?.includes("modify"));
   const canSetDefault = (record: LlmModel) => canModify(record) && !record.default;
   const canUnsetDefault = (record: LlmModel) => canModify(record) && Boolean(record.default);
 

--- a/src/modules/model-resources/utils/admin-access.test.ts
+++ b/src/modules/model-resources/utils/admin-access.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { hasModelResourcesAdminRole } from "@/modules/model-resources/utils/admin-access";
+
+describe("hasModelResourcesAdminRole", () => {
+  it("accepts admin and super_admin role keys", () => {
+    expect(hasModelResourcesAdminRole(["admin"])).toBe(true);
+    expect(hasModelResourcesAdminRole(["super_admin"])).toBe(true);
+    expect(hasModelResourcesAdminRole(["normal_user", "super_admin"])).toBe(true);
+  });
+
+  it("accepts Chinese role display names from /me", () => {
+    expect(hasModelResourcesAdminRole(["\u7cfb\u7edf\u7ba1\u7406\u5458"])).toBe(true);
+    expect(hasModelResourcesAdminRole(["\u8d85\u7ea7\u7ba1\u7406\u5458"])).toBe(true);
+  });
+
+  it("rejects non-admin roles and empty input", () => {
+    expect(hasModelResourcesAdminRole(["security"])).toBe(false);
+    expect(hasModelResourcesAdminRole([])).toBe(false);
+    expect(hasModelResourcesAdminRole(null)).toBe(false);
+    expect(hasModelResourcesAdminRole(undefined)).toBe(false);
+  });
+});

--- a/src/modules/model-resources/utils/admin-access.ts
+++ b/src/modules/model-resources/utils/admin-access.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/** Role names that unlock model-resources admin-only UI, such as the quota switch. */
+const ADMIN_ROLE_KEYS = new Set([
+  "admin",
+  "super_admin",
+  "\u7cfb\u7edf\u7ba1\u7406\u5458",
+  "\u8d85\u7ea7\u7ba1\u7406\u5458",
+]);
+
+/**
+ * Whether the caller's role list implies platform/system admin for UI gating.
+ * Prefer pairing with `/me/permissions`.is_admin when available because role strings
+ * alone miss accounts that are admin by identity but not listed as `"admin"`.
+ */
+export function hasModelResourcesAdminRole(roles: string[] | undefined | null): boolean {
+  if (!roles?.length) {
+    return false;
+  }
+
+  return roles.some((role) => ADMIN_ROLE_KEYS.has(role));
+}


### PR DESCRIPTION
## Summary
- restore platform admin quota switch visibility for model resources
- keep current main permission checks for model/quota management
- add role helper coverage for admin, super_admin, and Chinese admin display names

## Tests
- pnpm vitest run src/modules/model-resources/utils/admin-access.test.ts
- pnpm lint:types