### PR TITLE
fix(execution-factory): Skill 包内文件按目录树展示

### DIFF
--- a/src/modules/execution-factory-lab/components/SkillFileTreePanel.tsx
+++ b/src/modules/execution-factory-lab/components/SkillFileTreePanel.tsx
@@ -5,50 +5,22 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { FileOutlined, FolderOpenOutlined, FolderOutlined } from "@ant-design/icons";
-import { Alert, Spin, Tree } from "antd";
-import type { DataNode } from "antd/es/tree";
-import { useEffect, useMemo, useState, type Key } from "react";
+import { Alert, Spin } from "antd";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { SkillFileTreeView } from "@/modules/execution-factory/components/SkillFileTreeView";
 import {
   getSkillContent,
   readSkillFile,
 } from "@/modules/execution-factory-lab/services/capabilities-lab.service";
 import type { SkillFileSummary } from "@/modules/execution-factory-lab/types/capability";
-import {
-  buildSkillFileTree,
-  collectSkillFileTreeKeys,
-  type SkillFileTreeNode,
-} from "@/modules/execution-factory/utils/skill-file-tree";
+
+import styles from "./skill-file-tree-panel.module.css";
 
 type SkillFileTreePanelProps = {
   capabilityId: string;
 };
-
-function toTreeDataNodes(nodes: SkillFileTreeNode[]): DataNode[] {
-  return nodes.map((node) => {
-    if (node.isLeaf) {
-      return {
-        key: node.key,
-        isLeaf: true,
-        selectable: true,
-        icon: <FileOutlined />,
-        title: node.title,
-      };
-    }
-
-    return {
-      key: node.key,
-      isLeaf: false,
-      selectable: false,
-      icon: ({ expanded }: { expanded?: boolean }) =>
-        expanded ? <FolderOpenOutlined /> : <FolderOutlined />,
-      title: node.title,
-      children: toTreeDataNodes(node.children ?? []),
-    };
-  });
-}
 
 export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
   const { t } = useTranslation();
