### PR TITLE
fix(knowledge-network): show resource index state from data-catalog build tasks

### DIFF
--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -488,3 +488,5 @@ export function CatalogDetailPanel({
     </section>
   );
 }
+
+export default CatalogDetailPanel;

--- a/src/modules/data-catalog/scenes/DataCatalogScene.tsx
+++ b/src/modules/data-catalog/scenes/DataCatalogScene.tsx
@@ -7,14 +7,13 @@
 
 import { DatabaseOutlined } from "@ant-design/icons";
 import { Alert, Spin } from "antd";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { EmptyStatePanel } from "@/framework/ui/common/EmptyStatePanel";
-import { CatalogDetailPanel } from "@/modules/data-catalog/components/CatalogDetailPanel";
 import {
   CatalogTreePanel,
   type CatalogTreeSelection,
@@ -38,6 +37,10 @@ import type { DataConnectConnectorType } from "@/modules/data-connect/types/data
 import { catalogListAllQuery, listCatalogs, type CatalogRecord } from "@/shared/catalog";
 
 import styles from "./DataCatalogScene.module.css";
+
+const CatalogDetailPanel = lazy(
+  () => import("@/modules/data-catalog/components/CatalogDetailPanel"),
+);
 
 export type DataCatalogSceneProps = {
   selection: CatalogTreeSelection | null;
@@ -320,12 +323,20 @@ export function DataCatalogScene({
 
     if (selectedCatalog) {
       return (
-        <CatalogDetailPanel
-          catalog={selectedCatalog}
-          onCreateResource={(catalogId) => setResourceDrawer({ catalogId, open: true })}
-          onOpenResource={openResourceWorkspace}
-          tasks={tasks}
-        />
+        <Suspense
+          fallback={
+            <div className={styles.placeholder}>
+              <Spin />
+            </div>
+          }
+        >
+          <CatalogDetailPanel
+            catalog={selectedCatalog}
+            onCreateResource={(catalogId) => setResourceDrawer({ catalogId, open: true })}
+            onOpenResource={openResourceWorkspace}
+            tasks={tasks}
+          />
+        </Suspense>
       );
     }
 

--- a/src/modules/data-catalog/services/resource.service.ts
+++ b/src/modules/data-catalog/services/resource.service.ts
@@ -351,17 +351,32 @@ export async function countCatalogResources(
 }
 
 export async function getCatalogResource(id: string) {
-  if (useMock) {
-    return wait(mockResources.find((item) => item.id === id) ?? null);
+  const [resource] = await getCatalogResources([id]);
+  return resource ?? null;
+}
+
+export async function getCatalogResources(ids: string[]) {
+  const uniqueIds = Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean)));
+  if (uniqueIds.length === 0) {
+    return [];
   }
 
-  // GET /resources/:id 返回 {entries:[...]}(支持逗号多 id)
-  const response = await http.get<{ entries?: BackendResource[] }>(
-    `/vega-backend/v1/resources/${id}`,
-  );
+  if (useMock) {
+    const byId = new Map(mockResources.map((item) => [item.id, item]));
+    return wait(uniqueIds.map((id) => byId.get(id)).filter(Boolean) as CatalogResource[]);
+  }
 
-  const resource = response.data.entries?.[0];
-  return resource ? mapResource(resource) : null;
+  const resources: CatalogResource[] = [];
+  for (let index = 0; index < uniqueIds.length; index += 50) {
+    const chunk = uniqueIds.slice(index, index + 50);
+    const response = await http.get<{ entries?: BackendResource[] }>(
+      `/vega-backend/v1/resources/${chunk.join(",")}`,
+      { skipErrorToast: true },
+    );
+    resources.push(...(response.data.entries ?? []).map(mapResource));
+  }
+
+  return resources;
 }
 
 export async function createCatalogResource(input: ResourceCreateInput) {

--- a/src/modules/knowledge-network/components/object-type/ObjectTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/object-type/ObjectTypeListPanel.tsx
@@ -22,10 +22,8 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAppServices } from "@/framework/context/use-app-services";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
-import { formatIndexStateLabel } from "@/modules/data-catalog/lib/format-index-state";
-import { indexStateOf } from "@/modules/data-catalog/lib/index-state";
-import { listBuildTasks } from "@/modules/data-catalog/services/build-task.service";
-import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+import { formatResourceIndexStateLabel } from "@/modules/knowledge-network/utils/resource-index-state";
+import { useResourceIndexStates } from "@/modules/knowledge-network/hooks/useResourceIndexStates";
 import { JsonResourceImportButton } from "@/modules/knowledge-network/components/shared/JsonResourceImportButton";
 import { renderResourceIcon } from "@/modules/knowledge-network/components/shared/ResourceIconSelect";
 import {
@@ -90,8 +88,12 @@ export function ObjectTypeListPanel({
       : readStoredPageSize(PAGE_SIZE_STORAGE_SCOPE, 10),
   );
   const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>([]);
-  const [resourceBuildTasks, setResourceBuildTasks] = useState<BuildTask[]>([]);
-  const [resourceBuildTasksLoading, setResourceBuildTasksLoading] = useState(false);
+  const boundResourceIds = useMemo(
+    () => items.map((item) => item.dataSource?.id),
+    [items],
+  );
+  const { buildTasksByResourceId, loading: resourceBuildTasksLoading } =
+    useResourceIndexStates(boundResourceIds);
 
   useEffect(() => {
     const nextKeyword = searchParams.get("q") ?? "";
@@ -167,56 +169,6 @@ export function ObjectTypeListPanel({
     sortBy,
     sortDirection,
   ]);
-
-  const boundResourceIds = useMemo(
-    () =>
-      Array.from(
-        new Set(items.map((item) => item.dataSource?.id).filter((id): id is string => !!id)),
-      ),
-    [items],
-  );
-
-  useEffect(() => {
-    if (boundResourceIds.length === 0) {
-      setResourceBuildTasks([]);
-      setResourceBuildTasksLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setResourceBuildTasksLoading(true);
-
-    void Promise.all(
-      boundResourceIds.map((resourceId) => listBuildTasks({ resourceId, silent: true })),
-    )
-      .then((taskGroups) => {
-        if (!cancelled) {
-          setResourceBuildTasks(taskGroups.flat());
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setResourceBuildTasks([]);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setResourceBuildTasksLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [boundResourceIds]);
-
-  const buildTasksByResourceId = useMemo(() => {
-    const next = new Map<string, BuildTask[]>();
-    resourceBuildTasks.forEach((task) => {
-      next.set(task.resourceId, [...(next.get(task.resourceId) ?? []), task]);
-    });
-    return next;
-  }, [resourceBuildTasks]);
 
   const tagOptions = useMemo(() => {
     const tags = new Set<string>();
@@ -422,7 +374,7 @@ export function ObjectTypeListPanel({
 
         const label = resourceBuildTasksLoading
           ? t("knowledgeNetwork.objectTypeDataViewIndexLoading")
-          : formatIndexStateLabel(indexStateOf(buildTasksByResourceId.get(resourceId) ?? []), t);
+          : formatResourceIndexStateLabel(buildTasksByResourceId.get(resourceId) ?? [], t);
 
         return (
           <button

--- a/src/modules/knowledge-network/components/preview/OntologyGraphCard.tsx
+++ b/src/modules/knowledge-network/components/preview/OntologyGraphCard.tsx
@@ -32,19 +32,25 @@ import type {
   KnowledgeNetworkRelationTypeRecord,
 } from "@/modules/knowledge-network/types/knowledge-network";
 import { buildModelingPreviewGraph } from "@/modules/knowledge-network/utils/build-modeling-preview-graph";
+import { hasServingResourceIndex } from "@/modules/knowledge-network/utils/resource-index-state";
+import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
 
 import styles from "./OntologyGraphCard.module.css";
 
 type OntologyGraphCardProps = {
+  buildTasksByResourceId?: Map<string, BuildTask[]>;
   networkId: string;
   objectTypes?: KnowledgeNetworkObjectTypeRecord[];
   relationTypes?: KnowledgeNetworkRelationTypeRecord[];
+  resourceIndexLoading?: boolean;
 };
 
 export function OntologyGraphCard({
+  buildTasksByResourceId,
   networkId,
   objectTypes: objectTypesProp,
   relationTypes: relationTypesProp,
+  resourceIndexLoading = false,
 }: OntologyGraphCardProps) {
   const { t } = useTranslation();
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -95,10 +101,23 @@ export function OntologyGraphCard({
     [objectTypes, relationTypes],
   );
 
-  const indexedIds = useMemo(
-    () => new Set(objectTypes.filter((item) => item.hasIndex).map((item) => item.id)),
-    [objectTypes],
-  );
+  const indexedIds = useMemo(() => {
+    if (buildTasksByResourceId) {
+      return new Set(
+        objectTypes
+          .filter((item) => {
+            const resourceId = item.dataSource?.id;
+            if (!resourceId) {
+              return false;
+            }
+            return hasServingResourceIndex(buildTasksByResourceId.get(resourceId) ?? []);
+          })
+          .map((item) => item.id),
+      );
+    }
+
+    return new Set(objectTypes.filter((item) => item.hasIndex).map((item) => item.id));
+  }, [buildTasksByResourceId, objectTypes]);
 
   // 概念分组成员（节点 → 分组 id），供「按逻辑分组」排列聚类。各组取详情拿成员对象类。
   const [groupOf, setGroupOf] = useState<Map<string, string>>(new Map());
@@ -163,9 +182,11 @@ export function OntologyGraphCard({
           </div>
           <aside className={styles.graphAside}>
             <OntologyInspectorPanel
+              buildTasksByResourceId={buildTasksByResourceId}
               networkId={networkId}
               objectTypes={objectTypes}
               relationTypes={relationTypes}
+              resourceIndexLoading={resourceIndexLoading}
               selectedId={selectedId}
               onSelect={setSelectedId}
             />

--- a/src/modules/knowledge-network/components/preview/OntologyInspectorPanel.tsx
+++ b/src/modules/knowledge-network/components/preview/OntologyInspectorPanel.tsx
@@ -18,26 +18,62 @@ import type {
   KnowledgeNetworkRelationTypeRecord,
   ObjectTypeDetail,
 } from "@/modules/knowledge-network/types/knowledge-network";
+import {
+  formatResourceIndexStateLabel,
+  hasServingResourceIndex,
+} from "@/modules/knowledge-network/utils/resource-index-state";
+import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
 
 import styles from "./OntologyInspectorPanel.module.css";
 
 type OntologyInspectorPanelProps = {
+  buildTasksByResourceId?: Map<string, BuildTask[]>;
   networkId: string;
   objectTypes: KnowledgeNetworkObjectTypeRecord[];
   relationTypes: KnowledgeNetworkRelationTypeRecord[];
+  resourceIndexLoading?: boolean;
   selectedId: string | null;
   onSelect: (id: string | null) => void;
 };
 
 export function OntologyInspectorPanel({
+  buildTasksByResourceId,
   networkId,
   objectTypes,
   relationTypes,
+  resourceIndexLoading = false,
   selectedId,
   onSelect,
 }: OntologyInspectorPanelProps) {
   const { t } = useTranslation();
   const entity = objectTypes.find((item) => item.id === selectedId) ?? null;
+
+  const resolveIndexLabel = (record: KnowledgeNetworkObjectTypeRecord) => {
+    const resourceId = record.dataSource?.id;
+    if (!resourceId) {
+      return "—";
+    }
+    if (buildTasksByResourceId) {
+      if (resourceIndexLoading) {
+        return t("knowledgeNetwork.objectTypeDataViewIndexLoading");
+      }
+      return formatResourceIndexStateLabel(buildTasksByResourceId.get(resourceId) ?? [], t);
+    }
+    return record.hasIndex
+      ? t("knowledgeNetwork.previewIndexed")
+      : t("knowledgeNetwork.previewNotIndexed");
+  };
+
+  const hasIndexedLegend = (record: KnowledgeNetworkObjectTypeRecord) => {
+    const resourceId = record.dataSource?.id;
+    if (buildTasksByResourceId && resourceId) {
+      if (resourceIndexLoading) {
+        return false;
+      }
+      return hasServingResourceIndex(buildTasksByResourceId.get(resourceId) ?? []);
+    }
+    return record.hasIndex;
+  };
 
   const [detail, setDetail] = useState<ObjectTypeDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
@@ -89,7 +125,7 @@ export function OntologyInspectorPanel({
             >
               <span className={styles.dot} style={{ background: item.color || "#2e68ff" }} />
               <span className={styles.legendName}>{item.name}</span>
-              {item.hasIndex ? <span className={styles.legendIndexed} /> : null}
+              {hasIndexedLegend(item) ? <span className={styles.legendIndexed} /> : null}
             </button>
           ))}
         </div>
@@ -107,11 +143,7 @@ export function OntologyInspectorPanel({
         <span className={styles.headDot} style={{ background: entity.color || "#2e68ff" }} />
         <div className={styles.headTitle}>
           <strong>{entity.name}</strong>
-          <span>
-            {entity.hasIndex
-              ? t("knowledgeNetwork.previewIndexed")
-              : t("knowledgeNetwork.previewNotIndexed")}
-          </span>
+          <span>{resolveIndexLabel(entity)}</span>
         </div>
         <button
           type="button"
@@ -162,11 +194,7 @@ export function OntologyInspectorPanel({
         {detail?.dataSource ? (
           <div className={styles.bindCard}>
             <span className={styles.bindName}>{detail.dataSource.name}</span>
-            <Tag color={entity.hasIndex ? "success" : "default"} bordered={false}>
-              {entity.hasIndex
-                ? t("knowledgeNetwork.previewIndexed")
-                : t("knowledgeNetwork.previewNotIndexed")}
-            </Tag>
+            <Tag bordered={false}>{resolveIndexLabel(entity)}</Tag>
           </div>
         ) : (
           <div className={styles.bindNone}>{t("knowledgeNetwork.previewNoBind")}</div>

--- a/src/modules/knowledge-network/components/preview/OverviewOntologyBlock.module.css
+++ b/src/modules/knowledge-network/components/preview/OverviewOntologyBlock.module.css
@@ -46,6 +46,14 @@
   font-size: 12px;
 }
 
+.loadingPlaceholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  padding: 24px;
+}
+
 .tabs {
   background: #ffffff;
   border: 1px solid #d9e0ea;

--- a/src/modules/knowledge-network/components/preview/OverviewOntologyBlock.tsx
+++ b/src/modules/knowledge-network/components/preview/OverviewOntologyBlock.tsx
@@ -6,19 +6,21 @@
  */
 
 /**
- * 概述页本体区块 —— 一次拉取实体类 / 关系类（含明细），渲染本体图谱 +
- * 本体结构 / 数据绑定 表格。所有取数集中在此，避免重复请求。
+ * 概述页本体区块 —— 进入页面默认展示「本体预览」图谱；「本体结构」表格
+ * 在用户展开后再拉取明细，避免一次性加载全部对象类详情。
  */
 
 import { DownOutlined, RightOutlined } from "@ant-design/icons";
 import { Spin, Table, Tabs, Tag } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import type { CSSProperties } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { OntologyGraphCard } from "@/modules/knowledge-network/components/preview/OntologyGraphCard";
+import { useResourceIndexStates } from "@/modules/knowledge-network/hooks/useResourceIndexStates";
+import { formatResourceIndexStateLabel } from "@/modules/knowledge-network/utils/resource-index-state";
 import {
   getKnowledgeNetworkObjectTypeDetail,
   listKnowledgeNetworkObjectTypes,
@@ -50,7 +52,7 @@ export function OverviewOntologyBlock({
   const [objectTypes, setObjectTypes] = useState<KnowledgeNetworkObjectTypeRecord[]>([]);
   const [relationTypes, setRelationTypes] = useState<KnowledgeNetworkRelationTypeRecord[]>([]);
   const [detailById, setDetailById] = useState<Record<string, ObjectTypeDetail | null>>({});
-  const [structureLoading, setStructureLoading] = useState(true);
+  const [previewLoading, setPreviewLoading] = useState(true);
   const [detailLoading, setDetailLoading] = useState(false);
   const [entityPage, setEntityPage] = useState(1);
   const [entityPageSize, setEntityPageSize] = useState(10);
@@ -61,7 +63,9 @@ export function OverviewOntologyBlock({
 
   useEffect(() => {
     let cancelled = false;
-    setStructureLoading(true);
+    setPreviewLoading(true);
+    setObjectTypes([]);
+    setRelationTypes([]);
     setDetailById({});
     setEntityPage(1);
     setRelationPage(1);
@@ -78,20 +82,6 @@ export function OverviewOntologyBlock({
         }
         setObjectTypes(objects);
         setRelationTypes(relations);
-
-        const details = await Promise.all(
-          objects.map((item) =>
-            getKnowledgeNetworkObjectTypeDetail(networkId, item.id).catch(() => null),
-          ),
-        );
-        if (cancelled) {
-          return;
-        }
-        const map: Record<string, ObjectTypeDetail | null> = {};
-        objects.forEach((item, index) => {
-          map[item.id] = details[index] ?? null;
-        });
-        setDetailById(map);
       } catch {
         if (!cancelled) {
           setObjectTypes([]);
@@ -99,7 +89,7 @@ export function OverviewOntologyBlock({
         }
       } finally {
         if (!cancelled) {
-          setStructureLoading(false);
+          setPreviewLoading(false);
         }
       }
     })();
@@ -176,7 +166,31 @@ export function OverviewOntologyBlock({
     [objectTypes],
   );
 
-  const entityColumns: ColumnsType<KnowledgeNetworkObjectTypeRecord> = [
+  const boundResourceIds = useMemo(
+    () => objectTypes.map((item) => item.dataSource?.id),
+    [objectTypes],
+  );
+  const { buildTasksByResourceId, loading: resourceIndexLoading } =
+    useResourceIndexStates(boundResourceIds);
+
+  const renderResourceIndexState = useCallback(
+    (entity: KnowledgeNetworkObjectTypeRecord) => {
+      const resourceId = entity.dataSource?.id;
+      if (!resourceId) {
+        return <span className={styles.muted}>—</span>;
+      }
+
+      const label = resourceIndexLoading
+        ? t("knowledgeNetwork.objectTypeDataViewIndexLoading")
+        : formatResourceIndexStateLabel(buildTasksByResourceId.get(resourceId) ?? [], t);
+
+      return <span>{label}</span>;
+    },
+    [buildTasksByResourceId, resourceIndexLoading, t],
+  );
+
+  const entityColumns: ColumnsType<KnowledgeNetworkObjectTypeRecord> = useMemo(
+    () => [
     {
       title: t("knowledgeNetwork.previewEntityClasses"),
       key: "name",
@@ -200,15 +214,8 @@ export function OverviewOntologyBlock({
     {
       title: t("knowledgeNetwork.previewColIndex"),
       key: "index",
-      width: 110,
-      render: (_, entity) =>
-        entity.hasIndex ? (
-          <Tag color="success" bordered={false}>
-            {t("knowledgeNetwork.previewIndexed")}
-          </Tag>
-        ) : (
-          <span className={styles.muted}>{t("knowledgeNetwork.previewNotIndexed")}</span>
-        ),
+      width: 140,
+      render: (_, entity) => renderResourceIndexState(entity),
     },
     {
       title: t("knowledgeNetwork.previewColConceptGroups"),
@@ -224,7 +231,9 @@ export function OverviewOntologyBlock({
           <span className={styles.muted}>—</span>
         ),
     },
-  ];
+  ],
+    [detailById, hubIds, renderResourceIndexState, t],
+  );
 
   const relationColumns: ColumnsType<KnowledgeNetworkRelationTypeRecord> = [
     {
@@ -267,43 +276,39 @@ export function OverviewOntologyBlock({
     },
   ];
 
-  const bindingColumns: ColumnsType<KnowledgeNetworkObjectTypeRecord> = [
-    {
-      title: t("knowledgeNetwork.previewEntityClasses"),
-      key: "name",
-      render: (_, entity) => (
-        <span className={styles.tblName}>
-          <span className={styles.dot} style={{ background: entity.color || DEFAULT_COLOR }} />
-          <span>{entity.name}</span>
-        </span>
-      ),
-    },
-    {
-      title: t("knowledgeNetwork.previewColBoundResource"),
-      key: "resource",
-      render: (_, entity) => {
-        const detail = detailById[entity.id];
-        return detail?.dataSource ? (
-          <span className={styles.resourceName}>{detail.dataSource.name}</span>
-        ) : (
-          <span className={styles.muted}>{t("knowledgeNetwork.previewUnbound")}</span>
-        );
-      },
-    },
-    {
-      title: t("knowledgeNetwork.previewColIndexState"),
-      key: "indexState",
-      width: 120,
-      render: (_, entity) =>
-        entity.hasIndex ? (
-          <Tag color="success" bordered={false}>
-            {t("knowledgeNetwork.previewIndexed")}
-          </Tag>
-        ) : (
-          <Tag bordered={false}>{t("knowledgeNetwork.previewNotIndexed")}</Tag>
+  const bindingColumns: ColumnsType<KnowledgeNetworkObjectTypeRecord> = useMemo(
+    () => [
+      {
+        title: t("knowledgeNetwork.previewEntityClasses"),
+        key: "name",
+        render: (_, entity) => (
+          <span className={styles.tblName}>
+            <span className={styles.dot} style={{ background: entity.color || DEFAULT_COLOR }} />
+            <span>{entity.name}</span>
+          </span>
         ),
-    },
-  ];
+      },
+      {
+        title: t("knowledgeNetwork.previewColBoundResource"),
+        key: "resource",
+        render: (_, entity) => {
+          const resource = entity.dataSource ?? detailById[entity.id]?.dataSource;
+          return resource ? (
+            <span className={styles.resourceName}>{resource.name}</span>
+          ) : (
+            <span className={styles.muted}>{t("knowledgeNetwork.previewUnbound")}</span>
+          );
+        },
+      },
+      {
+        title: t("knowledgeNetwork.previewColIndexState"),
+        key: "indexState",
+        width: 140,
+        render: (_, entity) => renderResourceIndexState(entity),
+      },
+    ],
+    [detailById, renderResourceIndexState, t],
+  );
 
   const pagedObjectTypes = useMemo(() => {
     const start = (entityPage - 1) * entityPageSize;
@@ -322,119 +327,65 @@ export function OverviewOntologyBlock({
 
   return (
     <div className={styles.block}>
-      <OntologyGraphCard
-        networkId={networkId}
-        objectTypes={objectTypes}
-        relationTypes={relationTypes}
-      />
+      <Spin spinning={previewLoading}>
+        <OntologyGraphCard
+          buildTasksByResourceId={buildTasksByResourceId}
+          networkId={networkId}
+          objectTypes={objectTypes}
+          relationTypes={relationTypes}
+          resourceIndexLoading={resourceIndexLoading}
+        />
+      </Spin>
 
-      {objectTypes.length > 0 || structureLoading ? (
-        <Spin spinning={structureLoading}>
-          <div className={styles.structureCard}>
-            <button
-              className={`${styles.structureToggle} ${detailsExpanded ? styles.structureToggleExpanded : ""}`}
-              onClick={onToggleDetails}
-              type="button"
-            >
-              <span>{t("knowledgeNetwork.previewTabOntology")}</span>
-              <span className={styles.structureToggleIcon}>
-                {detailsExpanded ? <DownOutlined /> : <RightOutlined />}
-              </span>
-            </button>
-            {detailsExpanded ? (
+      {objectTypes.length > 0 || previewLoading ? (
+        <div className={styles.structureCard}>
+          <button
+            className={`${styles.structureToggle} ${detailsExpanded ? styles.structureToggleExpanded : ""}`}
+            onClick={onToggleDetails}
+            type="button"
+          >
+            <span>{t("knowledgeNetwork.previewTabOntology")}</span>
+            <span className={styles.structureToggleIcon}>
+              {detailsExpanded ? <DownOutlined /> : <RightOutlined />}
+            </span>
+          </button>
+          {detailsExpanded ? (
+            previewLoading ? (
+              <div className={styles.loadingPlaceholder}>
+                <Spin />
+              </div>
+            ) : (
               <Spin spinning={detailLoading}>
                 <Tabs
-                  className={styles.tabs}
-                  defaultActiveKey="ontology"
-                  items={[
-                    {
-                      key: "ontology",
-                      label: t("knowledgeNetwork.previewTabOntology"),
-                      children: (
-                        <div className={styles.sectionGrid}>
-                          <div className={styles.sectionCard}>
-                            <div className={styles.sectionCardTitle}>
-                              {t("knowledgeNetwork.previewEntityClasses")}
-                              <span className={styles.badge}>{objectTypes.length}</span>
-                            </div>
-                            <Table
-                              rowKey="id"
-                              size="small"
-                              columns={entityColumns}
-                              dataSource={pagedObjectTypes}
-                              pagination={false}
-                            />
-                            {objectTypes.length > 0 ? (
-                              <div className={styles.paginationBar}>
-                                <TablePaginationBar
-                                  current={entityPage}
-                                  onChange={(page, pageSize) => {
-                                    setEntityPage(page);
-                                    setEntityPageSize(pageSize);
-                                  }}
-                                  pageSize={entityPageSize}
-                                  showSizeChanger
-                                  showTotal={(total) => t("common.total", { total })}
-                                  total={objectTypes.length}
-                                />
-                              </div>
-                            ) : null}
-                          </div>
-                          <div className={`${styles.sectionCard} ${styles.sectionCardSecondary}`}>
-                            <div className={styles.sectionCardTitle}>
-                              {t("knowledgeNetwork.previewRelationClasses")}
-                              <span className={styles.badge}>{relationTypes.length}</span>
-                            </div>
-                            <Table
-                              rowKey="id"
-                              size="small"
-                              columns={relationColumns}
-                              dataSource={pagedRelationTypes}
-                              pagination={false}
-                            />
-                            {relationTypes.length > 0 ? (
-                              <div className={styles.paginationBar}>
-                                <TablePaginationBar
-                                  current={relationPage}
-                                  onChange={(page, pageSize) => {
-                                    setRelationPage(page);
-                                    setRelationPageSize(pageSize);
-                                  }}
-                                  pageSize={relationPageSize}
-                                  showSizeChanger
-                                  showTotal={(total) => t("common.total", { total })}
-                                  total={relationTypes.length}
-                                />
-                              </div>
-                            ) : null}
-                          </div>
-                        </div>
-                      ),
-                    },
-                    {
-                      key: "binding",
-                      label: t("knowledgeNetwork.previewTabBinding"),
-                      children: (
+                className={styles.tabs}
+                defaultActiveKey="ontology"
+                items={[
+                  {
+                    key: "ontology",
+                    label: t("knowledgeNetwork.previewTabOntology"),
+                    children: (
+                      <div className={styles.sectionGrid}>
                         <div className={styles.sectionCard}>
                           <div className={styles.sectionCardTitle}>
-                            {t("knowledgeNetwork.previewColBoundResource")}
+                            {t("knowledgeNetwork.previewEntityClasses")}
+                            <span className={styles.badge}>{objectTypes.length}</span>
                           </div>
                           <Table
                             rowKey="id"
                             size="small"
-                            columns={bindingColumns}
-                            dataSource={pagedBindingObjectTypes}
+                            columns={entityColumns}
+                            dataSource={pagedObjectTypes}
                             pagination={false}
                           />
                           {objectTypes.length > 0 ? (
                             <div className={styles.paginationBar}>
                               <TablePaginationBar
-                                current={bindingPage}
+                                current={entityPage}
                                 onChange={(page, pageSize) => {
-                                  setBindingPage(page);
-                                  setBindingPageSize(pageSize);
+                                  setEntityPage(page);
+                                  setEntityPageSize(pageSize);
                                 }}
-                                pageSize={bindingPageSize}
+                                pageSize={entityPageSize}
                                 showSizeChanger
                                 showTotal={(total) => t("common.total", { total })}
                                 total={objectTypes.length}
@@ -442,14 +393,76 @@ export function OverviewOntologyBlock({
                             </div>
                           ) : null}
                         </div>
-                      ),
-                    },
-                  ]}
-                />
-              </Spin>
-            ) : null}
-          </div>
-        </Spin>
+                        <div className={`${styles.sectionCard} ${styles.sectionCardSecondary}`}>
+                          <div className={styles.sectionCardTitle}>
+                            {t("knowledgeNetwork.previewRelationClasses")}
+                            <span className={styles.badge}>{relationTypes.length}</span>
+                          </div>
+                          <Table
+                            rowKey="id"
+                            size="small"
+                            columns={relationColumns}
+                            dataSource={pagedRelationTypes}
+                            pagination={false}
+                          />
+                          {relationTypes.length > 0 ? (
+                            <div className={styles.paginationBar}>
+                              <TablePaginationBar
+                                current={relationPage}
+                                onChange={(page, pageSize) => {
+                                  setRelationPage(page);
+                                  setRelationPageSize(pageSize);
+                                }}
+                                pageSize={relationPageSize}
+                                showSizeChanger
+                                showTotal={(total) => t("common.total", { total })}
+                                total={relationTypes.length}
+                              />
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
+                    ),
+                  },
+                  {
+                    key: "binding",
+                    label: t("knowledgeNetwork.previewTabBinding"),
+                    children: (
+                      <div className={styles.sectionCard}>
+                        <div className={styles.sectionCardTitle}>
+                          {t("knowledgeNetwork.previewColBoundResource")}
+                        </div>
+                        <Table
+                          rowKey="id"
+                          size="small"
+                          columns={bindingColumns}
+                          dataSource={pagedBindingObjectTypes}
+                          pagination={false}
+                        />
+                        {objectTypes.length > 0 ? (
+                          <div className={styles.paginationBar}>
+                            <TablePaginationBar
+                              current={bindingPage}
+                              onChange={(page, pageSize) => {
+                                setBindingPage(page);
+                                setBindingPageSize(pageSize);
+                              }}
+                              pageSize={bindingPageSize}
+                              showSizeChanger
+                              showTotal={(total) => t("common.total", { total })}
+                              total={objectTypes.length}
+                            />
+                          </div>
+                        ) : null}
+                      </div>
+                    ),
+                  },
+                ]}
+              />
+            </Spin>
+            )
+          ) : null}
+        </div>
       ) : null}
     </div>
   );

--- a/src/modules/knowledge-network/hooks/useResourceIndexStates.ts
+++ b/src/modules/knowledge-network/hooks/useResourceIndexStates.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { listBuildTasks } from "@/modules/data-catalog/services/build-task.service";
+import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+
+/** Load data-catalog index build tasks for a deduplicated set of resource ids. */
+export function useResourceIndexStates(resourceIds: Array<string | undefined>) {
+  const boundResourceIds = useMemo(
+    () =>
+      Array.from(new Set(resourceIds.filter((id): id is string => Boolean(id)))),
+    [resourceIds],
+  );
+
+  const [resourceBuildTasks, setResourceBuildTasks] = useState<BuildTask[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (boundResourceIds.length === 0) {
+      setResourceBuildTasks([]);
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    void Promise.all(
+      boundResourceIds.map((resourceId) => listBuildTasks({ resourceId, silent: true })),
+    )
+      .then((taskGroups) => {
+        if (!cancelled) {
+          setResourceBuildTasks(taskGroups.flat());
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResourceBuildTasks([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [boundResourceIds]);
+
+  const buildTasksByResourceId = useMemo(() => {
+    const next = new Map<string, BuildTask[]>();
+    resourceBuildTasks.forEach((task) => {
+      next.set(task.resourceId, [...(next.get(task.resourceId) ?? []), task]);
+    });
+    return next;
+  }, [resourceBuildTasks]);
+
+  return { buildTasksByResourceId, loading };
+}

--- a/src/modules/knowledge-network/hooks/useResourceIndexStates.ts
+++ b/src/modules/knowledge-network/hooks/useResourceIndexStates.ts
@@ -7,8 +7,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import { listBuildTasks } from "@/modules/data-catalog/services/build-task.service";
 import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+import { loadResourceIndexBuildTasks } from "@/modules/knowledge-network/utils/load-resource-index-build-tasks";
 
 /** Load data-catalog index build tasks for a deduplicated set of resource ids. */
 export function useResourceIndexStates(resourceIds: Array<string | undefined>) {
@@ -31,12 +31,10 @@ export function useResourceIndexStates(resourceIds: Array<string | undefined>) {
     let cancelled = false;
     setLoading(true);
 
-    void Promise.all(
-      boundResourceIds.map((resourceId) => listBuildTasks({ resourceId, silent: true })),
-    )
-      .then((taskGroups) => {
+    void loadResourceIndexBuildTasks(boundResourceIds)
+      .then((tasks) => {
         if (!cancelled) {
-          setResourceBuildTasks(taskGroups.flat());
+          setResourceBuildTasks(tasks);
         }
       })
       .catch(() => {

--- a/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
+++ b/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
@@ -69,8 +69,10 @@ export function KnowledgeNetworkWorkspaceScene({
     detail,
     detailError,
     detailLoading,
+    loadRecentObjects,
     loadWorkspaceData,
     metrics,
+    recentLoading,
     recentObjects,
     sectionError,
     sectionLoading,
@@ -190,9 +192,10 @@ export function KnowledgeNetworkWorkspaceScene({
         <WorkspaceOverviewSection
           detail={detail}
           detailLoading={detailLoading}
+          loadRecentObjects={loadRecentObjects}
           networkId={activeNetworkId}
           onEdit={() => setNetworkFormOpen(true)}
-          recentLoading={sectionLoading}
+          recentLoading={recentLoading}
           recentObjects={recentObjects}
         />
       );

--- a/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
+++ b/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
@@ -75,7 +75,6 @@ export function KnowledgeNetworkWorkspaceScene({
     recentLoading,
     recentObjects,
     sectionError,
-    sectionLoading,
   } = workspaceData;
 
   useEffect(() => {

--- a/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.tsx
@@ -41,6 +41,7 @@ import styles from "../KnowledgeNetworkWorkspaceScene.module.css";
 type WorkspaceOverviewSectionProps = {
   detail: KnowledgeNetworkRecord | null;
   detailLoading?: boolean;
+  loadRecentObjects: () => Promise<void>;
   networkId: string;
   onEdit: () => void;
   recentLoading?: boolean;
@@ -54,6 +55,7 @@ function formatOverviewCount(value?: number) {
 export function WorkspaceOverviewSection({
   detail,
   detailLoading = false,
+  loadRecentObjects,
   networkId,
   onEdit,
   recentLoading = false,
@@ -130,6 +132,14 @@ export function WorkspaceOverviewSection({
   useEffect(() => {
     setRecentPage(1);
   }, [networkId]);
+
+  useEffect(() => {
+    if (!recentExpanded) {
+      return;
+    }
+
+    void loadRecentObjects();
+  }, [loadRecentObjects, networkId, recentExpanded]);
 
   return (
     <div className={styles.overviewBox}>

--- a/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
+++ b/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
@@ -57,13 +57,43 @@ export function useWorkspaceData(
   const [tasks, setTasks] = useState<KnowledgeNetworkTaskRecord[]>([]);
   const [detailLoading, setDetailLoading] = useState(true);
   const [sectionLoading, setSectionLoading] = useState(false);
+  const [recentLoading, setRecentLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
   const [sectionError, setSectionError] = useState<string | null>(null);
   const loadedSectionsRef = useRef<Set<string>>(new Set());
+  const recentLoadedRef = useRef(false);
 
   const clearSectionCache = useCallback(() => {
     loadedSectionsRef.current.clear();
+    recentLoadedRef.current = false;
   }, []);
+
+  const loadRecentObjects = useCallback(
+    async (options?: { force?: boolean }) => {
+      if (!networkId) {
+        return;
+      }
+
+      if (!options?.force && recentLoadedRef.current) {
+        return;
+      }
+
+      setRecentLoading(true);
+      setSectionError(null);
+
+      try {
+        setRecentObjects(await listKnowledgeNetworkRecentObjects(networkId));
+        recentLoadedRef.current = true;
+      } catch (error) {
+        logServiceFallback("useWorkspaceData.overview.recentObjects", error);
+        setRecentObjects([]);
+        setSectionError(extractRequestErrorMessage(error));
+      } finally {
+        setRecentLoading(false);
+      }
+    },
+    [networkId],
+  );
 
   const loadDetail = useCallback(async () => {
     if (!networkId) {
@@ -99,23 +129,8 @@ export function useWorkspaceData(
 
       try {
         switch (targetSection) {
-          case "overview": {
-            const recentResult = await Promise.allSettled([
-              listKnowledgeNetworkRecentObjects(networkId),
-            ]);
-
-            if (recentResult[0]?.status === "fulfilled") {
-              setRecentObjects(recentResult[0].value);
-            } else {
-              const recentError: unknown = recentResult[0]?.reason;
-              logServiceFallback("useWorkspaceData.overview.recentObjects", recentError);
-              setRecentObjects([]);
-              setSectionError(
-                extractRequestErrorMessage(recentError ?? "Failed to load recent objects"),
-              );
-            }
+          case "overview":
             break;
-          }
           case "preview": {
             const [objectTypeResult, relationTypeResult] = await Promise.all([
               listKnowledgeNetworkObjectTypes(networkId),
@@ -177,6 +192,7 @@ export function useWorkspaceData(
 
   useEffect(() => {
     clearSectionCache();
+    setRecentObjects([]);
     void loadDetail();
   }, [clearSectionCache, loadDetail, networkId]);
 
@@ -267,10 +283,12 @@ export function useWorkspaceData(
     loadError: detailError,
     loading: sectionLoading,
     loadWorkspaceData,
+    loadRecentObjects,
     metricApiUnavailable,
     metrics,
     objectTypes,
     recentObjects,
+    recentLoading,
     relationTypes,
     reloadActionTypes,
     reloadConceptGroups,

--- a/src/modules/knowledge-network/utils/load-resource-index-build-tasks.test.ts
+++ b/src/modules/knowledge-network/utils/load-resource-index-build-tasks.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+import {
+  loadResourceIndexBuildTasks,
+  uniqueCatalogIdsFromResourceCatalogMap,
+} from "@/modules/knowledge-network/utils/load-resource-index-build-tasks";
+
+vi.mock("@/modules/data-catalog/services/resource.service", () => ({
+  getCatalogResources: vi.fn(),
+}));
+
+vi.mock("@/modules/data-catalog/services/build-task.service", () => ({
+  listBuildTasks: vi.fn(),
+}));
+
+import { listBuildTasks } from "@/modules/data-catalog/services/build-task.service";
+import { getCatalogResources } from "@/modules/data-catalog/services/resource.service";
+
+const mockedGetCatalogResources = vi.mocked(getCatalogResources);
+const mockedListBuildTasks = vi.mocked(listBuildTasks);
+
+function buildTask(resourceId: string, id = `${resourceId}-task`): BuildTask {
+  return {
+    id,
+    resourceId,
+    mode: "batch",
+    status: "succeeded",
+    embeddingFields: [],
+    buildKeyFields: [],
+    embeddingModel: "",
+    embeddingDegraded: false,
+    modelDimensions: 0,
+    fulltextFields: [],
+    fulltextAnalyzer: "",
+    totalCount: 1,
+    syncedCount: 1,
+    vectorizedCount: 1,
+    indexUsable: true,
+    failureDetail: "",
+    createdAt: 1,
+    createTime: "-",
+    finishTime: null,
+    lastEventAt: null,
+    error: null,
+  };
+}
+
+describe("uniqueCatalogIdsFromResourceCatalogMap", () => {
+  it("deduplicates catalog ids and ignores missing values", () => {
+    const map = new Map<string, string | undefined>([
+      ["r1", "cat-a"],
+      ["r2", "cat-a"],
+      ["r3", "cat-b"],
+      ["r4", undefined],
+    ]);
+
+    expect(uniqueCatalogIdsFromResourceCatalogMap(map)).toEqual(["cat-a", "cat-b"]);
+  });
+});
+
+describe("loadResourceIndexBuildTasks", () => {
+  beforeEach(() => {
+    mockedGetCatalogResources.mockReset();
+    mockedListBuildTasks.mockReset();
+  });
+
+  it("loads build tasks once per catalog and filters to bound resources", async () => {
+    mockedGetCatalogResources.mockResolvedValue([
+      { id: "r1", catalogId: "cat-a" } as never,
+      { id: "r2", catalogId: "cat-a" } as never,
+      { id: "r3", catalogId: "cat-b" } as never,
+    ]);
+    mockedListBuildTasks.mockImplementation(async ({ catalogId, resourceId }) => {
+      if (catalogId === "cat-a") {
+        return [buildTask("r1"), buildTask("r2"), buildTask("r9", "other-task")];
+      }
+      if (catalogId === "cat-b") {
+        return [buildTask("r3")];
+      }
+      if (resourceId) {
+        return [buildTask(resourceId, `${resourceId}-fallback`)];
+      }
+      return [];
+    });
+
+    const tasks = await loadResourceIndexBuildTasks(["r1", "r2", "r3"]);
+
+    expect(mockedGetCatalogResources).toHaveBeenCalledWith(["r1", "r2", "r3"]);
+    expect(mockedListBuildTasks).toHaveBeenCalledTimes(2);
+    expect(mockedListBuildTasks).toHaveBeenCalledWith({ catalogId: "cat-a", silent: true });
+    expect(mockedListBuildTasks).toHaveBeenCalledWith({ catalogId: "cat-b", silent: true });
+    expect(tasks.map((task) => task.resourceId).sort()).toEqual(["r1", "r2", "r3"]);
+  });
+
+  it("falls back to resource-scoped queries when catalog resolution fails", async () => {
+    mockedGetCatalogResources.mockResolvedValue([{ id: "r1", catalogId: "cat-a" } as never]);
+    mockedListBuildTasks.mockImplementation(async ({ catalogId, resourceId }) => {
+      if (catalogId === "cat-a") {
+        return [buildTask("r1")];
+      }
+      if (resourceId === "r2") {
+        return [buildTask("r2")];
+      }
+      return [];
+    });
+
+    const tasks = await loadResourceIndexBuildTasks(["r1", "r2"]);
+
+    expect(mockedListBuildTasks).toHaveBeenCalledWith({ catalogId: "cat-a", silent: true });
+    expect(mockedListBuildTasks).toHaveBeenCalledWith({ resourceId: "r2", silent: true });
+    expect(tasks.map((task) => task.resourceId).sort()).toEqual(["r1", "r2"]);
+  });
+});

--- a/src/modules/knowledge-network/utils/load-resource-index-build-tasks.test.ts
+++ b/src/modules/knowledge-network/utils/load-resource-index-build-tasks.test.ts
@@ -7,7 +7,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+import type { BuildTask, CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 import {
   loadResourceIndexBuildTasks,
   uniqueCatalogIdsFromResourceCatalogMap,
@@ -53,6 +53,22 @@ function buildTask(resourceId: string, id = `${resourceId}-task`): BuildTask {
   };
 }
 
+function catalogResource(id: string, catalogId: string): CatalogResource {
+  return {
+    id,
+    catalogId,
+    category: "table",
+    columnCount: 0,
+    description: "",
+    name: id,
+    rowCount: 0,
+    schema: [],
+    sourceIdentifier: "",
+    updateTime: "-",
+    updatedAt: 0,
+  };
+}
+
 describe("uniqueCatalogIdsFromResourceCatalogMap", () => {
   it("deduplicates catalog ids and ignores missing values", () => {
     const map = new Map<string, string | undefined>([
@@ -74,21 +90,21 @@ describe("loadResourceIndexBuildTasks", () => {
 
   it("loads build tasks once per catalog and filters to bound resources", async () => {
     mockedGetCatalogResources.mockResolvedValue([
-      { id: "r1", catalogId: "cat-a" } as never,
-      { id: "r2", catalogId: "cat-a" } as never,
-      { id: "r3", catalogId: "cat-b" } as never,
+      catalogResource("r1", "cat-a"),
+      catalogResource("r2", "cat-a"),
+      catalogResource("r3", "cat-b"),
     ]);
-    mockedListBuildTasks.mockImplementation(async ({ catalogId, resourceId }) => {
+    mockedListBuildTasks.mockImplementation(({ catalogId, resourceId }) => {
       if (catalogId === "cat-a") {
-        return [buildTask("r1"), buildTask("r2"), buildTask("r9", "other-task")];
+        return Promise.resolve([buildTask("r1"), buildTask("r2"), buildTask("r9", "other-task")]);
       }
       if (catalogId === "cat-b") {
-        return [buildTask("r3")];
+        return Promise.resolve([buildTask("r3")]);
       }
-      if (resourceId) {
-        return [buildTask(resourceId, `${resourceId}-fallback`)];
+      if (typeof resourceId === "string" && resourceId.length > 0) {
+        return Promise.resolve([buildTask(resourceId, `${resourceId}-fallback`)]);
       }
-      return [];
+      return Promise.resolve([]);
     });
 
     const tasks = await loadResourceIndexBuildTasks(["r1", "r2", "r3"]);
@@ -101,15 +117,15 @@ describe("loadResourceIndexBuildTasks", () => {
   });
 
   it("falls back to resource-scoped queries when catalog resolution fails", async () => {
-    mockedGetCatalogResources.mockResolvedValue([{ id: "r1", catalogId: "cat-a" } as never]);
-    mockedListBuildTasks.mockImplementation(async ({ catalogId, resourceId }) => {
+    mockedGetCatalogResources.mockResolvedValue([catalogResource("r1", "cat-a")]);
+    mockedListBuildTasks.mockImplementation(({ catalogId, resourceId }) => {
       if (catalogId === "cat-a") {
-        return [buildTask("r1")];
+        return Promise.resolve([buildTask("r1")]);
       }
       if (resourceId === "r2") {
-        return [buildTask("r2")];
+        return Promise.resolve([buildTask("r2")]);
       }
-      return [];
+      return Promise.resolve([]);
     });
 
     const tasks = await loadResourceIndexBuildTasks(["r1", "r2"]);

--- a/src/modules/knowledge-network/utils/load-resource-index-build-tasks.test.ts
+++ b/src/modules/knowledge-network/utils/load-resource-index-build-tasks.test.ts
@@ -94,7 +94,8 @@ describe("loadResourceIndexBuildTasks", () => {
       catalogResource("r2", "cat-a"),
       catalogResource("r3", "cat-b"),
     ]);
-    mockedListBuildTasks.mockImplementation(({ catalogId, resourceId }) => {
+    mockedListBuildTasks.mockImplementation((query = {}) => {
+      const { catalogId, resourceId } = query;
       if (catalogId === "cat-a") {
         return Promise.resolve([buildTask("r1"), buildTask("r2"), buildTask("r9", "other-task")]);
       }
@@ -118,7 +119,8 @@ describe("loadResourceIndexBuildTasks", () => {
 
   it("falls back to resource-scoped queries when catalog resolution fails", async () => {
     mockedGetCatalogResources.mockResolvedValue([catalogResource("r1", "cat-a")]);
-    mockedListBuildTasks.mockImplementation(({ catalogId, resourceId }) => {
+    mockedListBuildTasks.mockImplementation((query = {}) => {
+      const { catalogId, resourceId } = query;
       if (catalogId === "cat-a") {
         return Promise.resolve([buildTask("r1")]);
       }

--- a/src/modules/knowledge-network/utils/load-resource-index-build-tasks.ts
+++ b/src/modules/knowledge-network/utils/load-resource-index-build-tasks.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { listBuildTasks } from "@/modules/data-catalog/services/build-task.service";
+import { getCatalogResources } from "@/modules/data-catalog/services/resource.service";
+import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+
+export function uniqueCatalogIdsFromResourceCatalogMap(
+  resourceCatalogById: Map<string, string | undefined>,
+) {
+  return Array.from(
+    new Set(
+      [...resourceCatalogById.values()].filter((catalogId): catalogId is string =>
+        Boolean(catalogId),
+      ),
+    ),
+  );
+}
+
+export async function loadResourceIndexBuildTasks(
+  resourceIds: string[],
+): Promise<BuildTask[]> {
+  const boundResourceIds = Array.from(new Set(resourceIds.filter(Boolean)));
+  if (boundResourceIds.length === 0) {
+    return [];
+  }
+
+  const resourceIdSet = new Set(boundResourceIds);
+  const resources = await getCatalogResources(boundResourceIds);
+  const resourceCatalogById = new Map(resources.map((resource) => [resource.id, resource.catalogId]));
+  const catalogIds = uniqueCatalogIdsFromResourceCatalogMap(resourceCatalogById);
+  const unresolvedResourceIds = boundResourceIds.filter((resourceId) => {
+    const catalogId = resourceCatalogById.get(resourceId);
+    return !catalogId;
+  });
+
+  const [catalogTaskGroups, fallbackTaskGroups] = await Promise.all([
+    Promise.all(catalogIds.map((catalogId) => listBuildTasks({ catalogId, silent: true }))),
+    unresolvedResourceIds.length > 0
+      ? Promise.all(
+          unresolvedResourceIds.map((resourceId) =>
+            listBuildTasks({ resourceId, silent: true }),
+          ),
+        )
+      : Promise.resolve([]),
+  ]);
+
+  return [...catalogTaskGroups.flat(), ...fallbackTaskGroups.flat()].filter((task) =>
+    resourceIdSet.has(task.resourceId),
+  );
+}

--- a/src/modules/knowledge-network/utils/resource-index-state.test.ts
+++ b/src/modules/knowledge-network/utils/resource-index-state.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+import {
+  formatResourceIndexStateLabel,
+  hasServingResourceIndex,
+} from "@/modules/knowledge-network/utils/resource-index-state";
+
+const succeededTask: BuildTask = {
+  createdAt: 2,
+  id: "task-2",
+  mode: "batch",
+  resourceId: "res-1",
+  status: "succeeded",
+  syncedCount: 10,
+  totalCount: 10,
+  vectorizedCount: 10,
+};
+
+const failedTask: BuildTask = {
+  createdAt: 3,
+  id: "task-3",
+  mode: "batch",
+  resourceId: "res-1",
+  status: "failed",
+  syncedCount: 0,
+  totalCount: 10,
+  vectorizedCount: 0,
+};
+
+describe("hasServingResourceIndex", () => {
+  it("returns true when a succeeded build exists", () => {
+    expect(hasServingResourceIndex([failedTask, succeededTask])).toBe(true);
+  });
+
+  it("returns false when there are no serving tasks", () => {
+    expect(hasServingResourceIndex([])).toBe(false);
+    expect(hasServingResourceIndex([failedTask])).toBe(false);
+  });
+});
+
+describe("formatResourceIndexStateLabel", () => {
+  it("uses data-catalog index state labels", () => {
+    const t = ((key: string) => key) as never;
+    expect(formatResourceIndexStateLabel([succeededTask], t)).toBe("dataCatalog.indexState.built");
+    expect(formatResourceIndexStateLabel([], t)).toBe("dataCatalog.indexState.none");
+  });
+});

--- a/src/modules/knowledge-network/utils/resource-index-state.test.ts
+++ b/src/modules/knowledge-network/utils/resource-index-state.test.ts
@@ -13,27 +13,38 @@ import {
   hasServingResourceIndex,
 } from "@/modules/knowledge-network/utils/resource-index-state";
 
-const succeededTask: BuildTask = {
-  createdAt: 2,
-  id: "task-2",
-  mode: "batch",
-  resourceId: "res-1",
-  status: "succeeded",
-  syncedCount: 10,
-  totalCount: 10,
-  vectorizedCount: 10,
-};
+function buildTask(
+  status: BuildTask["status"],
+  overrides: Partial<BuildTask> = {},
+): BuildTask {
+  return {
+    id: "task-1",
+    resourceId: "res-1",
+    mode: "batch",
+    status,
+    embeddingFields: [],
+    buildKeyFields: [],
+    embeddingModel: "",
+    embeddingDegraded: false,
+    modelDimensions: 0,
+    fulltextFields: [],
+    fulltextAnalyzer: "",
+    totalCount: 10,
+    syncedCount: status === "succeeded" ? 10 : 0,
+    vectorizedCount: status === "succeeded" ? 10 : 0,
+    indexUsable: status === "succeeded",
+    failureDetail: "",
+    createdAt: 1,
+    createTime: "-",
+    finishTime: null,
+    lastEventAt: null,
+    error: null,
+    ...overrides,
+  };
+}
 
-const failedTask: BuildTask = {
-  createdAt: 3,
-  id: "task-3",
-  mode: "batch",
-  resourceId: "res-1",
-  status: "failed",
-  syncedCount: 0,
-  totalCount: 10,
-  vectorizedCount: 0,
-};
+const succeededTask = buildTask("succeeded", { id: "task-2", createdAt: 2 });
+const failedTask = buildTask("failed", { id: "task-3", createdAt: 3 });
 
 describe("hasServingResourceIndex", () => {
   it("returns true when a succeeded build exists", () => {

--- a/src/modules/knowledge-network/utils/resource-index-state.ts
+++ b/src/modules/knowledge-network/utils/resource-index-state.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { TFunction } from "i18next";
+
+import { formatIndexStateLabel } from "@/modules/data-catalog/lib/format-index-state";
+import { effectiveIndexOf, indexStateOf } from "@/modules/data-catalog/lib/index-state";
+import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+
+/** Whether the resource currently has a serving index (built or active streaming). */
+export function hasServingResourceIndex(tasks: BuildTask[]) {
+  return effectiveIndexOf(tasks) !== null;
+}
+
+export function formatResourceIndexStateLabel(tasks: BuildTask[], t: TFunction) {
+  return formatIndexStateLabel(indexStateOf(tasks), t);
+}


### PR DESCRIPTION
## Summary
- 在知识网络概览、对象类列表、本体图等位置展示绑定数据资源的索引构建状态（来自 data-catalog build-tasks）
- 新增 `useResourceIndexStates` hook 与索引状态格式化工具
- 优化请求策略：先批量解析 resource → catalog，再按 catalog 拉取 build-tasks，避免对每个 resource_id 并发 N+1 请求

## Test plan
- [ ] 打开知识网络概览页，确认对象类「索引状态」列展示正确
- [ ] 打开 Network 面板，确认 build-tasks 请求数显著减少（通常为 1 次 resources 批量查询 + 1~2 次 build-tasks by catalog）
- [ ] 对象类列表页索引状态列展示与概览一致
- [ ] 本体图节点/检查器中的索引状态展示正常
- [ ] `npm test -- --run src/modules/knowledge-network/utils/load-resource-index-build-tasks.test.ts`