### PR TITLE
fix(knowledge-network): complete #169 sidebar metrics race fix

### DIFF
--- a/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.test.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+
+import { useWorkspaceData } from "./useWorkspaceData";
+
+const {
+  getKnowledgeNetwork,
+  getMetricApiAvailability,
+  listKnowledgeNetworkMetrics,
+} = vi.hoisted(() => ({
+  getKnowledgeNetwork: vi.fn<() => Promise<KnowledgeNetworkRecord | null>>(),
+  getMetricApiAvailability: vi.fn(() => "ready"),
+  listKnowledgeNetworkMetrics: vi.fn(),
+}));
+
+vi.mock("@/modules/knowledge-network/services/knowledge-network.service", () => ({
+  getKnowledgeNetwork,
+  getMetricApiAvailability,
+  listKnowledgeNetworkActionTypes: vi.fn(() => []),
+  listKnowledgeNetworkConceptGroups: vi.fn(() => []),
+  listKnowledgeNetworkMetrics,
+  listKnowledgeNetworkObjectTypes: vi.fn(() => []),
+  listKnowledgeNetworkRecentObjects: vi.fn(() => []),
+  listKnowledgeNetworkRelationTypes: vi.fn(() => []),
+  listKnowledgeNetworkTasks: vi.fn(() => []),
+}));
+
+function createDetail(metricsTotal = 0): KnowledgeNetworkRecord {
+  return {
+    color: "#1677ff",
+    createTime: "2026-01-01",
+    creatorName: "admin",
+    description: "",
+    id: "kn-1",
+    identifier: "kn-1",
+    name: "Test KN",
+    statistics: {
+      actionTypesTotal: 0,
+      conceptGroupsTotal: 0,
+      metricsTotal,
+      objectTypesTotal: 0,
+      relationTypesTotal: 0,
+    },
+    tags: [],
+    updateTime: "2026-01-01",
+    updaterName: "admin",
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useWorkspaceData metrics sidebar count", () => {
+  it("merges metrics total when metrics resolves before detail in the same batch", async () => {
+    let resolveDetail: (value: KnowledgeNetworkRecord) => void = () => {};
+    const detailPromise = new Promise<KnowledgeNetworkRecord>((resolve) => {
+      resolveDetail = resolve;
+    });
+
+    getKnowledgeNetwork.mockReturnValue(detailPromise);
+    listKnowledgeNetworkMetrics.mockResolvedValue({
+      entries: [],
+      totalCount: 12,
+    });
+
+    const { result } = renderHook(() => useWorkspaceData("kn-1", "metrics"));
+
+    await waitFor(() => {
+      expect(listKnowledgeNetworkMetrics).toHaveBeenCalled();
+    });
+
+    resolveDetail(createDetail(0));
+
+    await waitFor(() => {
+      expect(result.current.detail?.statistics.metricsTotal).toBe(12);
+    });
+  });
+});

--- a/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
+++ b/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.ts
@@ -37,8 +37,8 @@ import type {
 } from "@/modules/knowledge-network/types/knowledge-network";
 
 import {
-  applyKnowledgeNetworkMetricsTotal,
   clearMetricsTotalPending,
+  commitMetricsTotalUpdate,
   createMetricsTotalPending,
   mergePendingMetricsTotalIntoDetail,
 } from "./workspaceMetricsTotal";
