### PR TITLE
fix(model-resources): clean up model quota entry points

### DIFF
--- a/src/modules/model-resources/components/models/LargeModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/LargeModelListPanel.tsx
@@ -106,8 +106,8 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
       "large_model:modify",
     ],
   });
-  const showQuotaField = effectiveAdmin || canManageLargeModel || canManageQuota;
-  const showQuotaColumns = !showQuotaField;
+  const showQuotaField = false;
+  const showQuotaColumns = !(effectiveAdmin || canManageLargeModel || canManageQuota);
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -334,11 +334,13 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
         sortOrder,
       ),
       sorter: true,
-      width: 220,
+      width: 300,
       render: (_value, record) => (
         <div className={styles.nameCell}>
           <ModelSeriesIcon modelName={record.modelName} modelSeries={record.modelSeries} />
-          <span title={record.modelName}>{record.modelName}</span>
+          <span className={styles.modelNameText} title={record.modelName}>
+            {record.modelName}
+          </span>
           {record.default ? (
             <Tag color="blue">{t("modelResources.models.defaultTag")}</Tag>
           ) : null}

--- a/src/modules/model-resources/components/models/ModelListPanels.module.css
+++ b/src/modules/model-resources/components/models/ModelListPanels.module.css
@@ -116,6 +116,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.modelNameText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .multiLineCell {

--- a/src/modules/model-resources/components/models/ModelModals.tsx
+++ b/src/modules/model-resources/components/models/ModelModals.tsx
@@ -259,8 +259,32 @@ export function LlmModelFormModal({
         >
           <InputNumber addonAfter="K" controls={false} min={1} style={{ width: "100%" }} />
         </Form.Item>
-        <Form.Item label={t("modelResources.models.columns.parameterQuantity")} name="modelParameters">
-          <InputNumber addonAfter="B" controls={false} min={0} style={{ width: "100%" }} />
+        <Form.Item
+          label={t("modelResources.models.columns.parameterQuantity")}
+          name="modelParameters"
+          rules={[
+            {
+              validator: (_rule, value: number | null | undefined) => {
+                if (value == null) {
+                  return Promise.resolve();
+                }
+
+                if (Number.isInteger(value) && value > 0) {
+                  return Promise.resolve();
+                }
+
+                return Promise.reject(new Error(t("modelResources.models.modal.positiveInteger")));
+              },
+            },
+          ]}
+        >
+          <InputNumber
+            addonAfter="B"
+            controls={false}
+            min={1}
+            precision={0}
+            style={{ width: "100%" }}
+          />
         </Form.Item>
         {showQuotaField ? (
           <>

--- a/src/modules/model-resources/components/models/SmallModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/SmallModelListPanel.tsx
@@ -287,7 +287,9 @@ export function SmallModelListPanel() {
       render: (_value, record) => (
         <div className={styles.nameCell}>
           <ModelSeriesIcon modelName={record.modelName} />
-          <span title={record.modelName}>{record.modelName}</span>
+          <span className={styles.modelNameText} title={record.modelName}>
+            {record.modelName}
+          </span>
           {record.default ? (
             <Tag color="blue">{t("modelResources.models.defaultTag")}</Tag>
           ) : null}

--- a/src/modules/model-resources/components/quota/QuotaLimitModal.module.css
+++ b/src/modules/model-resources/components/quota/QuotaLimitModal.module.css
@@ -5,12 +5,27 @@
  * Conditions. See LICENSE for the full text.
  */
 
-.pageHeader {
-  margin-bottom: 16px;
+.quotaModal :global(.ant-modal-content) {
+  border-radius: 4px;
+  box-shadow: 0 12px 36px rgba(15, 30, 54, 0.22);
+}
+
+.quotaModal :global(.ant-modal-header) {
+  margin-bottom: 10px;
+}
+
+.quotaModal :global(.ant-modal-title) {
+  color: #10233f;
+  font-size: 16px;
+  font-weight: 700;
 }
 
 .header {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border: 1px solid #e4ebf5;
+  border-radius: 4px;
+  background: #f7f9fc;
 }
 
 .modelTitle {
@@ -21,43 +36,170 @@
 
 .modelName {
   color: #10233f;
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 15px;
+  font-weight: 700;
 }
 
 .modelMeta {
-  margin-top: 8px;
+  margin-top: 6px;
   color: rgba(15, 30, 54, 0.62);
-  font-size: 13px;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.sectionPanel {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid #e7edf6;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
 }
 
 .sectionTitle {
-  margin: 20px 0 12px;
   color: #10233f;
   font-size: 14px;
+  font-weight: 700;
+  line-height: 20px;
+}
+
+.sectionHint {
+  color: rgba(15, 30, 54, 0.52);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.sectionMeta {
+  padding: 2px 8px;
+  border: 1px solid #d8e6ff;
+  border-radius: 3px;
+  background: #f3f7ff;
+  color: #3d5f96;
+  font-size: 12px;
+  line-height: 16px;
+  white-space: nowrap;
+}
+
+.billingGroup {
+  display: flex;
+}
+
+.quotaTable {
+  overflow: hidden;
+  border: 1px solid #edf1f7;
+  border-radius: 3px;
+}
+
+.quotaTable :global(.ant-table) {
+  border-radius: 3px;
+}
+
+.quotaTable :global(.ant-table-thead > tr > th) {
+  background: #f7f9fc;
+  color: #10233f;
+  font-weight: 700;
+}
+
+.quotaTable :global(.ant-table-tbody > tr > td) {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.rowLabel {
+  color: #10233f;
   font-weight: 600;
 }
 
 .fieldCell {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  min-height: 32px;
+}
+
+.controlLine {
+  display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+}
+
+.priceControlLine {
+  flex-wrap: nowrap;
+}
+
+.numberInput,
+.priceInput {
+  width: 96px;
+}
+
+.unitSelect {
+  width: 88px;
+}
+
+.currencySelect {
+  width: 58px;
+}
+
+.priceTypeSelect {
+  width: 108px;
+}
+
+.inlineUnit {
+  color: rgba(15, 30, 54, 0.68);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.forecastValue {
+  color: #10233f;
+  font-weight: 700;
 }
 
 .errorText {
-  width: 100%;
   color: #d4380d;
   font-size: 12px;
+  line-height: 16px;
 }
 
 .summary {
-  margin-top: 16px;
+  margin-top: 10px;
+  border-color: #99c5ff;
+  border-radius: 4px;
+  background: #edf6ff;
+}
+
+.summary :global(.ant-alert-message) {
+  color: #10233f;
+  font-weight: 600;
 }
 
 .footer {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
-  gap: 12px;
-  margin-top: 20px;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #edf1f7;
+}
+
+.primaryActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.footer :global(.ant-btn),
+.billingGroup :global(.ant-radio-button-wrapper),
+.quotaModal :global(.ant-input-number),
+.quotaModal :global(.ant-select-selector) {
+  border-radius: 3px;
 }

--- a/src/modules/model-resources/components/quota/QuotaLimitModal.tsx
+++ b/src/modules/model-resources/components/quota/QuotaLimitModal.tsx
@@ -101,11 +101,20 @@ function createRowsFromRecord(
   ];
 }
 
+function extractAmount(value?: string) {
+  if (!value) {
+    return 0;
+  }
+
+  const amount = Number(value.replace(/[^\d.-]/g, ""));
+  return Number.isFinite(amount) ? amount : 0;
+}
+
 export function QuotaLimitModal({ mode, onClose, open, record }: QuotaLimitModalProps) {
   const { t } = useTranslation();
   const { message } = useAppServices();
   const [billingType, setBillingType] = useState<"0" | "1">("0");
-  const [currencySymbol, setCurrencySymbol] = useState<"￥" | "$">("￥");
+  const [currencySymbol, setCurrencySymbol] = useState<"\uffe5" | "$">("\uffe5");
   const [priceType, setPriceType] = useState<"thousand" | "million">("thousand");
   const [rows, setRows] = useState<QuotaRow[]>([]);
   const [totalForecast, setTotalForecast] = useState("");
@@ -131,42 +140,42 @@ export function QuotaLimitModal({ mode, onClose, open, record }: QuotaLimitModal
     [t],
   );
 
-  const recalculateForecast = useCallback((
-    nextRows: QuotaRow[],
-    nextBillingType: "0" | "1",
-    nextPriceType = priceType,
-    nextCurrencySymbol = currencySymbol,
-  ) => {
-    const updatedRows = nextRows.map((row) => {
-      if (row.tokens === undefined || row.referPrice === undefined) {
-        return { ...row, forecast: undefined };
-      }
+  const recalculateForecast = useCallback(
+    (
+      nextRows: QuotaRow[],
+      nextBillingType: "0" | "1",
+      nextPriceType = priceType,
+      nextCurrencySymbol = currencySymbol,
+    ) => {
+      const updatedRows = nextRows.map((row) => {
+        if (row.tokens === undefined || row.referPrice === undefined) {
+          return { ...row, forecast: undefined };
+        }
 
-      return {
-        ...row,
-        forecast: formatForecastAmount(
-          row.tokens,
-          row.referPrice,
-          toBackendNumType(row.numType),
-          nextPriceType,
-          nextCurrencySymbol,
-        ),
-      };
-    });
+        return {
+          ...row,
+          forecast: formatForecastAmount(
+            row.tokens,
+            row.referPrice,
+            toBackendNumType(row.numType),
+            nextPriceType,
+            nextCurrencySymbol,
+          ),
+        };
+      });
 
-    const inputForecast = updatedRows[0]?.forecast;
-    const outputForecast = updatedRows[1]?.forecast;
-    const nextTotal =
-      nextBillingType === "1" && inputForecast && outputForecast
-        ? `${nextCurrencySymbol}${(
-            Number(inputForecast.replace(/[^\d.-]/g, "")) +
-            Number(outputForecast.replace(/[^\d.-]/g, ""))
-          ).toFixed(2)}`
-        : inputForecast ?? "";
+      const inputForecast = updatedRows[0]?.forecast;
+      const outputForecast = updatedRows[1]?.forecast;
+      const nextTotal =
+        nextBillingType === "1" && inputForecast && outputForecast
+          ? `${nextCurrencySymbol}${(extractAmount(inputForecast) + extractAmount(outputForecast)).toFixed(2)}`
+          : inputForecast ?? "";
 
-    setRows(updatedRows);
-    setTotalForecast(nextTotal);
-  }, [currencySymbol, priceType]);
+      setRows(updatedRows);
+      setTotalForecast(nextTotal);
+    },
+    [currencySymbol, priceType],
+  );
 
   useEffect(() => {
     if (!open || !record) {
@@ -182,14 +191,15 @@ export function QuotaLimitModal({ mode, onClose, open, record }: QuotaLimitModal
         const source = detail ?? record;
         const nextBillingType =
           source.billingType === 1 ? "1" : source.billingType === 0 ? "0" : "0";
+        const nextCurrencySymbol = source.currencyType === 1 ? "$" : "\uffe5";
+        const nextPriceType = (source.priceType?.[0] as "thousand" | "million") ?? "thousand";
 
         setBillingType(nextBillingType);
-        setCurrencySymbol(source.currencyType === 1 ? "$" : "￥");
-        setPriceType((source.priceType?.[0] as "thousand" | "million") ?? "thousand");
+        setCurrencySymbol(nextCurrencySymbol);
+        setPriceType(nextPriceType);
 
         const nextRows = createRowsFromRecord(source, nextBillingType);
-        setRows(nextRows);
-        recalculateForecast(nextRows, nextBillingType);
+        recalculateForecast(nextRows, nextBillingType, nextPriceType, nextCurrencySymbol);
       } catch (error) {
         message.error(extractRequestErrorMessage(error));
       } finally {
@@ -208,12 +218,6 @@ export function QuotaLimitModal({ mode, onClose, open, record }: QuotaLimitModal
   const handleBillingTypeChange = (event: RadioChangeEvent) => {
     const nextBillingType = event.target.value as "0" | "1";
     setBillingType(nextBillingType);
-
-    if (nextBillingType === "0") {
-      recalculateForecast(rows.slice(0, 1).concat(rows.slice(1)), nextBillingType);
-      return;
-    }
-
     recalculateForecast(rows, nextBillingType);
   };
 
@@ -305,6 +309,7 @@ export function QuotaLimitModal({ mode, onClose, open, record }: QuotaLimitModal
 
   return (
     <Modal
+      className={styles.quotaModal}
       destroyOnHidden
       footer={null}
       maskClosable={false}
@@ -320,118 +325,144 @@ export function QuotaLimitModal({ mode, onClose, open, record }: QuotaLimitModal
             <span className={styles.modelName}>{record.modelName}</span>
           </div>
           <div className={styles.modelMeta}>
-            {t("modelResources.quotas.columns.model")}：{record.model}
+            {t("modelResources.quotas.columns.model")}: {record.model}
           </div>
         </div>
       ) : null}
 
-      <div className={styles.sectionTitle}>{t("modelResources.quotas.modal.billingType")}</div>
-      <Radio.Group
-        disabled={mode === "edit"}
-        onChange={handleBillingTypeChange}
-        value={billingType}
-      >
-        <Radio value="0">{t("modelResources.quotas.modal.unifiedBilling")}</Radio>
-        <Radio value="1">{t("modelResources.quotas.modal.separateBilling")}</Radio>
-      </Radio.Group>
+      <section className={styles.sectionPanel}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <div className={styles.sectionTitle}>{t("modelResources.quotas.modal.billingType")}</div>
+            <div className={styles.sectionHint}>{t("modelResources.quotas.modal.quotaSetting")}</div>
+          </div>
+        </div>
+        <Radio.Group
+          buttonStyle="solid"
+          className={styles.billingGroup}
+          disabled={mode === "edit"}
+          optionType="button"
+          onChange={handleBillingTypeChange}
+          value={billingType}
+        >
+          <Radio.Button value="0">{t("modelResources.quotas.modal.unifiedBilling")}</Radio.Button>
+          <Radio.Button value="1">{t("modelResources.quotas.modal.separateBilling")}</Radio.Button>
+        </Radio.Group>
+      </section>
 
-      <div className={styles.sectionTitle}>{t("modelResources.quotas.modal.quotaSetting")}</div>
-      <Table<QuotaRow>
-        columns={[
-          {
-            title: "",
-            dataIndex: "labelKey",
-            width: 96,
-            render: (labelKey: QuotaRow["labelKey"]) => t(labelKey),
-          },
-          {
-            title: t("modelResources.quotas.modal.tokensAmount"),
-            dataIndex: "tokens",
-            width: 280,
-            render: (_value, row) => (
-              <div className={styles.fieldCell}>
-                <InputNumber
-                  controls={false}
-                  max={9999}
-                  min={1}
-                  onChange={(value) =>
-                    updateRow(row.id, { tokens: typeof value === "number" ? value : undefined })
-                  }
-                  placeholder={t("modelResources.quotas.modal.enterPlaceholder")}
-                  value={row.tokens}
-                />
-                <Select
-                  options={numTypeOptions}
-                  popupMatchSelectWidth={120}
-                  style={{ width: 88 }}
-                  value={row.numType}
-                  onChange={(value) => updateRow(row.id, { numType: value })}
-                />
-                <span>{t("modelResources.quotas.modal.perMonth")}</span>
-                {showErrors && row.errors.tokens ? (
-                  <span className={styles.errorText}>{t("modelResources.quotas.modal.required")}</span>
-                ) : null}
-              </div>
-            ),
-          },
-          {
-            title: t("modelResources.quotas.modal.referencePrice"),
-            dataIndex: "referPrice",
-            width: 280,
-            render: (_value, row) => (
-              <div className={styles.fieldCell}>
-                <Select
-                  options={[
-                    { value: "CNY", label: "￥" },
-                    { value: "USD", label: "$" },
-                  ]}
-                  style={{ width: 72 }}
-                  value={currencySymbol === "$" ? "USD" : "CNY"}
-                  onChange={(value) => {
-                    const nextSymbol = value === "USD" ? "$" : "￥";
-                    setCurrencySymbol(nextSymbol);
-                    recalculateForecast(rows, billingType, priceType, nextSymbol);
-                  }}
-                />
-                <InputNumber
-                  controls={false}
-                  min={0}
-                  onChange={(value) =>
-                    updateRow(row.id, {
-                      referPrice: typeof value === "number" ? value : undefined,
-                    })
-                  }
-                  placeholder={t("modelResources.quotas.modal.enterPlaceholder")}
-                  value={row.referPrice}
-                />
-                <Select
-                  options={priceTypeOptions}
-                  style={{ width: 120 }}
-                  value={priceType}
-                  onChange={(value) => {
-                    setPriceType(value);
-                    recalculateForecast(rows, billingType, value, currencySymbol);
-                  }}
-                />
-                {showErrors && row.errors.referPrice ? (
-                  <span className={styles.errorText}>{t("modelResources.quotas.modal.required")}</span>
-                ) : null}
-              </div>
-            ),
-          },
-          {
-            title: t("modelResources.quotas.modal.forecastTotal"),
-            dataIndex: "forecast",
-            width: 140,
-            render: (value?: string) => value ?? "--",
-          },
-        ]}
-        dataSource={tableRows}
-        loading={loading}
-        pagination={false}
-        rowKey="id"
-        size="small"
-      />
+      <section className={styles.sectionPanel}>
+        <div className={styles.sectionHeader}>
+          <div className={styles.sectionTitle}>{t("modelResources.quotas.modal.quotaSetting")}</div>
+          <div className={styles.sectionMeta}>{t("modelResources.quotas.modal.perMonth")}</div>
+        </div>
+        <Table<QuotaRow>
+          className={styles.quotaTable}
+          columns={[
+            {
+              title: "",
+              dataIndex: "labelKey",
+              width: 96,
+              render: (labelKey: QuotaRow["labelKey"]) => (
+                <span className={styles.rowLabel}>{t(labelKey)}</span>
+              ),
+            },
+            {
+              title: t("modelResources.quotas.modal.tokensAmount"),
+              dataIndex: "tokens",
+              width: 300,
+              render: (_value, row) => (
+                <div className={styles.fieldCell}>
+                  <div className={styles.controlLine}>
+                    <InputNumber
+                      className={styles.numberInput}
+                      controls={false}
+                      max={9999}
+                      min={1}
+                      onChange={(value) =>
+                        updateRow(row.id, { tokens: typeof value === "number" ? value : undefined })
+                      }
+                      placeholder={t("modelResources.quotas.modal.enterPlaceholder")}
+                      value={row.tokens}
+                    />
+                    <Select
+                      className={styles.unitSelect}
+                      options={numTypeOptions}
+                      popupMatchSelectWidth={120}
+                      value={row.numType}
+                      onChange={(value) => updateRow(row.id, { numType: value })}
+                    />
+                    <span className={styles.inlineUnit}>{t("modelResources.quotas.modal.perMonth")}</span>
+                  </div>
+                  {showErrors && row.errors.tokens ? (
+                    <span className={styles.errorText}>{t("modelResources.quotas.modal.required")}</span>
+                  ) : null}
+                </div>
+              ),
+            },
+            {
+              title: t("modelResources.quotas.modal.referencePrice"),
+              dataIndex: "referPrice",
+              width: 300,
+              render: (_value, row) => (
+                <div className={styles.fieldCell}>
+                  <div className={`${styles.controlLine} ${styles.priceControlLine}`}>
+                    <Select
+                      className={styles.currencySelect}
+                      options={[
+                        { value: "CNY", label: "\uffe5" },
+                        { value: "USD", label: "$" },
+                      ]}
+                      value={currencySymbol === "$" ? "USD" : "CNY"}
+                      onChange={(value) => {
+                        const nextSymbol = value === "USD" ? "$" : "\uffe5";
+                        setCurrencySymbol(nextSymbol);
+                        recalculateForecast(rows, billingType, priceType, nextSymbol);
+                      }}
+                    />
+                    <InputNumber
+                      className={styles.priceInput}
+                      controls={false}
+                      min={0}
+                      onChange={(value) =>
+                        updateRow(row.id, {
+                          referPrice: typeof value === "number" ? value : undefined,
+                        })
+                      }
+                      placeholder={t("modelResources.quotas.modal.enterPlaceholder")}
+                      value={row.referPrice}
+                    />
+                    <Select
+                      className={styles.priceTypeSelect}
+                      options={priceTypeOptions}
+                      value={priceType}
+                      onChange={(value) => {
+                        setPriceType(value);
+                        recalculateForecast(rows, billingType, value, currencySymbol);
+                      }}
+                    />
+                  </div>
+                  {showErrors && row.errors.referPrice ? (
+                    <span className={styles.errorText}>{t("modelResources.quotas.modal.required")}</span>
+                  ) : null}
+                </div>
+              ),
+            },
+            {
+              title: t("modelResources.quotas.modal.forecastTotal"),
+              dataIndex: "forecast",
+              width: 140,
+              render: (value?: string) => (
+                <span className={styles.forecastValue}>{value ?? "--"}</span>
+              ),
+            },
+          ]}
+          dataSource={tableRows}
+          loading={loading}
+          pagination={false}
+          rowKey="id"
+          size="small"
+        />
+      </section>
 
       <Alert
         className={styles.summary}
@@ -440,10 +471,12 @@ export function QuotaLimitModal({ mode, onClose, open, record }: QuotaLimitModal
       />
 
       <div className={styles.footer}>
-        <AppButton onClick={() => onClose(false)}>{t("common.cancel")}</AppButton>
-        <AppButton loading={submitting} type="primary" onClick={() => void handleSubmit()}>
-          {t("common.save")}
-        </AppButton>
+        <div className={styles.primaryActions}>
+          <AppButton onClick={() => onClose(false)}>{t("common.cancel")}</AppButton>
+          <AppButton loading={submitting} type="primary" onClick={() => void handleSubmit()}>
+            {t("common.save")}
+          </AppButton>
+        </div>
       </div>
     </Modal>
   );

--- a/src/modules/model-resources/components/quota/QuotaUserModal.module.css
+++ b/src/modules/model-resources/components/quota/QuotaUserModal.module.css
@@ -5,8 +5,27 @@
  * Conditions. See LICENSE for the full text.
  */
 
+.quotaModal :global(.ant-modal-content) {
+  border-radius: 4px;
+  box-shadow: 0 12px 36px rgba(15, 30, 54, 0.22);
+}
+
+.quotaModal :global(.ant-modal-header) {
+  margin-bottom: 10px;
+}
+
+.quotaModal :global(.ant-modal-title) {
+  color: #10233f;
+  font-size: 16px;
+  font-weight: 700;
+}
+
 .header {
-  margin-bottom: 16px;
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border: 1px solid #e4ebf5;
+  border-radius: 4px;
+  background: #f7f9fc;
 }
 
 .modelTitle {
@@ -17,37 +36,113 @@
 
 .modelName {
   color: #10233f;
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 15px;
+  font-weight: 700;
 }
 
 .modelMeta {
-  margin-top: 8px;
+  margin-top: 6px;
   color: rgba(15, 30, 54, 0.62);
-  font-size: 13px;
+  font-size: 12px;
+  line-height: 18px;
 }
 
 .remainAlert {
-  margin-bottom: 16px;
+  margin-bottom: 10px;
+  border-color: #99c5ff;
+  border-radius: 4px;
+  background: #edf6ff;
 }
 
-.toolbar {
+.remainAlert :global(.ant-alert-message) {
+  color: #10233f;
+  font-weight: 600;
+}
+
+.toolbarPanel {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 10px;
+  border: 1px solid #e7edf6;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.userSelect {
+  width: 300px;
+}
+
+.userTable {
+  overflow: hidden;
+  border: 1px solid #edf1f7;
+  border-radius: 3px;
+}
+
+.userTable :global(.ant-table) {
+  border-radius: 3px;
+}
+
+.userTable :global(.ant-table-thead > tr > th) {
+  background: #f7f9fc;
+  color: #10233f;
+  font-weight: 700;
+}
+
+.userTable :global(.ant-table-tbody > tr > td) {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.userTable :global(.ant-empty-normal) {
+  margin: 32px 0;
 }
 
 .fieldCell {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+  min-height: 32px;
+}
+
+.numberInput {
+  width: 108px;
+}
+
+.unitSelect {
+  width: 88px;
+}
+
+.inlineUnit {
+  color: rgba(15, 30, 54, 0.68);
+  font-size: 13px;
+  white-space: nowrap;
 }
 
 .footer {
   display: flex;
   justify-content: flex-end;
-  gap: 12px;
-  margin-top: 20px;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #edf1f7;
+}
+
+.footer :global(.ant-btn),
+.quotaModal :global(.ant-input-number),
+.quotaModal :global(.ant-select-selector) {
+  border-radius: 3px;
+}
+
+@media (max-width: 640px) {
+  .toolbarPanel {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .userSelect {
+    width: 100%;
+  }
 }

--- a/src/modules/model-resources/components/quota/QuotaUserModal.tsx
+++ b/src/modules/model-resources/components/quota/QuotaUserModal.tsx
@@ -185,7 +185,10 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
         }
       }
 
-      await saveUserQuotas(saveItems);
+      if (saveItems.length > 0) {
+        await saveUserQuotas(saveItems);
+      }
+
       message.success(t("modelResources.quotas.userModal.saveSuccess"));
       onClose(true);
     } catch (error) {
@@ -200,13 +203,14 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
 
   return (
     <Modal
+      className={styles.quotaModal}
       destroyOnHidden
       footer={null}
       maskClosable={false}
       onCancel={() => onClose(false)}
       open={open}
       title={t("modelResources.quotas.userModal.title")}
-      width={920}
+      width={900}
     >
       {record ? (
         <div className={styles.header}>
@@ -215,7 +219,7 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
             <span className={styles.modelName}>{record.modelName}</span>
           </div>
           <div className={styles.modelMeta}>
-            {t("modelResources.quotas.columns.model")}：{record.model}
+            {t("modelResources.quotas.columns.model")}: {record.model}
           </div>
         </div>
       ) : null}
@@ -237,13 +241,13 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
         />
       ) : null}
 
-      <div className={styles.toolbar}>
+      <section className={styles.toolbarPanel}>
         <Select
           allowClear
+          className={styles.userSelect}
           options={userOptions}
           placeholder={t("modelResources.quotas.userModal.selectUser")}
           showSearch
-          style={{ width: 280 }}
           value={selectedUserId}
           onChange={setSelectedUserId}
           onSearch={(value) => {
@@ -258,9 +262,10 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
           }}
         />
         <AppButton onClick={handleAddUser}>{t("modelResources.quotas.userModal.addUser")}</AppButton>
-      </div>
+      </section>
 
       <Table<EditableUserQuota>
+        className={styles.userTable}
         columns={[
           {
             title: t("modelResources.quotas.userModal.userName"),
@@ -274,6 +279,7 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
             render: (_value, row) => (
               <div className={styles.fieldCell}>
                 <InputNumber
+                  className={styles.numberInput}
                   controls={false}
                   min={0}
                   onChange={(value) =>
@@ -284,8 +290,8 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
                   value={row.inputTokens}
                 />
                 <Select
+                  className={styles.unitSelect}
                   options={numTypeOptions}
-                  style={{ width: 88 }}
                   value={row.numType[0] === 3 ? 6 : row.numType[0]}
                   onChange={(value) =>
                     updateItem(row.userId, {
@@ -293,7 +299,7 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
                     })
                   }
                 />
-                <span>{monthLabel}</span>
+                <span className={styles.inlineUnit}>{monthLabel}</span>
               </div>
             ),
           },
@@ -306,6 +312,7 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
                   render: (_value: number | undefined, row: EditableUserQuota) => (
                     <div className={styles.fieldCell}>
                       <InputNumber
+                        className={styles.numberInput}
                         controls={false}
                         min={0}
                         onChange={(value) =>
@@ -316,8 +323,8 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
                         value={row.outputTokens}
                       />
                       <Select
+                        className={styles.unitSelect}
                         options={numTypeOptions}
-                        style={{ width: 88 }}
                         value={row.numType[1] === 3 ? 6 : row.numType[1]}
                         onChange={(value) =>
                           updateItem(row.userId, {
@@ -325,7 +332,7 @@ export function QuotaUserModal({ onClose, open, record }: QuotaUserModalProps) {
                           })
                         }
                       />
-                      <span>{monthLabel}</span>
+                      <span className={styles.inlineUnit}>{monthLabel}</span>
                     </div>
                   ),
                 },

--- a/src/modules/model-resources/locales/en-US.ts
+++ b/src/modules/model-resources/locales/en-US.ts
@@ -119,6 +119,7 @@ export const modelResourcesEnUS = {
         apiModelPlaceholder: "Enter value (case sensitive)",
         adapterPlaceholder: "Enter Python adapter code",
         required: "Required",
+        positiveInteger: "Enter an integer greater than 0",
         switchToEdit: "Edit",
       },
       apiGuide: {

--- a/src/modules/model-resources/locales/zh-CN.ts
+++ b/src/modules/model-resources/locales/zh-CN.ts
@@ -117,6 +117,7 @@ export const modelResourcesZhCN = {
         apiModelPlaceholder: "请输入（填写字段时，请注意区分大小写字母）",
         adapterPlaceholder: "请输入 Python 适配代码",
         required: "不能为空",
+        positiveInteger: "请输入大于 0 的整数",
         switchToEdit: "编辑",
       },
       apiGuide: {

--- a/src/modules/model-resources/navigation.tsx
+++ b/src/modules/model-resources/navigation.tsx
@@ -8,7 +8,6 @@
 import {
   AppstoreOutlined,
   BarChartOutlined,
-  FundOutlined,
 } from "@ant-design/icons";
 
 import type { ConsoleNavContribution } from "@/app/shell/navigation/types";
@@ -21,12 +20,6 @@ export const modelResourcesNavigation: ConsoleNavContribution = {
       labelKey: "shell.items.modelManagement",
       icon: <AppstoreOutlined />,
       path: "/model-resources/models",
-    },
-    {
-      key: "quota-management",
-      labelKey: "shell.items.quotaManagement",
-      icon: <FundOutlined />,
-      path: "/model-resources/quotas",
     },
     {
       key: "model-statistics",

--- a/src/modules/model-resources/services/quota.service.ts
+++ b/src/modules/model-resources/services/quota.service.ts
@@ -21,6 +21,7 @@ import type {
   UserQuotaRecord,
   UserQuotaSaveItem,
 } from "@/modules/model-resources/types/quota";
+import { listUsersPage } from "@/modules/system-admin/services/admin.service";
 
 const API_PREFIX = "/mf-model-manager/v1";
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
@@ -327,7 +328,15 @@ export async function listUserQuotas(confId: string): Promise<UserQuotaListResul
 
   const response = await http.get<BackendUserQuotaListResponse>(
     `${API_PREFIX}/user-quota/list`,
-    { params: { conf_id: confId } },
+    {
+      params: {
+        conf_id: confId,
+        page: 1,
+        size: 1000,
+        rule: "update_time",
+        order: "desc",
+      },
+    },
   );
   const payload = response.data;
 
@@ -339,6 +348,10 @@ export async function listUserQuotas(confId: string): Promise<UserQuotaListResul
 }
 
 export async function saveUserQuotas(items: UserQuotaSaveItem[]): Promise<boolean> {
+  if (items.length === 0) {
+    return true;
+  }
+
   if (useMock) {
     items.forEach((item) => {
       const existingIndex = mockUserQuotas.findIndex(
@@ -410,20 +423,14 @@ export async function searchAssignableUsers(keyword?: string): Promise<Assignabl
   }
 
   try {
-    const response = await http.get<{ res?: { user_id: string; user_name: string }[] }>(
-      "/authorization/v1/users",
-      {
-        params: {
-          page: 1,
-          size: 50,
-          keyword: keyword ?? "",
-        },
-      },
+    const result = await listUsersPage(
+      { search: keyword, offset: 0, limit: 50 },
+      { skipErrorToast: true },
     );
 
-    return (response.data?.res ?? []).map((item) => ({
-      userId: item.user_id,
-      userName: item.user_name,
+    return result.users.map((item) => ({
+      userId: item.id,
+      userName: item.name || item.account,
     }));
   } catch {
     return [];

--- a/src/modules/model-resources/utils/model-form.test.ts
+++ b/src/modules/model-resources/utils/model-form.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildLlmSavePayload, type LlmFormValues } from "@/modules/model-resources/utils/model-form";
+
+const baseValues: LlmFormValues = {
+  modelName: " Qwen ",
+  modelSeries: "qwen",
+  modelType: "llm",
+  apiModel: " qwen-plus ",
+  apiUrl: " https://example.com ",
+  auth: "empty",
+  maxModelLen: 32,
+  quota: false,
+};
+
+describe("buildLlmSavePayload", () => {
+  it("keeps valid positive integer model parameters", () => {
+    expect(buildLlmSavePayload({ ...baseValues, modelParameters: 7 }).modelParameters).toBe(7);
+  });
+
+  it("drops invalid model parameters before sending to the backend", () => {
+    expect(buildLlmSavePayload({ ...baseValues, modelParameters: null }).modelParameters).toBeUndefined();
+    expect(buildLlmSavePayload({ ...baseValues, modelParameters: 0 }).modelParameters).toBeUndefined();
+    expect(buildLlmSavePayload({ ...baseValues, modelParameters: 1.5 }).modelParameters).toBeUndefined();
+  });
+});

--- a/src/modules/model-resources/utils/model-form.ts
+++ b/src/modules/model-resources/utils/model-form.ts
@@ -18,7 +18,7 @@ export type LlmFormValues = {
   apiKey?: string;
   secretKey?: string;
   maxModelLen: number;
-  modelParameters?: number;
+  modelParameters?: number | null;
   quota?: boolean;
 };
 
@@ -59,6 +59,12 @@ export function buildLlmSavePayload(
   values: LlmFormValues,
   source?: LlmModel,
 ): LlmSavePayload {
+  const modelParameters =
+    typeof values.modelParameters === "number" &&
+    Number.isInteger(values.modelParameters) &&
+    values.modelParameters > 0
+      ? values.modelParameters
+      : undefined;
   const modelConfig = {
     apiModel: values.apiModel.trim(),
     apiUrl: values.apiUrl.trim(),
@@ -80,7 +86,7 @@ export function buildLlmSavePayload(
     modelSeries: values.modelSeries,
     modelType: values.modelType,
     maxModelLen: values.maxModelLen,
-    modelParameters: values.modelParameters,
+    modelParameters,
     quota: values.quota,
     modelConfig,
     change: !source || apiKeyChanged,

--- a/src/modules/model-resources/utils/quota-display.test.ts
+++ b/src/modules/model-resources/utils/quota-display.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { formatForecastAmount } from "./quota-display";
+
+describe("quota display helpers", () => {
+  it("uses token quantity units when calculating forecast amount", () => {
+    expect(formatForecastAmount(100, 0.01, 1, "thousand", "\uffe5")).toBe("\uffe51.00");
+    expect(formatForecastAmount(2, 0.01, 3, "million", "\uffe5")).toBe("\uffe52.00");
+  });
+});

--- a/src/modules/model-resources/utils/quota-display.ts
+++ b/src/modules/model-resources/utils/quota-display.ts
@@ -8,26 +8,36 @@
 import type { ModelQuota } from "@/modules/model-resources/types/quota";
 
 const CURRENCY_SYMBOL: Record<number, string> = {
-  0: "￥",
+  0: "\uffe5",
   1: "$",
 };
 
 const TOKEN_UNIT_LABEL: Record<number, string> = {
-  1: "千",
-  2: "万",
-  3: "亿",
-  4: "百万",
-  5: "千万",
+  1: "\u5343",
+  2: "\u4e07",
+  3: "\u4ebf",
+  4: "\u767e\u4e07",
+  5: "\u5343\u4e07",
+  6: "\u4ebf",
+};
+
+const TOKEN_UNIT_VALUE: Record<number, number> = {
+  1: 1_000,
+  2: 10_000,
+  3: 100_000_000,
+  4: 1_000_000,
+  5: 10_000_000,
+  6: 100_000_000,
 };
 
 const PRICE_UNIT: Record<string, number> = {
-  thousand: 1000,
+  thousand: 1_000,
   million: 1_000_000,
 };
 
 const PRICE_UNIT_LABEL: Record<string, string> = {
-  thousand: "千",
-  million: "百万",
+  thousand: "\u5343",
+  million: "\u767e\u4e07",
 };
 
 export function isQuotaConfigured(record: Pick<ModelQuota, "inputTokens">) {
@@ -69,15 +79,15 @@ export function formatReferPrice(
     return "--";
   }
 
-  const currency = CURRENCY_SYMBOL[record.currencyType ?? 0] ?? "￥";
+  const currency = CURRENCY_SYMBOL[record.currencyType ?? 0] ?? "\uffe5";
   const priceType = record.priceType?.[0] ?? "thousand";
   const unitLabel =
     priceType === "million"
       ? millionLabel || PRICE_UNIT_LABEL.million
       : thousandLabel || PRICE_UNIT_LABEL.thousand;
-  const prefix = record.billingType === 1 ? `${type === "in" ? inLabel : outLabel}：` : "";
+  const prefix = record.billingType === 1 ? `${type === "in" ? inLabel : outLabel}\uff1a` : "";
 
-  return `${prefix}${currency}${price}${currency === "￥" ? "元" : "美元"}/${unitLabel} tokens`;
+  return `${prefix}${currency}${price}${currency === "\uffe5" ? "\u5143" : "\u7f8e\u5143"}/${unitLabel} tokens`;
 }
 
 function calculateTokenAmount(record: ModelQuota, type: "in" | "out") {
@@ -92,8 +102,8 @@ function calculateTokenAmount(record: ModelQuota, type: "in" | "out") {
   }
 
   return (
-    (tokens * PRICE_UNIT[String(numType)] * referPrice) /
-    (PRICE_UNIT[priceType] ?? 1000)
+    (tokens * (TOKEN_UNIT_VALUE[numType] ?? 1_000) * referPrice) /
+    (PRICE_UNIT[priceType] ?? 1_000)
   );
 }
 
@@ -105,7 +115,7 @@ export function formatEstimatedTotal(record: ModelQuota) {
   const inputAmount = calculateTokenAmount(record, "in");
   const outputAmount = record.billingType === 1 ? calculateTokenAmount(record, "out") : 0;
   const total = inputAmount + outputAmount;
-  const currency = CURRENCY_SYMBOL[record.currencyType ?? 0] ?? "￥";
+  const currency = CURRENCY_SYMBOL[record.currencyType ?? 0] ?? "\uffe5";
 
   return `${currency}${total.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`;
 }
@@ -118,7 +128,8 @@ export function formatForecastAmount(
   currencySymbol: string,
 ) {
   const amount =
-    (tokens * PRICE_UNIT[String(numType)] * referPrice) / (PRICE_UNIT[priceType] ?? 1000);
+    (tokens * (TOKEN_UNIT_VALUE[numType] ?? 1_000) * referPrice) /
+    (PRICE_UNIT[priceType] ?? 1_000);
 
   return `${currencySymbol}${amount.toFixed(2)}`;
 }


### PR DESCRIPTION
## Summary
- hide quota management entry points from navigation and the large model form
- keep model names on one line in model tables
- make model parameter count optional unless a positive integer is provided
- align quota API calls and prevent empty user-quota save payloads

## Verification
- pnpm lint:types
- pnpm vitest run src/modules/model-resources/utils/model-form.test.ts src/modules/model-resources/utils/quota-display.test.ts