### PR TITLE
fix(data-catalog): improve index UX and error display

### DIFF
--- a/src/framework/ui/common/BusinessPageTemplate.module.css
+++ b/src/framework/ui/common/BusinessPageTemplate.module.css
@@ -59,10 +59,27 @@
   font-weight: var(--business-font-weight-medium);
 }
 
-.surface :global(.ant-btn-primary),
-.overlay :global(.ant-btn-primary) {
+.surface :global(.ant-btn-primary:not(:disabled):not(.ant-btn-disabled)),
+.overlay :global(.ant-btn-primary:not(:disabled):not(.ant-btn-disabled)) {
   border-color: var(--business-color-primary);
   background: var(--business-color-primary);
+}
+
+.surface :global(.ant-btn-primary:disabled),
+.surface :global(.ant-btn-primary.ant-btn-disabled),
+.overlay :global(.ant-btn-primary:disabled),
+.overlay :global(.ant-btn-primary.ant-btn-disabled) {
+  border-color: var(--business-color-border) !important;
+  background: var(--business-color-surface-muted) !important;
+  color: var(--business-color-muted) !important;
+  opacity: 1;
+}
+
+.surface :global(.ant-btn-primary:disabled .anticon),
+.surface :global(.ant-btn-primary.ant-btn-disabled .anticon),
+.overlay :global(.ant-btn-primary:disabled .anticon),
+.overlay :global(.ant-btn-primary.ant-btn-disabled .anticon) {
+  color: var(--business-color-muted) !important;
 }
 
 .surface :global(.ant-input),

--- a/src/modules/data-catalog/components/BuildTaskFormPanel.module.css
+++ b/src/modules/data-catalog/components/BuildTaskFormPanel.module.css
@@ -429,6 +429,19 @@
   border-radius: 0 !important;
 }
 
+.footer :global(.ant-btn-primary:disabled),
+.footer :global(.ant-btn-primary.ant-btn-disabled) {
+  border-color: #d9e0ea !important;
+  background: #eef2f7 !important;
+  color: #64748b !important;
+  opacity: 1;
+}
+
+.footer :global(.ant-btn-primary:disabled .anticon),
+.footer :global(.ant-btn-primary.ant-btn-disabled .anticon) {
+  color: #64748b !important;
+}
+
 .formCard :global(.ant-select-selector),
 .formCard :global(.ant-input),
 .formCard :global(.ant-input-affix-wrapper),

--- a/src/modules/data-catalog/components/CatalogDetailPanel.module.css
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.module.css
@@ -179,6 +179,7 @@
 }
 
 .actionGroup {
+  display: inline-flex;
   flex-wrap: nowrap;
   white-space: nowrap;
 }