@@ -68,10 +68,26 @@ export function useWorkspaceData(
   const [sectionError, setSectionError] = useState<string | null>(null);
   const loadedSectionsRef = useRef<Set<string>>(new Set());
   const pendingMetricsTotalRef = useRef(createMetricsTotalPending());
+  const detailRef = useRef<KnowledgeNetworkRecord | null>(null);
+  detailRef.current = detail;
 
   const clearSectionCache = useCallback(() => {
     loadedSectionsRef.current.clear();
     clearMetricsTotalPending(pendingMetricsTotalRef.current);
+  }, []);
+
+  const applyMetricsTotalToDetail = useCallback((metricsTotal: number) => {
+    const nextDetail = commitMetricsTotalUpdate(
+      detailRef.current,
+      metricsTotal,
+      pendingMetricsTotalRef.current,
+    );
+    if (!nextDetail) {
+      return;
+    }
+
+    detailRef.current = nextDetail;
+    setDetail(nextDetail);
   }, []);
 
   const loadDetail = useCallback(async () => {
@@ -84,12 +100,13 @@ export function useWorkspaceData(
 
     try {
       const fetched = await getKnowledgeNetwork(networkId);
-      setDetail(
-        fetched
-          ? mergePendingMetricsTotalIntoDetail(fetched, pendingMetricsTotalRef.current)
-          : null,
-      );
+      const merged = fetched
+        ? mergePendingMetricsTotalIntoDetail(fetched, pendingMetricsTotalRef.current)
+        : null;
+      detailRef.current = merged;
+      setDetail(merged);
     } catch (error) {
+      detailRef.current = null;
       setDetail(null);
       setDetailError(extractRequestErrorMessage(error));
     } finally {
@@ -167,13 +184,7 @@ export function useWorkspaceData(
             if (integrateWorkspaceMetrics) {
               const metricResult = await listKnowledgeNetworkMetrics(networkId);
               setMetrics(metricResult.entries);
-              setDetail((prev) =>
-                applyKnowledgeNetworkMetricsTotal(
-                  prev,
-                  metricResult.totalCount,
-                  pendingMetricsTotalRef.current,
-                ),
-              );
+              applyMetricsTotalToDetail(metricResult.totalCount);
               setMetricApiUnavailable(getMetricApiAvailability() === "unsupported");
             }
             break;
@@ -193,7 +204,7 @@ export function useWorkspaceData(
         setSectionLoading(false);
       }
     },
-    [networkId],
+    [networkId, applyMetricsTotalToDetail],
   );
 
   useEffect(() => {
@@ -263,16 +274,10 @@ export function useWorkspaceData(
     loadedSectionsRef.current.delete(sectionCacheKey(networkId, "metrics"));
     const metricResult = await listKnowledgeNetworkMetrics(networkId);
     setMetrics(metricResult.entries);
-    setDetail((prev) =>
-      applyKnowledgeNetworkMetricsTotal(
-        prev,
-        metricResult.totalCount,
-        pendingMetricsTotalRef.current,
-      ),
-    );
+    applyMetricsTotalToDetail(metricResult.totalCount);
     setMetricApiUnavailable(getMetricApiAvailability() === "unsupported");
     loadedSectionsRef.current.add(sectionCacheKey(networkId, "metrics"));
-  }, [networkId]);
+  }, [networkId, applyMetricsTotalToDetail]);
 
   const reloadTasks = useCallback(async () => {
     if (!networkId || !integrateWorkspaceTasks) {

--- a/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.test.ts
+++ b/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
 
 import {
-  applyKnowledgeNetworkMetricsTotal,
+  commitMetricsTotalUpdate,
   createMetricsTotalPending,
   mergePendingMetricsTotalIntoDetail,
 } from "./workspaceMetricsTotal";
@@ -38,16 +38,16 @@ function createDetail(metricsTotal = 0): KnowledgeNetworkRecord {
 }
 
 describe("workspaceMetricsTotal", () => {
-  it("stores total in pending when detail is not loaded yet", () => {
+  it("stores total in pending synchronously when detail is not loaded yet", () => {
     const pending = createMetricsTotalPending();
 
-    expect(applyKnowledgeNetworkMetricsTotal(null, 12, pending)).toBeNull();
+    expect(commitMetricsTotalUpdate(null, 12, pending)).toBeNull();
     expect(pending.value).toBe(12);
   });
 
   it("merges pending total when detail arrives after metrics list", () => {
     const pending = createMetricsTotalPending();
-    applyKnowledgeNetworkMetricsTotal(null, 12, pending);
+    commitMetricsTotalUpdate(null, 12, pending);
 
     const merged = mergePendingMetricsTotalIntoDetail(createDetail(0), pending);
 
@@ -55,10 +55,19 @@ describe("workspaceMetricsTotal", () => {
     expect(pending.value).toBeNull();
   });
 
+  it("survives loadDetail reading pending before React applies detail updates", () => {
+    const pending = createMetricsTotalPending();
+    commitMetricsTotalUpdate(null, 12, pending);
+
+    const merged = mergePendingMetricsTotalIntoDetail(createDetail(0), pending);
+
+    expect(merged.statistics.metricsTotal).toBe(12);
+  });
+
   it("applies total immediately when detail is already loaded", () => {
     const pending = createMetricsTotalPending();
 
-    const updated = applyKnowledgeNetworkMetricsTotal(createDetail(0), 8, pending);
+    const updated = commitMetricsTotalUpdate(createDetail(0), 8, pending);
 
     expect(updated?.statistics.metricsTotal).toBe(8);
     expect(pending.value).toBeNull();

--- a/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.ts
+++ b/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.ts
@@ -42,18 +42,18 @@ export function mergeKnowledgeNetworkMetricsTotal(
   };
 }
 
-export function applyKnowledgeNetworkMetricsTotal(
-  detail: KnowledgeNetworkRecord | null,
+export function commitMetricsTotalUpdate(
+  currentDetail: KnowledgeNetworkRecord | null,
   metricsTotal: number,
   pending: MetricsTotalPending,
 ): KnowledgeNetworkRecord | null {
-  if (!detail) {
+  if (!currentDetail) {
     rememberMetricsTotal(pending, metricsTotal);
-    return detail;
+    return null;
   }
 
   clearMetricsTotalPending(pending);
-  return mergeKnowledgeNetworkMetricsTotal(detail, metricsTotal);
+  return mergeKnowledgeNetworkMetricsTotal(currentDetail, metricsTotal);
 }
 
 export function mergePendingMetricsTotalIntoDetail(


### PR DESCRIPTION
## Summary
Follow-up to #196 for openbkn-ai/bkn-studio#169.

- Stage metrics list `totalCount` synchronously via `commitMetricsTotalUpdate` instead of inside `setDetail` updaters
- Merge pending total when KN detail loads, even if both requests finish in the same React batch
- Add Hook-level regression test (`useWorkspaceData.test.tsx`)

## Context
- Original fix: #196 (merged)
- Backend companion (already merged): openbkn-ai/bkn-foundry#354
- Review finding: when metrics resolves before detail, pending was written only in a React updater, so `loadDetail` could read an empty pending and leave sidebar count at 0

## Test plan
- [x] `npm test -- src/modules/knowledge-network/scenes/workspace --run`
- [x] `npm run lint:types`
- [ ] Open metrics page directly: sidebar count matches list total
- [ ] Create/delete metric: sidebar count updates after refresh

Fixes #169