### PR TITLE
fix(data-catalog): paginate resource list

### DIFF
--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -6,13 +6,14 @@
  */
 
 import { DatabaseOutlined, SearchOutlined } from "@ant-design/icons";
-import { Input, Select, Space, Spin, Tooltip } from "antd";
+import { Alert, Input, Select, Space, Spin, Tooltip } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { PermissionGate } from "@/framework/permission/PermissionGate";
+import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { AppTable } from "@/framework/ui/common/AppTable";
 import { EmptyStatePanel } from "@/framework/ui/common/EmptyStatePanel";
@@ -24,11 +25,12 @@ import {
   indexStateOf,
   isCatalogPhysical,
 } from "@/modules/data-catalog/lib/index-state";
+import { parseResourceScope } from "@/modules/data-catalog/lib/resource-identifier";
+import { listCatalogResourcePage } from "@/modules/data-catalog/services/resource.service";
 import type {
   BuildTask,
   CatalogResource,
 } from "@/modules/data-catalog/types/data-catalog";
-import { parseResourceScope } from "@/modules/data-catalog/lib/resource-identifier";
 import type { CatalogRecord } from "@/shared/catalog";
 
 import styles from "./CatalogDetailPanel.module.css";
@@ -74,8 +76,6 @@ type CatalogDetailPanelProps = {
     tab?: "detail" | "index" | "preview",
     indexView?: "config",
   ) => void;
-  resources: CatalogResource[];
-  resourcesLoading?: boolean;
   tasks: BuildTask[];
 };
 