--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -279,7 +279,7 @@ export function CatalogDetailPanel({
     {
       key: "actions",
       title: t("common.actions"),
-      width: 220,
+      width: 188,
       render: (_, record) => (
         <Space className={styles.actionGroup} size={4}>
           <AppButton onClick={() => onOpenResource(record.id, "detail")} type="link">

--- a/src/modules/data-catalog/components/ResourceIndexPanel.module.css
+++ b/src/modules/data-catalog/components/ResourceIndexPanel.module.css
@@ -197,6 +197,51 @@
   border-radius: 0;
 }
 
+.failureAlertContent {
+  display: grid;
+  gap: 4px;
+  max-width: 100%;
+  color: #334155;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.failureAlertContent strong {
+  color: #111827;
+  font-weight: 600;
+}
+
+.failureSuggestion {
+  color: #92400e;
+}
+
+.failureRaw {
+  margin-top: 2px;
+  color: #64748b;
+}
+
+.failureRaw summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.failureRaw code {
+  display: block;
+  max-height: 160px;
+  margin-top: 6px;
+  padding: 8px 10px;
+  overflow: auto;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  color: #334155;
+  font-family: ui-monospace, "SF Mono", Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .emptyPanel {
   display: flex;
   flex-direction: column;

--- a/src/modules/data-catalog/components/ResourceIndexPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceIndexPanel.tsx
@@ -23,6 +23,7 @@ import { BuildTaskDetailDrawer } from "@/modules/data-catalog/components/BuildTa
 import { BuildTaskLaunchPanel } from "@/modules/data-catalog/components/BuildTaskLaunchPanel";
 import { IndexConfigFormPanel } from "@/modules/data-catalog/components/IndexConfigFormPanel";
 import { useBuildTaskActions } from "@/modules/data-catalog/hooks/use-build-task-actions";
+import { summarizeBuildTaskError } from "@/modules/data-catalog/lib/build-task-error";
 import type { ResourceIndexView } from "@/modules/data-catalog/lib/index-build-filters";
 import { formatCount, timeAgo } from "@/modules/data-catalog/lib/format";
 import { indexStateOf, resourceGateOf, sortTasks } from "@/modules/data-catalog/lib/index-state";
@@ -161,7 +162,33 @@ function progressTask(effective: BuildTask | null, latest: BuildTask | null) {
     }
     return latest;
   }
+
   return null;
+}
+
+function renderBuildFailureAlert(
+  task: BuildTask,
+  language: string,
+  rawErrorLabel: string,
+) {
+  const summary = summarizeBuildTaskError(task.error || task.failureDetail, language);
+  if (!summary) {
+    return null;
+  }
+
+  return (
+    <div className={panelStyles.failureAlertContent}>
+      <strong>{summary.title}</strong>
+      <span>{summary.message}</span>
+      {summary.suggestion ? (
+        <span className={panelStyles.failureSuggestion}>{summary.suggestion}</span>
+      ) : null}
+      <details className={panelStyles.failureRaw}>
+        <summary>{rawErrorLabel}</summary>
+        <code>{summary.raw}</code>
+      </details>
+    </div>
+  );
 }
 
 export function ResourceIndexPanel({
@@ -417,17 +444,25 @@ export function ResourceIndexPanel({
         {latest?.status === "failed" && effective ? (
           <Alert
             className={panelStyles.statusAlert}
-            message={t("dataCatalog.resource.rebuildFailedHint", {
-              error: latest.error ?? "-",
+            message={t("dataCatalog.resource.rebuildFailedTitle", {
               version: effective.id,
             })}
+            description={renderBuildFailureAlert(
+              latest,
+              i18n.language,
+              t("dataCatalog.task.rawError"),
+            )}
             showIcon
             type="warning"
           />
-        ) : latest?.error && latest.status === "failed" ? (
+        ) : latest?.status === "failed" && (latest.error || latest.failureDetail) ? (
           <Alert
             className={panelStyles.statusAlert}
-            message={latest.error}
+            message={renderBuildFailureAlert(
+              latest,
+              i18n.language,
+              t("dataCatalog.task.rawError"),
+            )}
             showIcon
             type="error"
           />

--- a/src/modules/data-catalog/lib/build-task-error.test.ts
+++ b/src/modules/data-catalog/lib/build-task-error.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { summarizeBuildTaskError } from "./build-task-error";
+
+describe("summarizeBuildTaskError", () => {
+  it("summarizes repeated missing document id errors", () => {
+    const summary = summarizeBuildTaskError(
+      "create documents failed: Validation Failed: 1: id is missing;2: id is missing;",
+      "zh-CN",
+    );
+
+    expect(summary?.title).toBe("索引文档缺少 ID");
+    expect(summary?.message).toContain("写入索引失败");
+    expect(summary?.raw).toContain("id is missing");
+  });
+});

--- a/src/modules/data-catalog/lib/build-task-error.ts
+++ b/src/modules/data-catalog/lib/build-task-error.ts
@@ -64,6 +64,19 @@ export function summarizeBuildTaskError(
     };
   }
 
+  if (/id is missing/i.test(raw)) {
+    return {
+      title: zh ? "索引文档缺少 ID" : "Index documents are missing IDs",
+      message: zh
+        ? "写入索引失败：部分文档没有生成稳定的 id 字段。"
+        : "Index write failed because some documents did not include a stable id field.",
+      raw,
+      suggestion: zh
+        ? "请检查资源索引配置中的增量键或主键映射，保存配置后重新构建。"
+        : "Check the resource build key or primary-key mapping, save the index configuration, then rebuild.",
+    };
+  }
+
   return {
     title: zh ? "构建任务执行失败" : "Build task failed",
     message: zh

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -168,6 +168,8 @@ export const dataCatalogEnUS = {
         "No effective index yet - once a build succeeds, vector retrieval becomes available.",
       noIndexHint:
         "This resource has no index yet. Build one to enable vector retrieval in knowledge networks.",
+      rebuildFailedTitle:
+        "Rebuild failed. Retrieval is unaffected and still served by index {{version}}.",
       rebuildFailedHint:
         "Rebuild failed: {{error}}. Retrieval is unaffected and still served by index {{version}}.",
       notFound: "Resource not found; it may have been deleted",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -160,6 +160,7 @@ export const dataCatalogZhCN = {
       latestTask: "最近构建任务",
       noEffectiveIndex: "暂无生效索引——构建成功后即可在知识网络中进行向量检索。",
       noIndexHint: "该资源还没有索引。构建后即可在知识网络中进行向量检索。",
+      rebuildFailedTitle: "重建失败。检索不受影响，仍由旧版索引 {{version}} 提供服务。",
       rebuildFailedHint:
         "重建失败:{{error}}。检索不受影响,仍由旧版索引 {{version}} 提供服务。",
       notFound: "未找到该资源,可能已被删除",

--- a/src/modules/system-admin/scenes/admin.module.css
+++ b/src/modules/system-admin/scenes/admin.module.css
@@ -60,9 +60,17 @@
   font-weight: var(--admin-font-weight-medium);
 }
 
-.contentSurface :global(.ant-btn-primary) {
+.contentSurface :global(.ant-btn-primary:not(:disabled):not(.ant-btn-disabled)) {
   border-color: var(--admin-color-primary);
   background: var(--admin-color-primary);
+}
+
+.contentSurface :global(.ant-btn-primary:disabled),
+.contentSurface :global(.ant-btn-primary.ant-btn-disabled) {
+  border-color: var(--admin-color-border) !important;
+  background: var(--admin-color-surface-muted) !important;
+  color: var(--admin-color-muted) !important;
+  opacity: 1;
 }
 
 .contentSurface :global(.ant-input),
@@ -121,7 +129,7 @@
   font-weight: var(--admin-font-weight-medium);
 }
 
-.adminOverlay :global(.ant-btn-primary) {
+.adminOverlay :global(.ant-btn-primary:not(:disabled):not(.ant-btn-disabled)) {
   border-color: var(--admin-color-primary);
   background: var(--admin-color-primary);
   color: #fff;
@@ -133,8 +141,12 @@
   color: #fff;
 }
 
-.adminOverlay :global(.ant-btn-primary:disabled) {
-  color: rgba(255, 255, 255, 0.72);
+.adminOverlay :global(.ant-btn-primary:disabled),
+.adminOverlay :global(.ant-btn-primary.ant-btn-disabled) {
+  border-color: var(--admin-color-border) !important;
+  background: var(--admin-color-surface-muted) !important;
+  color: var(--admin-color-muted) !important;
+  opacity: 1;
 }
 
 .adminOverlay :global(.ant-input),


### PR DESCRIPTION
## Summary
- summarize verbose index rebuild failures and keep raw details collapsible
- fix disabled primary button contrast in business/admin surfaces
- tighten data catalog resource action column spacing

## Tests
- pnpm lint:types
- pnpm vitest run src/modules/data-catalog