### PR TITLE
fix(data-catalog): 移除索引配置页假 embedding 模型硬编码兜底

### DIFF
--- a/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
@@ -34,7 +34,13 @@ import {
   extractRequestStatus,
   isActiveBuildTask,
 } from "@/modules/data-catalog/utils/build-task-guards";
-import { listSmallModels } from "@/modules/model-resources/services/small-model.service";
+import {
+  findUnregisteredEmbeddingModel,
+  isRegisteredEmbeddingModel,
+  loadEmbeddingModelOptions,
+  pickRegisteredEmbeddingModelId,
+  type EmbeddingModelsLoadState,
+} from "@/modules/data-catalog/utils/embedding-model-options";
 
 import formStyles from "./BuildTaskFormPanel.module.css";
 import styles from "./shared.module.css";
@@ -44,11 +50,6 @@ export type IndexConfigFormPanelProps = {
   onSaved?: () => void;
   resource: CatalogResource;
 };
-
-const FALLBACK_MODELS: EmbeddingModelOption[] = [
-  { id: "bge-m3", name: "BGE-M3", dimensions: 1024 },
-  { id: "bge-large-zh-v1.5", name: "BGE-Large-zh v1.5", dimensions: 1024 },
-];
 
 const FULLTEXT_ANALYZERS = ["standard", "ik_max_word", "hanlp_index"] as const;
 const INHERIT_VALUE = "__inherit__";
