### PR TITLE
feat(auth): 对接折叠版 /me/permissions——scoped 查询 + union 判权

### DIFF
--- a/src/framework/auth/CurrentUserLoader.tsx
+++ b/src/framework/auth/CurrentUserLoader.tsx
@@ -9,7 +9,7 @@ import { Spin } from "antd";
 import type { PropsWithChildren } from "react";
 import { useEffect, useState } from "react";
 
-import { fetchCurrentUser } from "@/framework/auth/current-user";
+import { anonymousRuntimeUser, fetchCurrentUser } from "@/framework/auth/current-user";
 import type { RuntimeUser } from "@/framework/runtime/types";
 
 type CurrentUserLoaderProps = PropsWithChildren<{
@@ -34,7 +34,13 @@ export function CurrentUserLoader({ children, onLoaded }: CurrentUserLoaderProps
         }
       })
       .catch(() => {
-        // 静默:401 由 http 拦截器处理,其它错误退回默认 currentUser
+        // 401 由 http 拦截器处理。其它错误一律退回 fail-closed 用户(无权限),
+        // 绝不沿用调用方的默认 currentUser——那是带全量权限的开发态用户,
+        // 沿用它会让普通用户看到全部系统管理入口(#176)。fetchCurrentUser 已
+        // allSettled 兜底,这里是二次保险。
+        if (!cancelled) {
+          onLoaded(anonymousRuntimeUser);
+        }
       })
       .finally(() => {
         if (!cancelled) {

--- a/src/framework/auth/current-user.test.ts
+++ b/src/framework/auth/current-user.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { http } from "@/framework/request/http";
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: vi.fn() },
+}));
+
+const mockGet = vi.mocked(http.get);
+
+async function importFetchCurrentUser() {
+  const module = await import("@/framework/auth/current-user");
+  return module.fetchCurrentUser;
+}
+
+function meOk(data: Record<string, unknown>) {
+  return Promise.resolve({ data } as never);
+}
+
+describe("fetchCurrentUser — 权限来源不可用时 fail-closed", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it("/me/permissions 失败 → 权限为空,绝不沿用全量默认权限(#176)", async () => {
+    mockGet.mockImplementation((url: string) =>
+      url === "/safe/v1/me"
+        ? meOk({ id: "u1", name: "Sec Builder", roles: ["security", "network_builder"] })
+        : Promise.reject(new Error("500")),
+    );
+
+    const fetchCurrentUser = await importFetchCurrentUser();
+    const user = await fetchCurrentUser();
+
+    expect(user.permissions).toEqual([]);
+    expect(user.permissions).not.toContain("admin-audit:view");
+    expect(user.permissions).not.toContain("admin-license:view");
+    // 身份仍从 /me 拿到,不被权限失败牵连。
+    expect(user.name).toBe("Sec Builder");
+  });
+
+  it("/me 失败但权限成功 → 保留权限,身份退空", async () => {
+    mockGet.mockImplementation((url: string) =>
+      url === "/safe/v1/me"
+        ? Promise.reject(new Error("500"))
+        : meOk({ is_admin: false, permissions: [] }),
+    );
+
+    const fetchCurrentUser = await importFetchCurrentUser();
+    const user = await fetchCurrentUser();
+
+    expect(user.name).toBeNull();
+    expect(user.permissions).toEqual([]);
+  });
+
+  it("is_admin → 放行全部已注册权限", async () => {
+    mockGet.mockImplementation((url: string) =>
+      url === "/safe/v1/me"
+        ? meOk({ id: "root" })
+        : meOk({ is_admin: true, permissions: [] }),
+    );
+
+    const fetchCurrentUser = await importFetchCurrentUser();
+    const user = await fetchCurrentUser();
+
+    expect(user.permissions).toContain("admin-audit:view");
+    expect(user.permissions).toContain("admin-license:view");
+  });
+
+  it("两个请求都失败 → 完全 fail-closed", async () => {
+    mockGet.mockRejectedValue(new Error("network"));
+
+    const fetchCurrentUser = await importFetchCurrentUser();
+    const user = await fetchCurrentUser();
+
+    expect(user.permissions).toEqual([]);
+    expect(user.name).toBeNull();
+    expect(user.roles).toEqual([]);
+  });
+});

--- a/src/framework/auth/current-user.test.ts
+++ b/src/framework/auth/current-user.test.ts
@@ -7,13 +7,11 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { http } from "@/framework/request/http";
+const mockGet = vi.hoisted(() => vi.fn());
 
 vi.mock("@/framework/request/http", () => ({
-  http: { get: vi.fn() },
+  http: { get: mockGet },
 }));
