### PR TITLE
feat(auth): 权限点对齐 bkn-safe 资源授权，补执行工厂菜单门禁

### DIFF
--- a/src/framework/auth/current-user.ts
+++ b/src/framework/auth/current-user.ts
@@ -5,6 +5,10 @@
  * Conditions. See LICENSE for the full text.
  */
 
+import {
+  deriveStudioPermissions,
+  flattenSafeGrants,
+} from "@/framework/auth/permission-map";
 import { http } from "@/framework/request/http";
 import { defaultDevPermissions } from "@/framework/runtime/module-manifests";
 import type { RuntimeUser } from "@/framework/runtime/types";
@@ -32,8 +36,10 @@ type MePermissionsResponse = {
 
 /**
  * 登录后拉取当前用户身份 + 权限,组装成 RuntimeUser。
- * 权限展平成 `type:op`(对齐各模块 manifest 的权限点);
- * is_admin(超级管理员/admin)放行全部已注册权限。
+ *
+ * bkn-safe 下发的是 `<resource_type>:<operation>`,与各模块 manifest 声明的权限点并非
+ * 同一套命名,需经 permission-map 翻译(见该文件注释)。is_admin(超级管理员/admin)
+ * 放行全部已注册权限。
  */
 export async function fetchCurrentUser(): Promise<RuntimeUser> {
   const [meResult, permResult] = await Promise.all([
@@ -46,13 +52,7 @@ export async function fetchCurrentUser(): Promise<RuntimeUser> {
   const me = meResult.data;
   const perm = permResult.data;
 
-  const flattened = (perm.permissions ?? []).flatMap((entry) => {
-    const type = entry.resource?.type;
-    if (!type) {
-      return [];
-    }
-    return (entry.operations ?? []).map((operation) => `${type}:${operation}`);
-  });
+  const safeGrants = flattenSafeGrants(perm.permissions);
 
   return {
     businessDomainId: null,
@@ -61,6 +61,6 @@ export async function fetchCurrentUser(): Promise<RuntimeUser> {
     roles: me.roles ?? [],
     permissions: perm.is_admin
       ? [...defaultDevPermissions]
-      : Array.from(new Set(flattened)),
+      : deriveStudioPermissions(defaultDevPermissions, safeGrants, false),
   };
 }

--- a/src/framework/auth/permission-map.test.ts
+++ b/src/framework/auth/permission-map.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveStudioPermissions,
+  flattenSafeGrants,
+  isStudioPermissionGranted,
+} from "@/framework/auth/permission-map";
+import { executionFactoryLabPermissions } from "@/modules/execution-factory-lab/permissions";
+import { executionFactoryLabModuleManifest } from "@/modules/execution-factory-lab/module.manifest";
+import { executionFactoryModuleManifest } from "@/modules/execution-factory/module.manifest";
+import { defaultDevPermissions } from "@/framework/runtime/module-manifests";
+
+/**
+ * 取自测试环境 10.211.55.4 上普通用户 test 的 /api/safe/v1/me/permissions 实际响应，
+ * 用真实授权形态而非臆造的数据做基准。
+ */
+const REAL_NON_ADMIN_GRANTS = [
+  {
+    operations: ["view_detail", "create", "modify", "delete", "authorize", "task_manage"],
+    resource: { id: "*", type: "catalog" },
+  },
+  {
+    operations: [
+      "create",
+      "modify",
+      "delete",
+      "view",
+      "publish",
+      "unpublish",
+      "authorize",
+      "public_access",
+      "execute",
+    ],
+    resource: { id: "*", type: "operator" },
+  },
+  {
+    operations: ["create", "modify", "delete", "view", "publish", "unpublish", "execute"],
+    resource: { id: "*", type: "tool_box" },
+  },
+  {
+    operations: ["create", "modify", "delete", "view", "publish"],
+    resource: { id: "*", type: "skill" },
+  },
+  {
+    operations: ["create", "modify", "delete", "view", "publish"],
+    resource: { id: "*", type: "mcp" },
+  },
+];
+
+describe("flattenSafeGrants", () => {
+  it("展平成 type:op，缺资源类型的条目丢弃", () => {
+    const flat = flattenSafeGrants([
+      { operations: ["create", "view"], resource: { id: "*", type: "operator" } },
+      { operations: ["create"], resource: { id: "*" } },
+      { operations: undefined, resource: { type: "skill" } },
+    ]);
+
+    expect(flat).toEqual(new Set(["operator:create", "operator:view"]));
+  });
+
+  it("空输入不炸", () => {
+    expect(flattenSafeGrants(undefined)).toEqual(new Set());
+  });
+});
+
+describe("isStudioPermissionGranted", () => {
+  const grants = flattenSafeGrants(REAL_NON_ADMIN_GRANTS);
+
+  it("直接同名的权限点保持既有行为", () => {
+    // data-catalog 声明的就是 bkn-safe 的原生串，不经翻译即成立。
+    expect(isStudioPermissionGranted("catalog:view_detail", grants, false)).toBe(true);
+    expect(isStudioPermissionGranted("catalog:task_manage", grants, false)).toBe(true);
+  });
+
+  it("能力的增删改查按 operator 判定，且 edit 落到 modify、debug 落到 execute", () => {
+    expect(isStudioPermissionGranted("execution-factory-lab:capability:create", grants, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory-lab:capability:view", grants, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory:operator:edit", grants, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory:operator:debug", grants, false)).toBe(true);
+  });
+
+  it("函数归算子，与后端 #345 的门禁同口径", () => {
+    expect(isStudioPermissionGranted("execution-factory-lab:function:create", grants, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory-lab:function:debug", grants, false)).toBe(true);
+  });
+
+  it("工具没有独立资源类型，写操作落到父工具箱的 modify", () => {
+    const withoutToolboxModify = flattenSafeGrants([
+      { operations: ["view", "create"], resource: { id: "*", type: "tool_box" } },
+    ]);
+
+    expect(isStudioPermissionGranted("execution-factory:tool:view", withoutToolboxModify, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory:tool:create", withoutToolboxModify, false)).toBe(false);
+    expect(isStudioPermissionGranted("execution-factory:tool:edit", withoutToolboxModify, false)).toBe(false);
+  });
+
+  it("市场浏览按 public_access 判定，不误用 bkn-safe 的同名 catalog 数据目录", () => {
+    // 只有 catalog 数据目录授权、没有任何 public_access 时，市场入口不应成立。
+    const onlyDataCatalog = flattenSafeGrants([
+      { operations: ["view_detail", "create"], resource: { id: "*", type: "catalog" } },
+    ]);
+    expect(isStudioPermissionGranted("execution-factory-lab:catalog:view", onlyDataCatalog, false)).toBe(false);
+
+    expect(isStudioPermissionGranted("execution-factory-lab:catalog:view", grants, false)).toBe(true);
+  });
+
+  it("市场安装暂时屏蔽，超管也不放行", () => {
+    expect(isStudioPermissionGranted("execution-factory-lab:catalog:install", grants, false)).toBe(false);
+    expect(isStudioPermissionGranted("execution-factory-lab:catalog:install", grants, true)).toBe(false);
+  });
+
+  it("沙箱运行时只认超管，与后端 CheckAdminPermission 同口径", () => {
+    expect(
+      isStudioPermissionGranted(executionFactoryLabPermissions.sandboxRuntimeView, grants, false),
+    ).toBe(false);
+    expect(
+      isStudioPermissionGranted(executionFactoryLabPermissions.sandboxRuntimeView, grants, true),
+    ).toBe(true);
+  });
+
+  it("零权限账号一条都拿不到", () => {
+    const empty = flattenSafeGrants([]);
+    for (const permission of defaultDevPermissions) {
+      expect(isStudioPermissionGranted(permission, empty, false)).toBe(false);
+    }
+  });
+
+  it("无法解析的权限点 fail-closed", () => {
+    expect(isStudioPermissionGranted("execution-factory:unknown:view", grants, false)).toBe(false);
+    expect(isStudioPermissionGranted("execution-factory:operator:teleport", grants, false)).toBe(false);
+    expect(isStudioPermissionGranted("garbage", grants, false)).toBe(false);
+  });
+
+  it("未纳入映射的模块保持原样，不因翻译而误得权限", () => {
+    // bkn-safe 发的是 knowledge_network（下划线），Studio 声明的是 knowledge-network，
+    // 两者本就不匹配；本映射不涉及该模块，行为维持不变。
+    const knowledgeGrants = flattenSafeGrants([
+      { operations: ["create"], resource: { id: "*", type: "knowledge_network" } },
+    ]);
+    expect(isStudioPermissionGranted("knowledge-network:create", knowledgeGrants, false)).toBe(false);
+  });
+});
+
+describe("执行工厂权限点覆盖", () => {
+  it("除去有意不映的三条，其余全部可由 bkn-safe 授权解析", () => {
+    // 四类资源全量授权的用户，理应命中执行工厂的每一个权限点。
+    const fullGrants = flattenSafeGrants(
+      ["operator", "tool_box", "mcp", "skill"].map((type) => ({
+        operations: [
+          "create",
+          "modify",
+          "delete",
+          "view",
+          "publish",
+          "unpublish",
+          "authorize",
+          "public_access",
+          "execute",
+        ],
+        resource: { id: "*", type },
+      })),
+    );
+    const all = [
+      ...executionFactoryModuleManifest.permissions,
+      ...executionFactoryLabModuleManifest.permissions,
+    ];
+
+    const unresolved = all.filter(
+      (permission) => !isStudioPermissionGranted(permission, fullGrants, false),
+    );
+
+    // catalog:install 暂时屏蔽（后端无对应端点）；sandbox-runtime:view 锚在 is_admin。
+    expect(unresolved.sort()).toEqual([
+      "execution-factory-lab:catalog:install",
+      "execution-factory-lab:sandbox-runtime:view",
+      "execution-factory:catalog:install",
+    ]);
+  });
+});
+
+describe("deriveStudioPermissions", () => {
+  it("只在已声明的权限点内推导，不凭空造串", () => {
+    const grants = flattenSafeGrants(REAL_NON_ADMIN_GRANTS);
+    const derived = deriveStudioPermissions(defaultDevPermissions, grants, false);
+
+    expect(derived.length).toBeGreaterThan(0);
+    for (const permission of derived) {
+      expect(defaultDevPermissions).toContain(permission);
+    }
+  });
+
+  it("普通用户拿得到能力相关权限——修复前这里恒为空", () => {
+    const grants = flattenSafeGrants(REAL_NON_ADMIN_GRANTS);
+    const derived = deriveStudioPermissions(defaultDevPermissions, grants, false);
+
+    expect(derived).toContain(executionFactoryLabPermissions.capabilityView);
+    expect(derived).toContain(executionFactoryLabPermissions.capabilityCreate);
+    expect(derived).not.toContain(executionFactoryLabPermissions.sandboxRuntimeView);
+  });
+});

--- a/src/framework/auth/permission-map.ts
+++ b/src/framework/auth/permission-map.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/**
+ * 把 bkn-safe 下发的资源授权翻译成 Studio 各模块声明的权限点。
+ *
+ * 两侧命名从来不是一套：bkn-safe 发的是 `<resource_type>:<operation>`（如 `operator:create`），
+ * Studio 声明的是 `<module>:<entity>:<action>`（如 `execution-factory:operator:create`）。
+ * 在此之前 current-user.ts 直接拿展平后的 `type:op` 去比对模块权限点，永远不可能命中，
+ * 于是所有非超管用户在执行工厂相关页面的权限集恒为空——后端明明授了 operator:create，
+ * 前端却连页面都进不去。
+ *
+ * 执行工厂后端只有四个资源类型：operator / tool_box / mcp / skill
+ * （adp/execution-factory/operator-integration/server/interfaces/logics_auth.go:53-58）。
+ * 下面的映射即以后端实际鉴权点为准，逐条对齐。
+ */
+
+/** bkn-safe 的资源类型。后端仅此四种。 */
+type SafeResourceType = "operator" | "tool_box" | "mcp" | "skill";
+
+const ALL_RESOURCE_TYPES: SafeResourceType[] = ["operator", "tool_box", "mcp", "skill"];
+
+/** Studio 的动作 → bkn-safe 的操作。词表不同，需逐个对齐。 */
+const ACTION_TO_OPERATION: Record<string, string> = {
+  create: "create",
+  delete: "delete",
+  // Studio 说 debug，后端记的是 execute
+  debug: "execute",
+  // Studio 说 edit，后端记的是 modify
+  edit: "modify",
+  execute: "execute",
+  publish: "publish",
+  unpublish: "unpublish",
+  view: "view",
+};
+
+/**
+ * Studio 的实体 → bkn-safe 的资源类型。
+ *
+ * capability、function 都是算子的表现形式，归 operator。
+ * tool 没有独立资源类型，一切工具级操作都授权到父工具箱（toolbox_handler 全线如此）。
+ */
+const ENTITY_TO_RESOURCE_TYPE: Record<string, SafeResourceType> = {
+  capability: "operator",
+  function: "operator",
+  mcp: "mcp",
+  operator: "operator",
+  skill: "skill",
+  tool: "tool_box",
+  toolbox: "tool_box",
+};
+
+/**
+ * 需要覆盖默认规则的条目。值为「命中即成立」的 `type:op` 列表，空数组表示恒不成立。
+ *
+ * 键是去掉模块前缀后的 `<entity>:<action>`，因此 execution-factory 与
+ * execution-factory-lab 两个模块共用同一套规则。
+ */
+const OVERRIDES: Record<string, string[]> = {
+  // 市场浏览：后端对四类资源统一按 public_access 判定，没有独立的 market 资源类型。
+  // 注意 bkn-safe 也有个叫 catalog 的资源类型，那是 Vega 数据目录，与此处的能力市场
+  // 同名不同物，绝不能映过去。
+  "catalog:view": ALL_RESOURCE_TYPES.map((type) => `${type}:public_access`),
+  // 市场安装：后端在执行工厂中没有对应端点，暂时屏蔽入口，待后端补齐再放开。
+  "catalog:install": [],
+  // 导入导出：导出读四类中任一，导入在目标类型上建。
+  "impex:export": ALL_RESOURCE_TYPES.map((type) => `${type}:view`),
+  "impex:import": ALL_RESOURCE_TYPES.map((type) => `${type}:create`),
+  // 工具没有自己的资源类型，写操作一律落到父工具箱的 modify。
+  "tool:create": ["tool_box:modify"],
+  "tool:delete": ["tool_box:modify"],
+  "tool:edit": ["tool_box:modify"],
+};
+
+/**
+ * 只有超管可见的权限点。这些页面返回跨租户运维数据，不隶属于任何单一业务资源，
+ * bkn-safe 侧也没有对应的资源类型可授，判定只能锚在 is_admin。
+ *
+ * 与执行工厂后端 CheckAdminPermission 同口径（复用 bkn-safe 的 safe_admin:console:manage）。
+ */
+const ADMIN_ONLY_SUFFIXES = new Set(["sandbox-runtime:view"]);
+
+/** 把 bkn-safe 的授权条目展平成 `type:op` 集合。 */
+export function flattenSafeGrants(
+  grants: { operations?: string[]; resource?: { id?: string; type?: string } }[] | undefined,
+): Set<string> {
+  const flat = new Set<string>();
+  for (const entry of grants ?? []) {
+    const type = entry.resource?.type;
+    if (!type) {
+      continue;
+    }
+    for (const operation of entry.operations ?? []) {
+      flat.add(`${type}:${operation}`);
+    }
+  }
+  return flat;
+}
+
+/**
+ * 适用本映射的模块前缀。
+ *
+ * 只翻译执行工厂两个模块。其余模块（knowledge-network、data-catalog、system-admin 等）
+ * 的权限点各有各的命名，且部分本就与 bkn-safe 直接同名，不在本次收敛范围内——对它们
+ * 保持原有的直接比对行为，避免顺手改动波及未经验证的模块。
+ */
+const MAPPED_MODULE_PREFIXES = ["execution-factory", "execution-factory-lab"];
+
+/**
+ * 判断某个 Studio 权限点在给定的 bkn-safe 授权集下是否成立。
+ *
+ * 判定顺序：
+ *   1. 与 bkn-safe 下发的 `type:op` 直接同名 —— 保留既有行为，任何模块都不会因本映射掉权限；
+ *   2. 超管专属权限点 —— 锚在 is_admin；
+ *   3. 执行工厂的翻译规则 —— 覆盖表优先于通用的实体/动作映射。
+ *
+ * 无法解析的权限点判为不成立（fail-closed）：宁可少给，不可错给。
+ */
+export function isStudioPermissionGranted(
+  studioPermission: string,
+  safeGrants: Set<string>,
+  isAdmin: boolean,
+): boolean {
+  // 1. 直接同名。data-catalog 的 `catalog:view_detail` 等即走这条。
+  if (safeGrants.has(studioPermission)) {
+    return true;
+  }
+
+  const segments = studioPermission.split(":");
+  if (segments.length < 3 || !MAPPED_MODULE_PREFIXES.includes(segments[0])) {
+    return false;
+  }
+  const suffix = segments.slice(1).join(":");
+
+  // 2. 超管专属。
+  if (ADMIN_ONLY_SUFFIXES.has(suffix)) {
+    return isAdmin;
+  }
+
+  // 3. 覆盖表优先。
+  const override = OVERRIDES[suffix];
+  if (override) {
+    return override.some((candidate) => safeGrants.has(candidate));
+  }
+
+  const [, entity, action] = segments;
+  const resourceType = ENTITY_TO_RESOURCE_TYPE[entity];
+  const operation = ACTION_TO_OPERATION[action];
+  if (!resourceType || !operation) {
+    return false;
+  }
+  return safeGrants.has(`${resourceType}:${operation}`);
+}
+
+/**
+ * 从 bkn-safe 授权推导出当前用户实际持有的 Studio 权限点。
+ *
+ * knownPermissions 是各模块 manifest 声明的全部权限点；只在这个集合内推导，
+ * 避免造出模块从未声明过的权限串。
+ */
+export function deriveStudioPermissions(
+  knownPermissions: readonly string[],
+  safeGrants: Set<string>,
+  isAdmin: boolean,
+): string[] {
+  return knownPermissions.filter((permission) =>
+    isStudioPermissionGranted(permission, safeGrants, isAdmin),
+  );
+}

--- a/src/modules/execution-factory-lab/navigation.tsx
+++ b/src/modules/execution-factory-lab/navigation.tsx
@@ -8,7 +8,10 @@
 import { AppstoreOutlined, CloudServerOutlined, ExperimentOutlined } from "@ant-design/icons";
 
 import type { ConsoleNavContribution } from "@/app/shell/navigation/types";
+import { executionFactoryLabPermissions } from "@/modules/execution-factory-lab/permissions";
 
+// 各项均声明所需权限：无权限的用户不该在侧边栏看到点进去只有一张空页的入口。
+// 沙箱运行时限超管，与后端 #339 的门禁同口径。
 export const executionFactoryLabNavigation: ConsoleNavContribution = {
   parentKey: "execution-factory-lab",
   items: [
@@ -17,18 +20,21 @@ export const executionFactoryLabNavigation: ConsoleNavContribution = {
       labelKey: "shell.items.executionFactoryLabCapabilities",
       icon: <ExperimentOutlined />,
       path: "/execution-factory-lab/capabilities",
+      permission: executionFactoryLabPermissions.capabilityView,
     },
     {
       key: "execution-factory-lab-catalog",
       labelKey: "shell.items.executionFactoryLabCatalog",
       icon: <AppstoreOutlined />,
       path: "/execution-factory-lab/catalog",
+      permission: executionFactoryLabPermissions.catalogView,
     },
     {
       key: "execution-factory-lab-sandbox-runtime",
       labelKey: "shell.items.executionFactoryLabSandboxRuntime",
       icon: <CloudServerOutlined />,
       path: "/execution-factory-lab/sandbox-runtime",
+      permission: executionFactoryLabPermissions.sandboxRuntimeView,
     },
   ],
 };

--- a/src/modules/execution-factory-lab/scenes/CatalogLabListScene.tsx
+++ b/src/modules/execution-factory-lab/scenes/CatalogLabListScene.tsx
@@ -116,7 +116,18 @@ export function CatalogLabListScene() {
   }
 
   return (
-    <PermissionGate permissions={executionFactoryLabPermissions.catalogView}>
+    <PermissionGate
+      fallback={
+        <section className={styles.page}>
+          <Alert
+            message={t("executionFactoryLab.permissionDeniedHint")}
+            showIcon
+            type="warning"
+          />
+        </section>
+      }
+      permissions={executionFactoryLabPermissions.catalogView}
+    >
       <section className={styles.page}>
         <div className={styles.intro}>
           <h2 className={styles.introTitle}>{t("executionFactoryLab.catalogTitle")}</h2>

--- a/src/modules/execution-factory-lab/scenes/SandboxRuntimeScene.tsx
+++ b/src/modules/execution-factory-lab/scenes/SandboxRuntimeScene.tsx
@@ -312,7 +312,18 @@ export function SandboxRuntimeScene() {
   ];
 
   return (
-    <PermissionGate permissions={executionFactoryLabPermissions.sandboxRuntimeView}>
+    <PermissionGate
+      fallback={
+        <section className={styles.page}>
+          <Alert
+            message={t("executionFactoryLab.permissionDeniedHint")}
+            showIcon
+            type="warning"
+          />
+        </section>
+      }
+      permissions={executionFactoryLabPermissions.sandboxRuntimeView}
+    >
       <section className={styles.page}>
         <div className={styles.intro}>
           <div>

--- a/src/modules/execution-factory/navigation.tsx
+++ b/src/modules/execution-factory/navigation.tsx
@@ -13,6 +13,9 @@ import {
 
 import type { ConsoleNavContribution } from "@/app/shell/navigation/types";
 
+// 各项均声明所需权限：无权限的用户不该在侧边栏看到点进去只有一张空页的入口。
+// 执行单元管理页同时承载算子与工具箱，任一可见即放行。
+// 沙箱运行时限超管，与后端 #339 的门禁同口径。
 export const executionFactoryNavigation: ConsoleNavContribution = {
   parentKey: "execution-factory",
   items: [
@@ -21,18 +24,22 @@ export const executionFactoryNavigation: ConsoleNavContribution = {
       labelKey: "shell.items.executionUnitManagement",
       icon: <ToolOutlined />,
       path: "/execution-factory/units",
+      permission: ["execution-factory:operator:view", "execution-factory:toolbox:view"],
+      permissionMode: "any",
     },
     {
       key: "all-execution-units",
       labelKey: "shell.items.allExecutionUnits",
       icon: <AppstoreOutlined />,
       path: "/execution-factory/catalog",
+      permission: "execution-factory:catalog:view",
     },
     {
       key: "execution-factory-sandbox-runtime",
       labelKey: "shell.items.executionFactorySandboxRuntime",
       icon: <CloudServerOutlined />,
       path: "/execution-factory/sandbox-runtime",
+      permission: "execution-factory-lab:sandbox-runtime:view",
     },
   ],
 };


### PR DESCRIPTION
## 问题

Studio 各模块声明的权限点是 `<module>:<entity>:<action>`，bkn-safe 下发的是 `<resource_type>:<operation>`，两者并非同一套命名。

`current-user.ts` 此前直接拿展平后的 `type:op` 与模块权限点比对，执行工厂的三段串永远不可能命中。结果是非超管用户在该模块的权限集恒为空——后端明明授了 `operator:create`，前端连页面都进不去，**只有超管能用整个执行工厂**。

## 改动

新增 `src/framework/auth/permission-map.ts` 做翻译层。映射以后端实际鉴权点为准逐条反推（执行工厂后端只有 `operator` / `tool_box` / `mcp` / `skill` 四个资源类型，见 `interfaces/logics_auth.go:53-58`）：

- `edit` → `modify`、`debug` → `execute`，词表不同需对齐
- `capability` 与 `function` 都归 `operator`
- `tool` 没有独立资源类型，写操作一律授权到父工具箱的 `modify`
- 市场浏览按四类的 `public_access` 判定。注意 bkn-safe 另有一个同名的 `catalog` 资源类型，那是 Vega 数据目录，与能力市场同名不同物，**不能映过去**
- `catalog:install` 暂时屏蔽，后端在执行工厂中没有对应端点
- `sandbox-runtime:view` 锚在 `is_admin`，与后端 `CheckAdminPermission` 同口径

### 严格增量，不会让任何模块掉权限

判定顺序为「直接同名 → 超管专属 → 执行工厂翻译」，且翻译只对 `execution-factory` 两个前缀生效：

| 模块 | 与 bkn-safe 的关系 | 本 PR 影响 |
|---|---|---|
| data-catalog | `catalog:*`、`resource:*` 本就同名 | 走直接同名分支，行为不变 |
| system-admin | `admin-user:create` 即 bkn-safe 原生形态 | 行为不变 |
| knowledge-network / data-connect / model-resources | 存在同类不一致 | 不在本次范围，行为维持原样，见 #181 |

无法解析的权限点 fail-closed。

### 菜单门禁

此前所有导航项都未声明 `permission`，`filterNavByPermission` 形同虚设：无权限用户照样看得见入口，点进去因 `PermissionGate` 的 `fallback` 默认为 `null` 而得到一张白页。现补齐两个模块的 `permission` 声明，并给市场页与沙箱页补上无权限空态。

## 验证

测试基准取自测试环境 10.211.55.4 上普通用户 `test` 的真实 `/me/permissions` 响应，而非构造数据。

其中一项断言执行工厂 51 个权限点中仅 `catalog:install` ×2 与 `sandbox-runtime:view` 三条不可解析——新增权限点漏配映射会直接测试失败。

`tsc --noEmit` 无错；`vitest` 58 个文件 / 239 项全过。

## 关联

- #181 —— 其余模块的同类不一致
- openbkn-ai/bkn-foundry#345 —— 执行工厂后端公开面缺授权检查
