### PR TITLE
fix(knowledge-network): restore resource selector popovers

### DIFF
--- a/src/modules/knowledge-network/components/shared/ResourceColorSelect.tsx
+++ b/src/modules/knowledge-network/components/shared/ResourceColorSelect.tsx
@@ -87,15 +87,18 @@ export function ResourceColorSelect({
 
   return (
     <Popover
-      content={open ? panel : null}
+      content={panel}
       destroyOnHidden
-      getPopupContainer={
-        inModal
-          ? () =>
-              (document.querySelector(".ant-modal-wrap") as HTMLElement) ??
-              document.body
-          : undefined
-      }
+      getPopupContainer={() => {
+        if (inModal) {
+          return (
+            (document.querySelector(".ant-modal-wrap") as HTMLElement) ??
+            document.body
+          );
+        }
+
+        return document.getElementById("root") ?? document.body;
+      }}
       onOpenChange={setOpen}
       open={open}
       trigger="click"

--- a/src/modules/knowledge-network/components/shared/ResourceIconSelect.tsx
+++ b/src/modules/knowledge-network/components/shared/ResourceIconSelect.tsx
@@ -189,7 +189,7 @@ export function ResourceIconSelect({
 
   return (
     <Popover
-      content={open ? popupRender() : null}
+      content={popupRender()}
       destroyOnHidden
       getPopupContainer={getPopupContainer}
       onOpenChange={setOpen}

--- a/src/modules/knowledge-network/components/shared/ResourceSelectors.test.tsx
+++ b/src/modules/knowledge-network/components/shared/ResourceSelectors.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ResourceColorSelect } from "./ResourceColorSelect";
+import { ResourceIconSelect } from "./ResourceIconSelect";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("resource appearance selectors", () => {
+  it("opens the color palette outside a modal and emits the selected color", () => {
+    const onChange = vi.fn();
+    render(<ResourceColorSelect inModal={false} onChange={onChange} value="#0e5fc5" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    const colorButtons = screen.getAllByRole("button");
+    expect(colorButtons).toHaveLength(15);
+
+    fireEvent.click(colorButtons[3]);
+    expect(onChange).toHaveBeenCalledWith("#323232");
+  });
+
+  it("opens the icon panel and emits a selected icon", () => {
+    const onChange = vi.fn();
+    render(<ResourceIconSelect inModal={false} onChange={onChange} value="icon-yingyongguanli" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByPlaceholderText("输入关键词筛选图标")).toBeTruthy();
+
+    const iconButtons = screen.getAllByRole("button");
+    fireEvent.click(iconButtons[2]);
+    expect(onChange).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Keep `ResourceColorSelect` and `ResourceIconSelect` Popover content mounted so controlled open-state transitions reliably display the selector panels.
- Use the application root as the non-modal color selector popup container to avoid clipping by page layout containers.
- Add regression tests covering color selection and icon-panel selection outside a modal.

Closes #222

## Test plan
- [x] `npx vitest run src/modules/knowledge-network/components/shared/ResourceSelectors.test.tsx`
- [x] `npx eslint src/modules/knowledge-network/components/shared/ResourceColorSelect.tsx src/modules/knowledge-network/components/shared/ResourceIconSelect.tsx src/modules/knowledge-network/components/shared/ResourceSelectors.test.tsx --config eslint.config.typechecked.js --max-warnings 0`
- [x] `npx tsc -b --pretty false`
- [ ] Manually verify color selection in action type, knowledge-network, object type, and concept group forms.
- [ ] Manually verify icon selection in object type forms.

Made with [Cursor](https://cursor.com)