### PR TITLE
fix(execution-factory): 工具配置页宽屏双栏布局，消除右侧空白

### DIFF
--- a/src/modules/execution-factory/components/HttpToolLifecyclePanel.module.css
+++ b/src/modules/execution-factory/components/HttpToolLifecyclePanel.module.css
@@ -6,9 +6,31 @@
  */
 
 .panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+@media (min-width: 1280px) {
+  .panel {
+    grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  }
+}
+
+.primaryColumn,
+.sideColumn {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-width: 0;
+}
+
+@media (min-width: 1280px) {
+  .sideColumn {
+    position: sticky;
+    top: 24px;
+  }
 }
 
 .section {
@@ -49,4 +71,3 @@
   border-color: #e2e8f0;
   background: #fbfdff;
 }
-

--- a/src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx
+++ b/src/modules/execution-factory/components/HttpToolLifecyclePanel.test.tsx
@@ -17,11 +17,12 @@ vi.mock("react-i18next", () => ({
 }));
 
 describe("HttpToolLifecyclePanel", () => {
-  it("keeps business fields and IO preview before advanced raw configuration", () => {
-    render(
+  it("keeps business fields before advanced config, with IO/debug in the side column", () => {
+    const { container } = render(
       <HttpToolLifecyclePanel
         advancedConfig={<div>raw openapi spec</div>}
         businessFields={<div>business summary fields</div>}
+        debugWorkbench={<div>debug workbench</div>}
         ioPreview={<div>request and response preview</div>}
         metadataTypeLabel="OpenAPI"
       />,
@@ -30,12 +31,34 @@ describe("HttpToolLifecyclePanel", () => {
     const business = screen.getByText("business summary fields");
     const ioPreview = screen.getByText("request and response preview");
     const advanced = screen.getByText("raw openapi spec");
+    const debug = screen.getByText("debug workbench");
 
     expect(screen.getByText("executionFactory.httpToolLifecycleSummaryTitle")).toBeTruthy();
     expect(screen.getByText("executionFactory.httpToolLifecyclePreviewTitle")).toBeTruthy();
     expect(screen.getByText("executionFactory.httpToolLifecycleAdvancedTitle")).toBeTruthy();
     expect(screen.getByText("OpenAPI")).toBeTruthy();
+
+    // Primary column: business then advanced
+    expect(business.compareDocumentPosition(advanced) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Side column: IO then debug; both after business in document order
     expect(business.compareDocumentPosition(ioPreview) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(ioPreview.compareDocumentPosition(advanced) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(ioPreview.compareDocumentPosition(debug) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    const panel = container.firstElementChild;
+    expect(panel?.children).toHaveLength(2);
+  });
+
+  it("renders without advanced or debug sections when omitted", () => {
+    render(
+      <HttpToolLifecyclePanel
+        businessFields={<div>business summary fields</div>}
+        ioPreview={<div>request and response preview</div>}
+        metadataTypeLabel="Function"
+      />,
+    );
+
+    expect(screen.getByText("business summary fields")).toBeTruthy();
+    expect(screen.getByText("request and response preview")).toBeTruthy();
+    expect(screen.queryByText("executionFactory.httpToolLifecycleAdvancedTitle")).toBeNull();
   });
 });

--- a/src/modules/execution-factory/components/HttpToolLifecyclePanel.tsx
+++ b/src/modules/execution-factory/components/HttpToolLifecyclePanel.tsx
@@ -30,52 +30,56 @@ export function HttpToolLifecyclePanel({
 
   return (
     <div className={styles.panel}>
-      <section className={styles.section}>
-        <div className={styles.sectionHeader}>
-          <div>
-            <h3 className={styles.sectionTitle}>
-              {t("executionFactory.httpToolLifecycleSummaryTitle")}
-            </h3>
-            <p className={styles.sectionDesc}>
-              {t("executionFactory.httpToolLifecycleSummaryDesc")}
-            </p>
-          </div>
-          <Tag className={styles.metadataTag}>{metadataTypeLabel}</Tag>
-        </div>
-        {businessFields}
-      </section>
-
-      <section className={styles.section}>
-        <div className={styles.sectionHeader}>
-          <div>
-            <h3 className={styles.sectionTitle}>
-              {t("executionFactory.httpToolLifecyclePreviewTitle")}
-            </h3>
-            <p className={styles.sectionDesc}>
-              {t("executionFactory.httpToolLifecyclePreviewDesc")}
-            </p>
-          </div>
-        </div>
-        {ioPreview}
-      </section>
-
-      {debugWorkbench ? debugWorkbench : null}
-
-      {advancedConfig ? (
-        <section className={`${styles.section} ${styles.advanced}`}>
+      <div className={styles.primaryColumn}>
+        <section className={styles.section}>
           <div className={styles.sectionHeader}>
             <div>
               <h3 className={styles.sectionTitle}>
-                {t("executionFactory.httpToolLifecycleAdvancedTitle")}
+                {t("executionFactory.httpToolLifecycleSummaryTitle")}
               </h3>
               <p className={styles.sectionDesc}>
-                {t("executionFactory.httpToolLifecycleAdvancedDesc")}
+                {t("executionFactory.httpToolLifecycleSummaryDesc")}
+              </p>
+            </div>
+            <Tag className={styles.metadataTag}>{metadataTypeLabel}</Tag>
+          </div>
+          {businessFields}
+        </section>
+
+        {advancedConfig ? (
+          <section className={`${styles.section} ${styles.advanced}`}>
+            <div className={styles.sectionHeader}>
+              <div>
+                <h3 className={styles.sectionTitle}>
+                  {t("executionFactory.httpToolLifecycleAdvancedTitle")}
+                </h3>
+                <p className={styles.sectionDesc}>
+                  {t("executionFactory.httpToolLifecycleAdvancedDesc")}
+                </p>
+              </div>
+            </div>
+            {advancedConfig}
+          </section>
+        ) : null}
+      </div>
+
+      <div className={styles.sideColumn}>
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <div>
+              <h3 className={styles.sectionTitle}>
+                {t("executionFactory.httpToolLifecyclePreviewTitle")}
+              </h3>
+              <p className={styles.sectionDesc}>
+                {t("executionFactory.httpToolLifecyclePreviewDesc")}
               </p>
             </div>
           </div>
-          {advancedConfig}
+          {ioPreview}
         </section>
-      ) : null}
+
+        {debugWorkbench ? debugWorkbench : null}
+      </div>
     </div>
   );
 }

--- a/src/modules/execution-factory/scenes/ToolDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/ToolDetailScene.tsx
@@ -182,7 +182,7 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
         {loading ? <Spin /> : null}
         {!loading && loadError ? <Alert message={loadError} showIcon type="error" /> : null}
         {!loading && !loadError ? (
-          <div className={styles.formSurface}>
+          <div className={styles.formSurfaceWide}>
             <Form form={form} layout="vertical">
               <HttpToolLifecyclePanel
                 advancedConfig={

--- a/src/modules/execution-factory/scenes/UnitFormScene.module.css
+++ b/src/modules/execution-factory/scenes/UnitFormScene.module.css
@@ -14,6 +14,16 @@
   box-shadow: 0 14px 34px rgba(22, 42, 69, 0.06);
 }
 
+.formSurfaceWide {
+  max-width: none;
+  width: 100%;
+  padding: 28px 30px;
+  border: 1px solid rgba(18, 40, 72, 0.08);
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 14px 34px rgba(22, 42, 69, 0.06);
+}
+
 .formLayout {
   display: grid;
   grid-template-columns: 160px minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- 工具配置页取消 `920px` 窄卡片限制，改为全宽表面
- `HttpToolLifecyclePanel` 在 ≥1280px 使用双栏：左侧业务/高级配置，右侧 IO 预览与调试（sticky）
- 更新单元测试覆盖双栏文档顺序

Fixes #212

## Test plan
- [ ] 宽屏打开工具编辑页，右侧不再大片空白，IO/调试与表单同屏可见
- [ ] 缩窄窗口到 `<1280px`，布局回退为单列且可正常操作
- [ ] 保存、取消、调试跳转（含 `?focus=debug`）行为正常
- [ ] 算子编辑页仍保持原 `formSurface` 宽度，未受影响

Made with [Cursor](https://cursor.com)