### PR TITLE
fix(执行工厂): 优化添加 API 表单与 OpenAPI 请求体预览

### DIFF
--- a/src/modules/execution-factory/components/ToolIoPanel.tsx
+++ b/src/modules/execution-factory/components/ToolIoPanel.tsx
@@ -15,6 +15,7 @@ import type {
   ToolRunLogEntry,
 } from "@/modules/execution-factory/types/tool";
 import { formatExecutionUnitTime } from "@/modules/execution-factory/utils/format-timestamp";
+import { resolveIoPreviewValue } from "@/modules/execution-factory/utils/generate-sample-json";
 
 import styles from "./ToolIoPanel.module.css";
 
@@ -129,7 +130,9 @@ export function ToolIoPanel({ functionInput, ioSpec, runLogs = [] }: ToolIoPanel
     children: (
       <div>
         <p className={styles.emptyHint}>{response.description ?? "-"}</p>
-        <pre className={styles.jsonPreview}>{renderJson(response.example ?? response.schema)}</pre>
+        <pre className={styles.jsonPreview}>
+          {renderJson(resolveIoPreviewValue(response.example, response.schema))}
+        </pre>
       </div>
     ),
   }));
@@ -161,7 +164,9 @@ export function ToolIoPanel({ functionInput, ioSpec, runLogs = [] }: ToolIoPanel
               <p className={styles.emptyHint}>{ioSpec.requestBodyDescription}</p>
             ) : null}
             <pre className={styles.jsonPreview}>
