### PR TITLE
fix(knowledge-network): align sidebar metrics count with total

### DIFF
--- a/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
+++ b/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
@@ -70,7 +70,6 @@ export function KnowledgeNetworkWorkspaceScene({
     detailError,
     detailLoading,
     loadWorkspaceData,
-    metrics,
     recentObjects,
     sectionError,
     sectionLoading,
@@ -127,7 +126,7 @@ export function KnowledgeNetworkWorkspaceScene({
         key: "metrics",
         label: t("knowledgeNetwork.workspaceMetrics"),
         icon: <LineChartOutlined />,
-        count: detail?.statistics.metricsTotal ?? metrics.length,
+        count: detail?.statistics.metricsTotal ?? 0,
       });
     }
 
@@ -140,7 +139,7 @@ export function KnowledgeNetworkWorkspaceScene({
     }
 
     return items;
-  }, [detail, metrics.length, t]);
+  }, [detail, t]);
 
   const primaryNavItems = navigationItems.filter(
     (item) => item.key === "overview",

--- a/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
+++ b/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
@@ -40,6 +40,23 @@ function sectionCacheKey(networkId: string, section: KnowledgeNetworkWorkspaceSe
   return `${networkId}:${section}`;
 }
 
+function withMetricsTotal(
+  detail: KnowledgeNetworkRecord | null,
+  metricsTotal: number,
+): KnowledgeNetworkRecord | null {
+  if (!detail) {
+    return detail;
+  }
+
+  return {
+    ...detail,
+    statistics: {
+      ...detail.statistics,
+      metricsTotal,
+    },
+  };
+}
+
 export function useWorkspaceData(
   networkId: string,
   section: KnowledgeNetworkWorkspaceSection,
@@ -153,6 +170,7 @@ export function useWorkspaceData(
             if (integrateWorkspaceMetrics) {
               const metricResult = await listKnowledgeNetworkMetrics(networkId);
               setMetrics(metricResult.entries);
+              setDetail((prev) => withMetricsTotal(prev, metricResult.totalCount));
               setMetricApiUnavailable(getMetricApiAvailability() === "unsupported");
             }
             break;
@@ -242,6 +260,7 @@ export function useWorkspaceData(
     loadedSectionsRef.current.delete(sectionCacheKey(networkId, "metrics"));
     const metricResult = await listKnowledgeNetworkMetrics(networkId);
     setMetrics(metricResult.entries);
+    setDetail((prev) => withMetricsTotal(prev, metricResult.totalCount));
     setMetricApiUnavailable(getMetricApiAvailability() === "unsupported");
     loadedSectionsRef.current.add(sectionCacheKey(networkId, "metrics"));
   }, [networkId]);


### PR DESCRIPTION
## Summary
- Sidebar metrics badge uses `detail.statistics.metricsTotal` (not paginated `metrics.length`)
- Loading/reloading metrics writes list `totalCount` back into local detail statistics so create/delete updates the badge immediately

## Why
Closes the Studio half of #169. Backend must also return `metrics_total` (see companion PR in bkn-foundry).

## Test plan
- [ ] Open a KN with metrics: sidebar count matches list total (not 0)
- [ ] Empty metrics KN shows 0
- [ ] Create/delete a metric and confirm sidebar count updates after refresh

Fixes #169