### PR TITLE
ci: pin valid Trivy action version

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: aquasecurity/trivy-action@0.28.0
+      - uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
## Summary
- Pin aquasecurity/trivy-action to v0.36.0 in security-scan workflow.
- Fix CI security scan failures caused by an invalid or unavailable Trivy action version reference.

## Validation
- CI-only workflow change; no frontend runtime behavior changed.