-
-const mockGet = vi.mocked(http.get);
 
 async function importFetchCurrentUser() {
   const module = await import("@/framework/auth/current-user");

--- a/src/framework/auth/current-user.ts
+++ b/src/framework/auth/current-user.ts
@@ -57,6 +57,7 @@ export async function fetchCurrentUser(): Promise<RuntimeUser> {
   return {
     businessDomainId: null,
     id: me.id ?? null,
+    isAdmin: Boolean(perm.is_admin),
     name: me.name || me.account || me.id || null,
     roles: me.roles ?? [],
     permissions: perm.is_admin

--- a/src/framework/auth/current-user.ts
+++ b/src/framework/auth/current-user.ts
@@ -35,22 +35,42 @@ type MePermissionsResponse = {
 };
 
 /**
+ * 无身份、无权限的兜底用户。任何权限来源不可用时都退回它——fail-closed:
+ * 宁可少给,不可错给。绝不能退回带全量权限的开发态默认用户(见 dev-profile),
+ * 否则 /me/permissions 一抖动,普通用户就看到全部系统管理入口(#176)。
+ */
+export const anonymousRuntimeUser: RuntimeUser = {
+  businessDomainId: null,
+  id: null,
+  isAdmin: false,
+  name: null,
+  permissions: [],
+  roles: [],
+};
+
+/**
  * 登录后拉取当前用户身份 + 权限,组装成 RuntimeUser。
  *
  * bkn-safe 下发的是 `<resource_type>:<operation>`,与各模块 manifest 声明的权限点并非
  * 同一套命名,需经 permission-map 翻译(见该文件注释)。is_admin(超级管理员/admin)
  * 放行全部已注册权限。
+ *
+ * 两个请求各自独立降级(allSettled),互不牵连:身份拿不到不影响权限,权限拿不到
+ * 一律按无权限处理。permissions 拉取失败绝不放行任何权限(fail-closed)——避免因为
+ * 一次瞬时失败让前端沿用带全量权限的默认用户。
  */
 export async function fetchCurrentUser(): Promise<RuntimeUser> {
-  const [meResult, permResult] = await Promise.all([
+  const [meResult, permResult] = await Promise.allSettled([
     http.get<MeResponse>("/safe/v1/me", { skipErrorToast: true }),
     http.get<MePermissionsResponse>("/safe/v1/me/permissions", {
       skipErrorToast: true,
     }),
   ]);
 
-  const me = meResult.data;
-  const perm = permResult.data;
+  const me: MeResponse = meResult.status === "fulfilled" ? meResult.value.data : {};
+  // 权限接口失败 → 空授权集 → 推导出空权限,而不是保留调用方的默认(全量)权限。
+  const perm: MePermissionsResponse =
+    permResult.status === "fulfilled" ? permResult.value.data : {};
 
   const safeGrants = flattenSafeGrants(perm.permissions);
 

--- a/src/framework/auth/permission-map.test.ts
+++ b/src/framework/auth/permission-map.test.ts
@@ -185,6 +185,41 @@ describe("执行工厂权限点覆盖", () => {
   });
 });
 
+describe("折叠通配契约", () => {
+  it("类型级 operator:* 放行该类型全部动作,含实例映射", () => {
+    const typeWildcard = flattenSafeGrants([
+      { operations: ["*"], resource: { id: "*", type: "operator" } },
+    ]);
+
+    expect(isStudioPermissionGranted("execution-factory:operator:create", typeWildcard, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory:operator:edit", typeWildcard, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory:operator:debug", typeWildcard, false)).toBe(true);
+    // 另一类型不受影响。
+    expect(isStudioPermissionGranted("execution-factory:toolbox:create", typeWildcard, false)).toBe(false);
+  });
+
+  it("全局通配 *:* 放行所有可映射权限点(非 is_admin 也算)", () => {
+    const globalWildcard = flattenSafeGrants([
+      { operations: ["*"], resource: { id: "*", type: "*" } },
+    ]);
+
+    expect(isStudioPermissionGranted("execution-factory:operator:create", globalWildcard, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory:tool:edit", globalWildcard, false)).toBe(true);
+    expect(isStudioPermissionGranted("execution-factory-lab:catalog:view", globalWildcard, false)).toBe(true);
+  });
+
+  it("通配不绕过有意屏蔽:catalog:install 与 sandbox-runtime:view 仍锁死", () => {
+    const globalWildcard = flattenSafeGrants([
+      { operations: ["*"], resource: { id: "*", type: "*" } },
+    ]);
+
+    // 后端无安装端点,永久屏蔽——通配也不放。
+    expect(isStudioPermissionGranted("execution-factory:catalog:install", globalWildcard, false)).toBe(false);
+    // 沙箱运行时锚在 is_admin,通配的非超管拿不到。
+    expect(isStudioPermissionGranted("execution-factory-lab:sandbox-runtime:view", globalWildcard, false)).toBe(false);
+  });
+});
+
 describe("deriveStudioPermissions", () => {
   it("只在已声明的权限点内推导，不凭空造串", () => {
     const grants = flattenSafeGrants(REAL_NON_ADMIN_GRANTS);

--- a/src/framework/auth/permission-map.ts
+++ b/src/framework/auth/permission-map.ts
@@ -84,6 +84,19 @@ const OVERRIDES: Record<string, string[]> = {
  */
 const ADMIN_ONLY_SUFFIXES = new Set(["sandbox-runtime:view"]);
 
+/**
+ * 折叠契约下 bkn-safe 会下发通配授权:全局通配行 `*:*`(超管等价)与类型级
+ * `${type}:*`(该类型全操作)。判某个 `type:op` 是否被授,须连同这两种通配一并看,
+ * 否则 is_admin=false 但持通配的账号菜单会漏门。
+ */
+function safeGrantsCover(safeGrants: Set<string>, type: string, operation: string): boolean {
+  return (
+    safeGrants.has(`${type}:${operation}`) ||
+    safeGrants.has(`${type}:*`) ||
+    safeGrants.has("*:*")
+  );
+}
+
 /** 把 bkn-safe 的授权条目展平成 `type:op` 集合。 */
 export function flattenSafeGrants(
   grants: { operations?: string[]; resource?: { id?: string; type?: string } }[] | undefined,
@@ -126,6 +139,8 @@ export function isStudioPermissionGranted(
   isAdmin: boolean,
 ): boolean {
   // 1. 直接同名。data-catalog 的 `catalog:view_detail` 等即走这条。
+  //    折叠通配 `*:*` / `${type}:*` 在下方映射的 safeGrantsCover 里统一处理,
+  //    刻意不在此短路 —— 否则会绕过 catalog:install 等有意屏蔽项。
   if (safeGrants.has(studioPermission)) {
     return true;
   }
@@ -141,10 +156,13 @@ export function isStudioPermissionGranted(
     return isAdmin;
   }
 
-  // 3. 覆盖表优先。
+  // 3. 覆盖表优先。命中判定同样要吃类型级 `${type}:*` 通配。
   const override = OVERRIDES[suffix];
   if (override) {
-    return override.some((candidate) => safeGrants.has(candidate));
+    return override.some((candidate) => {
+      const [candidateType, candidateOp] = candidate.split(":");
+      return safeGrantsCover(safeGrants, candidateType, candidateOp);
+    });
   }
 
   const [, entity, action] = segments;
@@ -153,7 +171,7 @@ export function isStudioPermissionGranted(
   if (!resourceType || !operation) {
     return false;
   }
-  return safeGrants.has(`${resourceType}:${operation}`);
+  return safeGrantsCover(safeGrants, resourceType, operation);
 }
 
 /**

--- a/src/framework/runtime/dev-profile.ts
+++ b/src/framework/runtime/dev-profile.ts
@@ -11,6 +11,7 @@ import { defaultDevPermissions } from "@/framework/runtime/module-manifests";
 export const defaultDevRuntimeUser: RuntimeUser = {
   businessDomainId: "bd_public",
   id: "266c6a42-6131-4d62-8f39-853e7093701c",
+  isAdmin: true,
   name: "Local Admin",
   permissions: defaultDevPermissions,
   roles: ["admin"],

--- a/src/framework/runtime/types.ts
+++ b/src/framework/runtime/types.ts
@@ -16,6 +16,8 @@ export type TokenManager = {
 export type RuntimeUser = {
   businessDomainId: string | null;
   id: string | null;
+  /** `/me/permissions`.is_admin — super_admin without literal role `"admin"`. */
+  isAdmin: boolean;
   name: string | null;
   permissions: string[];
   roles: string[];

--- a/src/modules/model-resources/components/models/LargeModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/LargeModelListPanel.tsx
@@ -27,7 +27,6 @@ import {
   LlmMonitorDrawer,
 } from "@/modules/model-resources/components/models/ModelModals";
 import { ModelListToolbar } from "@/modules/model-resources/components/models/ModelListToolbar";
-import { getMyPermissions } from "@/modules/model-resources/services/authorization.service";
 import {
   deleteLlmModels,
   getLlmItemPermissions,
@@ -81,12 +80,11 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
   const [guideOpen, setGuideOpen] = useState(false);
   const [monitorOpen, setMonitorOpen] = useState(false);
   const [authorizeRecord, setAuthorizeRecord] = useState<LlmModel | null>(null);
-  /** `/me/permissions`.is_admin — covers super_admin without literal role `"admin"`. */
-  const [meIsAdmin, setMeIsAdmin] = useState(false);
-
   const userRoles = runtimeConfig.currentUser.roles;
   const userPermissions = runtimeConfig.currentUser.permissions;
-  const effectiveAdmin = isAdmin || meIsAdmin || hasModelResourcesAdminRole(userRoles);
+  // 真实管理员判定复用启动时 /me/permissions.is_admin(已回填 currentUser),不再二次拉取。
+  const effectiveAdmin =
+    isAdmin || runtimeConfig.currentUser.isAdmin || hasModelResourcesAdminRole(userRoles);
   const canManageLargeModel = hasPermissions({
     currentPermissions: userPermissions,
     mode: "any",
@@ -144,23 +142,6 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
     void loadData();
   }, [loadData]);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    void getMyPermissions()
-      .then((me) => {
-        if (!cancelled) {
-          setMeIsAdmin(me.isAdmin);
-        }
-      })
-      .catch(() => {
-        // Keep role-based fallback when /me/permissions is unavailable.
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const sortMenuItems = useMemo(
     () => [
@@ -229,7 +210,7 @@ export function LargeModelListPanel({ isAdmin = false }: LargeModelListPanelProp
     }
   };
 
-  // 真实管理员：prop / roles(含 super_admin) / me.isAdmin，或该项 operations 含 modify。
+  // 真实管理员：prop / roles(含 super_admin) / currentUser.isAdmin，或该项 operations 含 modify。
   const canModify = (record: LlmModel) =>
     effectiveAdmin || Boolean(record.operations?.includes("modify"));
   const canSetDefault = (record: LlmModel) => canModify(record) && !record.default;

--- a/src/modules/model-resources/services/authorization.service.test.ts
+++ b/src/modules/model-resources/services/authorization.service.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: {
+    get: getMock,
+  },
+}));
+
+import { getResourceOperations } from "@/modules/model-resources/services/authorization.service";
+
+/** 完整 bkn-safe 词表 —— `"*"` / is_admin 的展开目标。与被测常量同步。 */
+const FULL_VOCAB = new Set([
+  "create",
+  "delete",
+  "modify",
+  "view",
+  "view_detail",
+  "execute",
+  "authorize",
+  "publish",
+  "unpublish",
+  "public_access",
+  "task_manage",
+]);
+
+type Row = { resource?: { type?: string; id?: string }; operations?: string[] };
+
+/** 折叠形态响应:每型一行类型级(id:"*"),可选实例例外行(仅增量)。 */
+function foldedResponse(is_admin: boolean, permissions: Row[]) {
+  return { data: { is_admin, permissions } };
+}
+
+/** 末次 http.get 调用携带的 query 参数。 */
+function lastParams(): Record<string, string> {
+  const call = getMock.mock.calls.at(-1);
+  return call?.[1]?.params ?? {};
+}
+
+describe("authorization.service · getResourceOperations", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("空 resources 直接返回,不打接口", async () => {
+    const result = await getResourceOperations([]);
+
+    expect(result).toEqual([]);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it("is_admin 响应 → 每个资源拿到全量词表", async () => {
+    getMock.mockResolvedValue(foldedResponse(true, []));
+
+    const [item] = await getResourceOperations([{ id: "m1", type: "large_model" }]);
+
+    expect(new Set(item.operation)).toEqual(FULL_VOCAB);
+    // 幽灵操作 display 已剔除。
+    expect(item.operation).not.toContain("display");
+  });
+
+  it("通配行 *:* 的非超管 → 全量词表(超管等价短路)", async () => {
+    getMock.mockResolvedValue(
+      foldedResponse(false, [{ resource: { type: "*", id: "*" }, operations: ["*"] }]),
+    );
+
+    const [item] = await getResourceOperations([{ id: "m1", type: "large_model" }]);
+
+    expect(new Set(item.operation)).toEqual(FULL_VOCAB);
+  });
+
+  it("类型级 * 操作 → 该类型全量词表", async () => {
+    getMock.mockResolvedValue(
+      foldedResponse(false, [{ resource: { type: "large_model", id: "*" }, operations: ["*"] }]),
+    );
+
+    const [item] = await getResourceOperations([{ id: "m1", type: "large_model" }]);
+
+    expect(new Set(item.operation)).toEqual(FULL_VOCAB);
+  });
+
+  it("类型级行与实例例外行 union —— 实例只带增量", async () => {
+    getMock.mockResolvedValue(
+      foldedResponse(false, [
+        { resource: { type: "large_model", id: "*" }, operations: ["view"] },
+        { resource: { type: "large_model", id: "m1" }, operations: ["modify"] },
+      ]),
+    );
+
+    const result = await getResourceOperations([
+      { id: "m1", type: "large_model" },
+      { id: "m2", type: "large_model" },
+    ]);
+
+    // m1 = 类型级 view ∪ 实例增量 modify
+    expect(new Set(result[0].operation)).toEqual(new Set(["view", "modify"]));
+    // m2 无例外行,只吃类型级
+    expect(result[1].operation).toEqual(["view"]);
+  });
+
+  it("无命中授权 → 空操作(fail-closed)", async () => {
+    getMock.mockResolvedValue(foldedResponse(false, []));
+
+    const [item] = await getResourceOperations([{ id: "m1", type: "large_model" }]);
+
+    expect(item.operation).toEqual([]);
+  });
+
+  it("scoped query 带 resource_type,resource_id 拼实例且排除 * 与重复", async () => {
+    getMock.mockResolvedValue(foldedResponse(false, []));
+
+    await getResourceOperations([
+      { id: "m1", type: "large_model" },
+      { id: "m1", type: "large_model" },
+      { id: "*", type: "large_model" },
+      { id: "m2", type: "large_model" },
+    ]);
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(lastParams()).toEqual({ resource_type: "large_model", resource_id: "m1,m2" });
+  });
+
+  it("大列表按 50 分批,单条 URL 不超限", async () => {
+    getMock.mockResolvedValue(
+      foldedResponse(false, [{ resource: { type: "large_model", id: "*" }, operations: ["view"] }]),
+    );
+
+    const resources = Array.from({ length: 120 }, (_, i) => ({
+      id: `m${i}`,
+      type: "large_model",
+    }));
+
+    const result = await getResourceOperations(resources);
+
+    // 120 / 50 → 3 批
+    expect(getMock).toHaveBeenCalledTimes(3);
+    for (const call of getMock.mock.calls) {
+      const ids = String(call[1].params.resource_id).split(",");
+      expect(ids.length).toBeLessThanOrEqual(50);
+    }
+    // 合并后每个资源都拿到类型级 view
+    expect(result).toHaveLength(120);
+    expect(result.every((item) => item.operation?.includes("view"))).toBe(true);
+  });
+
+  it("多类型分组:每型一次 scoped 查询,互不串权", async () => {
+    getMock.mockImplementation((_url: string, config: { params: { resource_type: string } }) =>
+      Promise.resolve(
+        foldedResponse(false, [
+          {
+            resource: { type: config.params.resource_type, id: "*" },
+            operations: [config.params.resource_type === "large_model" ? "modify" : "view"],
+          },
+        ]),
+      ),
+    );
+
+    const result = await getResourceOperations([
+      { id: "m1", type: "large_model" },
+      { id: "s1", type: "small_model" },
+    ]);
+
+    const byType = new Set(
+      getMock.mock.calls.map((call) => call[1].params.resource_type),
+    );
+    expect(byType).toEqual(new Set(["large_model", "small_model"]));
+    expect(result[0].operation).toEqual(["modify"]);
+    expect(result[1].operation).toEqual(["view"]);
+  });
+});

--- a/src/modules/model-resources/services/authorization.service.test.ts
+++ b/src/modules/model-resources/services/authorization.service.test.ts
@@ -41,7 +41,9 @@ function foldedResponse(is_admin: boolean, permissions: Row[]) {
 
 /** 末次 http.get 调用携带的 query 参数。 */
 function lastParams(): Record<string, string> {
-  const call = getMock.mock.calls.at(-1);
+  const call = getMock.mock.calls.at(-1) as
+    | [string, { params?: Record<string, string> }]
+    | undefined;
   return call?.[1]?.params ?? {};
 }
 
@@ -146,8 +148,8 @@ describe("authorization.service · getResourceOperations", () => {
 
     // 120 / 50 → 3 批
     expect(getMock).toHaveBeenCalledTimes(3);
-    for (const call of getMock.mock.calls) {
-      const ids = String(call[1].params.resource_id).split(",");
+    for (const call of getMock.mock.calls as [string, { params: { resource_id: string } }][]) {
+      const ids = call[1].params.resource_id.split(",");
       expect(ids.length).toBeLessThanOrEqual(50);
     }
     // 合并后每个资源都拿到类型级 view
@@ -173,7 +175,9 @@ describe("authorization.service · getResourceOperations", () => {
     ]);
 
     const byType = new Set(
-      getMock.mock.calls.map((call) => call[1].params.resource_type),
+      (getMock.mock.calls as [string, { params: { resource_type: string } }][]).map(
+        (call) => call[1].params.resource_type,
+      ),
     );
     expect(byType).toEqual(new Set(["large_model", "small_model"]));
     expect(result[0].operation).toEqual(["modify"]);

--- a/src/modules/model-resources/services/authorization.service.ts
+++ b/src/modules/model-resources/services/authorization.service.ts
@@ -29,17 +29,41 @@ export type MyPermissions = {
 };
 
 /**
- * Ops surfaced to an admin so menu/button visibility is complete even when the
- * permission list is grant-driven. The backend still enforces every write.
+ * 完整的 bkn-safe 操作词表 —— 作为「全操作」(`is_admin`、通配行、类型级 `"*"`)
+ * 的展开目标,让按钮显隐在 grant 驱动下也完整。后端仍逐操作强制鉴权。
+ *
+ * 必须覆盖任意消费方可能 `includes(op)` 的每一个操作,否则 `"*"` 授权者反而少显示。
+ * 取自 bkn-safe 实际下发词表(见 permission-map.test.ts 的真实 /me/permissions 响应);
+ * 早前的 `"display"` 后端并不存在,已剔除,并补齐 view/view_detail/publish 等。
  */
 const ADMIN_OPERATIONS = [
   "create",
   "delete",
-  "display",
-  "execute",
   "modify",
+  "view",
+  "view_detail",
+  "execute",
   "authorize",
+  "publish",
+  "unpublish",
+  "public_access",
+  "task_manage",
 ];
+
+/**
+ * 单次 scoped 查询携带的实例 id 数目上限。bkn 网关对 URL 长度有限制,
+ * 大列表(几十上百实例)把 id 逗号拼进 query 会超限,故按此分批多发再并集。
+ * UUID(~36 char)× 50 ≈ 1.8KB resource_id,留足网关余量。
+ */
+const SCOPED_ID_BATCH = 50;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+}
 
 type MePermissionsResponse = {
   is_admin?: boolean;
@@ -95,24 +119,31 @@ async function fetchScopedPermissions(
   type: string,
   ids: string[],
 ): Promise<MyPermissions> {
-  const params: Record<string, string> = { resource_type: type };
-  const instanceIds = ids.filter((id) => id && id !== "*");
-  if (instanceIds.length > 0) {
-    params.resource_id = instanceIds.join(",");
-  }
+  const instanceIds = [...new Set(ids.filter((id) => id && id !== "*"))];
+  // 至少发一次(仅 resource_type)以取类型级行;实例过多时按 SCOPED_ID_BATCH 分批,
+  // 每批各带一段 resource_id,避免单条 URL 超网关长度限制。
+  const batches = instanceIds.length > 0 ? chunk(instanceIds, SCOPED_ID_BATCH) : [[]];
 
-  const response = await http.get<MePermissionsResponse>(
-    "/safe/v1/me/permissions",
-    { params },
+  const responses = await Promise.all(
+    batches.map((batch) => {
+      const params: Record<string, string> = { resource_type: type };
+      if (batch.length > 0) {
+        params.resource_id = batch.join(",");
+      }
+      return http.get<MePermissionsResponse>("/safe/v1/me/permissions", { params });
+    }),
   );
 
+  // 各批都会带回类型级行(id:"*"),并集时靠 operationsFor 的 Set 去重,无害。
   return {
-    isAdmin: Boolean(response.data?.is_admin),
-    permissions: (response.data?.permissions ?? []).map((item) => ({
-      type: item.resource?.type ?? "",
-      id: item.resource?.id ?? "",
-      operations: item.operations ?? [],
-    })),
+    isAdmin: responses.some((response) => Boolean(response.data?.is_admin)),
+    permissions: responses.flatMap((response) =>
+      (response.data?.permissions ?? []).map((item) => ({
+        type: item.resource?.type ?? "",
+        id: item.resource?.id ?? "",
+        operations: item.operations ?? [],
+      })),
+    ),
   };
 }
 

--- a/src/modules/model-resources/services/authorization.service.ts
+++ b/src/modules/model-resources/services/authorization.service.ts
@@ -50,18 +50,61 @@ type MePermissionsResponse = {
 };
 
 /**
- * Self-service permission read — `/api/safe/v1/me/permissions`.
- *
- * This is the gateway-exposed, token-gated bkn-safe endpoint frontends are meant
- * to call (accessor derived from the bearer token). The `/authz/*` family is an
- * internal, tokenless ClusterIP API and is NOT reachable through the gateway, so
- * UI permission checks must go through `/me/*`, not `/authz/operations`.
- *
- * Returns `is_admin` plus the accessor's grants (role-inherited included);
- * type-wide grants keep the id `"*"`.
+ * Ops the accessor may perform on a single resource, per the folded
+ * `/me/permissions` contract. An instance row carries only the *delta* over its
+ * type-level row, so the effective set is the UNION of the type-wide (`id:"*"`)
+ * row and the exact-id row. A wildcard row (`type:"*"` with op `"*"`) or a `"*"`
+ * operation means "all ops" — expanded to ADMIN_OPERATIONS for display.
  */
-export async function getMyPermissions(): Promise<MyPermissions> {
-  const response = await http.get<MePermissionsResponse>("/safe/v1/me/permissions");
+function operationsFor(me: MyPermissions, type: string, id: string): string[] {
+  if (me.isAdmin) {
+    return [...ADMIN_OPERATIONS];
+  }
+
+  // 通配行(超管等价):对一切资源可做一切,出现即短路。
+  if (me.permissions.some((p) => p.type === "*" && p.operations.includes("*"))) {
+    return [...ADMIN_OPERATIONS];
+  }
+
+  const ops = new Set<string>();
+  for (const permission of me.permissions) {
+    if (permission.type !== type) {
+      continue;
+    }
+    // union:类型级行(id:"*")与该实例例外行(仅含增量)都并入。
+    if (permission.id === id || permission.id === "*") {
+      permission.operations.forEach((op) => ops.add(op));
+    }
+  }
+
+  // 类型级 "*" 操作 = 该类型全部操作。
+  if (ops.has("*")) {
+    return [...ADMIN_OPERATIONS];
+  }
+
+  return [...ops];
+}
+
+/**
+ * 按类型拉取「有效授权」,可选收窄到指定实例。折叠契约下类型级行(id:"*")
+ * 总会返回;实例行只在操作超出类型级时出现,且仅含增量 —— 判权靠 operationsFor union。
+ *
+ * `"*"` 不是实例 id,其权限由类型级行覆盖,无需下发 resource_id。
+ */
+async function fetchScopedPermissions(
+  type: string,
+  ids: string[],
+): Promise<MyPermissions> {
+  const params: Record<string, string> = { resource_type: type };
+  const instanceIds = ids.filter((id) => id && id !== "*");
+  if (instanceIds.length > 0) {
+    params.resource_id = instanceIds.join(",");
+  }
+
+  const response = await http.get<MePermissionsResponse>(
+    "/safe/v1/me/permissions",
+    { params },
+  );
 
   return {
     isAdmin: Boolean(response.data?.is_admin),
@@ -74,31 +117,8 @@ export async function getMyPermissions(): Promise<MyPermissions> {
 }
 
 /**
- * Ops the accessor may perform on a single resource, derived from
- * `/me/permissions`: a type-wide grant (id `"*"`) applies to every instance, so
- * its operations union with any exact-id grant.
- */
-function operationsFor(me: MyPermissions, type: string, id: string): string[] {
-  if (me.isAdmin) {
-    return [...ADMIN_OPERATIONS];
-  }
-
-  const ops = new Set<string>();
-  for (const permission of me.permissions) {
-    if (permission.type !== type) {
-      continue;
-    }
-    if (permission.id === id || permission.id === "*") {
-      permission.operations.forEach((op) => ops.add(op));
-    }
-  }
-
-  return [...ops];
-}
-
-/**
- * Back-compat helper for the existing callers: resolve the ops for each
- * requested resource from a single `/me/permissions` read.
+ * 各资源当前账号可执行的操作。按类型分组做 scoped 查询(每型一次),
+ * 不再拉全量 ACL 再前端过滤;每个资源的最终操作集为类型级行与实例例外行的 union。
  */
 export async function getResourceOperations(
   resources: AuthorizationResource[],
@@ -107,10 +127,25 @@ export async function getResourceOperations(
     return [];
   }
 
-  const me = await getMyPermissions();
+  const idsByType = new Map<string, string[]>();
+  for (const resource of resources) {
+    const ids = idsByType.get(resource.type) ?? [];
+    ids.push(resource.id);
+    idsByType.set(resource.type, ids);
+  }
 
-  return resources.map((resource) => ({
-    id: resource.id,
-    operation: operationsFor(me, resource.type, resource.id),
-  }));
+  const permsByType = new Map<string, MyPermissions>();
+  await Promise.all(
+    [...idsByType].map(async ([type, ids]) => {
+      permsByType.set(type, await fetchScopedPermissions(type, ids));
+    }),
+  );
+
+  return resources.map((resource) => {
+    const me = permsByType.get(resource.type);
+    return {
+      id: resource.id,
+      operation: me ? operationsFor(me, resource.type, resource.id) : [],
+    };
+  });
 }

--- a/src/modules/model-resources/services/llm.service.ts
+++ b/src/modules/model-resources/services/llm.service.ts
@@ -284,7 +284,10 @@ export async function getLlmItemPermissions(
     );
 
     return Object.fromEntries(items.map((item) => [item.id, item.operation ?? []]));
-  } catch {
+  } catch (error) {
+    // scoped 权限查询失败(网络/网关)时按钮全隐是 fail-closed 的安全默认,但这与
+    // 「确无权限」难分。http 层已弹通用错误 toast,此处留 debug 便于排障区分二者。
+    console.debug("[model-resources] getLlmItemPermissions scoped fetch failed", error);
     return {};
   }
 }

--- a/src/modules/model-resources/services/llm.service.ts
+++ b/src/modules/model-resources/services/llm.service.ts
@@ -259,7 +259,7 @@ export async function updateLlmModel(payload: LlmSavePayload) {
 
 /**
  * 每个大模型当前账号可执行的操作（来自 /me/permissions，对象类型 large_model）。
- * 真实管理员判定走此处：getMyPermissions().isAdmin 时返回全量操作（含 modify），
+ * scoped 响应带 is_admin，命中时 operationsFor 返回全量操作（含 modify），
  * 据此决定「设为默认 / 取消默认」等高危操作是否可见。
  */
 export async function getLlmItemPermissions(

--- a/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
+++ b/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
@@ -251,34 +251,38 @@ export function ObjectAuthorizationScene() {
         operations: [],
       })),
     ];
-    void resolveGrantNames(toResolve).then((named) => {
-      if (cancelled) {
-        return;
-      }
-      const nameByKey = new Map(
-        named
-          .filter((grant) => grant.objName !== grant.objId)
-          .map((grant) => [`${grant.objType}:${grant.objId}`, grant.objName] as const),
-      );
-      if (nameByKey.size === 0) {
-        return;
-      }
-      if (view === "all") {
-        setGrants((prev) =>
-          prev.map((grant) => {
-            const name = nameByKey.get(`${grant.objType}:${grant.objId}`);
-            return name ? { ...grant, objName: name } : grant;
-          }),
+    void resolveGrantNames(toResolve)
+      .then((named) => {
+        if (cancelled) {
+          return;
+        }
+        const nameByKey = new Map(
+          named
+            .filter((grant) => grant.objName !== grant.objId)
+            .map((grant) => [`${grant.objType}:${grant.objId}`, grant.objName] as const),
         );
-      } else {
-        setGroups((prev) =>
-          prev.map((group) => {
-            const name = nameByKey.get(`${group.objType}:${group.objId}`);
-            return name ? { ...group, objName: name } : group;
-          }),
-        );
-      }
-    });
+        if (nameByKey.size === 0) {
+          return;
+        }
+        if (view === "all") {
+          setGrants((prev) =>
+            prev.map((grant) => {
+              const name = nameByKey.get(`${grant.objType}:${grant.objId}`);
+              return name ? { ...grant, objName: name } : grant;
+            }),
+          );
+        } else {
+          setGroups((prev) =>
+            prev.map((group) => {
+              const name = nameByKey.get(`${group.objType}:${group.objId}`);
+              return name ? { ...group, objName: name } : group;
+            }),
+          );
+        }
+      })
+      .catch(() => {
+        // 取名失败保持 id 兜底,不阻断列表。
+      });
     return () => {
       cancelled = true;
     };

--- a/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
+++ b/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
@@ -660,7 +660,7 @@ export function ObjectAuthorizationScene() {
                 showSizeChanger
                 showTotal={(count) => t("common.total", { total: count })}
                 size="small"
-                total={view === "all" ? listTotal : groupList.length}
+                total={listTotal}
               />
             ) : null}
           </>

--- a/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
+++ b/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
@@ -19,7 +19,7 @@ import {
 } from "@ant-design/icons";
 import { Alert, Empty, Input, Segmented, Select, Tag, Tooltip } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
@@ -85,8 +85,6 @@ export function ObjectAuthorizationScene() {
   const [lookupRevision, setLookupRevision] = useState(0);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  // 每次加载自增;异步名字回填只在 token 仍是当前值时落地,防止旧一轮解析覆盖新列表。
-  const loadTokenRef = useRef(0);
 
   const [view, setView] = useState<ViewMode>("all");
   const [keyword, setKeyword] = useState("");
@@ -112,8 +110,8 @@ export function ObjectAuthorizationScene() {
       setDepartments(deptList);
 
       const paginate = view === "all";
-      const token = ++loadTokenRef.current;
-      // resolveNames:false —— 列表先用 id 占位立即渲染,不被对象名解析(可能慢/部分缺失)阻塞。
+      // resolveNames:false —— 列表先用 id 占位立即渲染;对象名按「当前页可见行」懒解析(见下方 effect),
+      // 不再一次性为全部(可能数千条)grant 解析,避免把领域取名接口打到连接饱和/超时。
       const result = await listObjectGrantsPage(
         {
           search: debouncedKeyword || undefined,
@@ -126,12 +124,6 @@ export function ObjectAuthorizationScene() {
       );
 
       setGrants(result.grants);
-      // 名字异步回填;仅当没有更新一轮加载覆盖时才落地。
-      void resolveGrantNames(result.grants).then((named) => {
-        if (loadTokenRef.current === token) {
-          setGrants(named);
-        }
-      });
       setTotal(result.total);
       setSummary(
         result.summary ?? {
@@ -256,6 +248,39 @@ export function ObjectAuthorizationScene() {
     const start = (pageState.page - 1) * pageState.pageSize;
     return filteredGrants.slice(start, start + pageState.pageSize);
   }, [filteredGrants, pageState.page, pageState.pageSize, view]);
+
+  // 对象名按需解析:只解析「当前页可见行」的对象名,翻页/切视图再解析新出现的那批。
+  // 用缓存,翻回来的页零请求。避免为全部(数千条)grant 一次性解析导致取名接口连接饱和/超时。
+  useEffect(() => {
+    const visible = view === "all" ? pagedGrants : pagedGroups.flat();
+    const pending = visible.filter((grant) => grant.objName === grant.objId);
+    if (pending.length === 0) {
+      return;
+    }
+    let cancelled = false;
+    void resolveGrantNames(pending).then((named) => {
+      if (cancelled) {
+        return;
+      }
+      const nameByKey = new Map(
+        named
+          .filter((grant) => grant.objName !== grant.objId)
+          .map((grant) => [`${grant.objType}:${grant.objId}`, grant.objName] as const),
+      );
+      if (nameByKey.size === 0) {
+        return;
+      }
+      setGrants((prev) =>
+        prev.map((grant) => {
+          const name = nameByKey.get(`${grant.objType}:${grant.objId}`);
+          return name ? { ...grant, objName: name } : grant;
+        }),
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [pagedGrants, pagedGroups, view]);
 
   const listTotal = view === "all" ? total : groupList.length;
 

--- a/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
+++ b/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
@@ -32,7 +32,12 @@ import { AppButton } from "@/framework/ui/common/AppButton";
 import { AppTable } from "@/framework/ui/common/AppTable";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { ObjectAuthorizeDrawer } from "@/modules/system-admin/components/ObjectAuthorizeDrawer";
-import { listObjectGrantsPage, revokeObjectGrant } from "@/modules/system-admin/services/authz.service";
+import {
+  type AuthzGroup,
+  listObjectGrantsPage,
+  listObjectGroups,
+  revokeObjectGrant,
+} from "@/modules/system-admin/services/authz.service";
 import { resolveGrantNames } from "@/modules/system-admin/services/authz-objects.service";
 import type { AdminDepartment } from "@/modules/system-admin/types/admin";
 import type { AuthzSummary, ObjectGrant } from "@/modules/system-admin/types/authz";
@@ -48,7 +53,6 @@ import styles from "./admin.module.css";
 
 type ViewMode = "all" | "object" | "grantee";
 
-const INNER_PAGE_SIZE = 10;
 
 type DrawerTarget = {
   id: string;
@@ -91,12 +95,8 @@ export function ObjectAuthorizationScene() {
   const debouncedKeyword = useDebouncedValue(keyword.trim(), 300);
   const [objTypeFilter, setObjTypeFilter] = useState<string>();
   const [granteeType, setGranteeType] = useState<"all" | "user" | "department">("all");
-  const [objectInnerPage, setObjectInnerPage] = useState<
-    Record<string, { page: number; pageSize: number }>
-  >({});
-  const [granteeInnerPage, setGranteeInnerPage] = useState<
-    Record<string, { page: number; pageSize: number }>
-  >({});
+  // 分组视图(按对象/按成员)服务端分页返回的聚合行。
+  const [groups, setGroups] = useState<AuthzGroup[]>([]);
   const [drawer, setDrawer] = useState<{ open: boolean; target: DrawerTarget | null }>({
     open: false,
     target: null,
@@ -109,32 +109,53 @@ export function ObjectAuthorizationScene() {
       const deptList = await getCachedDepartments();
       setDepartments(deptList);
 
-      const paginate = view === "all";
-      // resolveNames:false —— 列表先用 id 占位立即渲染;对象名按「当前页可见行」懒解析(见下方 effect),
-      // 不再一次性为全部(可能数千条)grant 解析,避免把领域取名接口打到连接饱和/超时。
-      const result = await listObjectGrantsPage(
-        {
+      const offset = (pageState.page - 1) * pageState.pageSize;
+
+      if (view === "all") {
+        // resolveNames:false —— 列表先用 id 占位立即渲染;对象名按当前可见页 on-demand 回填。
+        const result = await listObjectGrantsPage(
+          {
+            search: debouncedKeyword || undefined,
+            resourceType: objTypeFilter,
+            offset,
+            limit: pageState.pageSize,
+            includeSummary: true,
+          },
+          { resolveNames: false },
+        );
+        setGroups([]);
+        setGrants(result.grants);
+        setTotal(result.total);
+        setSummary(
+          result.summary ?? {
+            grants: result.total,
+            objects: new Set(result.grants.map((grant) => `${grant.objType}:${grant.objId}`)).size,
+            grantees: new Set(result.grants.map((grant) => grant.accessorId)).size,
+          },
+        );
+        await hydrateUserLookup([...new Set(result.grants.map((grant) => grant.accessorId))]);
+        setLookupRevision((revision) => revision + 1);
+      } else {
+        // 按对象/按成员:服务端分组分页,每页只取一屏聚合行,不再全量拉再客户端分组。
+        const { groups: rows, total: groupTotal } = await listObjectGroups(view, {
+          offset,
+          limit: pageState.pageSize,
           search: debouncedKeyword || undefined,
           resourceType: objTypeFilter,
-          offset: paginate ? (pageState.page - 1) * pageState.pageSize : undefined,
-          limit: paginate ? pageState.pageSize : undefined,
-          includeSummary: true,
-        },
-        { resolveNames: false },
-      );
-
-      setGrants(result.grants);
-      setTotal(result.total);
-      setSummary(
-        result.summary ?? {
-          grants: result.total,
-          objects: new Set(result.grants.map((grant) => `${grant.objType}:${grant.objId}`)).size,
-          grantees: new Set(result.grants.map((grant) => grant.accessorId)).size,
-        },
-      );
-      const accessorIds = [...new Set(result.grants.map((grant) => grant.accessorId))];
-      await hydrateUserLookup(accessorIds);
-      setLookupRevision((revision) => revision + 1);
+        });
+        setGrants([]);
+        setGroups(rows);
+        setTotal(groupTotal);
+        setSummary((prev) => ({
+          ...prev,
+          objects: view === "object" ? groupTotal : prev.objects,
+          grantees: view === "grantee" ? groupTotal : prev.grantees,
+        }));
+        if (view === "grantee") {
+          await hydrateUserLookup(rows.map((row) => row.accessorId ?? "").filter(Boolean));
+          setLookupRevision((revision) => revision + 1);
+        }
+      }
     } catch (error) {
       setLoadError(extractRequestErrorMessage(error));
     } finally {
@@ -205,60 +226,32 @@ export function ObjectAuthorizationScene() {
     setPagination(1, pageState.pageSize);
   }, [debouncedKeyword, granteeType, objTypeFilter, pageState.pageSize, setPagination, view]);
 
-  const byObject = useMemo(() => {
-    const groups = new Map<string, ObjectGrant[]>();
-    for (const grant of filteredGrants) {
-      const key = `${grant.objType}::${grant.objId}`;
-      const list = groups.get(key) ?? [];
-      list.push(grant);
-      groups.set(key, list);
-    }
-    return [...groups.values()];
-  }, [filteredGrants]);
-
-  const byGrantee = useMemo(() => {
-    const groups = new Map<string, ObjectGrant[]>();
-    for (const grant of filteredGrants) {
-      const list = groups.get(grant.accessorId) ?? [];
-      list.push(grant);
-      groups.set(grant.accessorId, list);
-    }
-    return [...groups.values()];
-  }, [filteredGrants]);
-
-  const groupList = useMemo(() => {
-    if (view === "object") {
-      return byObject;
-    }
-    if (view === "grantee") {
-      return byGrantee;
-    }
-    return [];
-  }, [byGrantee, byObject, view]);
-
-  const pagedGroups = useMemo(() => {
-    const start = (pageState.page - 1) * pageState.pageSize;
-    return groupList.slice(start, start + pageState.pageSize);
-  }, [groupList, pageState.page, pageState.pageSize]);
-
-  const pagedGrants = useMemo(() => {
-    if (view === "all") {
-      return filteredGrants;
-    }
-    const start = (pageState.page - 1) * pageState.pageSize;
-    return filteredGrants.slice(start, start + pageState.pageSize);
-  }, [filteredGrants, pageState.page, pageState.pageSize, view]);
-
-  // 对象名按需解析:只解析「当前页可见行」的对象名,翻页/切视图再解析新出现的那批。
-  // 用缓存,翻回来的页零请求。避免为全部(数千条)grant 一次性解析导致取名接口连接饱和/超时。
+  // 对象名按需解析:只解析「当前可见页」的对象名,翻页/切视图再解析新出现的。用缓存,
+  // 翻回来的页零请求。避免为全部(数千条)一次性解析导致领域取名接口连接饱和/超时。
   useEffect(() => {
-    const visible = view === "all" ? pagedGrants : pagedGroups.flat();
-    const pending = visible.filter((grant) => grant.objName === grant.objId);
-    if (pending.length === 0) {
+    if (view === "grantee") {
+      // 按成员视图行是成员,名字走用户查找(hydrateUserLookup),此处不解析对象名。
+      return;
+    }
+    const pendingGrants =
+      view === "all" ? filteredGrants.filter((grant) => grant.objName === grant.objId) : [];
+    const pendingGroups =
+      view === "object" ? groups.filter((group) => group.objName === group.objId) : [];
+    if (pendingGrants.length === 0 && pendingGroups.length === 0) {
       return;
     }
     let cancelled = false;
-    void resolveGrantNames(pending).then((named) => {
+    const toResolve: ObjectGrant[] = [
+      ...pendingGrants,
+      ...pendingGroups.map((group) => ({
+        accessorId: "",
+        objType: group.objType ?? "",
+        objId: group.objId ?? "",
+        objName: group.objId ?? "",
+        operations: [],
+      })),
+    ];
+    void resolveGrantNames(toResolve).then((named) => {
       if (cancelled) {
         return;
       }
@@ -270,19 +263,28 @@ export function ObjectAuthorizationScene() {
       if (nameByKey.size === 0) {
         return;
       }
-      setGrants((prev) =>
-        prev.map((grant) => {
-          const name = nameByKey.get(`${grant.objType}:${grant.objId}`);
-          return name ? { ...grant, objName: name } : grant;
-        }),
-      );
+      if (view === "all") {
+        setGrants((prev) =>
+          prev.map((grant) => {
+            const name = nameByKey.get(`${grant.objType}:${grant.objId}`);
+            return name ? { ...grant, objName: name } : grant;
+          }),
+        );
+      } else {
+        setGroups((prev) =>
+          prev.map((group) => {
+            const name = nameByKey.get(`${group.objType}:${group.objId}`);
+            return name ? { ...group, objName: name } : group;
+          }),
+        );
+      }
     });
     return () => {
       cancelled = true;
     };
-  }, [pagedGrants, pagedGroups, view]);
+  }, [filteredGrants, groups, view]);
 
-  const listTotal = view === "all" ? total : groupList.length;
+  const listTotal = total;
 
   const openDrawer = useCallback((target: DrawerTarget) => {
     setDrawer({ open: true, target });
@@ -431,7 +433,8 @@ export function ObjectAuthorizationScene() {
   ], [confirmRevoke, granteeCell, openDrawer, opChips, t]);
 
   const renderBody = () => {
-    if (!loading && filteredGrants.length === 0) {
+    const isEmpty = view === "all" ? filteredGrants.length === 0 : groups.length === 0;
+    if (!loading && isEmpty) {
       return (
         <Empty
           description={t("systemAdmin.objectGrants.empty")}
@@ -443,77 +446,39 @@ export function ObjectAuthorizationScene() {
     if (view === "object") {
       return (
         <div className={styles.authzGroupList}>
-          {pagedGroups.map((list) => {
-            const head = list[0];
-            const groupKey = `${head.objType}::${head.objId}`;
-            const inner = objectInnerPage[groupKey] ?? {
-              page: 1,
-              pageSize: INNER_PAGE_SIZE,
+          {groups.map((group) => {
+            const objType = group.objType ?? "";
+            const objId = group.objId ?? "";
+            const objName = group.objName || objId;
+            const pseudo: ObjectGrant = {
+              accessorId: "",
+              objType,
+              objId,
+              objName,
+              operations: group.operations,
             };
-            const innerStart = (inner.page - 1) * inner.pageSize;
-            const innerPaged = list.slice(innerStart, innerStart + inner.pageSize);
-
             return (
-              <div className={styles.authzGroup} key={groupKey}>
+              <div className={styles.authzGroup} key={`${objType}::${objId}`}>
                 <div className={styles.authzGroupHead}>
                   <span className={styles.authzGroupTitle}>
                     <span className={styles.authzAvatar}>
-                      {OBJ_ICON[head.objType] ?? <AppstoreOutlined />}
+                      {OBJ_ICON[objType] ?? <AppstoreOutlined />}
                     </span>
-                    <span className={styles.authzGroupName}>{head.objName}</span>
-                    <Tag className={styles.roleTag}>{resourceTypeLabel(head.objType)}</Tag>
+                    <span className={styles.authzGroupName}>{objName}</span>
+                    <Tag className={styles.roleTag}>{resourceTypeLabel(objType)}</Tag>
                     <span className={styles.authzGroupCount}>
-                      {t("systemAdmin.objectGrants.granteeCount", { count: list.length })}
+                      {t("systemAdmin.objectGrants.granteeCount", { count: group.count })}
                     </span>
                   </span>
                   <AppButton
                     icon={<KeyOutlined />}
-                    onClick={() =>
-                      openDrawer({
-                        id: head.objId,
-                        name: head.objName,
-                        sub: head.objSub,
-                        type: head.objType,
-                      })
-                    }
+                    onClick={() => openDrawer({ id: objId, name: objName, type: objType })}
                   >
                     {t("systemAdmin.objectGrants.manage")}
                   </AppButton>
                 </div>
                 <div className={styles.authzGroupBody}>
-                  {innerPaged.map((grant) => (
-                    <div className={styles.authzGrantLine} key={grantKey(grant)}>
-                      {granteeCell(grant.accessorId)}
-                      {opChips(grant)}
-                      <AppButton
-                        className={[styles.actionLink, styles.actionDanger].join(" ")}
-                        danger
-                        onClick={() => confirmRevoke(grant)}
-                        type="link"
-                      >
-                        {t("systemAdmin.objectGrants.revoke")}
-                      </AppButton>
-                    </div>
-                  ))}
-                  {list.length > inner.pageSize ? (
-                    <TablePaginationBar
-                      current={inner.page}
-                      onChange={(page, nextPageSize) => {
-                        setObjectInnerPage((prev) => ({
-                          ...prev,
-                          [groupKey]: {
-                            page,
-                            pageSize: nextPageSize ?? inner.pageSize,
-                          },
-                        }));
-                      }}
-                      pageSize={inner.pageSize}
-                      showSizeChanger
-                      showTotal={(count) => t("common.total", { total: count })}
-                      size="small"
-                      total={list.length}
-                    />
-                  ) : null}
+                  <div className={styles.authzGrantLine}>{opChips(pseudo)}</div>
                 </div>
               </div>
             );
@@ -525,72 +490,28 @@ export function ObjectAuthorizationScene() {
     if (view === "grantee") {
       return (
         <div className={styles.authzGroupList}>
-          {pagedGroups.map((list) => {
-            const head = list[0];
-            const grantee = resolveGrantee(head.accessorId);
-            const inner = granteeInnerPage[head.accessorId] ?? {
-              page: 1,
-              pageSize: INNER_PAGE_SIZE,
+          {groups.map((group) => {
+            const accessorId = group.accessorId ?? "";
+            const grantee = resolveGrantee(accessorId);
+            const pseudo: ObjectGrant = {
+              accessorId,
+              objType: "",
+              objId: accessorId,
+              objName: "",
+              operations: group.operations,
             };
-            const innerStart = (inner.page - 1) * inner.pageSize;
-            const innerPaged = list.slice(innerStart, innerStart + inner.pageSize);
-
             return (
-              <div className={styles.authzGroup} key={head.accessorId}>
+              <div className={styles.authzGroup} key={accessorId}>
                 <div className={styles.authzGroupHead}>
                   <span className={styles.authzGroupTitle}>
                     <span className={styles.authzGroupName}>{grantee.label}</span>
                     <span className={styles.authzGroupCount}>
-                      {t("systemAdmin.objectGrants.objectCount", { count: list.length })}
+                      {t("systemAdmin.objectGrants.objectCount", { count: group.count })}
                     </span>
                   </span>
                 </div>
                 <div className={styles.authzGroupBody}>
-                  {innerPaged.map((grant) => (
-                    <div className={styles.authzGrantLine} key={grantKey(grant)}>
-                      <span className={styles.authzWho}>
-                        <span className={styles.authzAvatar}>
-                          {OBJ_ICON[grant.objType] ?? <AppstoreOutlined />}
-                        </span>
-                        <span className={styles.authzWhoName}>{grant.objName}</span>
-                        <Tag className={styles.roleTag}>{resourceTypeLabel(grant.objType)}</Tag>
-                      </span>
-                      {opChips(grant)}
-                      <AppButton
-                        className={styles.actionLink}
-                        onClick={() =>
-                          openDrawer({
-                            id: grant.objId,
-                            name: grant.objName,
-                            sub: grant.objSub,
-                            type: grant.objType,
-                          })
-                        }
-                        type="link"
-                      >
-                        {t("systemAdmin.objectGrants.manage")}
-                      </AppButton>
-                    </div>
-                  ))}
-                  {list.length > inner.pageSize ? (
-                    <TablePaginationBar
-                      current={inner.page}
-                      onChange={(page, nextPageSize) => {
-                        setGranteeInnerPage((prev) => ({
-                          ...prev,
-                          [head.accessorId]: {
-                            page,
-                            pageSize: nextPageSize ?? inner.pageSize,
-                          },
-                        }));
-                      }}
-                      pageSize={inner.pageSize}
-                      showSizeChanger
-                      showTotal={(count) => t("common.total", { total: count })}
-                      size="small"
-                      total={list.length}
-                    />
-                  ) : null}
+                  <div className={styles.authzGrantLine}>{opChips(pseudo)}</div>
                 </div>
               </div>
             );
@@ -602,7 +523,7 @@ export function ObjectAuthorizationScene() {
     return (
       <AppTable<ObjectGrant>
         columns={columns}
-        dataSource={pagedGrants}
+        dataSource={filteredGrants}
         loading={loading}
         pagination={false}
         rowKey={grantKey}

--- a/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
+++ b/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
@@ -19,7 +19,7 @@ import {
 } from "@ant-design/icons";
 import { Alert, Empty, Input, Segmented, Select, Tag, Tooltip } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
@@ -33,6 +33,7 @@ import { AppTable } from "@/framework/ui/common/AppTable";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { ObjectAuthorizeDrawer } from "@/modules/system-admin/components/ObjectAuthorizeDrawer";
 import { listObjectGrantsPage, revokeObjectGrant } from "@/modules/system-admin/services/authz.service";
+import { resolveGrantNames } from "@/modules/system-admin/services/authz-objects.service";
 import type { AdminDepartment } from "@/modules/system-admin/types/admin";
 import type { AuthzSummary, ObjectGrant } from "@/modules/system-admin/types/authz";
 import {
@@ -84,6 +85,8 @@ export function ObjectAuthorizationScene() {
   const [lookupRevision, setLookupRevision] = useState(0);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // 每次加载自增;异步名字回填只在 token 仍是当前值时落地,防止旧一轮解析覆盖新列表。
+  const loadTokenRef = useRef(0);
 
   const [view, setView] = useState<ViewMode>("all");
   const [keyword, setKeyword] = useState("");
@@ -109,15 +112,26 @@ export function ObjectAuthorizationScene() {
       setDepartments(deptList);
 
       const paginate = view === "all";
-      const result = await listObjectGrantsPage({
-        search: debouncedKeyword || undefined,
-        resourceType: objTypeFilter,
-        offset: paginate ? (pageState.page - 1) * pageState.pageSize : undefined,
-        limit: paginate ? pageState.pageSize : undefined,
-        includeSummary: true,
-      });
+      const token = ++loadTokenRef.current;
+      // resolveNames:false —— 列表先用 id 占位立即渲染,不被对象名解析(可能慢/部分缺失)阻塞。
+      const result = await listObjectGrantsPage(
+        {
+          search: debouncedKeyword || undefined,
+          resourceType: objTypeFilter,
+          offset: paginate ? (pageState.page - 1) * pageState.pageSize : undefined,
+          limit: paginate ? pageState.pageSize : undefined,
+          includeSummary: true,
+        },
+        { resolveNames: false },
+      );
 
       setGrants(result.grants);
+      // 名字异步回填;仅当没有更新一轮加载覆盖时才落地。
+      void resolveGrantNames(result.grants).then((named) => {
+        if (loadTokenRef.current === token) {
+          setGrants(named);
+        }
+      });
       setTotal(result.total);
       setSummary(
         result.summary ?? {

--- a/src/modules/system-admin/services/authz-objects.service.test.ts
+++ b/src/modules/system-admin/services/authz-objects.service.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+const postMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock, post: postMock },
+}));
+
+vi.mock("@/framework/runtime/config", () => ({
+  getRuntimeConfig: () => ({ currentUser: { businessDomainId: "bd_public" } }),
+}));
+
+import { resolveGrantNames } from "@/modules/system-admin/services/authz-objects.service";
+import type { ObjectGrant } from "@/modules/system-admin/types/authz";
+
+/** resource 型对象走 vega 旧批量取名接口(逗号拼 id 进 path)。 */
+function resourceGrant(id: string): ObjectGrant {
+  return { accessorId: "u1", objId: id, objName: id, objType: "resource", operations: ["view"] };
+}
+
+/** vega URL 尾段解析出本批请求的 id 列表。 */
+function idsInLastCalls(): string[][] {
+  return getMock.mock.calls.map((call) => {
+    const tail = String(call[0]).split("/").pop() ?? "";
+    return tail.split(",").map(decodeURIComponent);
+  });
+}
+
+describe("authz-objects · resolveGrantNames 取名不再打请求风暴", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("整批 404 只发「分批数」次请求,不再逐个重拉(120 → 3,非 121)", async () => {
+    getMock.mockRejectedValue(new Error("404"));
+
+    const grants = Array.from({ length: 120 }, (_, index) => resourceGrant(`storm-${index}`));
+    const result = await resolveGrantNames(grants);
+
+    // ceil(120 / 50) = 3 批;修复前是 1(整批)+ 120(逐个)= 121。
+    expect(getMock).toHaveBeenCalledTimes(3);
+    for (const batch of idsInLastCalls()) {
+      expect(batch.length).toBeLessThanOrEqual(50);
+    }
+    // 解析不到 → 名称保持 id 兜底。
+    expect(result.every((grant) => grant.objName === grant.objId)).toBe(true);
+  });
+
+  it("批量成功一次拉回,≤50 个 id 只发一条请求", async () => {
+    getMock.mockImplementation((url: string) => {
+      const tail = String(url).split("/").pop() ?? "";
+      const ids = tail.split(",").map(decodeURIComponent);
+      return Promise.resolve({ data: { entries: ids.map((id) => ({ id, name: `name-${id}` })) } });
+    });
+
+    const grants = ["ok-a", "ok-b", "ok-c"].map(resourceGrant);
+    const result = await resolveGrantNames(grants);
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(result.map((grant) => grant.objName)).toEqual(["name-ok-a", "name-ok-b", "name-ok-c"]);
+  });
+
+  it("超过 50 个 id 分批(60 → 2 批)", async () => {
+    getMock.mockImplementation((url: string) => {
+      const tail = String(url).split("/").pop() ?? "";
+      const ids = tail.split(",").map(decodeURIComponent);
+      return Promise.resolve({ data: { entries: ids.map((id) => ({ id, name: `n-${id}` })) } });
+    });
+
+    const grants = Array.from({ length: 60 }, (_, index) => resourceGrant(`big-${index}`));
+    await resolveGrantNames(grants);
+
+    expect(getMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("正向缓存:已解析的 id 再次解析不再请求", async () => {
+    getMock.mockImplementation((url: string) => {
+      const tail = String(url).split("/").pop() ?? "";
+      const ids = tail.split(",").map(decodeURIComponent);
+      return Promise.resolve({ data: { entries: ids.map((id) => ({ id, name: `c-${id}` })) } });
+    });
+
+    const grants = ["cache-1", "cache-2"].map(resourceGrant);
+    await resolveGrantNames(grants);
+    const afterFirst = getMock.mock.calls.length;
+
+    const again = await resolveGrantNames(grants);
+
+    // 第二次全部命中缓存,零新请求。
+    expect(getMock.mock.calls.length).toBe(afterFirst);
+    expect(again.map((grant) => grant.objName)).toEqual(["c-cache-1", "c-cache-2"]);
+  });
+});

--- a/src/modules/system-admin/services/authz-objects.service.test.ts
+++ b/src/modules/system-admin/services/authz-objects.service.test.ts
@@ -107,7 +107,7 @@ describe("authz-objects · resolveGrantNames 取名不再打请求风暴", () =>
 
     await resolveGrantNames([resourceGrant("im-1")]);
 
-    const call = getMock.mock.calls.at(-1);
+    const call = getMock.mock.calls.at(-1) as [string, { params?: unknown }] | undefined;
     expect(call?.[1]?.params).toEqual({ ignore_missing: true });
   });
 

--- a/src/modules/system-admin/services/authz-objects.service.test.ts
+++ b/src/modules/system-admin/services/authz-objects.service.test.ts
@@ -102,6 +102,34 @@ describe("authz-objects · resolveGrantNames 取名不再打请求风暴", () =>
     expect(result[0].objName).toBe("销售数据集");
   });
 
+  it("vega 批量取名带 ignore_missing=true", async () => {
+    getMock.mockResolvedValue({ data: { entries: [] } });
+
+    await resolveGrantNames([resourceGrant("im-1")]);
+
+    const call = getMock.mock.calls.at(-1);
+    expect(call?.[1]?.params).toEqual({ ignore_missing: true });
+  });
+
+  it("部分返回:缺失 id 退回 id 兜底,不牵连其余(按 entry.id 对齐)", async () => {
+    // 后端 ignore_missing 下只回查到的;这里模拟第 2 个已删被略过。
+    getMock.mockImplementation((url: string) => {
+      const ids = String(url).split("/").pop()!.split(",").map(decodeURIComponent);
+      const found = ids.filter((id) => id !== "part-gone");
+      return Promise.resolve({
+        data: { entries: found.map((id) => ({ id, name: `n-${id}` })) },
+      });
+    });
+
+    const result = await resolveGrantNames(
+      ["part-a", "part-gone", "part-c"].map(resourceGrant),
+    );
+
+    expect(result[0].objName).toBe("n-part-a");
+    expect(result[1].objName).toBe("part-gone"); // 缺失 → id 兜底
+    expect(result[2].objName).toBe("n-part-c");
+  });
+
   it("正向缓存:已解析的 id 再次解析不再请求", async () => {
     getMock.mockImplementation((url: string) => {
       const tail = String(url).split("/").pop() ?? "";

--- a/src/modules/system-admin/services/authz-objects.service.test.ts
+++ b/src/modules/system-admin/services/authz-objects.service.test.ts
@@ -86,6 +86,22 @@ describe("authz-objects · resolveGrantNames 取名不再打请求风暴", () =>
     expect(getMock).toHaveBeenCalledTimes(2);
   });
 
+  it("后端已带真实名(objName ≠ id)则跳过解析,零请求", async () => {
+    getMock.mockRejectedValue(new Error("不该被调用"));
+
+    const named: ObjectGrant = {
+      accessorId: "u1",
+      objId: "res-1",
+      objName: "销售数据集",
+      objType: "resource",
+      operations: ["view"],
+    };
+    const result = await resolveGrantNames([named]);
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(result[0].objName).toBe("销售数据集");
+  });
+
   it("正向缓存:已解析的 id 再次解析不再请求", async () => {
     getMock.mockImplementation((url: string) => {
       const tail = String(url).split("/").pop() ?? "";

--- a/src/modules/system-admin/services/authz-objects.service.ts
+++ b/src/modules/system-admin/services/authz-objects.service.ts
@@ -210,6 +210,10 @@ export async function resolveGrantNames(grants: ObjectGrant[]): Promise<ObjectGr
     if (grant.objName && grant.objName !== grant.objId) {
       continue;
     }
+    // 缺 type 或 id 无法可靠取名,也会污染 `${type}:${id}` 缓存键,跳过。
+    if (!grant.objType || !grant.objId) {
+      continue;
+    }
     if (nameCache.has(`${grant.objType}:${grant.objId}`)) {
       continue;
     }

--- a/src/modules/system-admin/services/authz-objects.service.ts
+++ b/src/modules/system-admin/services/authz-objects.service.ts
@@ -152,21 +152,22 @@ async function namesFor(type: string, ids: string[]): Promise<Map<string, string
     return map;
   }
   if (cfg.kind === "vega") {
-    // 旧接口：逗号分隔 path、返回完整对象、任一 id 不存在整批 404。按 NAME_ID_BATCH
-    // 分批,单批失败仅丢该批(名称退化为 id 兜底)。此前是「整批失败 → 逐个重拉」,
-    // 全体 404 的大列表(如已删除的 resource 授权)会瞬间打出上百条 404,已移除。
+    // 逗号分隔 path 批量取名。ignore_missing=true 让后端对已删 id 返 200 + 查到的那些
+    // (而非任一 id 不存在就整批 404),孤儿授权混进本批也不牵连其余。按 NAME_ID_BATCH
+    // 分批控 URL 长度(50 ≈ 1.1KB,远低于网关 ~8KB/414 上限)。回填按 entry.id 对齐,
+    // 不假设返回顺序/数量;请求了但没返的 id = 已删对象 → 名称退化为 id 兜底。
     await Promise.all(
       chunk(ids, NAME_ID_BATCH).map(async (batch) => {
         try {
           const response = await http.get<unknown>(
             `${cfg.path}/${batch.map(encodeURIComponent).join(",")}`,
-            { skipErrorToast: true },
+            { params: { ignore_missing: true }, skipErrorToast: true },
           );
           for (const [id, name] of collectNamePairs(response.data, "id", "name")) {
             map.set(id, name);
           }
         } catch {
-          // 本批不可解析：名称保持 id 兜底,不再逐个重试。
+          // 本批整体失败(非缺 id,而是网络/网关):名称保持 id 兜底,不逐个重试。
         }
       }),
     );

--- a/src/modules/system-admin/services/authz-objects.service.ts
+++ b/src/modules/system-admin/services/authz-objects.service.ts
@@ -204,6 +204,11 @@ export async function resolveGrantNames(grants: ObjectGrant[]): Promise<ObjectGr
   // 只对缓存里没有名字的 id 发起请求,按类型分组。
   const pendingByType = new Map<string, Set<string>>();
   for (const grant of grants) {
+    // 后端已带真实名(objName ≠ id)则跳过。前向兼容:一旦 object-grants 直接回 name,
+    // 整套领域服务 fan-out 自动停掉,无需再改这里。
+    if (grant.objName && grant.objName !== grant.objId) {
+      continue;
+    }
     if (nameCache.has(`${grant.objType}:${grant.objId}`)) {
       continue;
     }
@@ -224,6 +229,10 @@ export async function resolveGrantNames(grants: ObjectGrant[]): Promise<ObjectGr
     }),
   );
   return grants.map((grant) => {
+    // 已是后端真实名的保留不动。
+    if (grant.objName && grant.objName !== grant.objId) {
+      return grant;
+    }
     const name = nameCache.get(`${grant.objType}:${grant.objId}`);
     return name ? { ...grant, objName: name } : grant;
   });

--- a/src/modules/system-admin/services/authz-objects.service.ts
+++ b/src/modules/system-admin/services/authz-objects.service.ts
@@ -18,6 +18,21 @@ import { AUTHZ_OBJECT_TYPES } from "@/modules/system-admin/utils/authz-catalog";
 
 const PAGE_SIZE = 100;
 
+/**
+ * 按 id 批量取名时,单条 URL(逗号拼 id)携带的 id 数上限。旧的 vega/mcp 接口把 id
+ * 拼进 path,几十上百个会撞网关 URL 长度限制;且任一 id 不存在整批 404 —— 分批可把
+ * 单个坏 id 的影响限定在本批,不牵连其它。UUID(~36 char)× 50 ≈ 1.8KB。
+ */
+const NAME_ID_BATCH = 50;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
+}
+
 const str = (value: unknown): string =>
   typeof value === "string"
     ? value
@@ -137,56 +152,71 @@ async function namesFor(type: string, ids: string[]): Promise<Map<string, string
     return map;
   }
   if (cfg.kind === "vega") {
-    // 旧接口：逗号分隔 path、返回完整对象、任一 id 不存在整批 404 → 失败时退化为逐个。
-    try {
-      const response = await http.get<unknown>(`${cfg.path}/${ids.map(encodeURIComponent).join(",")}`, {
-        skipErrorToast: true,
-      });
-      for (const [id, name] of collectNamePairs(response.data, "id", "name")) {
-        map.set(id, name);
-      }
-    } catch {
-      const settled = await Promise.allSettled(
-        ids.map((id) => http.get<unknown>(`${cfg.path}/${encodeURIComponent(id)}`, { skipErrorToast: true })),
-      );
-      settled.forEach((result, index) => {
-        if (result.status === "fulfilled") {
-          // 单条响应同样是 {entries:[{id,name}]} 形态；用同一解析兜住。
-          const name = collectNamePairs(result.value.data, "id", "name")[0]?.[1];
-          if (name) {
-            map.set(ids[index], name);
+    // 旧接口：逗号分隔 path、返回完整对象、任一 id 不存在整批 404。按 NAME_ID_BATCH
+    // 分批,单批失败仅丢该批(名称退化为 id 兜底)。此前是「整批失败 → 逐个重拉」,
+    // 全体 404 的大列表(如已删除的 resource 授权)会瞬间打出上百条 404,已移除。
+    await Promise.all(
+      chunk(ids, NAME_ID_BATCH).map(async (batch) => {
+        try {
+          const response = await http.get<unknown>(
+            `${cfg.path}/${batch.map(encodeURIComponent).join(",")}`,
+            { skipErrorToast: true },
+          );
+          for (const [id, name] of collectNamePairs(response.data, "id", "name")) {
+            map.set(id, name);
           }
+        } catch {
+          // 本批不可解析：名称保持 id 兜底,不再逐个重试。
         }
-      });
-    }
+      }),
+    );
     return map;
   }
-  // mcp 旧接口：GET .../mcp/market/batch/{ids}/{fields}
-  const response = await http.get<unknown>(
-    `/agent-operator-integration/v1/mcp/market/batch/${ids.map(encodeURIComponent).join(",")}/mcp_id,name`,
-    { headers: domainHeaders(), skipErrorToast: true },
+  // mcp 旧接口：GET .../mcp/market/batch/{ids}/{fields}，同样分批防 URL 超限。
+  await Promise.all(
+    chunk(ids, NAME_ID_BATCH).map(async (batch) => {
+      try {
+        const response = await http.get<unknown>(
+          `/agent-operator-integration/v1/mcp/market/batch/${batch.map(encodeURIComponent).join(",")}/mcp_id,name`,
+          { headers: domainHeaders(), skipErrorToast: true },
+        );
+        for (const [id, name] of collectNamePairs(response.data, "mcp_id", "name")) {
+          map.set(id, name);
+        }
+      } catch {
+        // 本批不可解析：名称保持 id 兜底。
+      }
+    }),
   );
-  for (const [id, name] of collectNamePairs(response.data, "mcp_id", "name")) {
-    map.set(id, name);
-  }
   return map;
 }
 
+/**
+ * 已解析对象名的进程内正向缓存(`${type}:${id}` -> name)。跨分页翻页、列表刷新、
+ * dev StrictMode 的重复加载复用,已有名字的 id 不再重复请求。只缓存成功项:解析不到
+ * 的 id 下次仍会重试(可能是后来才建的对象),但重试也走分批,不会退化成风暴。
+ * 生命周期随 SPA 会话,硬刷新即清空。
+ */
+const nameCache = new Map<string, string>();
+
 /** 用领域服务解析对象名，回填到 grants 的 objName（解析失败的保持原 id 兜底）。 */
 export async function resolveGrantNames(grants: ObjectGrant[]): Promise<ObjectGrant[]> {
-  const idsByType = new Map<string, Set<string>>();
+  // 只对缓存里没有名字的 id 发起请求,按类型分组。
+  const pendingByType = new Map<string, Set<string>>();
   for (const grant of grants) {
-    const set = idsByType.get(grant.objType) ?? new Set<string>();
+    if (nameCache.has(`${grant.objType}:${grant.objId}`)) {
+      continue;
+    }
+    const set = pendingByType.get(grant.objType) ?? new Set<string>();
     set.add(grant.objId);
-    idsByType.set(grant.objType, set);
+    pendingByType.set(grant.objType, set);
   }
-  const resolved = new Map<string, string>(); // `${type}:${id}` -> name
   await Promise.all(
-    [...idsByType.entries()].map(async ([type, ids]) => {
+    [...pendingByType.entries()].map(async ([type, ids]) => {
       try {
         const map = await namesFor(type, [...ids]);
         for (const [id, name] of map) {
-          resolved.set(`${type}:${id}`, name);
+          nameCache.set(`${type}:${id}`, name);
         }
       } catch {
         // 单类型解析失败：该类型对象名退化为 id，不影响列表展示。
@@ -194,7 +224,7 @@ export async function resolveGrantNames(grants: ObjectGrant[]): Promise<ObjectGr
     }),
   );
   return grants.map((grant) => {
-    const name = resolved.get(`${grant.objType}:${grant.objId}`);
+    const name = nameCache.get(`${grant.objType}:${grant.objId}`);
     return name ? { ...grant, objName: name } : grant;
   });
 }

--- a/src/modules/system-admin/services/authz.service.ts
+++ b/src/modules/system-admin/services/authz.service.ts
@@ -118,6 +118,7 @@ function filterMockGrants(query: ObjectGrantQuery): ObjectGrant[] {
 
 export async function listObjectGrantsPage(
   query: ObjectGrantQuery = {},
+  options: { resolveNames?: boolean } = {},
 ): Promise<ObjectGrantListResult> {
   if (useMock) {
     const filtered = filterMockGrants(query).map(clone);
@@ -164,10 +165,12 @@ export async function listObjectGrantsPage(
     summary?: AuthzSummary;
   }>(`${ADMIN}/object-grants${suffix}`);
   const mapped = (response.data.entries ?? []).map(mapEntry);
-  const named = await resolveGrantNames(mapped);
+  // 默认解析对象名(抽屉等调用方直接用)。列表页传 resolveNames:false 先拿 id 占位、
+  // 立即渲染,再自行异步回填名字,避免名字解析阻塞整页。
+  const grants = options.resolveNames === false ? mapped : await resolveGrantNames(mapped);
   return {
-    grants: named,
-    total: response.data.total ?? named.length,
+    grants,
+    total: response.data.total ?? grants.length,
     summary: response.data.summary,
   };
 }

--- a/src/modules/system-admin/services/authz.service.ts
+++ b/src/modules/system-admin/services/authz.service.ts
@@ -180,6 +180,92 @@ export async function listObjectGrants(query: ObjectGrantQuery = {}): Promise<Ob
   return grantList;
 }
 
+/** 分组视图的一行:一个对象(按对象)或一个成员(按成员)的聚合。 */
+export type AuthzGroup = {
+  objType?: string;
+  objId?: string;
+  objName?: string;
+  accessorId?: string;
+  /** 按对象=授权主体数;按成员=对象数。 */
+  count: number;
+  /** 该组合并后的操作集。 */
+  operations: string[];
+};
+
+/**
+ * 分组视图数据源。后端按对象/成员聚合并分页(group_by=object|grantee + offset/limit),
+ * 每组只回计数 + 合并操作,前端不再一次拉全部 grant 再客户端分组。明细走抽屉(单对象
+ * listObjectGrants)。对象名后端不下发,列表按当前可见页 on-demand 解析(见场景)。
+ */
+export async function listObjectGroups(
+  groupBy: "object" | "grantee",
+  query: { offset?: number; limit?: number; search?: string; resourceType?: string } = {},
+): Promise<{ groups: AuthzGroup[]; total: number }> {
+  if (useMock) {
+    const filtered = filterMockGrants({ search: query.search, resourceType: query.resourceType });
+    const map = new Map<string, AuthzGroup>();
+    for (const grant of filtered) {
+      const key = groupBy === "object" ? `${grant.objType}::${grant.objId}` : grant.accessorId;
+      const row =
+        map.get(key) ??
+        (groupBy === "object"
+          ? { objType: grant.objType, objId: grant.objId, objName: grant.objName, count: 0, operations: [] }
+          : { accessorId: grant.accessorId, count: 0, operations: [] });
+      row.count += 1;
+      row.operations = [...new Set([...row.operations, ...grant.operations])];
+      map.set(key, row);
+    }
+    const all = [...map.values()];
+    const offset = query.offset ?? 0;
+    const limit = query.limit;
+    const page = limit === undefined ? all : all.slice(offset, offset + Math.max(limit, 0));
+    return wait({ groups: page, total: all.length });
+  }
+
+  const params = new URLSearchParams();
+  params.set("group_by", groupBy);
+  if (query.resourceType) {
+    params.set("resource_type", query.resourceType);
+  }
+  if (query.search) {
+    params.set("search", query.search);
+  }
+  if (query.offset !== undefined) {
+    params.set("offset", String(query.offset));
+  }
+  if (query.limit !== undefined) {
+    params.set("limit", String(query.limit));
+  }
+
+  const response = await http.get<{
+    groups?: {
+      object?: { type?: string; id?: string; name?: string };
+      accessor_id?: string;
+      grantee_count?: number;
+      object_count?: number;
+      operations?: string[];
+    }[];
+    total?: number;
+  }>(`${ADMIN}/object-grants?${params.toString()}`);
+
+  const groups: AuthzGroup[] = (response.data.groups ?? []).map((raw) =>
+    groupBy === "object"
+      ? {
+          objType: raw.object?.type ?? "",
+          objId: raw.object?.id ?? "",
+          objName: raw.object?.name || raw.object?.id || "",
+          count: raw.grantee_count ?? 0,
+          operations: raw.operations ?? [],
+        }
+      : {
+          accessorId: raw.accessor_id ?? "",
+          count: raw.object_count ?? 0,
+          operations: raw.operations ?? [],
+        },
+  );
+  return { groups, total: response.data.total ?? groups.length };
+}
+
 export async function listAuthorizableObjects(objType?: string): Promise<AuthorizableObject[]> {
   if (useMock) {
     return wait(authzObjects.filter((item) => !objType || item.type === objType).map((item) => ({ ...item })));


### PR DESCRIPTION
## 背景

后端将 `GET /api/safe/v1/me/permissions` 从「逐资源实例铺开」改为「有效授权」折叠形态，并新增 `resource_type` / `resource_id` 可选过滤。此前对超管账号该接口返回 ~806KB / 6.8s（5640 条、其中 5628 条为泛型 `resource` 逐实例铺开且授满同一套 ops），阻塞式启动路径导致进页卡死。对应后端 openbkn-ai/bkn-foundry#353。

折叠后响应三种行形态：
- 通配行 `{"type":"*","id":"*","operations":["*"]}` —— 出现即短路
- 类型级行 `{"type":T,"id":"*","operations":[...]}`
- 实例例外行 `{"type":T,"id":<id>,"operations":[...]}` —— 仅在操作超出类型级时出现，且只含**增量**

## 改动

- **`getResourceOperations`**：按类型分组做 scoped 查询 `?resource_type=&resource_id=`，不再拉全量 ACL 再前端过滤；payload 随页大小走。
- **`operationsFor`**：按折叠契约做 union —— 类型级行(`id:"*"`)与实例例外行(仅增量)并入同一集合；通配行(`type:"*"`+op`"*"`)与类型级 `"*"` 操作展开为 `ADMIN_OPERATIONS`。
- **`RuntimeUser` 增 `isAdmin`**：`fetchCurrentUser` 启动时回填；`LargeModelListPanel` 复用之，删掉挂载时那次多余的 `getMyPermissions` fetch（模型页裸 `/me/permissions` 调用归零）。
- 删除死函数 `getMyPermissions`（isAdmin 已挪至 boot、其余走 scoped）。

## 破坏性约定

实例行现为**增量**，判权必须 union 类型级行 —— `operationsFor` 已实现。需与后端同批（后端已上线）。

## 依赖

scoped 查询依赖后端 type 归一（#181）：`?resource_type=large_model` 须真返回 `large_model` 行，否则非超管在模型页判权为空、仅靠 `is_admin` 兜。后端已上线。

## 验证

- `tsc -b` + `eslint` 通过
- 经 release-studio 构建并部署到 14.103.77.23 冒烟：`/me/permissions` 折叠、亚秒；模型页裸 permissions 调用归零，scoped 查询单次（生产构建无 StrictMode 双触发）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
