### PR TITLE
fix(knowledge-network): 改进对象类型数据属性映射交互 (#172)

### DIFF
--- a/src/modules/knowledge-network/components/object-type/data-attribute/ObjectTypeDataAttributeEditor.module.css
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/ObjectTypeDataAttributeEditor.module.css
@@ -307,11 +307,23 @@
 }
 
 .panelItemHighlighted {
-  background: #f1f7ff;
+  background: #e6f4ff;
+  box-shadow: inset 3px 0 0 #1677ff;
+}
+
+.panelItemHighlighted:hover {
+  background: #d6ebff;
 }
 
 .panelItemMapped {
   background: rgba(22, 119, 255, 0.04);
+}
+
+/* Pending selection must stay visible even when the field is already mapped. */
+.panelItemMapped.panelItemHighlighted,
+.panelItemMapped.panelItemHighlighted:hover {
+  background: #e6f4ff;
+  box-shadow: inset 3px 0 0 #1677ff;
 }
 
 .itemContent {

--- a/src/modules/knowledge-network/components/object-type/data-attribute/ObjectTypeDataAttributeEditor.tsx
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/ObjectTypeDataAttributeEditor.tsx
@@ -9,6 +9,7 @@ import {
   BookOutlined,
   CompressOutlined,
   DeleteOutlined,
+  DisconnectOutlined,
   EllipsisOutlined,
   InfoCircleFilled,
   MinusOutlined,
@@ -287,6 +288,13 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
     [dataSource, onChange],
   );
 
+  const clearPendingViewField = useCallback(() => {
+    setPendingViewField(null);
+    setAlertMessage((current) =>
+      current === t("knowledgeNetwork.objectTypeClickToConnect") ? "" : current,
+    );
+  }, [t]);
+
   const loadViewFields = useCallback(
     async (viewId: string) => {
       if (!viewId) {
@@ -366,6 +374,22 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
     return () => window.removeEventListener("resize", handleResize);
   }, [recalculateConnections]);
 
+  useEffect(() => {
+    if (!pendingViewField) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+      clearPendingViewField();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [clearPendingViewField, pendingViewField]);
+
   useImperativeHandle(
     ref,
     () => ({
@@ -443,6 +467,25 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
     );
   };
 
+  const selectPendingViewField = (field: ObjectTypeResourceField) => {
+    if (pendingViewField?.name === field.name) {
+      clearPendingViewField();
+      return;
+    }
+    setPendingViewField(field);
+    setAlertMessage(t("knowledgeNetwork.objectTypeClickToConnect"));
+  };
+
+  const disconnectPropertyMapping = (name: string, event: React.MouseEvent) => {
+    event.stopPropagation();
+    updateProperties(
+      dataProperties.map((item) =>
+        item.name === name ? { ...item, mappedField: undefined } : item,
+      ),
+    );
+    void message.success(t("knowledgeNetwork.objectTypeMappingCleared"));
+  };
+
   const connectProperty = (property: ObjectTypeDataProperty) => {
     if (logicNameSet.has(property.name)) {
       return;
@@ -482,8 +525,7 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
           : item,
       ),
     );
-    setPendingViewField(null);
-    setAlertMessage("");
+    clearPendingViewField();
   };
 
   const handleAddProperty = (property: ObjectTypeDataProperty) => {
@@ -713,7 +755,21 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
   return (
     <div className={styles.root}>
       {alertMessage ? (
-        <Alert banner closable message={alertMessage} onClose={() => setAlertMessage("")} type="error" />
+        <Alert
+          banner
+          closable
+          message={alertMessage}
+          onClose={() => {
+            if (alertMessage === t("knowledgeNetwork.objectTypeClickToConnect")) {
+              clearPendingViewField();
+              return;
+            }
+            setAlertMessage("");
+          }}
+          type={
+            alertMessage === t("knowledgeNetwork.objectTypeClickToConnect") ? "info" : "error"
+          }
+        />
       ) : null}
 
       <div className={styles.infoBar}>
@@ -929,10 +985,7 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
                           .filter(Boolean)
                           .join(" ")}
                         key={field.name}
-                        onClick={() => {
-                          setPendingViewField(field);
-                          setAlertMessage(t("knowledgeNetwork.objectTypeClickToConnect"));
-                        }}
+                        onClick={() => selectPendingViewField(field)}
                       >
                         <div className={styles.itemContent}>
                           <FieldTypeIcon type={field.type} />
@@ -1074,6 +1127,16 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
                           ) : null}
                         </div>
                         <div className={styles.itemIconsActions}>
+                          {property.mappedField ? (
+                            <Tooltip title={t("knowledgeNetwork.objectTypeClearMapping")}>
+                              <DisconnectOutlined
+                                className={styles.rowActionIcon}
+                                onClick={(event) =>
+                                  disconnectPropertyMapping(property.name, event)
+                                }
+                              />
+                            </Tooltip>
+                          ) : null}
                           {canBeDisplayKey(property.type) ? (
                             property.displayKey ? (
                               <StarFilled

--- a/src/modules/knowledge-network/locales/en-US/object-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/object-type.ts
@@ -23,6 +23,8 @@ export const objecttypePart = {
     objectTypeClearResourceDescription: "Clear the current bound resource and its mappings?",
     objectTypeClearResourceTitle: "Clear resource",
     objectTypeClickToConnect: "Click an object type property on the right to complete the mapping.",
+    objectTypeClearMapping: "Clear mapping",
+    objectTypeMappingCleared: "Mapping cleared",
     objectTypeConceptGroups: "Concept groups",
     objectTypeConceptGroupsPlaceholder: "Select related concept groups",
     objectTypeCreateDescription: "Create an object type and its properties through a multi-step form.",

--- a/src/modules/knowledge-network/locales/zh-CN/object-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/object-type.ts
@@ -22,6 +22,8 @@ export const objecttypePart = {
     objectTypeClearResourceDescription: "确认清空当前绑定资源及其映射关系吗？",
     objectTypeClearResourceTitle: "清空资源",
     objectTypeClickToConnect: "请点击右侧对象类属性完成映射连接。",
+    objectTypeClearMapping: "取消映射",
+    objectTypeMappingCleared: "已取消映射关系",
     objectTypeConceptGroups: "关联概念分组",
     objectTypeConceptGroupsPlaceholder: "选择关联的概念分组",
     objectTypeCreateDescription: "通过多步表单创建对象类及其属性。",


### PR DESCRIPTION
## Summary

- 强化左侧资源字段「待关联」选中态：提高背景对比度、增加左侧蓝色描边，并覆盖 hover / 已映射行的样式优先级
- 支持取消待关联选中：再次点击同一字段、按 Esc、或关闭顶部引导 Alert 时同步清空 `pendingViewField`
- 已映射属性行新增「取消映射」操作（`DisconnectOutlined`），可单独清除 `mappedField` 而不删除属性或其他映射
- 引导提示由 error 改为 info，与待关联操作语义一致

## 关联 Issue

Closes #172

## Test plan

- [ ] 打开对象类型编辑页数据属性画布，点击左侧未映射字段，选中态清晰可见（含 hover）
- [ ] 点击已映射字段，待关联态仍可与普通已映射态区分
- [ ] 再次点击同一字段、按 Esc、或关闭顶部 Alert，待选中与引导提示同步消失
- [ ] 在已映射属性行点击「取消映射」，连线消失，属性保留，其他映射不受影响
- [ ] 左字段 → 右属性正常建立映射流程不受影响