### PR TITLE
ci: 分支 push 自动跑构建（quality/smoke/execution-factory）

### DIFF
--- a/.github/workflows/ci-execution-factory.yml
+++ b/.github/workflows/ci-execution-factory.yml
@@ -5,18 +5,14 @@
 
 name: ci-execution-factory
 
+# Push events cover every branch, so same-repo PRs skip their duplicate run
+# (the push run on the head SHA reports the same check) and pull_request is
+# solely a fork-PR fallback. Paths therefore live only on the push trigger —
+# workflow files don't support YAML anchors, so the list can't be factored.
 on:
   pull_request:
-    paths:
-      - 'src/modules/execution-factory/**'
-      - 'tests/execution-factory/**'
-      - 'specs/execution-factory/**'
-      - 'vite.config.ts'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/ci-execution-factory.yml'
   push:
-    branches: [main]
+    branches: ['**']
     paths:
       - 'src/modules/execution-factory/**'
       - 'tests/execution-factory/**'
@@ -29,6 +25,7 @@ on:
 jobs:
   vitest-l1:
     name: L1 vitest (execution-factory)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -5,10 +5,13 @@
 
 name: ci-quality
 
+# Push events cover every branch, so same-repo PRs skip their duplicate run
+# (the push run on the head SHA reports the same check). The pull_request
+# trigger remains for fork PRs, whose pushes cannot run workflows here.
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: ['**']
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +24,7 @@ permissions:
 jobs:
   quality:
     name: ci-quality
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -5,10 +5,13 @@
 
 name: ci-smoke
 
+# Push events cover every branch, so same-repo PRs skip their duplicate run
+# (the push run on the head SHA reports the same check). The pull_request
+# trigger remains for fork PRs, whose pushes cannot run workflows here.
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: ['**']
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +24,7 @@ permissions:
 jobs:
   smoke:
     name: ci-smoke
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## 背景
CI 之前只在 `pull_request` 和 push main 时触发。分支没开 PR（或 PR merge 后再 push）就完全不构建 —— #198 merge 后分支 push 无 CI 即此问题。

## 改动
- `ci-quality` / `ci-smoke` / `ci-execution-factory`：`push` 触发扩到所有分支（`branches: ['**']`，不含 tag）
- 同仓库 PR 的 `pull_request` run 用 job 级 `if` 跳过，避免同一 head SHA 双跑；push run 的 check 同样挂在 commit 上，PR 页正常显示。`pull_request` 触发保留给 fork PR（fork 的 push 无法在本仓库跑）
- `ci-execution-factory` 的 paths 过滤只留 push 侧，去掉重复列表（workflow 不支持 YAML anchor）；fork PR 兜底 run 不做 paths 过滤
- `security-scan`（codeql/trivy 重）与 `release-studio`（推镜像）维持 PR/main/tag 触发不变

## 验证
本分支 push 本身即触发新版 push run —— 见本 PR checks。

🤖 Generated with [Claude Code](https://claude.com/claude-code)