### PR TITLE
fix(knowledge-network): align sidebar metrics count with total

### DIFF
--- a/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
+++ b/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
@@ -70,7 +70,6 @@ export function KnowledgeNetworkWorkspaceScene({
     detailError,
     detailLoading,
     loadWorkspaceData,
-    metrics,
     recentObjects,
     sectionError,
     sectionLoading,
@@ -127,7 +126,7 @@ export function KnowledgeNetworkWorkspaceScene({
         key: "metrics",
         label: t("knowledgeNetwork.workspaceMetrics"),
         icon: <LineChartOutlined />,
-        count: detail?.statistics.metricsTotal ?? metrics.length,
+        count: detail?.statistics.metricsTotal ?? 0,
       });
     }
 
@@ -140,7 +139,7 @@ export function KnowledgeNetworkWorkspaceScene({
     }
 
     return items;
-  }, [detail, metrics.length, t]);
+  }, [detail, t]);
 
   const primaryNavItems = navigationItems.filter(
     (item) => item.key === "overview",

--- a/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
+++ b/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
@@ -84,7 +84,11 @@ export function useWorkspaceData(
 
     try {
       const fetched = await getKnowledgeNetwork(networkId);
-      setDetail(mergePendingMetricsTotalIntoDetail(fetched, pendingMetricsTotalRef.current));
+      setDetail(
+        fetched
+          ? mergePendingMetricsTotalIntoDetail(fetched, pendingMetricsTotalRef.current)
+          : null,
+      );
     } catch (error) {
       setDetail(null);
       setDetailError(extractRequestErrorMessage(error));

--- a/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
+++ b/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
@@ -40,6 +40,23 @@ function sectionCacheKey(networkId: string, section: KnowledgeNetworkWorkspaceSe
   return `${networkId}:${section}`;
 }
 
+function withMetricsTotal(
+  detail: KnowledgeNetworkRecord | null,
+  metricsTotal: number,
+): KnowledgeNetworkRecord | null {
+  if (!detail) {
+    return detail;
+  }
+
+  return {
+    ...detail,
+    statistics: {
+      ...detail.statistics,
+      metricsTotal,
+    },
+  };
+}
+
 export function useWorkspaceData(
   networkId: string,
   section: KnowledgeNetworkWorkspaceSection,
@@ -153,6 +170,7 @@ export function useWorkspaceData(
             if (integrateWorkspaceMetrics) {
               const metricResult = await listKnowledgeNetworkMetrics(networkId);
               setMetrics(metricResult.entries);
+              setDetail((prev) => withMetricsTotal(prev, metricResult.totalCount));
               setMetricApiUnavailable(getMetricApiAvailability() === "unsupported");
             }
             break;
@@ -242,6 +260,7 @@ export function useWorkspaceData(
     loadedSectionsRef.current.delete(sectionCacheKey(networkId, "metrics"));
     const metricResult = await listKnowledgeNetworkMetrics(networkId);
     setMetrics(metricResult.entries);
+    setDetail((prev) => withMetricsTotal(prev, metricResult.totalCount));
     setMetricApiUnavailable(getMetricApiAvailability() === "unsupported");
     loadedSectionsRef.current.add(sectionCacheKey(networkId, "metrics"));
   }, [networkId]);

--- a/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
+++ b/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
@@ -36,25 +36,15 @@ import type {
   KnowledgeNetworkTaskRecord,
 } from "@/modules/knowledge-network/types/knowledge-network";
 
+import {
+  applyKnowledgeNetworkMetricsTotal,
+  clearMetricsTotalPending,
+  createMetricsTotalPending,
+  mergePendingMetricsTotalIntoDetail,
+} from "./workspaceMetricsTotal";
+
 function sectionCacheKey(networkId: string, section: KnowledgeNetworkWorkspaceSection) {
   return `${networkId}:${section}`;
-}
-
-function withMetricsTotal(
-  detail: KnowledgeNetworkRecord | null,
-  metricsTotal: number,
-): KnowledgeNetworkRecord | null {
-  if (!detail) {
-    return detail;
-  }
-
-  return {
-    ...detail,
-    statistics: {
-      ...detail.statistics,
-      metricsTotal,
-    },
-  };
 }
 
 export function useWorkspaceData(
@@ -77,9 +67,11 @@ export function useWorkspaceData(
   const [detailError, setDetailError] = useState<string | null>(null);
   const [sectionError, setSectionError] = useState<string | null>(null);
   const loadedSectionsRef = useRef<Set<string>>(new Set());
+  const pendingMetricsTotalRef = useRef(createMetricsTotalPending());
 
   const clearSectionCache = useCallback(() => {
     loadedSectionsRef.current.clear();
+    clearMetricsTotalPending(pendingMetricsTotalRef.current);
   }, []);
 
   const loadDetail = useCallback(async () => {
@@ -91,7 +83,8 @@ export function useWorkspaceData(
     setDetailError(null);
 
     try {
-      setDetail(await getKnowledgeNetwork(networkId));
+      const fetched = await getKnowledgeNetwork(networkId);
+      setDetail(mergePendingMetricsTotalIntoDetail(fetched, pendingMetricsTotalRef.current));
     } catch (error) {
       setDetail(null);
       setDetailError(extractRequestErrorMessage(error));
@@ -170,7 +163,13 @@ export function useWorkspaceData(
             if (integrateWorkspaceMetrics) {
               const metricResult = await listKnowledgeNetworkMetrics(networkId);
               setMetrics(metricResult.entries);
-              setDetail((prev) => withMetricsTotal(prev, metricResult.totalCount));
+              setDetail((prev) =>
+                applyKnowledgeNetworkMetricsTotal(
+                  prev,
+                  metricResult.totalCount,
+                  pendingMetricsTotalRef.current,
+                ),
+              );
               setMetricApiUnavailable(getMetricApiAvailability() === "unsupported");
             }
             break;
@@ -260,7 +259,13 @@ export function useWorkspaceData(
     loadedSectionsRef.current.delete(sectionCacheKey(networkId, "metrics"));
     const metricResult = await listKnowledgeNetworkMetrics(networkId);
     setMetrics(metricResult.entries);
-    setDetail((prev) => withMetricsTotal(prev, metricResult.totalCount));
+    setDetail((prev) =>
+      applyKnowledgeNetworkMetricsTotal(
+        prev,
+        metricResult.totalCount,
+        pendingMetricsTotalRef.current,
+      ),
+    );
     setMetricApiUnavailable(getMetricApiAvailability() === "unsupported");
     loadedSectionsRef.current.add(sectionCacheKey(networkId, "metrics"));
   }, [networkId]);

--- a/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.test.ts
+++ b/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+
+import {
+  applyKnowledgeNetworkMetricsTotal,
+  createMetricsTotalPending,
+  mergePendingMetricsTotalIntoDetail,
+} from "./workspaceMetricsTotal";
+
+function createDetail(metricsTotal = 0): KnowledgeNetworkRecord {
+  return {
+    color: "#1677ff",
+    createTime: "2026-01-01",
+    creatorName: "admin",
+    description: "",
+    id: "kn-1",
+    identifier: "kn-1",
+    name: "Test KN",
+    statistics: {
+      actionTypesTotal: 0,
+      conceptGroupsTotal: 0,
+      metricsTotal,
+      objectTypesTotal: 0,
+      relationTypesTotal: 0,
+    },
+    tags: [],
+    updateTime: "2026-01-01",
+    updaterName: "admin",
+  };
+}
+
+describe("workspaceMetricsTotal", () => {
+  it("stores total in pending when detail is not loaded yet", () => {
+    const pending = createMetricsTotalPending();
+
+    expect(applyKnowledgeNetworkMetricsTotal(null, 12, pending)).toBeNull();
+    expect(pending.value).toBe(12);
+  });
+
+  it("merges pending total when detail arrives after metrics list", () => {
+    const pending = createMetricsTotalPending();
+    applyKnowledgeNetworkMetricsTotal(null, 12, pending);
+
+    const merged = mergePendingMetricsTotalIntoDetail(createDetail(0), pending);
+
+    expect(merged.statistics.metricsTotal).toBe(12);
+    expect(pending.value).toBeNull();
+  });
+
+  it("applies total immediately when detail is already loaded", () => {
+    const pending = createMetricsTotalPending();
+
+    const updated = applyKnowledgeNetworkMetricsTotal(createDetail(0), 8, pending);
+
+    expect(updated?.statistics.metricsTotal).toBe(8);
+    expect(pending.value).toBeNull();
+  });
+});

--- a/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.ts
+++ b/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+
+export type MetricsTotalPending = {
+  value: number | null;
+};
+
+export function createMetricsTotalPending(): MetricsTotalPending {
+  return { value: null };
+}
+
+export function clearMetricsTotalPending(pending: MetricsTotalPending): void {
+  pending.value = null;
+}
+
+export function rememberMetricsTotal(pending: MetricsTotalPending, metricsTotal: number): void {
+  pending.value = metricsTotal;
+}
+
+export function consumePendingMetricsTotal(pending: MetricsTotalPending): number | null {
+  const metricsTotal = pending.value;
+  pending.value = null;
+  return metricsTotal;
+}
+
+export function mergeKnowledgeNetworkMetricsTotal(
+  detail: KnowledgeNetworkRecord,
+  metricsTotal: number,
+): KnowledgeNetworkRecord {
+  return {
+    ...detail,
+    statistics: {
+      ...detail.statistics,
+      metricsTotal,
+    },
+  };
+}
+
+export function applyKnowledgeNetworkMetricsTotal(
+  detail: KnowledgeNetworkRecord | null,
+  metricsTotal: number,
+  pending: MetricsTotalPending,
+): KnowledgeNetworkRecord | null {
+  if (!detail) {
+    rememberMetricsTotal(pending, metricsTotal);
+    return detail;
+  }
+
+  clearMetricsTotalPending(pending);
+  return mergeKnowledgeNetworkMetricsTotal(detail, metricsTotal);
+}
+
+export function mergePendingMetricsTotalIntoDetail(
+  detail: KnowledgeNetworkRecord,
+  pending: MetricsTotalPending,
+): KnowledgeNetworkRecord {
+  const metricsTotal = consumePendingMetricsTotal(pending);
+  if (metricsTotal === null) {
+    return detail;
+  }
+
+  return mergeKnowledgeNetworkMetricsTotal(detail, metricsTotal);
+}


### PR DESCRIPTION
## Summary
- Sidebar metrics badge uses `detail.statistics.metricsTotal` instead of paginated `metrics.length`
- Loading/reloading metrics writes list `totalCount` back into local detail statistics so create/delete updates the badge immediately

## Why
Closes the Studio half of #169. Backend must also return `metrics_total` (companion PR: openbkn-ai/bkn-foundry#354).

## Test plan
- [ ] Open a KN with metrics: sidebar count matches list total (not 0)
- [ ] Empty metrics KN shows 0
- [ ] Create/delete a metric and confirm sidebar count updates after refresh

Fixes #169