@@ -142,7 +143,9 @@ export function IndexConfigFormPanel({
   const [defaultFulltextAnalyzer, setDefaultFulltextAnalyzer] = useState<string>("standard");
   const [fieldFilter, setFieldFilter] = useState("");
   const [models, setModels] = useState<EmbeddingModelOption[]>([]);
-  const [modelsLoaded, setModelsLoaded] = useState(false);
+  const [modelsLoadState, setModelsLoadState] = useState<EmbeddingModelsLoadState>("idle");
+  const [modelsLoadError, setModelsLoadError] = useState<string | null>(null);
+  const [orphanSavedModel, setOrphanSavedModel] = useState<string | null>(null);
   const [defaultModelId, setDefaultModelId] = useState<string>();
   const [error, setError] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
@@ -210,7 +213,10 @@ export function IndexConfigFormPanel({
     setFieldFilter("");
     setError(null);
     setDirty(false);
-    setModelsLoaded(false);
+    setModelsLoadState("idle");
+    setModelsLoadError(null);
+    setOrphanSavedModel(null);
+    setModels([]);
     setSchema(resource.schema);
 
     const hydrateFromResource = (detail: CatalogResource) => {
@@ -262,37 +268,48 @@ export function IndexConfigFormPanel({
       }
 
       try {
-        const result = await listSmallModels({
-          modelType: "embedding",
-          page: 1,
-          size: 100,
-        });
-        const options = result.items
-          .filter((item) => item.modelType === "embedding")
-          .map((item) => ({
-            dimensions: item.embeddingDim ?? 1024,
-            id: item.modelName,
-            name: item.modelName,
-          }));
-        const list = options.length > 0 ? options : FALLBACK_MODELS;
-        setModels(list);
-        setDefaultModelId(
-          preferredModel && list.some((item) => item.id === preferredModel)
-            ? preferredModel
-            : list[0]?.id,
-        );
-      } catch {
-        setModels(FALLBACK_MODELS);
-        setDefaultModelId(
-          preferredModel && FALLBACK_MODELS.some((item) => item.id === preferredModel)
-            ? preferredModel
-            : FALLBACK_MODELS[0].id,
-        );
-      } finally {
-        setModelsLoaded(true);
+        setModelsLoadState("loading");
+        setModelsLoadError(null);
+        const loaded = await loadEmbeddingModelOptions();
+        setModels(loaded.options);
+        setModelsLoadState(loaded.state);
+        setModelsLoadError(loaded.errorMessage);
+
+        if (loaded.state === "ready") {
+          const orphan = findUnregisteredEmbeddingModel(loaded.options, [preferredModel]);
+          setOrphanSavedModel(orphan);
+          setDefaultModelId(pickRegisteredEmbeddingModelId(loaded.options, preferredModel));
+        } else {
+          setOrphanSavedModel(preferredModel.trim() ? preferredModel.trim() : null);
+          setDefaultModelId(undefined);
+        }
+      } catch (loadError) {
+        setModels([]);
+        setModelsLoadState("error");
+        setModelsLoadError(extractRequestErrorMessage(loadError));
+        setOrphanSavedModel(preferredModel.trim() ? preferredModel.trim() : null);
+        setDefaultModelId(undefined);
       }
     })();
   }, [active, resource]);
+
+  const reloadEmbeddingModels = async () => {
+    setModelsLoadState("loading");
+    setModelsLoadError(null);
+    const preferred = defaultModelId ?? orphanSavedModel ?? "";
+    const loaded = await loadEmbeddingModelOptions();
+    setModels(loaded.options);
+    setModelsLoadState(loaded.state);
+    setModelsLoadError(loaded.errorMessage);
+    if (loaded.state === "ready") {
+      const orphan = findUnregisteredEmbeddingModel(loaded.options, [preferred, orphanSavedModel]);
+      setOrphanSavedModel(orphan);
+      setDefaultModelId(pickRegisteredEmbeddingModelId(loaded.options, preferred));
+    } else {
+      setOrphanSavedModel(preferred.trim() ? preferred.trim() : null);
+      setDefaultModelId(undefined);
+    }
+  };
 
   const defaultModel = useMemo(
     () => models.find((item) => item.id === defaultModelId) ?? null,
@@ -362,15 +379,50 @@ export function IndexConfigFormPanel({
       (fieldFulltextAnalyzerGroups[field] ?? []).some((feature) => !feature.value?.trim()),
     );
     const embeddingNeedsDefault = embeddingFields.some((field) =>
-      (fieldEmbeddingModelGroups[field] ?? []).some((feature) => !feature.value?.trim()),
+      (eligibleEmbeddingModelGroups[field] ?? []).some((feature) => !feature.value?.trim()),
     );
     if (fulltextNeedsDefault && !defaultFulltextAnalyzer) {
       setError(t("dataCatalog.build.defaultAnalyzerRequired"));
       return false;
     }
-    if (embeddingNeedsDefault && !defaultModel) {
-      setError(t("dataCatalog.build.modelRequired"));
-      return false;
+    if (embeddingFields.length > 0) {
+      if (modelsLoadState === "loading" || modelsLoadState === "idle") {
+        setError(t("dataCatalog.build.modelsLoading"));
+        return false;
+      }
+      if (modelsLoadState === "error") {
+        setError(
+          t("dataCatalog.build.modelsLoadError", {
+            message: modelsLoadError ?? t("dataCatalog.build.modelsLoadErrorFallback"),
+          }),
+        );
+        return false;
+      }
+      if (modelsLoadState === "empty" || models.length === 0) {
+        setError(t("dataCatalog.build.noModels"));
+        return false;
+      }
+      if (embeddingNeedsDefault && !defaultModelId) {
+        setError(t("dataCatalog.build.modelRequired"));
+        return false;
+      }
+      if (
+        embeddingNeedsDefault &&
+        defaultModelId &&
+        !isRegisteredEmbeddingModel(defaultModelId, models)
+      ) {
+        setError(t("dataCatalog.build.savedModelUnavailable", { model: defaultModelId }));
+        return false;
+      }
+      for (const field of embeddingFields) {
+        for (const feature of eligibleEmbeddingModelGroups[field] ?? []) {
+          const override = feature.value?.trim();
+          if (override && !isRegisteredEmbeddingModel(override, models)) {
+            setError(t("dataCatalog.build.savedModelUnavailable", { model: override }));
+            return false;
+          }
+        }
+      }
     }
     return true;
   };
@@ -555,7 +607,11 @@ export function IndexConfigFormPanel({
     );
   };
 
-  const noModels = modelsLoaded && models.length === 0;
+  const noModels =
+    modelsLoadState === "empty" || (modelsLoadState === "ready" && models.length === 0);
+  const modelsLoadFailed = modelsLoadState === "error";
+  const modelsLoading = modelsLoadState === "loading" || modelsLoadState === "idle";
+  const embeddingBlocked = noModels || modelsLoadFailed || modelsLoading;
   const hasIndexFeatures = embeddingFields.length > 0 || fulltextFields.length > 0;
   const selectedEmbeddingGroups = featureField ? (eligibleEmbeddingModelGroups[featureField.name] ?? []) : [];
   const selectedFulltextGroups = featureField ? (eligibleFulltextAnalyzerGroups[featureField.name] ?? []) : [];
@@ -822,7 +878,44 @@ export function IndexConfigFormPanel({
                       {t("dataCatalog.build.defaultEmbeddingModel")}
                     </span>
                   </div>
-                  {noModels ? (
+                  {modelsLoading ? (
+                    <Select
+                      disabled
+                      loading
+                      placeholder={t("dataCatalog.build.modelsLoading")}
+                      style={{ width: "100%" }}
+                    />
+                  ) : modelsLoadFailed ? (
+                    <Alert
+                      action={
+                        <Space size={4}>
+                          <AppButton
+                            onClick={() => {
+                              void reloadEmbeddingModels();
+                            }}
+                            size="small"
+                            type="link"
+                          >
+                            {t("dataCatalog.build.retryLoadModels")}
+                          </AppButton>
+                          <AppButton
+                            onClick={() => {
+                              void navigate("/model-resources/models");
+                            }}
+                            size="small"
+                            type="link"
+                          >
+                            {t("dataCatalog.build.goConnectModel")}
+                          </AppButton>
+                        </Space>
+                      }
+                      message={t("dataCatalog.build.modelsLoadError", {
+                        message: modelsLoadError ?? "",
+                      })}
+                      showIcon
+                      type="error"
+                    />
+                  ) : noModels ? (
                     <Alert
                       action={
                         <AppButton
@@ -840,17 +933,30 @@ export function IndexConfigFormPanel({
                       type="warning"
                     />
                   ) : (
-                    <Select
-                      allowClear
-                      onChange={(value) => {
-                        setDefaultModelId(value);
-                        markDirty();
-                      }}
-                      options={modelOptions}
-                      placeholder={t("dataCatalog.build.defaultEmbeddingModel")}
-                      style={{ width: "100%" }}
-                      value={defaultModelId}
-                    />
+                    <>
+                      {orphanSavedModel ? (
+                        <Alert
+                          message={t("dataCatalog.build.savedModelUnavailable", {
+                            model: orphanSavedModel,
+                          })}
+                          showIcon
+                          style={{ marginBottom: 8 }}
+                          type="warning"
+                        />
+                      ) : null}
+                      <Select
+                        allowClear
+                        onChange={(value) => {
+                          setDefaultModelId(value);
+                          setOrphanSavedModel(null);
+                          markDirty();
+                        }}
+                        options={modelOptions}
+                        placeholder={t("dataCatalog.build.defaultEmbeddingModel")}
+                        style={{ width: "100%" }}
+                        value={defaultModelId}
+                      />
+                    </>
                   )}
                   <div className={formStyles.fieldHint}>
                     {t("dataCatalog.build.defaultModelDimensions", {
@@ -1022,7 +1128,7 @@ export function IndexConfigFormPanel({
               t("dataCatalog.build.roleEmbedding"),
               selectedEmbeddingGroups,
               modelOptions,
-              noModels,
+              embeddingBlocked,
             )}
             {renderFeatureRows(
               "fulltext",
@@ -1050,7 +1156,7 @@ export function IndexConfigFormPanel({
       <div className={formStyles.footer}>
         <Space style={{ marginLeft: "auto" }}>
           <AppButton
-            disabled={actionsLocked || saving || (noModels && embeddingFields.length > 0)}
+            disabled={actionsLocked || saving || (embeddingFields.length > 0 && embeddingBlocked)}
             loading={saving}
             onClick={() => void saveConfig()}
             type="primary"

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -305,6 +305,12 @@ export const dataCatalogEnUS = {
       noModels:
         "No embedding models connected; cannot save a config that includes embedding fields.",
       goConnectModel: "Connect a model",
+      modelsLoading: "Loading embedding models…",
+      modelsLoadError: "Failed to load embedding models: {{message}}",
+      modelsLoadErrorFallback: "Retry later or check model management service",
+      retryLoadModels: "Retry",
+      savedModelUnavailable:
+        'Saved embedding model "{{model}}" is not registered in this environment. Select a connected model.',
       dimensions: "Vector Dimensions",
       dimensionsHint:
         "(preview from model; server writes actual dimensions when the build runs)",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -285,6 +285,12 @@ export const dataCatalogZhCN = {
       modelRequired: "请选择 Embedding 模型。",
       noModels: "尚未接入 embedding 模型,无法保存含向量字段的配置。",
       goConnectModel: "去接入模型",
+      modelsLoading: "正在加载 embedding 模型列表…",
+      modelsLoadError: "加载 embedding 模型失败：{{message}}",
+      modelsLoadErrorFallback: "请稍后重试或检查模型管理服务",
+      retryLoadModels: "重试",
+      savedModelUnavailable:
+        "已保存的 embedding 模型「{{model}}」不在当前环境注册表中，请重新选择已接入的模型。",
       dimensions: "向量维度",
       dimensionsHint: "(随模型联动预览；实际维度由服务端在构建时写入)",
     },

--- a/src/modules/data-catalog/utils/embedding-model-options.test.ts
+++ b/src/modules/data-catalog/utils/embedding-model-options.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  findUnregisteredEmbeddingModel,
+  isRegisteredEmbeddingModel,
+  loadEmbeddingModelOptions,
+  pickRegisteredEmbeddingModelId,
+} from "@/modules/data-catalog/utils/embedding-model-options";
+import { listSmallModels } from "@/modules/model-resources/services/small-model.service";
+
+vi.mock("@/modules/model-resources/services/small-model.service", () => ({
+  listSmallModels: vi.fn(),
+}));
+
+describe("embedding-model-options", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns ready state with model_name ids from model management", async () => {
+    vi.mocked(listSmallModels).mockResolvedValue({
+      items: [
+        {
+          modelId: "uuid-1",
+          modelName: "bge-m3-prod",
+          modelType: "embedding",
+          embeddingDim: 1024,
+        },
+      ],
+      total: 1,
+    });
+
+    const result = await loadEmbeddingModelOptions();
+    expect(result.state).toBe("ready");
+    expect(result.options).toEqual([
+      { id: "bge-m3-prod", name: "bge-m3-prod", dimensions: 1024 },
+    ]);
+  });
+
+  it("returns empty state when no embedding models are registered", async () => {
+    vi.mocked(listSmallModels).mockResolvedValue({ items: [], total: 0 });
+
+    const result = await loadEmbeddingModelOptions();
+    expect(result.state).toBe("empty");
+    expect(result.options).toEqual([]);
+  });
+
+  it("returns error state instead of fallback options when API fails", async () => {
+    vi.mocked(listSmallModels).mockRejectedValue(new Error("network down"));
+
+    const result = await loadEmbeddingModelOptions();
+    expect(result.state).toBe("error");
+    expect(result.options).toEqual([]);
+    expect(result.errorMessage).toContain("network down");
+  });
+
+  it("prefers a registered saved model id", () => {
+    const options = [
+      { id: "model-a", name: "model-a", dimensions: 768 },
+      { id: "model-b", name: "model-b", dimensions: 1024 },
+    ];
+    expect(pickRegisteredEmbeddingModelId(options, "model-b")).toBe("model-b");
+    expect(pickRegisteredEmbeddingModelId(options, "missing")).toBe("model-a");
+  });
+
+  it("detects orphan saved models", () => {
+    const options = [{ id: "model-a", name: "model-a", dimensions: 768 }];
+    expect(
+      findUnregisteredEmbeddingModel(options, ["bge-m3", "model-a", ""]),
+    ).toBe("bge-m3");
+    expect(isRegisteredEmbeddingModel("model-a", options)).toBe(true);
+    expect(isRegisteredEmbeddingModel("bge-m3", options)).toBe(false);
+  });
+});

--- a/src/modules/data-catalog/utils/embedding-model-options.ts
+++ b/src/modules/data-catalog/utils/embedding-model-options.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { extractRequestErrorMessage } from "@/framework/request/error-message";
+import type { EmbeddingModelOption } from "@/modules/data-catalog/types/data-catalog";
+import { listSmallModels } from "@/modules/model-resources/services/small-model.service";
+
+export type EmbeddingModelsLoadState = "idle" | "loading" | "ready" | "empty" | "error";
+
+export type EmbeddingModelsLoadResult = {
+  errorMessage: string | null;
+  options: EmbeddingModelOption[];
+  state: EmbeddingModelsLoadState;
+};
+
+/**
+ * Load embedding models from model management. Never fabricates fallback options —
+ * callers must treat empty/error as blocking states for vector index configuration.
+ */
+export async function loadEmbeddingModelOptions(): Promise<EmbeddingModelsLoadResult> {
+  try {
+    const result = await listSmallModels({
+      modelType: "embedding",
+      page: 1,
+      size: 100,
+    });
+    const options = result.items
+      .filter((item) => item.modelType === "embedding")
+      .map((item) => ({
+        dimensions: item.embeddingDim ?? 1024,
+        // Vega validates against mf-model-manager model_name (not a client-side alias).
+        id: item.modelName.trim(),
+        name: item.modelName.trim(),
+      }))
+      .filter((item) => item.id.length > 0);
+
+    if (options.length === 0) {
+      return { state: "empty", options: [], errorMessage: null };
+    }
+
+    return { state: "ready", options, errorMessage: null };
+  } catch (error) {
+    return {
+      state: "error",
+      options: [],
+      errorMessage: extractRequestErrorMessage(error),
+    };
+  }
+}
+
+/** Pick a default model id that exists in the registry. */
+export function pickRegisteredEmbeddingModelId(
+  options: EmbeddingModelOption[],
+  preferred?: string,
+): string | undefined {
+  const trimmed = preferred?.trim();
+  if (trimmed && options.some((item) => item.id === trimmed)) {
+    return trimmed;
+  }
+
+  return options[0]?.id;
+}
+
+export function isRegisteredEmbeddingModel(
+  modelId: string | undefined | null,
+  options: EmbeddingModelOption[],
+): boolean {
+  const trimmed = modelId?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return options.some((item) => item.id === trimmed);
+}
+
+/** Saved resource config references a model that is not in the current registry. */
+export function findUnregisteredEmbeddingModel(
+  options: EmbeddingModelOption[],
+  candidates: Array<string | undefined | null>,
+): string | null {
+  const registered = new Set(options.map((item) => item.id));
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim();
+    if (trimmed && !registered.has(trimmed)) {
+      return trimmed;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- **问题**：索引配置页在 `listSmallModels` 失败或返回空时，会硬编码兜底 `bge-m3` / `bge-large-zh-v1.5`。用户据此保存后，Vega 校验注册表找不到模型，返回 `embedding model "bge-m3" for field "..." not found`。
- **原则**：Embedding 模型只能来自模型管理注册表，前端不得伪造选项；真实注册的 `bge-m3` 仍可正常使用。
- **改动**：
  - 新增 `embedding-model-options.ts`：统一加载，返回 `ready | empty | error`，无 fallback
  - `IndexConfigFormPanel`：loading / 加载失败（可重试）/ 空列表（引导去接入）三种态；含向量字段时阻断非法保存
  - 历史配置若引用未注册模型（孤儿模型），告警并要求重选
  - 补充中英文文案与单测

## Test plan
- [ ] 模型管理已注册 embedding（含真实 `bge-m3`）：下拉可见，保存成功
- [ ] 模型列表为空：含向量字段时无法保存，提示去接入模型
- [ ] `listSmallModels` 失败：展示错误 + 重试，不会出现假 `bge-m3`
- [ ] 历史配置含未注册模型名：打开配置有警告，重选真实模型后方可保存
- [ ] `pnpm test -- --run src/modules/data-catalog/utils/embedding-model-options.test.ts`

Fixes #184