### PR TITLE
fix: share auth tokens across browser tabs via cookies

### DIFF
--- a/MICRO_APP_CONTRACT.md
+++ b/MICRO_APP_CONTRACT.md
@@ -99,7 +99,7 @@ token 能力至少应支持：
 当应用不是被宿主挂载时：
 
 - runtime 使用本地默认配置
-- 可以从 `sessionStorage` 读取本地 token
+- 可以从 Cookie 读取本地 token（`bkn_access_token` / `bkn_refresh_token` / `bkn_id_token`；同域 tab 共享。OAuth PKCE 临时态仍在 `sessionStorage`）
 - 应用仍需完整可启动、可调试、可构建
 
 ## 业务域参数约束

--- a/src/framework/auth/oauth.test.ts
+++ b/src/framework/auth/oauth.test.ts
@@ -24,6 +24,12 @@ describe("oauth", () => {
       });
     }
     window.sessionStorage.clear();
+    for (const part of document.cookie ? document.cookie.split("; ") : []) {
+      const name = part.split("=")[0];
+      if (name) {
+        document.cookie = `${name}=; path=/; max-age=0`;
+      }
+    }
   });
 
   afterEach(() => {
@@ -81,9 +87,10 @@ describe("oauth", () => {
     expect(body.get("code_verifier")).toBe("verifier-1");
     expect(body.get("redirect_uri")).toBe("http://localhost:3000/studio/callback");
 
-    expect(window.sessionStorage.getItem("bkn_access_token")).toBe("access-1");
-    expect(window.sessionStorage.getItem("bkn_refresh_token")).toBe("refresh-1");
-    expect(window.sessionStorage.getItem("bkn_id_token")).toBe("id-1");
+    expect(document.cookie).toContain("bkn_access_token=access-1");
+    expect(document.cookie).toContain("bkn_refresh_token=refresh-1");
+    expect(document.cookie).toContain("bkn_id_token=id-1");
+    expect(window.sessionStorage.getItem("bkn_access_token")).toBeNull();
     expect(window.sessionStorage.getItem("bkn_oauth_state")).toBeNull();
     expect(window.sessionStorage.getItem("bkn_oauth_verifier")).toBeNull();
     expect(window.sessionStorage.getItem("bkn_oauth_return_to")).toBeNull();

--- a/src/framework/auth/token-store.test.ts
+++ b/src/framework/auth/token-store.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearStoredTokens,
+  getStoredAccessToken,
+  getStoredIdToken,
+  getStoredRefreshToken,
+  storeTokens,
+} from "@/framework/auth/token-store";
+
+function clearDocumentCookies() {
+  for (const part of document.cookie ? document.cookie.split("; ") : []) {
+    const name = part.split("=")[0];
+    if (name) {
+      document.cookie = `${name}=; path=/; max-age=0`;
+    }
+  }
+}
+
+describe("token-store", () => {
+  beforeEach(() => {
+    clearDocumentCookies();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    clearDocumentCookies();
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("stores and reads tokens from cookies", () => {
+    storeTokens({
+      accessToken: " access-1 ",
+      refreshToken: "refresh-1",
+      idToken: "id-1",
+    });
+
+    expect(getStoredAccessToken()).toBe("access-1");
+    expect(getStoredRefreshToken()).toBe("refresh-1");
+    expect(getStoredIdToken()).toBe("id-1");
+    expect(window.sessionStorage.getItem("bkn_access_token")).toBeNull();
+  });
+
+  it("migrates legacy sessionStorage tokens into cookies once", () => {
+    window.sessionStorage.setItem("bkn_access_token", "legacy-access");
+    window.sessionStorage.setItem("bkn_refresh_token", "legacy-refresh");
+    window.sessionStorage.setItem("bkn_id_token", "legacy-id");
+
+    expect(getStoredAccessToken()).toBe("legacy-access");
+    expect(getStoredRefreshToken()).toBe("legacy-refresh");
+    expect(getStoredIdToken()).toBe("legacy-id");
+    expect(window.sessionStorage.getItem("bkn_access_token")).toBeNull();
+  });
+
+  it("keeps existing id token when refresh omits id_token", () => {
+    storeTokens({
+      accessToken: "access-1",
+      refreshToken: "refresh-1",
+      idToken: "id-1",
+    });
+
+    storeTokens({
+      accessToken: "access-2",
+      refreshToken: "refresh-2",
+    });
+
+    expect(getStoredAccessToken()).toBe("access-2");
+    expect(getStoredRefreshToken()).toBe("refresh-2");
+    expect(getStoredIdToken()).toBe("id-1");
+  });
+
+  it("clears cookies and broadcasts logout to other tabs", () => {
+    storeTokens({ accessToken: "access-1", refreshToken: "refresh-1" });
+
+    const postMessage = vi.fn();
+    vi.stubGlobal(
+      "BroadcastChannel",
+      class {
+        postMessage = postMessage;
+        addEventListener() {
+          return undefined;
+        }
+        removeEventListener() {
+          return undefined;
+        }
+        close() {
+          return undefined;
+        }
+      },
+    );
+
+    clearStoredTokens();
+
+    expect(getStoredAccessToken()).toBe("");
+    expect(getStoredRefreshToken()).toBe("");
+    expect(postMessage).toHaveBeenCalledWith({ type: "logout" });
+  });
+});

--- a/src/framework/auth/token-store.ts
+++ b/src/framework/auth/token-store.ts
@@ -5,20 +5,158 @@
  * Conditions. See LICENSE for the full text.
  */
 
+/**
+ * Auth tokens live in cookies so same-origin tabs share login state.
+ * OAuth PKCE handshake keys stay in sessionStorage (see oauth.ts).
+ *
+ * Cookie jar is not HttpOnly (SPA still needs to attach Bearer headers).
+ * Cross-tab logout uses BroadcastChannel — cookie changes do not fire
+ * the `storage` event.
+ */
+
 const ACCESS_TOKEN_KEY = "bkn_access_token";
 const REFRESH_TOKEN_KEY = "bkn_refresh_token";
 const ID_TOKEN_KEY = "bkn_id_token";
 
+/** Days until cookie expiry (align with typical refresh lifetime). */
+const TOKEN_COOKIE_MAX_AGE_DAYS = 7;
+
+const AUTH_CHANNEL_NAME = "bkn-auth";
+
+export type AuthBroadcastMessage = { type: "logout" };
+
+/**
+ * Host-only cookies (no Domain attribute) so localhost / IPs work and tabs
+ * on the same host still share login. Parent-domain sharing can be added later
+ * if Studio is served across sibling subdomains.
+ */
+function cookieOptions(): string {
+  const parts = [
+    "path=/",
+    "SameSite=Lax",
+    `max-age=${TOKEN_COOKIE_MAX_AGE_DAYS * 24 * 60 * 60}`,
+  ];
+  if (window.location.protocol === "https:") {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+function readCookie(name: string): string {
+  const prefix = `${encodeURIComponent(name)}=`;
+  const parts = document.cookie ? document.cookie.split("; ") : [];
+  for (const part of parts) {
+    if (part.startsWith(prefix)) {
+      return decodeURIComponent(part.slice(prefix.length)).trim();
+    }
+  }
+  return "";
+}
+
+function writeCookie(name: string, value: string): boolean {
+  document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}; ${cookieOptions()}`;
+  // Browsers silently drop oversized cookies (~4KB). Detect so callers can react.
+  return readCookie(name) === value.trim();
+}
+
+function removeCookie(name: string): void {
+  const base = ["path=/", "SameSite=Lax", "max-age=0"];
+  if (window.location.protocol === "https:") {
+    base.push("Secure");
+  }
+  document.cookie = `${encodeURIComponent(name)}=; ${base.join("; ")}`;
+}
+
+/**
+ * One-shot migration for sessions that logged in before the cookie store.
+ * Safe to call repeatedly: no-ops once cookies are present or legacy is empty.
+ */
+function migrateFromSessionStorageOnce(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (readCookie(ACCESS_TOKEN_KEY)) {
+    return;
+  }
+  const legacyAccess = window.sessionStorage.getItem(ACCESS_TOKEN_KEY)?.trim();
+  if (!legacyAccess) {
+    return;
+  }
+
+  writeCookie(ACCESS_TOKEN_KEY, legacyAccess);
+
+  const legacyRefresh = window.sessionStorage.getItem(REFRESH_TOKEN_KEY)?.trim();
+  if (legacyRefresh) {
+    writeCookie(REFRESH_TOKEN_KEY, legacyRefresh);
+  }
+
+  const legacyId = window.sessionStorage.getItem(ID_TOKEN_KEY)?.trim();
+  if (legacyId) {
+    writeCookie(ID_TOKEN_KEY, legacyId);
+  }
+
+  window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+  window.sessionStorage.removeItem(REFRESH_TOKEN_KEY);
+  window.sessionStorage.removeItem(ID_TOKEN_KEY);
+}
+
+function getAuthChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === "undefined") {
+    return null;
+  }
+  try {
+    return new BroadcastChannel(AUTH_CHANNEL_NAME);
+  } catch {
+    return null;
+  }
+}
+
+function broadcastLogout(): void {
+  const channel = getAuthChannel();
+  if (!channel) {
+    return;
+  }
+  const message: AuthBroadcastMessage = { type: "logout" };
+  channel.postMessage(message);
+  channel.close();
+}
+
+/**
+ * Subscribe to cross-tab auth events (e.g. logout). Returns an unsubscribe fn.
+ */
+export function subscribeAuthBroadcast(
+  onMessage: (message: AuthBroadcastMessage) => void,
+): () => void {
+  const channel = getAuthChannel();
+  if (!channel) {
+    return () => undefined;
+  }
+
+  const handler = (event: MessageEvent<AuthBroadcastMessage>) => {
+    if (event.data?.type === "logout") {
+      onMessage(event.data);
+    }
+  };
+  channel.addEventListener("message", handler);
+  return () => {
+    channel.removeEventListener("message", handler);
+    channel.close();
+  };
+}
+
 export function getStoredAccessToken() {
-  return window.sessionStorage.getItem(ACCESS_TOKEN_KEY)?.trim() ?? "";
+  migrateFromSessionStorageOnce();
+  return readCookie(ACCESS_TOKEN_KEY);
 }
 
 export function getStoredRefreshToken() {
-  return window.sessionStorage.getItem(REFRESH_TOKEN_KEY)?.trim() ?? "";
+  migrateFromSessionStorageOnce();
+  return readCookie(REFRESH_TOKEN_KEY);
 }
 
 export function getStoredIdToken() {
-  return window.sessionStorage.getItem(ID_TOKEN_KEY)?.trim() ?? "";
+  migrateFromSessionStorageOnce();
+  return readCookie(ID_TOKEN_KEY);
 }
 
 export function storeTokens(tokens: {
@@ -26,21 +164,49 @@ export function storeTokens(tokens: {
   refreshToken?: string;
   idToken?: string;
 }) {
-  window.sessionStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken.trim());
+  const accessOk = writeCookie(ACCESS_TOKEN_KEY, tokens.accessToken.trim());
+  if (!accessOk) {
+    console.error(
+      "[auth] failed to persist access token cookie (possibly exceeds browser size limit)",
+    );
+  }
 
   if (tokens.refreshToken?.trim()) {
-    window.sessionStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken.trim());
+    const refreshOk = writeCookie(REFRESH_TOKEN_KEY, tokens.refreshToken.trim());
+    if (!refreshOk) {
+      console.error(
+        "[auth] failed to persist refresh token cookie (possibly exceeds browser size limit)",
+      );
+    }
   } else {
-    window.sessionStorage.removeItem(REFRESH_TOKEN_KEY);
+    // Match prior sessionStorage behavior: omit/empty clears refresh.
+    removeCookie(REFRESH_TOKEN_KEY);
   }
 
+  // Only overwrite id token when the token response includes one. Refresh
+  // grants often omit id_token; wiping the cookie would break hydra logout
+  // (id_token_hint).
   if (tokens.idToken?.trim()) {
-    window.sessionStorage.setItem(ID_TOKEN_KEY, tokens.idToken.trim());
+    const idOk = writeCookie(ID_TOKEN_KEY, tokens.idToken.trim());
+    if (!idOk) {
+      console.error(
+        "[auth] failed to persist id token cookie (possibly exceeds browser size limit)",
+      );
+    }
   }
-}
 
-export function clearStoredTokens() {
+  // Drop any leftover sessionStorage tokens from older builds.
   window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
   window.sessionStorage.removeItem(REFRESH_TOKEN_KEY);
   window.sessionStorage.removeItem(ID_TOKEN_KEY);
+}
+
+export function clearStoredTokens() {
+  removeCookie(ACCESS_TOKEN_KEY);
+  removeCookie(REFRESH_TOKEN_KEY);
+  removeCookie(ID_TOKEN_KEY);
+  window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+  window.sessionStorage.removeItem(REFRESH_TOKEN_KEY);
+  window.sessionStorage.removeItem(ID_TOKEN_KEY);
+  broadcastLogout();
 }

--- a/src/framework/runtime/bootstrap.tsx
+++ b/src/framework/runtime/bootstrap.tsx
@@ -10,6 +10,7 @@ import { createRoot } from "react-dom/client";
 
 import { App } from "@/app/App";
 import i18n from "@/app/locales/i18n";
+import { subscribeAuthBroadcast } from "@/framework/auth/token-store";
 import {
   createRuntimeConfig,
   readWindowRuntimeInput,
@@ -19,7 +20,20 @@ import type { RuntimeInput } from "@/framework/runtime/types";
 
 const roots = new WeakMap<Element, ReturnType<typeof createRoot>>();
 
+let authBroadcastUnsub: (() => void) | undefined;
+
+function ensureAuthBroadcastListener() {
+  if (authBroadcastUnsub) {
+    return;
+  }
+  authBroadcastUnsub = subscribeAuthBroadcast(() => {
+    // Another tab cleared cookies; reload so AuthGate drops to sign-in.
+    window.location.reload();
+  });
+}
+
 export function mountApp(container: Element, runtimeInput: RuntimeInput = {}) {
+  ensureAuthBroadcastListener();
   const runtimeConfig = createRuntimeConfig(runtimeInput);
   setRuntimeConfig(runtimeConfig);
   void i18n.changeLanguage(runtimeConfig.locale);


### PR DESCRIPTION
## Summary
- Persist OAuth access/refresh/id tokens in host-only cookies so same-origin tabs share login state (fixes #164).
- Migrate legacy `sessionStorage` tokens once; keep PKCE handshake keys in `sessionStorage`.
- Broadcast logout via `BroadcastChannel('bkn-auth')` so other tabs reload to the sign-in gate; update micro-app contract docs and unit tests.

## Test plan
- [ ] Tab A logs in → open a new Tab B with the same Studio URL → Tab B enters the app without re-entering credentials
- [ ] Confirm Cookies contain `bkn_access_token` (and refresh/id when present); `sessionStorage` no longer holds those keys
- [ ] Tab A logs out → Tab B reloads and returns to the unauthenticated/sign-in state
- [ ] `pnpm test -- --run src/framework/auth/token-store.test.ts src/framework/auth/oauth.test.ts`
- [ ] Optional: seed legacy `sessionStorage` token, refresh, verify migration into Cookie