-              {renderJson(ioSpec?.requestBodyExample ?? ioSpec?.requestBodySchema)}
+              {renderJson(
+                resolveIoPreviewValue(ioSpec?.requestBodyExample, ioSpec?.requestBodySchema),
+              )}
             </pre>
           </section>
           {responseTabs.length ? (

--- a/src/modules/execution-factory/components/create-menu/QuickAddApiForm.test.ts
+++ b/src/modules/execution-factory/components/create-menu/QuickAddApiForm.test.ts
@@ -12,6 +12,7 @@ import { parseCurlCommand } from "@/modules/execution-factory/utils/curl-to-open
 import {
   buildEffectiveQuickApiValues,
   buildQuickApiSubmissionFromValues,
+  resolveQuickApiFormContract,
 } from "@/modules/execution-factory/utils/quick-api-contract";
 
 function createValues(
@@ -161,6 +162,32 @@ describe("QuickAddApiForm editable contract", () => {
     expect(body.example).toEqual({ query: "search schema", enable_rerank: true });
     expect(body.schema.type).toBe("object");
     expect(body.schema.properties.enable_rerank.type).toBe("boolean");
+  });
+
+  it("derives serverUrl and path from apiUrl when hidden contract fields are empty", () => {
+    const resolved = resolveQuickApiFormContract(
+      createValues({
+        serverUrl: "",
+        path: "",
+        summary: "Describe Resource",
+        apiUrl: "https://14.103.77.23/api/agent-retrieval/v1/kn/describe_resource",
+        method: "POST",
+        parameters: [
+          {
+            name: "Authorization",
+            in: "header",
+            required: false,
+            type: "string",
+          },
+        ],
+      }),
+    );
+
+    const submission = buildQuickApiSubmissionFromValues(resolved);
+
+    expect(submission?.serviceUrl).toBe("https://14.103.77.23");
+    expect(submission?.path).toBe("/api/agent-retrieval/v1/kn/describe_resource");
+    expect(submission?.method).toBe("POST");
   });
 
   it("keeps parameters detected from cURL when form-only fields are not mounted", () => {

--- a/src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx
+++ b/src/modules/execution-factory/components/create-menu/QuickAddApiForm.tsx
@@ -20,6 +20,8 @@ import {
 import {
   buildEffectiveQuickApiValues,
   buildQuickApiSubmissionFromValues,
+  mergeQuickApiParameters,
+  resolveQuickApiFormContract,
   type QuickApiContractFormValues,
 } from "@/modules/execution-factory/utils/quick-api-contract";
 import {
@@ -99,9 +101,12 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
       return undefined;
     }
 
+    const contractValues =
+      inputMode === "form" ? resolveQuickApiFormContract(watchedValues) : watchedValues;
+
     return buildSpecFromValues(
       buildEffectiveQuickApiValues(
-        watchedValues,
+        contractValues,
         inputMode,
         detectedUrlParameters,
         detectedCurlContract,
@@ -217,12 +222,23 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
     }
 
     form.setFields([{ name: "apiUrl", errors: [] }]);
+    const currentParams = (form.getFieldValue("parameters") ?? []) as QuickApiParameter[];
+    const mergedParams = mergeQuickApiParameters(result.value.queryParams, currentParams);
     applyParsedApi(result.value, { preserveManualContract: true });
+    setDetectedUrlParameters([]);
+    form.setFieldsValue({ parameters: mergedParams });
   };
 
   const handleFinish = (values: QuickAddApiFormValues) => {
+    const resolvedValues =
+      inputMode === "form" ? resolveQuickApiFormContract(values) : values;
+
     if (inputMode === "form") {
-      if (!values.serverUrl?.trim() || !values.path?.trim() || !values.method?.trim()) {
+      if (
+        !resolvedValues.serverUrl?.trim() ||
+        !resolvedValues.path?.trim() ||
+        !resolvedValues.method?.trim()
+      ) {
         setParseHint(t("executionFactory.quickApiBuildFailed"));
         return;
       }
@@ -230,7 +246,7 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
 
     const submission = buildQuickApiSubmissionFromValues(
       buildEffectiveQuickApiValues(
-        values,
+        resolvedValues,
         inputMode,
         detectedUrlParameters,
         detectedCurlContract,
@@ -248,14 +264,14 @@ export const QuickAddApiForm = forwardRef<QuickAddApiFormHandle, QuickAddApiForm
     }
 
     const targetValues =
-      values.toolboxMode === "existing"
+      resolvedValues.toolboxMode === "existing"
         ? {
-            ...values,
+            ...resolvedValues,
             toolboxName: undefined,
             toolboxDescription: undefined,
           }
         : {
-            ...values,
+            ...resolvedValues,
             boxId: undefined,
           };
 

--- a/src/modules/execution-factory/components/create-menu/QuickApiContractEditor.tsx
+++ b/src/modules/execution-factory/components/create-menu/QuickApiContractEditor.tsx
@@ -11,6 +11,8 @@ import { useTranslation } from "react-i18next";
 
 import { CapabilityBusinessIntro } from "@/modules/execution-factory/components/CapabilityBusinessIntro";
 
+import styles from "./create-menu.module.css";
+
 const PARAMETER_LOCATIONS = ["query", "path", "header", "cookie"];
 const PARAMETER_TYPES = ["string", "integer", "number", "boolean"];
 const CONTENT_TYPES = [
@@ -48,13 +50,21 @@ export function QuickApiContractEditor() {
                 size="small"
               >
                 <Space align="start" size={8} wrap>
-                  <Form.Item
-                    label={t("executionFactory.parameterName")}
-                    name={[field.name, "name"]}
-                    rules={[{ required: true, message: t("common.required") }]}
-                  >
-                    <Input style={{ width: 160 }} />
-                  </Form.Item>
+                  <div className={styles.parameterIdentityColumn}>
+                    <Form.Item
+                      label={t("executionFactory.parameterName")}
+                      name={[field.name, "name"]}
+                      rules={[{ required: true, message: t("common.required") }]}
+                    >
+                      <Input />
+                    </Form.Item>
+                    <Form.Item
+                      label={t("executionFactory.parameterDescription")}
+                      name={[field.name, "description"]}
+                    >
+                      <Input.TextArea autoSize={{ minRows: 1, maxRows: 3 }} />
+                    </Form.Item>
+                  </div>
                   <Form.Item
                     label={t("executionFactory.globalParameterIn")}
                     name={[field.name, "in"]}
@@ -88,12 +98,6 @@ export function QuickApiContractEditor() {
                     <Input style={{ width: 160 }} />
                   </Form.Item>
                 </Space>
-                <Form.Item
-                  label={t("executionFactory.parameterDescription")}
-                  name={[field.name, "description"]}
-                >
-                  <Input />
-                </Form.Item>
               </Card>
             ))}
             <Button

--- a/src/modules/execution-factory/components/create-menu/create-menu.module.css
+++ b/src/modules/execution-factory/components/create-menu/create-menu.module.css
@@ -174,3 +174,18 @@
   gap: 16px;
   margin-top: 8px;
 }
+
+.parameterIdentityColumn {
+  display: flex;
+  flex-direction: column;
+  min-width: 220px;
+  max-width: 280px;
+}
+
+.parameterIdentityColumn :global(.ant-form-item) {
+  margin-bottom: 8px;
+}
+
+.parameterIdentityColumn :global(.ant-form-item:last-child) {
+  margin-bottom: 0;
+}

--- a/src/modules/execution-factory/utils/generate-sample-json.test.ts
+++ b/src/modules/execution-factory/utils/generate-sample-json.test.ts
@@ -11,6 +11,7 @@ import {
   buildDebugPayloadSample,
   buildDefaultDebugBody,
   generateSampleFromJsonSchema,
+  resolveIoPreviewValue,
 } from "@/modules/execution-factory/utils/generate-sample-json";
 
 describe("generate-sample-json", () => {
@@ -28,6 +29,49 @@ describe("generate-sample-json", () => {
       input: "hello",
       count: 0,
     });
+  });
+
+  it("uses empty defaults for string/array/number/boolean fields", () => {
+    const sample = generateSampleFromJsonSchema({
+      description: "业务知识网络创建请求体",
+      required: ["name", "branch"],
+      type: "object",
+      properties: {
+        id: { description: "业务知识网络ID", type: "string" },
+        name: { description: "业务知识网络名称", type: "string" },
+        tags: { description: "标签", type: "array", items: { type: "string" } },
+        comment: { description: "备注", type: "string" },
+        icon: { description: "图标", type: "string" },
+        color: { description: "颜色", type: "string" },
+        branch: { description: "分支ID", type: "string" },
+        enabled: { type: "boolean" },
+        limit: { type: "integer" },
+      },
+    });
+
+    expect(sample).toEqual({
+      id: "",
+      name: "",
+      tags: [],
+      comment: "",
+      icon: "",
+      color: "",
+      branch: "",
+      enabled: false,
+      limit: 0,
+    });
+  });
+
+  it("prefers explicit examples over schema-derived samples in IO preview", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    };
+
+    expect(resolveIoPreviewValue({ name: "demo" }, schema)).toEqual({ name: "demo" });
+    expect(resolveIoPreviewValue(undefined, schema)).toEqual({ name: "" });
   });
 
   it("builds debug body from ioSpec request schema", () => {

--- a/src/modules/execution-factory/utils/generate-sample-json.ts
+++ b/src/modules/execution-factory/utils/generate-sample-json.ts
@@ -101,8 +101,7 @@ export function generateSampleFromJsonSchema(schema: unknown, root?: unknown): u
   }
 
   if (type === "array") {
-    const itemSample = generateSampleFromJsonSchema(current.items ?? { type: "string" }, rootSchema);
-    return itemSample === undefined ? [] : [itemSample];
+    return [];
   }
 
   if (type === "object" || current.properties) {
@@ -199,4 +198,18 @@ export function buildDefaultDebugBody(source?: DebugPayloadSource | ToolIoSpec):
     source && "parameters" in source ? { ioSpec: source } : source;
 
   return JSON.stringify(buildDebugPayloadSample(normalized), null, 2);
+}
+
+/** Prefer explicit example; otherwise derive a request/response payload sample from JSON Schema. */
+export function resolveIoPreviewValue(example?: unknown, schema?: unknown): unknown {
+  if (example !== undefined) {
+    return example;
+  }
+
+  if (schema === undefined) {
+    return undefined;
+  }
+
+  const sample = generateSampleFromJsonSchema(schema);
+  return sample === null ? schema : sample;
 }

--- a/src/modules/execution-factory/utils/quick-api-contract.ts
+++ b/src/modules/execution-factory/utils/quick-api-contract.ts
@@ -8,6 +8,7 @@
 import {
   buildOpenApiFromQuickApi,
   inferQuickApiSchemaFromValue,
+  parseQuickApiUrl,
   type QuickApiParameter,
   type QuickApiRequestBody,
   type QuickApiResponse,
@@ -36,7 +37,7 @@ export type QuickApiContractFormValues = {
   responses?: QuickApiResponseFormValue[];
 };
 
-function mergeParameters(
+export function mergeQuickApiParameters(
   detected: QuickApiParameter[],
   manual: QuickApiParameter[] | undefined,
 ) {
@@ -68,7 +69,33 @@ export function buildEffectiveQuickApiValues<T extends QuickApiContractFormValue
 
   return {
     ...values,
-    parameters: mergeParameters(detectedUrlParameters, values.parameters),
+    parameters: mergeQuickApiParameters(detectedUrlParameters, values.parameters),
+  };
+}
+
+export function resolveQuickApiFormContract<T extends QuickApiContractFormValues & { apiUrl?: string }>(
+  values: T,
+): T {
+  if (values.serverUrl?.trim() && values.path?.trim()) {
+    return values;
+  }
+
+  const apiUrl = values.apiUrl?.trim();
+  if (!apiUrl) {
+    return values;
+  }
+
+  const parsed = parseQuickApiUrl(apiUrl);
+  if (!parsed.ok) {
+    return values;
+  }
+
+  return {
+    ...values,
+    serverUrl: parsed.value.serverUrl,
+    path: parsed.value.path,
+    summary: values.summary?.trim() ? values.summary : parsed.value.summary,
+    parameters: mergeQuickApiParameters(parsed.value.queryParams, values.parameters),
   };
 }
 


### PR DESCRIPTION
﻿## 背景

「添加 API」表单在填表模式下，识别结果回填不完整，保存时容易因缺少 serverUrl/path 失败；导入 OpenAPI 后的 IO 预览也会直接展示 Schema 片段，而不是实际可调用的入参样例。

## 改动说明

- 调整参数编辑排版：参数名与参数描述放在同一列，便于对照填写
- 点击「识别接口信息」后，将 URL 解析出的参数合并回填到参数列表，并刷新预览
- 保存时若未先点击识别，自动从完整 API 地址推导 serverUrl/path，减少「无法生成 API 定义」误报
- OpenAPI 导入/工具 IO 预览：无显式 example 时，按 Schema 生成请求体/响应体样例（字符串空串、数组空列表、数字 0、布尔 false），不再直接展示 Schema 原文

## 验证建议

- [ ] 「添加 API」→「填表单」：填写完整 API 地址后点识别，确认参数列表与预览更新
- [ ] 仅填写 API 地址与接口名称后直接「保存并完成」，确认可正常生成定义
- [ ] 导入 OpenAPI 后查看请求体预览，确认为实际入参骨架而非 type/properties 片段
- [ ] 相关单测通过
