### PR TITLE
fix(execution-factory): 已发布执行单元下线改为提交 offline

### DIFF
--- a/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.test.tsx
+++ b/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ExecutionUnitCardMenu } from "@/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu";
+import type { ExecutionUnitCardItem } from "@/modules/execution-factory/components/execution-unit/types";
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: {
+    type: "3rdParty",
+    init: vi.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/framework/permission/PermissionGate", () => ({
+  PermissionGate: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+function buildItem(status: string): ExecutionUnitCardItem {
+  return {
+    id: "box-1",
+    name: "Demo Toolbox",
+    status,
+  };
+}
+
+describe("ExecutionUnitCardMenu lifecycle actions", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it("fires offline (not unpublish) when taking a published toolbox down", () => {
+    const onAction = vi.fn();
+
+    render(
+      <ExecutionUnitCardMenu
+        activeTab="toolbox"
+        item={buildItem("published")}
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "executionFactory.cardMenu.more" }));
+    const menu = screen.getByRole("menu");
+    expect(within(menu).queryByText("executionFactory.cardMenu.unpublish")).toBeNull();
+    fireEvent.click(within(menu).getByText("executionFactory.offline"));
+
+    expect(onAction).toHaveBeenCalledWith("offline", expect.objectContaining({ status: "published" }));
+    expect(onAction).not.toHaveBeenCalledWith("unpublish", expect.anything());
+  });
+
+  it("fires publish for an offline toolbox so it can go back online", () => {
+    const onAction = vi.fn();
+
+    render(
+      <ExecutionUnitCardMenu
+        activeTab="toolbox"
+        item={buildItem("offline")}
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "executionFactory.cardMenu.more" }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("executionFactory.publish"));
+
+    expect(onAction).toHaveBeenCalledWith("publish", expect.objectContaining({ status: "offline" }));
+  });
+});

--- a/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx
+++ b/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 
 import { PermissionGate } from "@/framework/permission/PermissionGate";
 import { AppButton } from "@/framework/ui/common/AppButton";
+import { getExecutionUnitLifecycleActions } from "@/modules/execution-factory/utils/execution-unit-lifecycle";
 
 import type { ExecutionUnitCardItem, ExecutionUnitTab } from "./types";
 
@@ -211,29 +212,17 @@ export function ExecutionUnitCardMenu({
     );
   }
 
