### PR TITLE
fix(model-resources): 小模型表单补齐 batch_size 与必填校验

### DIFF
--- a/src/modules/model-resources/components/models/SmallModelFormModal.tsx
+++ b/src/modules/model-resources/components/models/SmallModelFormModal.tsx
@@ -81,6 +81,7 @@ export function SmallModelFormModal({ mode, onClose, open, record }: SmallModelF
       modelType: "embedding",
       auth: "empty",
       adapter: false,
+      batchSize: 32,
     });
   }, [form, mode, open, record]);
 
@@ -268,19 +269,38 @@ export function SmallModelFormModal({ mode, onClose, open, record }: SmallModelF
         )}
         {modelTypeValue === "embedding" ? (
           <>
-            <Form.Item label={t("modelResources.models.modal.vectorDimension")} name="embeddingDim">
+            <Form.Item
+              label={t("modelResources.models.modal.vectorDimension")}
+              name="embeddingDim"
+              rules={[{ required: true, message: t("modelResources.models.modal.required") }]}
+            >
               <InputNumber controls={false} min={1} style={{ width: "100%" }} />
             </Form.Item>
-            <Form.Item label={t("modelResources.models.modal.batchSize")} name="batchSize">
+            <Form.Item
+              label={t("modelResources.models.modal.batchSize")}
+              name="batchSize"
+              rules={[{ required: true, message: t("modelResources.models.modal.required") }]}
+            >
               <InputNumber controls={false} min={1} style={{ width: "100%" }} />
             </Form.Item>
-            <Form.Item label={t("modelResources.models.modal.maxNumberOfTokens")} name="maxTokens">
+            <Form.Item
+              label={t("modelResources.models.modal.maxNumberOfTokens")}
+              name="maxTokens"
+              rules={[{ required: true, message: t("modelResources.models.modal.required") }]}
+            >
               <InputNumber controls={false} min={1} style={{ width: "100%" }} />
             </Form.Item>
           </>
         ) : null}
         {modelTypeValue === "reranker" ? (
           <>
+            <Form.Item
+              label={t("modelResources.models.modal.batchSize")}
+              name="batchSize"
+              rules={[{ required: true, message: t("modelResources.models.modal.required") }]}
+            >
+              <InputNumber controls={false} min={1} style={{ width: "100%" }} />
+            </Form.Item>
             <Form.Item label={t("modelResources.models.modal.maxNumberOfDocuments")} name="maxDocuments">
               <InputNumber controls={false} min={1} style={{ width: "100%" }} />
             </Form.Item>


### PR DESCRIPTION
## Summary
- reranker 接入表单增加必填「批次大小」，新建默认 `batchSize: 32`，避免测试/保存时报 `batch_size 参数缺失`
- embedding 的向量维度、批次大小、单次最大 Token 增加必填标识与前端校验，与后端契约对齐
- 关联 Issue: https://github.com/openbkn-ai/bkn-studio/issues/190

## Test plan
- [ ] 新建 embedding：未填向量维度 / 批次大小 / 最大 Token 时前端拦截并显示必填星标
- [ ] 新建 reranker：可见批次大小输入框，默认 32；不填时前端拦截
- [ ] 填写合法参数后，「测试连接」与「保存」请求体均包含 `batch_size`
- [ ] 回归 embedding 原有接入与编辑流程正常
