### PR TITLE
feat(bkn-studio): 根据 scheme 自动配置 HTTPS 重定向策略

### DIFF
--- a/deploy/charts/bkn-studio/templates/ingress.yaml
+++ b/deploy/charts/bkn-studio/templates/ingress.yaml
@@ -4,10 +4,14 @@ kind: Ingress
 metadata:
   name: {{ .Values.image.name }}-ingress
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- if eq .Values.accessAddress.scheme "https" }}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- else }}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
 spec:
   {{- if .Values.ingress.ingressClass }}
   ingressClassName: {{ .Values.ingress.ingressClass }}

--- a/deploy/charts/bkn-studio/values.yaml
+++ b/deploy/charts/bkn-studio/values.yaml
@@ -25,9 +25,6 @@ service:
 # with mode:"hosted", so studio boots gate-less as the default local-admin user
 # — no login, no auth. Set false only when the deployment has no bkn-safe.
 accessAddress:
-  host: 192.168.89.193
-  path: /
-  port: 443
   scheme: https
 
 auth:

--- a/deploy/charts/bkn-studio/values.yaml
+++ b/deploy/charts/bkn-studio/values.yaml
@@ -24,6 +24,12 @@ service:
 # normal Foundry install). false = NO bkn-safe: a ConfigMap overrides config.js
 # with mode:"hosted", so studio boots gate-less as the default local-admin user
 # — no login, no auth. Set false only when the deployment has no bkn-safe.
+accessAddress:
+  host: 192.168.89.193
+  path: /
+  port: 443
+  scheme: https
+
 auth:
   enabled: true
 
@@ -33,8 +39,6 @@ auth:
 ingress:
   enabled: true
   ingressClass: class-443
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
   path: /studio
   # Also claim the bare root (Exact /) and hand it to studio's nginx, which
   # 302s / -> /studio/ — so https://<gateway>/ lands in the studio shell.


### PR DESCRIPTION
feat(bkn-studio): 根据 accessAddress.scheme 自动配置 HTTPS 重定向
- 当 accessAddress.scheme 为 https 时，启用 force-ssl-redirect 和 ssl-redirect
- 当 scheme 为 http 时，禁用 SSL 重定向