### PR TITLE
fix: correct knowledge network field type badges

### DIFF
--- a/src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.test.tsx
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FieldTypeIcon } from "./FieldTypeIcon";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FieldTypeIcon", () => {
+  it.each(["float", "double", "decimal", "number", "numeric", "real"])(
+    "renders %s as floating numeric type",
+    (type) => {
+      render(<FieldTypeIcon type={type} />);
+
+      expect(screen.getByText("float")).toBeTruthy();
+      expect(screen.queryByText("[Str]")).toBeNull();
+    },
+  );
+
+  it.each(["integer", "unsigned integer", "bigint", "smallint"])(
+    "renders %s as integer type",
+    (type) => {
+      render(<FieldTypeIcon type={type} />);
+
+      expect(screen.getByText("int")).toBeTruthy();
+      expect(screen.queryByText("[Str]")).toBeNull();
+    },
+  );
+});

--- a/src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.tsx
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.tsx
@@ -20,8 +20,24 @@ type FieldTypeIconProps = {
 function getFieldTypeLabel(type?: string) {
   const normalized = (type ?? "string").toLowerCase();
 
-  if (normalized === "integer" || normalized === "double") {
+  if (
+    normalized === "integer" ||
+    normalized === "unsigned integer" ||
+    normalized === "bigint" ||
+    normalized === "smallint"
+  ) {
     return "int";
+  }
+
+  if (
+    normalized === "float" ||
+    normalized === "double" ||
+    normalized === "decimal" ||
+    normalized === "number" ||
+    normalized === "numeric" ||
+    normalized === "real"
+  ) {
+    return "float";
   }
 
   if (normalized === "boolean") {
@@ -51,23 +67,27 @@ export function FieldTypeIcon({ type }: FieldTypeIconProps) {
 
   const label = getFieldTypeLabel(type);
 
-  if (label === "int") {
+  if (label === "int" || label === "float") {
     return (
-      <span className={styles.typeBadge}>
+      <span className={styles.typeBadge} title={type}>
         <NumberOutlined className={styles.typeBadgeIcon} />
-        <span>int</span>
+        <span>{label}</span>
       </span>
     );
   }
 
   if (label === "bool") {
     return (
-      <span className={styles.typeBadge}>
+      <span className={styles.typeBadge} title={type}>
         <FieldBinaryOutlined className={styles.typeBadgeIcon} />
         <span>bool</span>
       </span>
     );
   }
 
-  return <span className={styles.typeBadge}>[{label}]</span>;
+  return (
+    <span className={styles.typeBadge} title={type}>
+      [{label}]
+    </span>
+  );
 }

--- a/src/modules/knowledge-network/components/shared/DetailTableColumnSettingsButton.test.ts
+++ b/src/modules/knowledge-network/components/shared/DetailTableColumnSettingsButton.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  readDetailTableColumnConfig,
+  writeDetailTableColumnConfig,
+} from "./DetailTableColumnSettingsButton";
+
+const storageKey = "bkn-detail-table-columns:detail-table:object-property";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("readDetailTableColumnConfig", () => {
+  it("returns saved config when the stored payload has the expected shape", () => {
+    writeDetailTableColumnConfig("detail-table:object-property", {
+      order: ["name", "type"],
+      visibility: {
+        name: true,
+        type: false,
+      },
+    });
+
+    expect(readDetailTableColumnConfig("detail-table:object-property")).toEqual({
+      order: ["name", "type"],
+      visibility: {
+        name: true,
+        type: false,
+      },
+    });
+  });
+
+  it.each([
+    "{}",
+    '{"visibility":{}}',
+    '{"order":["name"]}',
+    '{"order":"name","visibility":{}}',
+    '{"order":["name"],"visibility":[]}',
+    '{"order":["name"],"visibility":{"name":"true"}}',
+  ])("ignores malformed but parseable payload %s", (payload) => {
+    localStorage.setItem(storageKey, payload);
+
+    expect(readDetailTableColumnConfig("detail-table:object-property")).toBeNull();
+  });
+});

--- a/src/modules/knowledge-network/components/shared/DetailTableColumnSettingsButton.tsx
+++ b/src/modules/knowledge-network/components/shared/DetailTableColumnSettingsButton.tsx
@@ -44,13 +44,35 @@ type DetailTableColumnSettingsButtonProps = {
 
 const STORAGE_PREFIX = "bkn-detail-table-columns:";
 
+function isColumnVisibilityPayload(value: unknown): value is ColumnVisibilityPayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every((item) => typeof item === "boolean")
+  );
+}
+
+function isSavedColumnConfig(value: unknown): value is SavedColumnConfig {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Array.isArray((value as Partial<SavedColumnConfig>).order) &&
+    (value as Partial<SavedColumnConfig>).order?.every((item) => typeof item === "string") ===
+      true &&
+    isColumnVisibilityPayload((value as Partial<SavedColumnConfig>).visibility)
+  );
+}
+
 export function readDetailTableColumnConfig(scope: string): SavedColumnConfig | null {
   try {
     const raw = localStorage.getItem(`${STORAGE_PREFIX}${scope}`);
     if (!raw) {
       return null;
     }
-    return JSON.parse(raw) as SavedColumnConfig;
+    const parsed: unknown = JSON.parse(raw);
+    return isSavedColumnConfig(parsed) ? parsed : null;
   } catch {
     return null;
   }

--- a/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
@@ -42,7 +42,15 @@ import type {
 import styles from "./ObjectTypeDetailScene.module.css";
 
 function normalizedSearchText(value: unknown) {
-  return String(value ?? "").toLowerCase();
+  if (typeof value === "string") {
+    return value.toLowerCase();
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value).toLowerCase();
+  }
+
+  return "";
 }
 
 export function ObjectTypeDetailScene() {

--- a/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
@@ -41,6 +41,10 @@ import type {
 
 import styles from "./ObjectTypeDetailScene.module.css";
 
+function normalizedSearchText(value: unknown) {
+  return String(value ?? "").toLowerCase();
+}
+
 export function ObjectTypeDetailScene() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -176,8 +180,8 @@ export function ObjectTypeDetailScene() {
 
     return items.filter(
       (item) =>
-        item.name.toLowerCase().includes(normalized) ||
-        item.displayName.toLowerCase().includes(normalized),
+        normalizedSearchText(item.name).includes(normalized) ||
+        normalizedSearchText(item.displayName).includes(normalized),
     );
   }, [detail?.dataProperties, keyword]);
 
@@ -191,8 +195,8 @@ export function ObjectTypeDetailScene() {
 
     return items.filter(
       (item) =>
-        item.name.toLowerCase().includes(normalized) ||
-        item.displayName.toLowerCase().includes(normalized),
+        normalizedSearchText(item.name).includes(normalized) ||
+        normalizedSearchText(item.displayName).includes(normalized),
     );
   }, [detail?.logicProperties, keyword]);
 

--- a/src/modules/knowledge-network/services/mappers/index.ts
+++ b/src/modules/knowledge-network/services/mappers/index.ts
@@ -113,20 +113,23 @@ export function mapDataProperty(
     primaryKeys: string[];
   },
 ): ObjectTypeDataProperty {
+  const name = item.name ?? item.original_name ?? item.display_name ?? "";
+  const displayName = item.display_name ?? name;
+
   return {
     comment: item.comment,
-    displayKey: item.name === meta.displayKey,
-    displayName: item.display_name ?? item.name,
+    displayKey: name === meta.displayKey,
+    displayName,
     incrementalKey: false,
     mappedField: item.mapped_field
       ? {
-          displayName: item.mapped_field.display_name ?? item.mapped_field.name,
-          name: item.mapped_field.name,
+          displayName: item.mapped_field.display_name ?? item.mapped_field.name ?? "",
+          name: item.mapped_field.name ?? "",
           type: item.mapped_field.type ?? "string",
         }
       : undefined,
-    name: item.name,
-    primaryKey: meta.primaryKeys.includes(item.name),
+    name,
+    primaryKey: meta.primaryKeys.includes(name),
     type: item.type ?? "string",
   };
 }


### PR DESCRIPTION
## Summary
- Fix knowledge-network field type badges so float-like schema types no longer render as `[Str]`.
- Normalize integer-like schema types to `int` and float-like schema types to `float`, and keep the raw type visible via the badge title.
- Guard object property table rendering against malformed column-setting cache in `localStorage`.
- Make object detail property search tolerant of incomplete historical field data.
- Prevent the object property column-settings popover from entering a React render/update loop when it receives a new but equivalent column order array.
- Add unit tests for numeric type badge rendering and malformed column-setting cache handling.

## Problem Fixed
- On object type data-property mapping pages, `float` fields such as `unit_price` and `total_price` were shown as `[Str]` because the badge component did not recognize float-like types.
- On object type property list pages, some users could occasionally hit the route-level `500 ҳ�淢���쳣` page. One trigger was malformed but parseable `localStorage` column configuration, or incomplete historical property data combined with search.
- The latest reproduced screenshot shows React production error `#185` with no failed network request. This points to a client render/update loop. The concrete loop was in the property table column-settings flow: the parent passed `tableColumns.map(...)` inline on every render, while the popover effect synced that prop back into local draft state whenever the popover was open.

## Verification
- `pnpm vitest run src/modules/knowledge-network/components/shared/DetailTableColumnSettingsButton.test.ts src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.test.tsx`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec tsc -b --pretty false`