@@ -83,8 +83,6 @@ export function CatalogDetailPanel({
   catalog,
   onCreateResource,
   onOpenResource,
-  resources,
-  resourcesLoading = false,
   tasks,
 }: CatalogDetailPanelProps) {
   const { t } = useTranslation();
@@ -97,6 +95,11 @@ export function CatalogDetailPanel({
   const [indexFilter, setIndexFilter] = useState<string>("");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+  const [resources, setResources] = useState<CatalogResource[]>([]);
+  const [resourceTotal, setResourceTotal] = useState(0);
+  const [resourcesLoading, setResourcesLoading] = useState(false);
+  const [resourceLoadError, setResourceLoadError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
   const [nameColumnWidth, setNameColumnWidth] = useState(() => {
     try {
       const value = window.localStorage.getItem("data-catalog.resourceNameColumnWidth");
@@ -109,6 +112,8 @@ export function CatalogDetailPanel({
   const resizingRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
   const physical = isCatalogPhysical(catalog);
+  const hasResourceQuery =
+    resourceKeyword.trim().length > 0 || categoryFilter.length > 0 || indexFilter.length > 0;
 
   const tasksByResource = useMemo(() => {
     const map = new Map<string, BuildTask[]>();
@@ -118,27 +123,13 @@ export function CatalogDetailPanel({
     return map;
   }, [tasks]);
 
-  const filteredResources = useMemo(() => {
-    const kw = resourceKeyword.trim().toLowerCase();
+  const displayResources = useMemo(() => {
     return resources.filter((resource) => {
-      if (activeDb) {
+      if (activeDb && activeSchema) {
         const scope = parseResourceScope(resource.sourceIdentifier);
-        if (!scope.database || scope.database !== activeDb) {
+        if (!scope.schema || scope.schema !== activeSchema) {
           return false;
         }
-        if (activeSchema && (!scope.schema || scope.schema !== activeSchema)) {
-          return false;
-        }
-      }
-      if (
-        kw &&
-        !resource.name.toLowerCase().includes(kw) &&
-        !(resource.sourceIdentifier ?? "").toLowerCase().includes(kw)
-      ) {
-        return false;
-      }
-      if (categoryFilter && resource.category !== categoryFilter) {
-        return false;
       }
       if (indexFilter) {
         const key = indexStateOf(tasksByResource.get(resource.id) ?? []).key;
@@ -148,24 +139,50 @@ export function CatalogDetailPanel({
       }
       return true;
     });
-  }, [
-    resources,
-    resourceKeyword,
-    categoryFilter,
-    indexFilter,
-    tasksByResource,
-    activeDb,
-    activeSchema,
-  ]);
+  }, [activeDb, activeSchema, indexFilter, resources, tasksByResource]);
 
   useEffect(() => {
     setPage(1);
   }, [resourceKeyword, categoryFilter, indexFilter, catalog.id, activeDb, activeSchema]);
 
-  const pagedResources = useMemo(() => {
-    const start = (page - 1) * pageSize;
-    return filteredResources.slice(start, start + pageSize);
-  }, [filteredResources, page, pageSize]);
+  useEffect(() => {
+    let cancelled = false;
+    setResourcesLoading(true);
+    setResourceLoadError(null);
+
+    void listCatalogResourcePage({
+      catalogId: catalog.id,
+      category: categoryFilter ? (categoryFilter as CatalogResource["category"]) : undefined,
+      database: activeDb || undefined,
+      keyword: resourceKeyword,
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
+    })
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        setResources(result.items);
+        setResourceTotal(result.total);
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        setResources([]);
+        setResourceTotal(0);
+        setResourceLoadError(extractRequestErrorMessage(error));
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setResourcesLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeDb, catalog.id, categoryFilter, page, pageSize, reloadKey, resourceKeyword]);
 
   useEffect(() => {
     const handleMove = (event: MouseEvent) => {
@@ -347,7 +364,7 @@ export function CatalogDetailPanel({
             )}
           </div>
         </div>
-        {resources.length > 0 ? (
+        {resourceTotal > 0 || hasResourceQuery ? (
           <div className={styles.toolbarFilters}>
             <Input
               allowClear
@@ -398,7 +415,18 @@ export function CatalogDetailPanel({
           <div className={styles.tableLoading}>
             <Spin />
           </div>
-        ) : resources.length === 0 ? (
+        ) : resourceLoadError ? (
+          <Alert
+            action={
+              <AppButton onClick={() => setReloadKey((value) => value + 1)} type="link">
+                {t("common.retry")}
+              </AppButton>
+            }
+            message={resourceLoadError}
+            showIcon
+            type="error"
+          />
+        ) : resourceTotal === 0 && !hasResourceQuery ? (
           <EmptyStatePanel
             action={
               physical ? (
@@ -426,7 +454,7 @@ export function CatalogDetailPanel({
             icon={<DatabaseOutlined />}
             title={t("dataCatalog.catalog.resourceSection")}
           />
-        ) : filteredResources.length === 0 ? (
+        ) : displayResources.length === 0 ? (
           <EmptyStatePanel
             description={t("dataCatalog.resource.noMatch")}
             icon={<DatabaseOutlined />}
@@ -435,7 +463,7 @@ export function CatalogDetailPanel({
         ) : (
           <AppTable<CatalogResource>
             columns={resourceColumns}
-            dataSource={pagedResources}
+            dataSource={displayResources}
             locale={{ emptyText: t("dataCatalog.resource.noMatch") }}
             pagination={false}
             rowKey="id"
@@ -444,7 +472,7 @@ export function CatalogDetailPanel({
         )}
       </TableSurface>
 
-      {filteredResources.length > 0 ? (
+      {resourceTotal > 0 ? (
         <TablePaginationBar
           current={page}
           onChange={(nextPage, nextPageSize) => {
@@ -454,7 +482,7 @@ export function CatalogDetailPanel({
           pageSize={pageSize}
           showSizeChanger
           showTotal={(count) => t("common.total", { total: count })}
-          total={filteredResources.length}
+          total={indexFilter || activeSchema ? displayResources.length : resourceTotal}
         />
       ) : null}
     </section>

--- a/src/modules/data-catalog/scenes/DataCatalogScene.tsx
+++ b/src/modules/data-catalog/scenes/DataCatalogScene.tsx
@@ -23,6 +23,7 @@ import { ResourceFormDrawer } from "@/modules/data-catalog/components/ResourceFo
 import { listBuildTasks } from "@/modules/data-catalog/services/build-task.service";
 import { subscribeMockDb } from "@/modules/data-catalog/services/mock-db";
 import {
+  countCatalogResources,
   isCatalogScanning,
   listCatalogResources,
   listCatalogScans,
@@ -66,7 +67,6 @@ export function DataCatalogScene({
   const [tasks, setTasks] = useState<BuildTask[]>([]);
   const [scans, setScans] = useState<CatalogScanRecord[]>([]);
   const [loading, setLoading] = useState(true);
-  const [detailLoading, setDetailLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const [resourceDrawer, setResourceDrawer] = useState<{
@@ -112,8 +112,7 @@ export function DataCatalogScene({
   }, []);
 
   const refreshResourceTotal = useCallback(async () => {
-    const items = await listCatalogResources();
-    setResourceTotal(items.length);
+    setResourceTotal(await countCatalogResources());
   }, []);
 
   const loadAll = useCallback(async () => {
@@ -165,27 +164,11 @@ export function DataCatalogScene({
     if (!selectedCatalogId) {
       setResources([]);
       setTasks([]);
-      setDetailLoading(false);
       return;
     }
 
-    let cancelled = false;
-    void loadCatalogDetail(selectedCatalogId).finally(() => {
-      if (!cancelled) {
-        setDetailLoading(false);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
+    void loadCatalogDetail(selectedCatalogId);
   }, [loadCatalogDetail, loading, selectedCatalogId]);
-
-  useLayoutEffect(() => {
-    if (!loading && selectedCatalogId) {
-      setDetailLoading(true);
-    }
-  }, [loading, selectedCatalogId]);
 
   const hasActiveWork = useMemo(
     () =>
@@ -252,14 +235,6 @@ export function DataCatalogScene({
     }
     return ids;
   }, [catalogs, scans, selectedCatalog]);
-
-  const selectedCatalogResources = useMemo(
-    () =>
-      selectedCatalog
-        ? resources.filter((resource) => resource.catalogId === selectedCatalog.id)
-        : [],
-    [resources, selectedCatalog],
-  );
 
   const openResourceWorkspace = useCallback(
     (
@@ -349,8 +324,6 @@ export function DataCatalogScene({
           catalog={selectedCatalog}
           onCreateResource={(catalogId) => setResourceDrawer({ catalogId, open: true })}
           onOpenResource={openResourceWorkspace}
-          resources={selectedCatalogResources}
-          resourcesLoading={detailLoading}
           tasks={tasks}
         />
       );

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -76,6 +76,7 @@ type ListResponse<T> = {
 };
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const BUILD_TASK_LIST_PAGE_SIZE = 200;
 
 const wait = async <T,>(value: T, delay = 180) =>
   new Promise<T>((resolve) => {
@@ -289,20 +290,34 @@ export async function listBuildTasks(
 
   // 后端 status 仅支持单值且枚举与前端不同(completed/stopped),
   // 统一拉全量后在前端按归一化状态过滤。
-  const response = await http.get<ListResponse<BackendBuildTask>>(
-    "/vega-backend/v1/build-tasks",
-    {
-      params: {
-        limit: 200,
-        offset: 0,
-        resource_id: query.resourceId || undefined,
-        catalog_id: query.catalogId || undefined,
-      },
-      skipErrorToast: query.silent,
-    },
-  );
+  const tasks: BuildTask[] = [];
+  let offset = 0;
+  let total = Number.POSITIVE_INFINITY;
 
-  return filterTasks(response.data.entries.map(mapBuildTask), query);
+  while (tasks.length < total) {
+    const response = await http.get<ListResponse<BackendBuildTask>>(
+      "/vega-backend/v1/build-tasks",
+      {
+        params: {
+          limit: BUILD_TASK_LIST_PAGE_SIZE,
+          offset,
+          resource_id: query.resourceId || undefined,
+          catalog_id: query.catalogId || undefined,
+        },
+        skipErrorToast: query.silent,
+      },
+    );
+    const pageItems = response.data.entries.map(mapBuildTask);
+    tasks.push(...pageItems);
+    total = response.data.total_count;
+
+    if (pageItems.length === 0 || pageItems.length < BUILD_TASK_LIST_PAGE_SIZE) {
+      break;
+    }
+    offset += pageItems.length;
+  }
+
+  return filterTasks(tasks, query);
 }
 
 // 前端归一状态 → 后端枚举。paused 同时覆盖 stopping/stopped;listening 即后端 running。

--- a/src/modules/data-catalog/services/resource.service.ts
+++ b/src/modules/data-catalog/services/resource.service.ts
@@ -213,6 +213,7 @@ type ListResponse<T> = {
 };
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+const RESOURCE_LIST_PAGE_SIZE = 500;
 
 const wait = async <T,>(value: T, delay = 180) =>
   new Promise<T>((resolve) => {
@@ -266,16 +267,32 @@ function filterResources(items: CatalogResource[], query: ResourceListQuery) {
       item.id.toLowerCase().includes(keyword);
     const matchesCatalog = !query.catalogId || item.catalogId === query.catalogId;
     const matchesCategory = !query.category || item.category === query.category;
+    const matchesDatabase =
+      !query.database ||
+      item.sourceIdentifier === query.database ||
+      item.sourceIdentifier.startsWith(`${query.database}.`);
 
-    return matchesKeyword && matchesCatalog && matchesCategory;
+    return matchesKeyword && matchesCatalog && matchesCategory && matchesDatabase;
   });
 }
 
-export async function listCatalogResources(
+export type CatalogResourcePage = {
+  items: CatalogResource[];
+  total: number;
+};
+
+export async function listCatalogResourcePage(
   query: ResourceListQuery = {},
-): Promise<CatalogResource[]> {
+): Promise<CatalogResourcePage> {
+  const offset = Math.max(0, query.offset ?? 0);
+  const limit = query.limit ?? RESOURCE_LIST_PAGE_SIZE;
+
   if (useMock) {
-    return wait(filterResources([...mockResources], query));
+    const filtered = filterResources([...mockResources], query);
+    return wait({
+      items: limit === -1 ? filtered.slice(offset) : filtered.slice(offset, offset + limit),
+      total: filtered.length,
+    });
   }
 
   const response = await http.get<ListResponse<BackendResource>>(
@@ -284,14 +301,53 @@ export async function listCatalogResources(
       params: {
         catalog_id: query.catalogId || undefined,
         category: query.category || undefined,
-        limit: 500,
+        database: query.database || undefined,
+        limit,
         name: query.keyword?.trim() || undefined,
-        offset: 0,
+        offset,
       },
     },
   );
 
-  return response.data.entries.map(mapResource);
+  return {
+    items: response.data.entries.map(mapResource),
+    total: response.data.total_count,
+  };
+}
+
+export async function listCatalogResources(
+  query: ResourceListQuery = {},
+): Promise<CatalogResource[]> {
+  if (query.limit !== undefined || query.offset !== undefined) {
+    return (await listCatalogResourcePage(query)).items;
+  }
+
+  const resources: CatalogResource[] = [];
+  let offset = 0;
+  let total = Number.POSITIVE_INFINITY;
+
+  while (resources.length < total) {
+    const page = await listCatalogResourcePage({
+      ...query,
+      limit: RESOURCE_LIST_PAGE_SIZE,
+      offset,
+    });
+    resources.push(...page.items);
+    total = page.total;
+
+    if (page.items.length === 0 || page.items.length < RESOURCE_LIST_PAGE_SIZE) {
+      break;
+    }
+    offset += page.items.length;
+  }
+
+  return resources;
+}
+
+export async function countCatalogResources(
+  query: ResourceListQuery = {},
+): Promise<number> {
+  return (await listCatalogResourcePage({ ...query, limit: 1, offset: 0 })).total;
 }
 
 export async function getCatalogResource(id: string) {

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -64,7 +64,10 @@ export type CatalogResource = {
 export type ResourceListQuery = {
   catalogId?: string;
   category?: ResourceCategory;
+  database?: string;
   keyword?: string;
+  limit?: number;
+  offset?: number;
 };
 
 export type ResourceCreateInput = {


### PR DESCRIPTION
## Summary
- load the data catalog resource table through backend pagination instead of a fixed first 500 records
- keep resource totals based on backend total_count and add request error retry handling
- paginate build-task loading so index state data is not capped by the first 200 records

## Scope
- This closes #178 for the right-side data catalog resource list and related total/count handling.
- Left-side tree lazy loading is not included in this PR because it needs backend scope/child-node pagination support; that follow-up remains tracked in #180.

## Validation
- pnpm exec tsc --noEmit --pretty false
- pnpm run lint:types

Closes #178