-  // 状态机：unpublish/editing/offline → published；published → offline（不可回 unpublish）
-  if (
-    item.status === "unpublish" ||
-    item.status === "editing" ||
-    item.status === "offline"
-  ) {
+  for (const lifecycleAction of getExecutionUnitLifecycleActions(item.status)) {
     pushMenuAction(
       menuItems,
-      "publish",
-      t("executionFactory.publish"),
+      lifecycleAction,
+      t(
+        lifecycleAction === "publish"
+          ? "executionFactory.publish"
+          : "executionFactory.offline",
+      ),
       onAction,
-      "publish",
-      item,
-    );
-  }
-
-  if (item.status === "published") {
-    pushMenuAction(
-      menuItems,
-      "offline",
-      t("executionFactory.offline"),
-      onAction,
-      "offline",
+      lifecycleAction,
       item,
     );
   }

--- a/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx
+++ b/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx
@@ -24,7 +24,6 @@ export type ExecutionUnitCardAction =
   | "download"
   | "updatePackage"
   | "publish"
-  | "unpublish"
   | "offline"
   | "delete"
   | "install"
@@ -212,7 +211,12 @@ export function ExecutionUnitCardMenu({
     );
   }
 
-  if (item.status === "unpublish" || item.status === "editing") {
+  // 状态机：unpublish/editing/offline → published；published → offline（不可回 unpublish）
+  if (
+    item.status === "unpublish" ||
+    item.status === "editing" ||
+    item.status === "offline"
+  ) {
     pushMenuAction(
       menuItems,
       "publish",
@@ -226,16 +230,8 @@ export function ExecutionUnitCardMenu({
   if (item.status === "published") {
     pushMenuAction(
       menuItems,
-      "unpublish",
-      t("executionFactory.cardMenu.unpublish"),
-      onAction,
-      "unpublish",
-      item,
-    );
-    pushMenuAction(
-      menuItems,
       "offline",
-      t("executionFactory.statuses.offline"),
+      t("executionFactory.offline"),
       onAction,
       "offline",
       item,

--- a/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
+++ b/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
@@ -916,39 +916,6 @@ export function ExecutionUnitListScene({
         return;
       }
 
-      if (action === "unpublish") {
-        if (activeTab === "operator" && item.version) {
-          runStatusChange(
-            "unpublish",
-            "executionFactory.operatorStatusChangeConfirmTitle",
-            "executionFactory.operatorStatusChangeConfirmDescription",
-            () => updateOperatorStatus(item.id, item.version!, "unpublish"),
-          );
-        } else if (activeTab === "toolbox") {
-          runStatusChange(
-            "unpublish",
-            "executionFactory.toolboxStatusChangeConfirmTitle",
-            "executionFactory.toolboxStatusChangeConfirmDescription",
-            () => updateToolboxStatus(item.id, "unpublish"),
-          );
-        } else if (activeTab === "mcp") {
-          runStatusChange(
-            "unpublish",
-            "executionFactory.mcpStatusChangeConfirmTitle",
-            "executionFactory.mcpStatusChangeConfirmDescription",
-            () => updateMcpStatus(item.id, "unpublish"),
-          );
-        } else if (activeTab === "skill") {
-          runStatusChange(
-            "unpublish",
-            "executionFactory.skillStatusChangeConfirmTitle",
-            "executionFactory.skillStatusChangeConfirmDescription",
-            () => updateSkillStatus(item.id, "unpublish"),
-          );
-        }
-        return;
-      }
-
       if (action === "offline") {
         if (activeTab === "operator" && item.version) {
           runStatusChange(

--- a/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
+++ b/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
@@ -58,7 +58,6 @@ import type { SkillRecord, SkillStatus } from "@/modules/execution-factory/types
 import type { ToolboxRecord, ToolboxStatus } from "@/modules/execution-factory/types/toolbox";
 import {
   resolveLifecycleActionStatus,
-  type ExecutionUnitLifecycleAction,
 } from "@/modules/execution-factory/utils/execution-unit-lifecycle";
 import {
   collectLocalResourceIds,
@@ -888,7 +887,7 @@ export function ExecutionUnitListScene({
       }
 
       if (action === "publish" || action === "offline") {
-        const nextStatus = resolveLifecycleActionStatus(action as ExecutionUnitLifecycleAction);
+        const nextStatus = resolveLifecycleActionStatus(action);
         if (activeTab === "operator" && item.version) {
           runStatusChange(
             nextStatus,

--- a/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
+++ b/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
@@ -57,6 +57,10 @@ import type { OperatorRecord, PublicOperatorStatus } from "@/modules/execution-f
 import type { SkillRecord, SkillStatus } from "@/modules/execution-factory/types/skill";
 import type { ToolboxRecord, ToolboxStatus } from "@/modules/execution-factory/types/toolbox";
 import {
+  resolveLifecycleActionStatus,
+  type ExecutionUnitLifecycleAction,
+} from "@/modules/execution-factory/utils/execution-unit-lifecycle";
+import {
   collectLocalResourceIds,
   invalidateLocalResourceIdsCache,
 } from "@/modules/execution-factory/utils/collect-local-resource-ids";
@@ -883,67 +887,35 @@ export function ExecutionUnitListScene({
         return;
       }
 
-      if (action === "publish") {
+      if (action === "publish" || action === "offline") {
+        const nextStatus = resolveLifecycleActionStatus(action as ExecutionUnitLifecycleAction);
         if (activeTab === "operator" && item.version) {
           runStatusChange(
-            "published",
+            nextStatus,
             "executionFactory.operatorStatusChangeConfirmTitle",
             "executionFactory.operatorStatusChangeConfirmDescription",
-            () => updateOperatorStatus(item.id, item.version!, "published"),
+            () => updateOperatorStatus(item.id, item.version!, nextStatus),
           );
         } else if (activeTab === "toolbox") {
           runStatusChange(
-            "published",
+            nextStatus,
             "executionFactory.toolboxStatusChangeConfirmTitle",
             "executionFactory.toolboxStatusChangeConfirmDescription",
-            () => updateToolboxStatus(item.id, "published"),
+            () => updateToolboxStatus(item.id, nextStatus),
           );
         } else if (activeTab === "mcp") {
           runStatusChange(
-            "published",
+            nextStatus,
             "executionFactory.mcpStatusChangeConfirmTitle",
             "executionFactory.mcpStatusChangeConfirmDescription",
-            () => updateMcpStatus(item.id, "published"),
+            () => updateMcpStatus(item.id, nextStatus),
           );
         } else if (activeTab === "skill") {
           runStatusChange(
-            "published",
+            nextStatus,
             "executionFactory.skillStatusChangeConfirmTitle",
             "executionFactory.skillStatusChangeConfirmDescription",
-            () => updateSkillStatus(item.id, "published"),
-          );
-        }
-        return;
-      }
-
-      if (action === "offline") {
-        if (activeTab === "operator" && item.version) {
-          runStatusChange(
-            "offline",
-            "executionFactory.operatorStatusChangeConfirmTitle",
-            "executionFactory.operatorStatusChangeConfirmDescription",
-            () => updateOperatorStatus(item.id, item.version!, "offline"),
-          );
-        } else if (activeTab === "toolbox") {
-          runStatusChange(
-            "offline",
-            "executionFactory.toolboxStatusChangeConfirmTitle",
-            "executionFactory.toolboxStatusChangeConfirmDescription",
-            () => updateToolboxStatus(item.id, "offline"),
-          );
-        } else if (activeTab === "mcp") {
-          runStatusChange(
-            "offline",
-            "executionFactory.mcpStatusChangeConfirmTitle",
-            "executionFactory.mcpStatusChangeConfirmDescription",
-            () => updateMcpStatus(item.id, "offline"),
-          );
-        } else if (activeTab === "skill") {
-          runStatusChange(
-            "offline",
-            "executionFactory.skillStatusChangeConfirmTitle",
-            "executionFactory.skillStatusChangeConfirmDescription",
-            () => updateSkillStatus(item.id, "offline"),
+            () => updateSkillStatus(item.id, nextStatus),
           );
         }
         return;

--- a/src/modules/execution-factory/utils/execution-unit-lifecycle.test.ts
+++ b/src/modules/execution-factory/utils/execution-unit-lifecycle.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getExecutionUnitLifecycleActions,
+  resolveLifecycleActionStatus,
+} from "./execution-unit-lifecycle";
+
+describe("getExecutionUnitLifecycleActions", () => {
+  it("offers publish for draft, editing, and offline units", () => {
+    expect(getExecutionUnitLifecycleActions("unpublish")).toEqual(["publish"]);
+    expect(getExecutionUnitLifecycleActions("editing")).toEqual(["publish"]);
+    expect(getExecutionUnitLifecycleActions("offline")).toEqual(["publish"]);
+  });
+
+  it("offers only offline for published units (never unpublish)", () => {
+    const actions = getExecutionUnitLifecycleActions("published");
+
+    expect(actions).toEqual(["offline"]);
+    expect(actions).not.toContain("unpublish");
+  });
+
+  it("returns no lifecycle actions for unknown or missing status", () => {
+    expect(getExecutionUnitLifecycleActions(undefined)).toEqual([]);
+    expect(getExecutionUnitLifecycleActions("")).toEqual([]);
+    expect(getExecutionUnitLifecycleActions("unknown")).toEqual([]);
+  });
+});
+
+describe("resolveLifecycleActionStatus", () => {
+  it("maps publish to published", () => {
+    expect(resolveLifecycleActionStatus("publish")).toBe("published");
+  });
+
+  it("maps offline take-down to offline, not unpublish", () => {
+    expect(resolveLifecycleActionStatus("offline")).toBe("offline");
+    expect(resolveLifecycleActionStatus("offline")).not.toBe("unpublish");
+  });
+
+  it("keeps published → offline as the only take-down transition for cards", () => {
+    const actions = getExecutionUnitLifecycleActions("published");
+    const statuses = actions.map(resolveLifecycleActionStatus);
+
+    expect(statuses).toEqual(["offline"]);
+  });
+});

--- a/src/modules/execution-factory/utils/execution-unit-lifecycle.ts
+++ b/src/modules/execution-factory/utils/execution-unit-lifecycle.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/**
+ * Lifecycle actions exposed on execution-unit cards.
+ *
+ * Backend status machine (operator-integration):
+ * - unpublish / editing / offline → published
+ * - published → offline (NOT unpublish)
+ */
+export type ExecutionUnitLifecycleAction = "publish" | "offline";
+
+export type ExecutionUnitLifecycleStatus = "published" | "offline";
+
+export function getExecutionUnitLifecycleActions(
+  status: string | undefined,
+): ExecutionUnitLifecycleAction[] {
+  if (status === "unpublish" || status === "editing" || status === "offline") {
+    return ["publish"];
+  }
+
+  if (status === "published") {
+    return ["offline"];
+  }
+
+  return [];
+}
+
+/**
+ * Maps a UI lifecycle action to the API status payload.
+ * Published take-down must submit `offline`, never `unpublish`.
+ */
+export function resolveLifecycleActionStatus(
+  action: ExecutionUnitLifecycleAction,
+): ExecutionUnitLifecycleStatus {
+  return action === "publish" ? "published" : "offline";
+}


### PR DESCRIPTION
## Summary
- 修复已发布工具箱/算子/MCP/Skill 点击「取消发布」时错误提交 `unpublish` 导致 `ToolBoxStatusInvalid` 的问题（Fixes #209）
- 已发布态菜单仅保留「下线」，统一提交 `offline`；已下线可重新「发布」
- 文案对仗的后续优化见 #210，本 PR 不改状态枚举

## Test plan
- [ ] 创建并发布工具箱，卡片菜单点击「下线」，确认请求 body 为 `{status:offline}`，状态变为已下线
- [ ] 已下线工具箱可再次点击「发布」，状态回到已发布
- [ ] 未发布工具箱「发布」流程不受影响
- [ ] 对算子 / MCP / Skill 已发布态做同样下线操作，无 `StatusInvalid` 报错

Made with [Cursor](https://cursor.com)