### PR TITLE
fix(execution-factory-lab): 沙箱运行时页改走公开面路由

### DIFF
--- a/src/modules/execution-factory-lab/module.manifest.ts
+++ b/src/modules/execution-factory-lab/module.manifest.ts
@@ -14,7 +14,7 @@ export const executionFactoryLabModuleManifest = {
   requiresShell: true,
   supportsEmbedded: false,
   supportsReadOnly: false,
-  services: ["capabilities-lab/v1", "agent-operator-integration/internal-v1/sandbox"],
+  services: ["capabilities-lab/v1", "agent-operator-integration/v1/sandbox"],
   scenes: [
     {
       id: "execution-factory-lab.capabilities",

--- a/src/modules/execution-factory-lab/services/sandbox-runtime.service.test.ts
+++ b/src/modules/execution-factory-lab/services/sandbox-runtime.service.test.ts
@@ -17,9 +17,7 @@ import {
 
 describe("sandbox-runtime.service", () => {
   it("uses the http client relative API prefix without duplicating /api", () => {
-    expect(SANDBOX_RUNTIME_API_PREFIX).toBe(
-      "/agent-operator-integration/internal-v1/sandbox",
-    );
+    expect(SANDBOX_RUNTIME_API_PREFIX).toBe("/agent-operator-integration/v1/sandbox");
     expect(SANDBOX_RUNTIME_API_PREFIX).not.toMatch(/^\/api\//);
   });
 

--- a/src/modules/execution-factory-lab/services/sandbox-runtime.service.ts
+++ b/src/modules/execution-factory-lab/services/sandbox-runtime.service.ts
@@ -15,8 +15,7 @@ import type {
   SandboxSessionSummary,
 } from "@/modules/execution-factory-lab/types/sandbox-runtime";
 
-export const SANDBOX_RUNTIME_API_PREFIX =
-  "/agent-operator-integration/internal-v1/sandbox";
+export const SANDBOX_RUNTIME_API_PREFIX = "/agent-operator-integration/v1/sandbox";
 
 type BackendHealth = {
   status?: string;

--- a/tests/e2e/specs/execution-factory/e2e-capability-factory-navigation.spec.ts
+++ b/tests/e2e/specs/execution-factory/e2e-capability-factory-navigation.spec.ts
@@ -23,7 +23,7 @@ test.describe("Capability Factory navigation", () => {
     });
 
     await page.route(
-      "**/api/agent-operator-integration/internal-v1/sandbox/health",
+      "**/api/agent-operator-integration/v1/sandbox/health",
       async (route) => {
         sandboxRequests.push(route.request().url());
         await route.fulfill({
@@ -41,7 +41,7 @@ test.describe("Capability Factory navigation", () => {
       },
     );
     await page.route(
-      "**/api/agent-operator-integration/internal-v1/sandbox/pool",
+      "**/api/agent-operator-integration/v1/sandbox/pool",
       async (route) => {
         sandboxRequests.push(route.request().url());
         await route.fulfill({
@@ -58,7 +58,7 @@ test.describe("Capability Factory navigation", () => {
       },
     );
     await page.route(
-      "**/api/agent-operator-integration/internal-v1/sandbox/sessions**",
+      "**/api/agent-operator-integration/v1/sandbox/sessions**",
       async (route) => {
         sandboxRequests.push(route.request().url());
         await route.fulfill({


### PR DESCRIPTION
配合 openbkn-ai/bkn-foundry#339。**必须先合后端那个 PR**，否则 `/v1/sandbox` 尚不存在。

## 问题

沙箱运行时观测页此前从浏览器直连执行工厂的 `internal-v1` 路由：

```ts
export const SANDBOX_RUNTIME_API_PREFIX =
  "/agent-operator-integration/internal-v1/sandbox";
```

该路由组**不校验令牌**——身份完全来自调用方自填的 `X-Account-ID` 头，缺失时后端还会降级为硬编码管理员。为了让本页可用，整个 `internal-v1` 前缀被发布到了 Ingress，连带把同组下的沙箱代码执行（`function/exec`）、三条执行代理、内置组件注册、组件导入等 40 条接口一并暴露到集群外。

按平台惯例，内部面（各服务的 `/in`、执行工厂的 `internal-v1`）不应被 UI 调用。

## 改动

改走公开面 `/v1/sandbox`。公开面走令牌内省，能拿到经校验的真实身份；后端在 bkn-foundry#339 中已把这四条只读接口注册到公开面并叠加超管门禁（判定复用 bkn-safe 的 `safe_admin:console:manage` 能力位）。

| 文件 | 改动 |
| --- | --- |
| `services/sandbox-runtime.service.ts` | 前缀改为 `/agent-operator-integration/v1/sandbox` |
| `services/sandbox-runtime.service.test.ts` | 断言同步 |
| `module.manifest.ts` | 服务声明同步 |
| `tests/e2e/.../e2e-capability-factory-navigation.spec.ts` | 三处路由 mock 同步 |

全仓 `internal-v1` 零残留。

## 上线顺序

1. 合 bkn-foundry#339 —— 后端两条路径并存，本页仍走 `internal-v1`，**无感**
2. 合本 PR —— 前端切到 `/v1`，`internal-v1` 空转但仍在，**无感**
3. 后端第三个 PR —— 删 `internal-v1` 的 sandbox 注册与 `values.yaml` 的 Ingress 条目

任意时刻至少一条路径可用，零不可用窗口。

## 验证

`npx vitest run src/modules/execution-factory-lab/services/sandbox-runtime.service.test.ts` 通过（4 tests）。

**顺带发现一个与本 PR 无关的问题**：vitest 未排除 `.claude/worktrees/`，会把遗留 worktree 里的旧副本一并扫入测试。本次运行中 `.claude/worktrees/chore-bkn-trace-locale/` 下的旧文件报了失败。建议在 vitest 配置的 `exclude` 中加上该目录，否则任何本地 worktree 都会污染测试结果。本 PR 未改。

## 权限影响

下沉到公开面后叠加了超管门禁，**非超管账号将无法访问本页**。此前 `internal-v1` 无任何鉴权，任何人可见。若产品上希望普通用户能看自己的会话，需要另做按 account 过滤的设计（后端 issue bkn-foundry#326 中已记录该待决项）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)