@@ -57,10 +29,6 @@ export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
   const [files, setFiles] = useState<SkillFileSummary[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [preview, setPreview] = useState<string>("");
-  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
-
-  const fileTree = useMemo(() => buildSkillFileTree(files), [files]);
-  const treeData = useMemo(() => toTreeDataNodes(fileTree), [fileTree]);
 
   useEffect(() => {
     setLoading(true);
@@ -85,10 +53,6 @@ export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
   }, [capabilityId]);
 
   useEffect(() => {
-    setExpandedKeys(collectSkillFileTreeKeys(fileTree));
-  }, [fileTree]);
-
-  useEffect(() => {
     if (!selectedPath) {
       return;
     }
@@ -109,41 +73,18 @@ export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
   }
 
   return (
-    <div style={{ display: "grid", gridTemplateColumns: "280px 1fr", gap: 16 }}>
+    <div className={styles.layout}>
       {files.length > 0 ? (
-        <Tree
-          blockNode
-          expandedKeys={expandedKeys}
-          onExpand={(keys) => setExpandedKeys(keys)}
-          onSelect={(selectedKeys) => {
-            const key = selectedKeys[0];
-            if (typeof key === "string" && files.some((item) => item.relPath === key)) {
-              setSelectedPath(key);
-            }
-          }}
-          selectedKeys={selectedPath ? [selectedPath] : []}
-          showIcon
-          style={{
-            background: "#fff",
-            border: "1px solid #f0f0f0",
-            borderRadius: 8,
-            padding: 8,
-          }}
-          treeData={treeData}
+        <SkillFileTreeView
+          className={styles.tree}
+          files={files}
+          onSelectFile={setSelectedPath}
+          selectedPath={selectedPath}
         />
       ) : (
         <Alert message={t("executionFactoryLab.skillFilesEmpty")} showIcon type="info" />
       )}
-      <pre
-        style={{
-          background: "#fafafa",
-          border: "1px solid #f0f0f0",
-          borderRadius: 8,
-          minHeight: 240,
-          padding: 12,
-          whiteSpace: "pre-wrap",
-        }}
-      >
+      <pre className={styles.preview}>
         {preview || t("executionFactoryLab.skillFilePreviewEmpty")}
       </pre>
     </div>

--- a/src/modules/execution-factory-lab/components/SkillFileTreePanel.tsx
+++ b/src/modules/execution-factory-lab/components/SkillFileTreePanel.tsx
@@ -5,10 +5,10 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Alert, List, Spin } from "antd";
-
-import { useEffect, useState } from "react";
-
+import { FileOutlined, FolderOpenOutlined, FolderOutlined } from "@ant-design/icons";
+import { Alert, Spin, Tree } from "antd";
+import type { DataNode } from "antd/es/tree";
+import { useEffect, useMemo, useState, type Key } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -16,10 +16,39 @@ import {
   readSkillFile,
 } from "@/modules/execution-factory-lab/services/capabilities-lab.service";
 import type { SkillFileSummary } from "@/modules/execution-factory-lab/types/capability";
+import {
+  buildSkillFileTree,
+  collectSkillFileTreeKeys,
+  type SkillFileTreeNode,
+} from "@/modules/execution-factory/utils/skill-file-tree";
 
 type SkillFileTreePanelProps = {
   capabilityId: string;
 };
+
+function toTreeDataNodes(nodes: SkillFileTreeNode[]): DataNode[] {
+  return nodes.map((node) => {
+    if (node.isLeaf) {
+      return {
+        key: node.key,
+        isLeaf: true,
+        selectable: true,
+        icon: <FileOutlined />,
+        title: node.title,
+      };
+    }
+
+    return {
+      key: node.key,
+      isLeaf: false,
+      selectable: false,
+      icon: ({ expanded }: { expanded?: boolean }) =>
+        expanded ? <FolderOpenOutlined /> : <FolderOutlined />,
+      title: node.title,
+      children: toTreeDataNodes(node.children ?? []),
+    };
+  });
+}
 
 export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
   const { t } = useTranslation();
@@ -28,6 +57,10 @@ export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
   const [files, setFiles] = useState<SkillFileSummary[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [preview, setPreview] = useState<string>("");
+  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
+
+  const fileTree = useMemo(() => buildSkillFileTree(files), [files]);
+  const treeData = useMemo(() => toTreeDataNodes(fileTree), [fileTree]);
 
   useEffect(() => {
     setLoading(true);
@@ -36,7 +69,11 @@ export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
       .then((content) => {
         setFiles(content.files);
         if (content.files.length > 0) {
-          setSelectedPath(content.files[0].relPath);
+          setSelectedPath(
+            content.files.find((item) => item.relPath === "SKILL.md")?.relPath ??
+              content.files[0]?.relPath ??
+              null,
+          );
         } else if (content.content) {
           setPreview(content.content);
         }
@@ -46,6 +83,10 @@ export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
       })
       .finally(() => setLoading(false));
   }, [capabilityId]);
+
+  useEffect(() => {
+    setExpandedKeys(collectSkillFileTreeKeys(fileTree));
+  }, [fileTree]);
 
   useEffect(() => {
     if (!selectedPath) {
@@ -68,24 +109,31 @@ export function SkillFileTreePanel({ capabilityId }: SkillFileTreePanelProps) {
   }
 
   return (
-    <div style={{ display: "grid", gridTemplateColumns: "240px 1fr", gap: 16 }}>
-      <List
-        bordered
-        dataSource={files}
-        locale={{ emptyText: t("executionFactoryLab.skillFilesEmpty") }}
-        renderItem={(item) => (
-          <List.Item
-            onClick={() => setSelectedPath(item.relPath)}
-            style={{
-              cursor: "pointer",
-              background: selectedPath === item.relPath ? "#f0f7ff" : undefined,
-            }}
-          >
-            {item.relPath}
-          </List.Item>
-        )}
-        size="small"
-      />
+    <div style={{ display: "grid", gridTemplateColumns: "280px 1fr", gap: 16 }}>
+      {files.length > 0 ? (
+        <Tree
+          blockNode
+          expandedKeys={expandedKeys}
+          onExpand={(keys) => setExpandedKeys(keys)}
+          onSelect={(selectedKeys) => {
+            const key = selectedKeys[0];
+            if (typeof key === "string" && files.some((item) => item.relPath === key)) {
+              setSelectedPath(key);
+            }
+          }}
+          selectedKeys={selectedPath ? [selectedPath] : []}
+          showIcon
+          style={{
+            background: "#fff",
+            border: "1px solid #f0f0f0",
+            borderRadius: 8,
+            padding: 8,
+          }}
+          treeData={treeData}
+        />
+      ) : (
+        <Alert message={t("executionFactoryLab.skillFilesEmpty")} showIcon type="info" />
+      )}
       <pre
         style={{
           background: "#fafafa",

--- a/src/modules/execution-factory-lab/components/skill-file-tree-panel.module.css
+++ b/src/modules/execution-factory-lab/components/skill-file-tree-panel.module.css
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+.layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+}
+
+.tree {
+  padding: 8px;
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.preview {
+  min-height: 240px;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+  background: #fafafa;
+  white-space: pre-wrap;
+}

--- a/src/modules/execution-factory/components/SkillFileTreeView.tsx
+++ b/src/modules/execution-factory/components/SkillFileTreeView.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { FileOutlined, FolderOpenOutlined, FolderOutlined } from "@ant-design/icons";
+import { Tree } from "antd";
+import type { DataNode } from "antd/es/tree";
+import { useEffect, useMemo, useState, type CSSProperties, type Key, type ReactNode } from "react";
+
+import { formatSkillFileSize } from "@/modules/execution-factory/utils/skill-file-preview";
+import {
+  buildSkillFileTree,
+  getDefaultSkillFileTreeExpandedKeys,
+  type SkillFileTreeLeaf,
+  type SkillFileTreeNode,
+} from "@/modules/execution-factory/utils/skill-file-tree";
+
+import styles from "./skill-file-tree-view.module.css";
+
+export type SkillFileTreeViewProps = {
+  files: SkillFileTreeLeaf[];
+  selectedPath?: string | null;
+  onSelectFile: (relPath: string) => void;
+  showFileMeta?: boolean;
+  className?: string;
+  style?: CSSProperties;
+};
+
+function toTreeDataNodes(
+  nodes: SkillFileTreeNode[],
+  options: { showFileMeta: boolean },
+): DataNode[] {
+  return nodes.map((node) => {
+    if (node.isLeaf) {
+      const meta = options.showFileMeta
+        ? [node.file?.mimeType, formatSkillFileSize(node.file?.size)].filter(Boolean).join(" · ")
+        : "";
+
+      return {
+        key: node.key,
+        isLeaf: true,
+        selectable: true,
+        icon: <FileOutlined />,
+        title: (
+          <span className={styles.leaf}>
+            <span className={styles.title}>{node.title}</span>
+            {meta ? <span className={styles.meta}>{meta}</span> : null}
+          </span>
+        ),
+      };
+    }
+
+    return {
+      key: node.key,
+      isLeaf: false,
+      selectable: false,
+      icon: ({ expanded }: { expanded?: boolean }) =>
+        expanded ? <FolderOpenOutlined /> : <FolderOutlined />,
+      title: <span className={styles.title}>{node.title}</span>,
+      children: toTreeDataNodes(node.children ?? [], options),
+    };
+  });
+}
+
+export function SkillFileTreeView({
+  files,
+  selectedPath,
+  onSelectFile,
+  showFileMeta = false,
+  className,
+  style,
+}: SkillFileTreeViewProps): ReactNode {
+  const fileTree = useMemo(() => buildSkillFileTree(files), [files]);
+  const treeData = useMemo(
+    () => toTreeDataNodes(fileTree, { showFileMeta }),
+    [fileTree, showFileMeta],
+  );
+  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
+
+  useEffect(() => {
+    setExpandedKeys(getDefaultSkillFileTreeExpandedKeys(fileTree, files.length));
+  }, [fileTree, files.length]);
+
+  return (
+    <Tree
+      blockNode
+      className={[styles.tree, className].filter(Boolean).join(" ")}
+      expandedKeys={expandedKeys}
+      onExpand={(keys) => setExpandedKeys(keys)}
+      onSelect={(selectedKeys) => {
+        const key = selectedKeys[0];
+        if (typeof key === "string" && files.some((item) => item.relPath === key)) {
+          onSelectFile(key);
+        }
+      }}
+      selectedKeys={selectedPath ? [selectedPath] : []}
+      showIcon
+      style={style}
+      treeData={treeData}
+    />
+  );
+}

--- a/src/modules/execution-factory/components/skill-file-tree-view.module.css
+++ b/src/modules/execution-factory/components/skill-file-tree-view.module.css
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+.tree {
+  background: transparent;
+}
+
+.tree :global(.ant-tree-node-content-wrapper) {
+  min-width: 0;
+}
+
+.leaf {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.title {
+  overflow: hidden;
+  color: rgba(0, 0, 0, 0.88);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+  line-height: 18px;
+}

--- a/src/modules/execution-factory/scenes/SkillDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/SkillDetailScene.tsx
@@ -10,19 +10,15 @@ import {
   CalendarOutlined,
   ClockCircleOutlined,
   DownloadOutlined,
-  FileOutlined,
   FileTextOutlined,
-  FolderOpenOutlined,
-  FolderOutlined,
   HistoryOutlined,
   IdcardOutlined,
   SettingOutlined,
   ThunderboltOutlined,
   UserOutlined,
 } from "@ant-design/icons";
-import { Alert, Breadcrumb, Empty, Layout, Space, Spin, Tag, Tree, Typography } from "antd";
-import type { DataNode } from "antd/es/tree";
-import { useCallback, useEffect, useMemo, useState, type Key } from "react";
+import { Alert, Breadcrumb, Empty, Layout, Space, Spin, Tag, Typography } from "antd";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
@@ -31,6 +27,7 @@ import { PermissionGate } from "@/framework/permission/PermissionGate";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { DetailMetaPanel } from "@/modules/execution-factory/components/DetailMetaPanel";
+import { SkillFileTreeView } from "@/modules/execution-factory/components/SkillFileTreeView";
 import { SkillHistoryDrawer } from "@/modules/execution-factory/components/SkillHistoryDrawer";
 import {
   downloadSkillPackage,
@@ -52,12 +49,6 @@ import {
 } from "@/modules/execution-factory/utils/detail-display";
 import { formatAuditUserDisplay } from "@/modules/execution-factory/utils/audit-user-display";
 import { formatExecutionUnitTime } from "@/modules/execution-factory/utils/format-timestamp";
-import { formatSkillFileSize } from "@/modules/execution-factory/utils/skill-file-preview";
-import {
-  buildSkillFileTree,
-  collectSkillFileTreeKeys,
-  type SkillFileTreeNode,
-} from "@/modules/execution-factory/utils/skill-file-tree";
 import { useAuditUserDirectory } from "@/modules/execution-factory/utils/use-audit-user-directory";
 
 import styles from "./toolbox-detail.module.css";
@@ -86,39 +77,6 @@ function buildFileEntries(content: SkillContentResult | null): SkillFileSummary[
   return summaries;
 }
 
-function toTreeDataNodes(nodes: SkillFileTreeNode[]): DataNode[] {
-  return nodes.map((node) => {
-    if (node.isLeaf) {
-      const meta = [node.file?.mimeType, formatSkillFileSize(node.file?.size)]
-        .filter(Boolean)
-        .join(" · ");
-
-      return {
-        key: node.key,
-        isLeaf: true,
-        selectable: true,
-        icon: <FileOutlined />,
-        title: (
-          <span className={styles.fileTreeLeaf}>
-            <span className={styles.fileTreeTitle}>{node.title}</span>
-            {meta ? <span className={styles.fileTreeMeta}>{meta}</span> : null}
-          </span>
-        ),
-      };
-    }
-
-    return {
-      key: node.key,
-      isLeaf: false,
-      selectable: false,
-      icon: ({ expanded }: { expanded?: boolean }) =>
-        expanded ? <FolderOpenOutlined /> : <FolderOutlined />,
-      title: <span className={styles.fileTreeTitle}>{node.title}</span>,
-      children: toTreeDataNodes(node.children ?? []),
-    };
-  });
-}
-
 export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
   const { t } = useTranslation();
   const auditUserDirectory = useAuditUserDirectory();
@@ -137,11 +95,8 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
   const [contentLoadError, setContentLoadError] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [downloading, setDownloading] = useState(false);
-  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
 
   const fileEntries = useMemo(() => buildFileEntries(content), [content]);
-  const fileTree = useMemo(() => buildSkillFileTree(fileEntries), [fileEntries]);
-  const fileTreeData = useMemo(() => toTreeDataNodes(fileTree), [fileTree]);
 
   const loadDetail = useCallback(async () => {
     setLoading(true);
@@ -176,10 +131,6 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
   useEffect(() => {
     void loadDetail();
   }, [loadDetail]);
-
-  useEffect(() => {
-    setExpandedKeys(collectSkillFileTreeKeys(fileTree));
-  }, [fileTree]);
 
   useEffect(() => {
     if (fileEntries.length === 0) {
@@ -458,25 +409,16 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
                   </span>
                 </div>
                 <div className={styles.fileTreeWrap}>
-                  <Tree
-                    blockNode
-                    className={styles.fileTree}
-                    expandedKeys={expandedKeys}
-                    onExpand={(keys) => setExpandedKeys(keys)}
-                    onSelect={(selectedKeys) => {
-                      const key = selectedKeys[0];
-                      if (typeof key !== "string") {
-                        return;
-                      }
-
-                      const nextFile = fileEntries.find((item) => item.relPath === key);
+                  <SkillFileTreeView
+                    files={fileEntries}
+                    onSelectFile={(relPath) => {
+                      const nextFile = fileEntries.find((item) => item.relPath === relPath);
                       if (nextFile) {
                         setSelectedFile(nextFile);
                       }
                     }}
-                    selectedKeys={selectedFile ? [selectedFile.relPath] : []}
-                    showIcon
-                    treeData={fileTreeData}
+                    selectedPath={selectedFile?.relPath}
+                    showFileMeta
                   />
                 </div>
               </Sider>

--- a/src/modules/execution-factory/scenes/SkillDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/SkillDetailScene.tsx
@@ -10,15 +10,19 @@ import {
   CalendarOutlined,
   ClockCircleOutlined,
   DownloadOutlined,
+  FileOutlined,
   FileTextOutlined,
+  FolderOpenOutlined,
+  FolderOutlined,
   HistoryOutlined,
   IdcardOutlined,
   SettingOutlined,
   ThunderboltOutlined,
   UserOutlined,
 } from "@ant-design/icons";
-import { Alert, Breadcrumb, Empty, Layout, Space, Spin, Tag, Typography } from "antd";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Alert, Breadcrumb, Empty, Layout, Space, Spin, Tag, Tree, Typography } from "antd";
+import type { DataNode } from "antd/es/tree";
+import { useCallback, useEffect, useMemo, useState, type Key } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
@@ -49,6 +53,11 @@ import {
 import { formatAuditUserDisplay } from "@/modules/execution-factory/utils/audit-user-display";
 import { formatExecutionUnitTime } from "@/modules/execution-factory/utils/format-timestamp";
 import { formatSkillFileSize } from "@/modules/execution-factory/utils/skill-file-preview";
+import {
+  buildSkillFileTree,
+  collectSkillFileTreeKeys,
+  type SkillFileTreeNode,
+} from "@/modules/execution-factory/utils/skill-file-tree";
 import { useAuditUserDirectory } from "@/modules/execution-factory/utils/use-audit-user-directory";
 
 import styles from "./toolbox-detail.module.css";
@@ -77,6 +86,39 @@ function buildFileEntries(content: SkillContentResult | null): SkillFileSummary[
   return summaries;
 }
 
+function toTreeDataNodes(nodes: SkillFileTreeNode[]): DataNode[] {
+  return nodes.map((node) => {
+    if (node.isLeaf) {
+      const meta = [node.file?.mimeType, formatSkillFileSize(node.file?.size)]
+        .filter(Boolean)
+        .join(" · ");
+
+      return {
+        key: node.key,
+        isLeaf: true,
+        selectable: true,
+        icon: <FileOutlined />,
+        title: (
+          <span className={styles.fileTreeLeaf}>
+            <span className={styles.fileTreeTitle}>{node.title}</span>
+            {meta ? <span className={styles.fileTreeMeta}>{meta}</span> : null}
+          </span>
+        ),
+      };
+    }
+
+    return {
+      key: node.key,
+      isLeaf: false,
+      selectable: false,
+      icon: ({ expanded }: { expanded?: boolean }) =>
+        expanded ? <FolderOpenOutlined /> : <FolderOutlined />,
+      title: <span className={styles.fileTreeTitle}>{node.title}</span>,
+      children: toTreeDataNodes(node.children ?? []),
+    };
+  });
+}
+
 export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
   const { t } = useTranslation();
   const auditUserDirectory = useAuditUserDirectory();
@@ -95,8 +137,11 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
   const [contentLoadError, setContentLoadError] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [downloading, setDownloading] = useState(false);
+  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
 
   const fileEntries = useMemo(() => buildFileEntries(content), [content]);
+  const fileTree = useMemo(() => buildSkillFileTree(fileEntries), [fileEntries]);
+  const fileTreeData = useMemo(() => toTreeDataNodes(fileTree), [fileTree]);
 
   const loadDetail = useCallback(async () => {
     setLoading(true);
@@ -131,6 +176,10 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
   useEffect(() => {
     void loadDetail();
   }, [loadDetail]);
+
+  useEffect(() => {
+    setExpandedKeys(collectSkillFileTreeKeys(fileTree));
+  }, [fileTree]);
 
   useEffect(() => {
     if (fileEntries.length === 0) {
@@ -408,26 +457,27 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
                     <FileTextOutlined /> {t("executionFactory.skillFilesSectionTitle")}
                   </span>
                 </div>
-                <div className={styles.toolList}>
-                  {fileEntries.map((item, index) => {
-                    const active = selectedFile?.relPath === item.relPath;
+                <div className={styles.fileTreeWrap}>
+                  <Tree
+                    blockNode
+                    className={styles.fileTree}
+                    expandedKeys={expandedKeys}
+                    onExpand={(keys) => setExpandedKeys(keys)}
+                    onSelect={(selectedKeys) => {
+                      const key = selectedKeys[0];
+                      if (typeof key !== "string") {
+                        return;
+                      }
 
-                    return (
-                      <div
-                        className={`${styles.toolItem} ${active ? styles.toolItemActive : ""}`}
-                        key={item.relPath}
-                        onClick={() => setSelectedFile(item)}
-                      >
-                        <div className={styles.toolItemTop}>
-                          <span className={styles.toolIndex}>{index + 1}</span>
-                          <span className={styles.toolName}>{item.relPath}</span>
-                        </div>
-                        <div className={styles.toolDesc}>
-                          {[item.mimeType, formatSkillFileSize(item.size)].filter(Boolean).join(" · ") || "-"}
-                        </div>
-                      </div>
-                    );
-                  })}
+                      const nextFile = fileEntries.find((item) => item.relPath === key);
+                      if (nextFile) {
+                        setSelectedFile(nextFile);
+                      }
+                    }}
+                    selectedKeys={selectedFile ? [selectedFile.relPath] : []}
+                    showIcon
+                    treeData={fileTreeData}
+                  />
                 </div>
               </Sider>
               <Content className={styles.content}>

--- a/src/modules/execution-factory/scenes/toolbox-detail.module.css
+++ b/src/modules/execution-factory/scenes/toolbox-detail.module.css
@@ -131,6 +131,41 @@
   overflow: auto;
 }
 
+.fileTreeWrap {
+  max-height: calc(100vh - 320px);
+  overflow: auto;
+  padding: 4px 0;
+}
+
+.fileTree {
+  background: transparent;
+}
+
+.fileTree :global(.ant-tree-node-content-wrapper) {
+  min-width: 0;
+}
+
+.fileTreeLeaf {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.fileTreeTitle {
+  overflow: hidden;
+  color: rgba(0, 0, 0, 0.88);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fileTreeMeta {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+  line-height: 18px;
+}
+
 .toolItem {
   padding: 12px;
   border: 1px solid rgba(0, 0, 0, 0.08);

--- a/src/modules/execution-factory/scenes/toolbox-detail.module.css
+++ b/src/modules/execution-factory/scenes/toolbox-detail.module.css
@@ -137,35 +137,6 @@
   padding: 4px 0;
 }
 
-.fileTree {
-  background: transparent;
-}
-
-.fileTree :global(.ant-tree-node-content-wrapper) {
-  min-width: 0;
-}
-
-.fileTreeLeaf {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-.fileTreeTitle {
-  overflow: hidden;
-  color: rgba(0, 0, 0, 0.88);
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.fileTreeMeta {
-  color: rgba(0, 0, 0, 0.45);
-  font-size: 12px;
-  line-height: 18px;
-}
-
 .toolItem {
   padding: 12px;
   border: 1px solid rgba(0, 0, 0, 0.08);

--- a/src/modules/execution-factory/utils/skill-file-tree.test.ts
+++ b/src/modules/execution-factory/utils/skill-file-tree.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSkillFileTree,
+  collectSkillFileTreeKeys,
+} from "@/modules/execution-factory/utils/skill-file-tree";
+
+describe("buildSkillFileTree", () => {
+  it("groups nested paths into a directory tree", () => {
+    const tree = buildSkillFileTree([
+      { relPath: "SKILL.md", mimeType: "text/markdown", size: 10 },
+      { relPath: "bin/mysql.exe", mimeType: "application/octet-stream", size: 20 },
+      { relPath: "bin/ssleay32.dll", size: 30 },
+      { relPath: "datasets/catalog.json", mimeType: "application/json", size: 40 },
+      { relPath: "datasets/supply-chain/data.sql", size: 50 },
+    ]);
+
+    expect(tree.map((node) => node.title)).toEqual(["bin", "datasets", "SKILL.md"]);
+
+    const bin = tree.find((node) => node.key === "bin/");
+    expect(bin?.isLeaf).toBe(false);
+    expect(bin?.children?.map((child) => child.title)).toEqual(["mysql.exe", "ssleay32.dll"]);
+    expect(bin?.children?.[0]?.file?.relPath).toBe("bin/mysql.exe");
+
+    const datasets = tree.find((node) => node.key === "datasets/");
+    const supplyChain = datasets?.children?.find((child) => child.key === "datasets/supply-chain/");
+    expect(supplyChain?.children?.[0]?.file?.relPath).toBe("datasets/supply-chain/data.sql");
+
+    const skillMd = tree.find((node) => node.key === "SKILL.md");
+    expect(skillMd?.isLeaf).toBe(true);
+    expect(skillMd?.file?.relPath).toBe("SKILL.md");
+  });
+
+  it("normalizes backslashes and ignores empty paths", () => {
+    const tree = buildSkillFileTree([
+      { relPath: "scripts\\dataset.js" },
+      { relPath: "" },
+      { relPath: "/" },
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.key).toBe("scripts/");
+    expect(tree[0]?.children?.[0]?.file?.relPath).toBe("scripts/dataset.js");
+  });
+
+  it("collects expandable directory keys", () => {
+    const tree = buildSkillFileTree([
+      { relPath: "a/b/c.txt" },
+      { relPath: "root.txt" },
+    ]);
+
+    expect(collectSkillFileTreeKeys(tree)).toEqual(["a/", "a/b/"]);
+  });
+});

--- a/src/modules/execution-factory/utils/skill-file-tree.test.ts
+++ b/src/modules/execution-factory/utils/skill-file-tree.test.ts
@@ -9,7 +9,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildSkillFileTree,
+  buildSkillFileTreeWithConflicts,
   collectSkillFileTreeKeys,
+  getDefaultSkillFileTreeExpandedKeys,
+  SKILL_FILE_TREE_FULL_EXPAND_LIMIT,
 } from "@/modules/execution-factory/utils/skill-file-tree";
 
 describe("buildSkillFileTree", () => {
@@ -50,12 +53,43 @@ describe("buildSkillFileTree", () => {
     expect(tree[0]?.children?.[0]?.file?.relPath).toBe("scripts/dataset.js");
   });
 
-  it("collects expandable directory keys", () => {
+  it("keeps the first path shape when file and directory collide", () => {
+    const fileFirst = buildSkillFileTreeWithConflicts([
+      { relPath: "bin" },
+      { relPath: "bin/mysql.exe" },
+    ]);
+    expect(fileFirst.nodes).toHaveLength(1);
+    expect(fileFirst.nodes[0]?.isLeaf).toBe(true);
+    expect(fileFirst.nodes[0]?.file?.relPath).toBe("bin");
+    expect(fileFirst.conflicts).toEqual(["bin/mysql.exe"]);
+
+    const dirFirst = buildSkillFileTreeWithConflicts([
+      { relPath: "bin/mysql.exe" },
+      { relPath: "bin" },
+    ]);
+    expect(dirFirst.nodes).toHaveLength(1);
+    expect(dirFirst.nodes[0]?.isLeaf).toBe(false);
+    expect(dirFirst.nodes[0]?.children?.[0]?.file?.relPath).toBe("bin/mysql.exe");
+    expect(dirFirst.conflicts).toEqual(["bin"]);
+  });
+
+  it("collects expandable directory keys with optional depth limit", () => {
     const tree = buildSkillFileTree([
       { relPath: "a/b/c.txt" },
       { relPath: "root.txt" },
     ]);
 
     expect(collectSkillFileTreeKeys(tree)).toEqual(["a/", "a/b/"]);
+    expect(collectSkillFileTreeKeys(tree, { maxDepth: 1 })).toEqual(["a/"]);
+  });
+
+  it("expands only the first level for large packages", () => {
+    const files = Array.from({ length: SKILL_FILE_TREE_FULL_EXPAND_LIMIT + 1 }, (_, index) => ({
+      relPath: `dir/nested/file-${index}.txt`,
+    }));
+    const tree = buildSkillFileTree(files);
+
+    expect(getDefaultSkillFileTreeExpandedKeys(tree, files.length)).toEqual(["dir/"]);
+    expect(getDefaultSkillFileTreeExpandedKeys(tree, 2)).toEqual(["dir/", "dir/nested/"]);
   });
 });

--- a/src/modules/execution-factory/utils/skill-file-tree.ts
+++ b/src/modules/execution-factory/utils/skill-file-tree.ts
@@ -76,8 +76,7 @@ export function buildSkillFileTree(files: SkillFileTreeLeaf[]): SkillFileTreeNod
     let current = root;
     let prefix = "";
 
-    for (let index = 0; index < segments.length; index += 1) {
-      const segment = segments[index]!;
+    for (const [index, segment] of segments.entries()) {
       const isLeaf = index === segments.length - 1;
       prefix = prefix ? `${prefix}/${segment}` : segment;
       const key = isLeaf ? prefix : `${prefix}/`;

--- a/src/modules/execution-factory/utils/skill-file-tree.ts
+++ b/src/modules/execution-factory/utils/skill-file-tree.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export type SkillFileTreeLeaf = {
+  relPath: string;
+  mimeType?: string;
+  size?: number;
+  fileType?: string;
+};
+
+export type SkillFileTreeNode = {
+  key: string;
+  title: string;
+  isLeaf: boolean;
+  children?: SkillFileTreeNode[];
+  file?: SkillFileTreeLeaf;
+};
+
+type MutableNode = {
+  key: string;
+  title: string;
+  isLeaf: boolean;
+  children?: Map<string, MutableNode>;
+  file?: SkillFileTreeLeaf;
+};
+
+function compareNodes(a: SkillFileTreeNode, b: SkillFileTreeNode): number {
+  if (a.isLeaf !== b.isLeaf) {
+    return a.isLeaf ? 1 : -1;
+  }
+
+  return a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+}
+
+function freezeNode(node: MutableNode): SkillFileTreeNode {
+  if (node.isLeaf) {
+    return {
+      key: node.key,
+      title: node.title,
+      isLeaf: true,
+      file: node.file,
+    };
+  }
+
+  const children = [...(node.children?.values() ?? [])].map(freezeNode).sort(compareNodes);
+  return {
+    key: node.key,
+    title: node.title,
+    isLeaf: false,
+    children,
+  };
+}
+
+/**
+ * Build a directory tree from skill package file summaries.
+ * Directory keys use a trailing slash (e.g. `bin/`) so they never collide with a file named `bin`.
+ */
+export function buildSkillFileTree(files: SkillFileTreeLeaf[]): SkillFileTreeNode[] {
+  const root = new Map<string, MutableNode>();
+
+  for (const file of files) {
+    const relPath = file.relPath.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+    if (!relPath) {
+      continue;
+    }
+
+    const segments = relPath.split("/").filter(Boolean);
+    if (segments.length === 0) {
+      continue;
+    }
+
+    let current = root;
+    let prefix = "";
+
+    for (let index = 0; index < segments.length; index += 1) {
+      const segment = segments[index]!;
+      const isLeaf = index === segments.length - 1;
+      prefix = prefix ? `${prefix}/${segment}` : segment;
+      const key = isLeaf ? prefix : `${prefix}/`;
+
+      let node = current.get(segment);
+      if (!node) {
+        node = {
+          key,
+          title: segment,
+          isLeaf,
+          children: isLeaf ? undefined : new Map(),
+        };
+        current.set(segment, node);
+      }
+
+      if (isLeaf) {
+        node.isLeaf = true;
+        node.file = {
+          relPath: prefix,
+          mimeType: file.mimeType,
+          size: file.size,
+          fileType: file.fileType,
+        };
+        node.children = undefined;
+        break;
+      }
+
+      if (!node.children) {
+        node.children = new Map();
+      }
+      node.isLeaf = false;
+      current = node.children;
+    }
+  }
+
+  return [...root.values()].map(freezeNode).sort(compareNodes);
+}
+
+export function collectSkillFileTreeKeys(nodes: SkillFileTreeNode[]): string[] {
+  const keys: string[] = [];
+
+  const walk = (items: SkillFileTreeNode[]) => {
+    for (const item of items) {
+      if (!item.isLeaf) {
+        keys.push(item.key);
+        if (item.children?.length) {
+          walk(item.children);
+        }
+      }
+    }
+  };
+
+  walk(nodes);
+  return keys;
+}

--- a/src/modules/execution-factory/utils/skill-file-tree.ts
+++ b/src/modules/execution-factory/utils/skill-file-tree.ts
@@ -20,6 +20,11 @@ export type SkillFileTreeNode = {
   file?: SkillFileTreeLeaf;
 };
 
+export type BuildSkillFileTreeResult = {
+  nodes: SkillFileTreeNode[];
+  conflicts: string[];
+};
+
 type MutableNode = {
   key: string;
   title: string;
@@ -27,6 +32,9 @@ type MutableNode = {
   children?: Map<string, MutableNode>;
   file?: SkillFileTreeLeaf;
 };
+
+/** Packages larger than this only expand the first directory level by default. */
+export const SKILL_FILE_TREE_FULL_EXPAND_LIMIT = 80;
 
 function compareNodes(a: SkillFileTreeNode, b: SkillFileTreeNode): number {
   if (a.isLeaf !== b.isLeaf) {
@@ -55,15 +63,27 @@ function freezeNode(node: MutableNode): SkillFileTreeNode {
   };
 }
 
+function normalizeRelPath(relPath: string): string {
+  return relPath.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
 /**
  * Build a directory tree from skill package file summaries.
- * Directory keys use a trailing slash (e.g. `bin/`) so they never collide with a file named `bin`.
+ * Directory keys use a trailing slash (e.g. `bin/`) so Tree keys never collide with a file named `bin`.
+ * If the same segment is both a file and a directory prefix, keep the first shape and record a conflict.
  */
 export function buildSkillFileTree(files: SkillFileTreeLeaf[]): SkillFileTreeNode[] {
+  return buildSkillFileTreeWithConflicts(files).nodes;
+}
+
+export function buildSkillFileTreeWithConflicts(
+  files: SkillFileTreeLeaf[],
+): BuildSkillFileTreeResult {
   const root = new Map<string, MutableNode>();
+  const conflicts: string[] = [];
 
   for (const file of files) {
-    const relPath = file.relPath.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+    const relPath = normalizeRelPath(file.relPath);
     if (!relPath) {
       continue;
     }
@@ -75,6 +95,7 @@ export function buildSkillFileTree(files: SkillFileTreeLeaf[]): SkillFileTreeNod
 
     let current = root;
     let prefix = "";
+    let skipped = false;
 
     for (const [index, segment] of segments.entries()) {
       const isLeaf = index === segments.length - 1;
@@ -90,10 +111,21 @@ export function buildSkillFileTree(files: SkillFileTreeLeaf[]): SkillFileTreeNod
           children: isLeaf ? undefined : new Map(),
         };
         current.set(segment, node);
+      } else if (isLeaf && !node.isLeaf) {
+        // Existing directory vs new file with the same path segment.
+        conflicts.push(relPath);
+        skipped = true;
+        break;
+      } else if (!isLeaf && node.isLeaf) {
+        // Existing file vs new nested path under the same segment.
+        conflicts.push(relPath);
+        skipped = true;
+        break;
       }
 
       if (isLeaf) {
         node.isLeaf = true;
+        node.key = key;
         node.file = {
           relPath: prefix,
           mimeType: file.mimeType,
@@ -108,27 +140,52 @@ export function buildSkillFileTree(files: SkillFileTreeLeaf[]): SkillFileTreeNod
         node.children = new Map();
       }
       node.isLeaf = false;
+      node.key = key;
       current = node.children;
+    }
+
+    if (skipped) {
+      continue;
     }
   }
 
-  return [...root.values()].map(freezeNode).sort(compareNodes);
+  return {
+    nodes: [...root.values()].map(freezeNode).sort(compareNodes),
+    conflicts,
+  };
 }
 
-export function collectSkillFileTreeKeys(nodes: SkillFileTreeNode[]): string[] {
+export function collectSkillFileTreeKeys(
+  nodes: SkillFileTreeNode[],
+  options?: { maxDepth?: number },
+): string[] {
   const keys: string[] = [];
+  const maxDepth = options?.maxDepth;
 
-  const walk = (items: SkillFileTreeNode[]) => {
+  const walk = (items: SkillFileTreeNode[], depth: number) => {
     for (const item of items) {
-      if (!item.isLeaf) {
-        keys.push(item.key);
-        if (item.children?.length) {
-          walk(item.children);
-        }
+      if (item.isLeaf) {
+        continue;
+      }
+
+      keys.push(item.key);
+      if (item.children?.length && (maxDepth === undefined || depth < maxDepth)) {
+        walk(item.children, depth + 1);
       }
     }
   };
 
-  walk(nodes);
+  walk(nodes, 1);
   return keys;
+}
+
+export function getDefaultSkillFileTreeExpandedKeys(
+  nodes: SkillFileTreeNode[],
+  fileCount: number,
+): string[] {
+  if (fileCount > SKILL_FILE_TREE_FULL_EXPAND_LIMIT) {
+    return collectSkillFileTreeKeys(nodes, { maxDepth: 1 });
+  }
+
+  return collectSkillFileTreeKeys(nodes);
 }


### PR DESCRIPTION
﻿## Summary
- Skill 详情「包内文件」由平铺编号列表改为按 `relPath` 组装的目录树展示
- Lab `SkillFileTreePanel` 同步改为目录树
- 新增 `buildSkillFileTree` 工具与单测

## Test plan
- [ ] 上传含 `bin/`、`datasets/`、`scripts/` 等层级的 Skill zip
- [ ] 详情页「包内文件」按目录层级展示，可展开/折叠
- [ ] 点击叶子文件可正常预览
- [ ] `npx vitest run src/modules/execution-factory/utils/skill-file-tree.test.ts` 通过

Fixes #205
