### PR TITLE
fix(data-catalog): adapt resource previews to Vega paging

### DIFF
--- a/src/modules/data-catalog/services/resource.service.test.ts
+++ b/src/modules/data-catalog/services/resource.service.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const postMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { post: postMock },
+}));
+
+describe("resource.service · previewCatalogResource", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    postMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses Vega paging and the GET method override", async () => {
+    postMock.mockResolvedValue({ data: { entries: [{ id: "r-1" }], total_count: 42 } });
+    const { previewCatalogResource } = await import(
+      "@/modules/data-catalog/services/resource.service"
+    );
+
+    const result = await previewCatalogResource("r-1", { limit: 10, offset: 20 });
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/vega-backend/v1/resources/r-1/data",
+      {
+        need_total: true,
+        paging: { limit: 10, mode: "single", offset: 20 },
+      },
+      { headers: { "X-HTTP-Method-Override": "GET" } },
+    );
+    expect(result).toEqual({ rows: [{ id: "r-1" }], total: 42 });
+  });
+});

--- a/src/modules/data-catalog/services/resource.service.ts
+++ b/src/modules/data-catalog/services/resource.service.ts
@@ -559,9 +559,12 @@ export async function previewCatalogResource(
   }>(
     `/vega-backend/v1/resources/${id}/data`,
     {
-      limit: query.limit,
       need_total: true,
-      offset: query.offset,
+      paging: {
+        limit: query.limit,
+        mode: "single",
+        offset: query.offset,
+      },
     },
     { headers: { "X-HTTP-Method-Override": "GET" } },
   );

--- a/src/modules/knowledge-network/services/object-type-resource.service.test.ts
+++ b/src/modules/knowledge-network/services/object-type-resource.service.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+const postMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock, post: postMock },
+}));
+
+describe("object-type-resource.service · getObjectTypeResourcePreview", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    getMock.mockReset();
+    postMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses Vega paging for the object-type resource preview", async () => {
+    getMock.mockResolvedValue({
+      data: {
+        entries: [{ id: "r-1", name: "orders", schema_definition: [{ name: "id" }] }],
+      },
+    });
+    postMock.mockResolvedValue({ data: { entries: [{ id: 1 }], total_count: 1 } });
+    const { getObjectTypeResourcePreview } = await import(
+      "@/modules/knowledge-network/services/object-type-resource.service"
+    );
+
+    const result = await getObjectTypeResourcePreview("kn-1", "r-1");
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/vega-backend/v1/resources/r-1/data",
+      {
+        need_total: true,
+        paging: { limit: 20, mode: "single", offset: 0 },
+      },
+      { headers: { "X-HTTP-Method-Override": "GET" } },
+    );
+    expect(result?.rowTotalCount).toBe(1);
+  });
+});

--- a/src/modules/knowledge-network/services/object-type-resource.service.ts
+++ b/src/modules/knowledge-network/services/object-type-resource.service.ts
@@ -302,9 +302,12 @@ export async function getObjectTypeResourcePreview(
     http.post<BackendResourcePreviewResponse>(
       `/vega-backend/v1/resources/${resourceId}/data`,
       {
-        limit: 20,
         need_total: true,
-        offset: 0,
+        paging: {
+          limit: 20,
+          mode: "single",
+          offset: 0,
+        },
       },
       {
         headers: {


### PR DESCRIPTION
## 1. 变更说明（Purpose）

- 解决的问题：Foundry 的 Vega Resource Data API 已将分页参数迁移到 paging 对象；Studio 的资源预览仍发送顶层 limit/offset，导致与新契约不兼容。
- 实现功能：数据目录和知识网络对象类型的资源预览均改为发送 single paging 请求。
- 关联 Issue：#203

## 2. 修改类型（Type of Change）

- [x] Bug 修复
- [x] 测试用例

## 3. 实现方案（How & Why）

- 将两个 POST /vega-backend/v1/resources/{id}/data 调用的 body 从顶层 limit/offset 调整为 paging: { mode: "single", limit, offset }。
- 保留 X-HTTP-Method-Override: GET、need_total: true 和现有 offset UI 分页，无需引入 cursor 交互。
- 新增服务层回归测试，断言 paging body、GET method-override header 和 entries/total_count 映射。

## 4. 自测清单（Self Check）

- [x] 本地编译/运行通过（corepack pnpm check）
- [x] 新增/修改了测试用例
- [x] 已验证功能正常（69 个测试文件、294 个测试通过）
- [x] 无日志/异常/报错
- [x] 兼容相关场景（数据目录与知识网络资源预览）

## 5. 截图/日志（可选）

无 UI 变更。

## 6. 检查项（Reviewer 用）

- [x] 代码逻辑清晰
- [x] 命名规范、无冗余代码
- [x] 安全/权限无问题
- [x] 符合团队编码规范
- [x] 合并不会影响主分支

## 7. 备注（Notes）

本次仅适配 single + offset 分页；当前预览页大小为 10/20，符合 Vega 新接口约束。
