### PR TITLE
fix: prevent object property column settings render loop

### DIFF
--- a/src/modules/knowledge-network/components/object-type/ObjectTypePropertyTable.tsx
+++ b/src/modules/knowledge-network/components/object-type/ObjectTypePropertyTable.tsx
@@ -156,11 +156,16 @@ export function ObjectTypePropertyTable({
     [columns],
   );
 
+  const tableColumnKeys = useMemo(
+    () => tableColumns.map((column) => column.key),
+    [tableColumns],
+  );
+
   return (
     <div className={styles.tableSection}>
       <div className={styles.tableToolbar}>
         <DetailTableColumnSettingsButton
-          columnOrder={tableColumns.map((column) => column.key)}
+          columnOrder={tableColumnKeys}
           columns={ObjectTypePropertyTableColumns}
           onChange={handleColumnConfigChange}
           storageScope={storageScope}

--- a/src/modules/knowledge-network/components/shared/DetailTableColumnSettingsButton.tsx
+++ b/src/modules/knowledge-network/components/shared/DetailTableColumnSettingsButton.tsx
@@ -100,6 +100,22 @@ function mergeColumnOrder(order: string[], columns: DetailTableColumnDefinition[
   return next;
 }
 
+function areStringArraysEqual(left: string[], right: string[]) {
+  return left.length === right.length && left.every((item, index) => item === right[index]);
+}
+
+function areColumnVisibilityPayloadsEqual(
+  left: ColumnVisibilityPayload,
+  right: ColumnVisibilityPayload,
+) {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key) => left[key] === right[key])
+  );
+}
+
 function isColumnVisible(key: string, visibility: ColumnVisibilityPayload) {
   return visibility[key] !== false;
 }
@@ -125,8 +141,13 @@ export function DetailTableColumnSettingsButton({
     if (!open) {
       return;
     }
-    setDraftOrder(mergeColumnOrder(columnOrder, columns));
-    setDraftVisibility(value);
+    const nextOrder = mergeColumnOrder(columnOrder, columns);
+    setDraftOrder((current) =>
+      areStringArraysEqual(current, nextOrder) ? current : nextOrder,
+    );
+    setDraftVisibility((current) =>
+      areColumnVisibilityPayloadsEqual(current, value) ? current : value,
+    );
   }, [columnOrder, columns, open, value]);
 
   const moveRow = (index: number, direction: -1 | 1) => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,7 @@ export default defineConfig(({ mode }) => {
       env: {
         VITE_USE_MOCK: "true",
       },
+      setupFiles: ["./src/test/setup.ts"],
       exclude: [
         "**/node_modules/**",
         "**/dist/**",


### PR DESCRIPTION
## Summary
- Prevent the object type property table column-settings popover from triggering a React render/update loop.
- Pass a memoized column-order array from the property table instead of creating a new array on every render.
- Add equality guards before syncing the popover draft order and visibility state.

## Root Cause
The production console shows React error `#185` and a repeated React scheduling stack, with no failing network request. That points to a client-side maximum update depth / render loop.

The concrete loop is in the object type property table column-settings flow:
- `ObjectTypePropertyTable` passed `tableColumns.map(...)` inline as `columnOrder`, creating a new array each render.
- `DetailTableColumnSettingsButton` had an effect that depended on `columnOrder` while the popover was open.
- The effect wrote the derived order back into local draft state every time, causing render -> new array prop -> effect -> state update repeatedly.

## Verification
- `pnpm vitest run src/modules/knowledge-network/components/shared/DetailTableColumnSettingsButton.test.ts src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.test.tsx`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec tsc -b --pretty false`
