### PR TITLE
fix(knowledge-network): remove redundant resource list imports

### DIFF
--- a/src/modules/knowledge-network/components/action-type/ActionTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeListPanel.tsx
@@ -26,13 +26,11 @@ import { useAppServices } from "@/framework/context/use-app-services";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
-import { JsonResourceImportButton } from "@/modules/knowledge-network/components/shared/JsonResourceImportButton";
 import { usePersistentPageSize } from "@/modules/knowledge-network/components/shared/usePersistentPageSize";
 import { buildActionTypeKindSelectOptions } from "@/modules/knowledge-network/constants/action-type-kinds";
 import type {
   KnowledgeNetworkActionTypeKind,
   KnowledgeNetworkActionTypeRecord,
-  KnowledgeNetworkImportMode,
   KnowledgeNetworkObjectTypeRecord,
 } from "@/modules/knowledge-network/types/knowledge-network";
 
@@ -44,10 +42,6 @@ type ActionTypeListPanelProps = {
   networkId: string;
   objectTypes: KnowledgeNetworkObjectTypeRecord[];
   onDelete: (records: KnowledgeNetworkActionTypeRecord[]) => Promise<void>;
-  onImport: (
-    payload: Record<string, unknown>,
-    importMode?: KnowledgeNetworkImportMode,
-  ) => Promise<void>;
   onRefresh: () => Promise<void>;
 };
 
@@ -74,7 +68,6 @@ export function ActionTypeListPanel({
   networkId,
   objectTypes,
   onDelete,
-  onImport,
   onRefresh,
 }: ActionTypeListPanelProps) {
   const { t } = useTranslation();
@@ -371,11 +364,6 @@ export function ActionTypeListPanel({
           >
             {t("common.delete")}
           </AppButton>
-          <JsonResourceImportButton
-            className={styles.toolbarButton}
-            onImported={onRefresh}
-            onImport={onImport}
-          />
         </div>
         <div className={styles.toolbarRight}>
           <button

--- a/src/modules/knowledge-network/components/object-type/ObjectTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/object-type/ObjectTypeListPanel.tsx
@@ -24,7 +24,6 @@ import { AppButton } from "@/framework/ui/common/AppButton";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { formatResourceIndexStateLabel } from "@/modules/knowledge-network/utils/resource-index-state";
 import { useResourceIndexStates } from "@/modules/knowledge-network/hooks/useResourceIndexStates";
-import { JsonResourceImportButton } from "@/modules/knowledge-network/components/shared/JsonResourceImportButton";
 import { renderResourceIcon } from "@/modules/knowledge-network/components/shared/ResourceIconSelect";
 import {
   readPositiveInteger,
@@ -33,7 +32,6 @@ import {
 } from "@/modules/knowledge-network/components/shared/usePersistentPageSize";
 import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import type {
-  KnowledgeNetworkImportMode,
   KnowledgeNetworkObjectTypeRecord,
 } from "@/modules/knowledge-network/types/knowledge-network";
 
@@ -44,10 +42,6 @@ type ObjectTypeListPanelProps = {
   loading?: boolean;
   networkId: string;
   onDelete: (records: KnowledgeNetworkObjectTypeRecord[]) => Promise<void>;
-  onImport: (
-    payload: Record<string, unknown>,
-    importMode?: KnowledgeNetworkImportMode,
-  ) => Promise<void>;
   onRefresh: () => Promise<void>;
 };
 
@@ -66,7 +60,6 @@ export function ObjectTypeListPanel({
   loading,
   networkId,
   onDelete,
-  onImport,
   onRefresh,
 }: ObjectTypeListPanelProps) {
   const { t } = useTranslation();
@@ -483,11 +476,6 @@ export function ObjectTypeListPanel({
           >
             {t("common.delete")}
           </AppButton>
-          <JsonResourceImportButton
-            className={styles.toolbarButton}
-            onImported={onRefresh}
-            onImport={onImport}
-          />
         </div>
         <div className={styles.toolbarRight}>
           <Input

--- a/src/modules/knowledge-network/components/relation-type/RelationTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/relation-type/RelationTypeListPanel.tsx
@@ -26,10 +26,8 @@ import { useAppServices } from "@/framework/context/use-app-services";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
-import { JsonResourceImportButton } from "@/modules/knowledge-network/components/shared/JsonResourceImportButton";
 import { usePersistentPageSize } from "@/modules/knowledge-network/components/shared/usePersistentPageSize";
 import type {
-  KnowledgeNetworkImportMode,
   KnowledgeNetworkObjectTypeRecord,
   KnowledgeNetworkRelationTypeRecord,
 } from "@/modules/knowledge-network/types/knowledge-network";
@@ -42,10 +40,6 @@ type RelationTypeListPanelProps = {
   networkId: string;
   objectTypes: KnowledgeNetworkObjectTypeRecord[];
   onDelete: (records: KnowledgeNetworkRelationTypeRecord[]) => Promise<void>;
-  onImport: (
-    payload: Record<string, unknown>,
-    importMode?: KnowledgeNetworkImportMode,
-  ) => Promise<void>;
   onRefresh: () => Promise<void>;
 };
 
@@ -55,7 +49,6 @@ export function RelationTypeListPanel({
   networkId,
   objectTypes,
   onDelete,
-  onImport,
   onRefresh,
 }: RelationTypeListPanelProps) {
   const { t } = useTranslation();
@@ -396,11 +389,6 @@ export function RelationTypeListPanel({
           >
             {t("common.delete")}
           </AppButton>
-          <JsonResourceImportButton
-            className={styles.toolbarButton}
-            onImported={onRefresh}
-            onImport={onImport}
-          />
         </div>
         <div className={styles.toolbarRight}>
           <button

--- a/src/modules/knowledge-network/locales/en-US/action-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/action-type.ts
@@ -66,9 +66,6 @@ export const actiontypePart = {
     actionTypeExecutionConfigSubtitle:
       "Maintain the action execution source and parameter mappings.",
     actionTypeExecutionTitle: "Action type execution",
-    actionTypeImportPending:
-      "JSON import for action types will be aligned with the legacy Vega flow in a later slice.",
-    actionTypeImportTitle: "Import action types",
     actionTypeKind: "Action type",
     actionTypeKindCreate: "Add",
     actionTypeKindDelete: "Delete",

--- a/src/modules/knowledge-network/locales/en-US/object-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/object-type.ts
@@ -83,9 +83,6 @@ export const objecttypePart = {
     objectTypeEmptyNoSearchResult: "No matching object types found",
     objectTypeHasIndex: "Resource index state",
     objectTypeIdPattern: "Only lowercase letters, numbers, underscores, and hyphens are allowed.",
-    objectTypeImportPending:
-      "The legacy Vega import flow for object types will be aligned in a later slice.",
-    objectTypeImportTitle: "Import object types",
     objectTypeIndexed: "Resource indexed",
     objectTypeKeyNotConfigured: "Not configured",
     objectTypeLogicAttributeCreateTitle: "Add logic property",

--- a/src/modules/knowledge-network/locales/en-US/relation-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/relation-type.ts
@@ -46,9 +46,6 @@ export const relationtypePart = {
     relationTypeEditTitle: "Edit relation type",
     relationTypeEmptyValue: "—",
     relationTypeEmptyNoSearchResult: "No matching relation types found.",
-    relationTypeImportPending:
-      "The legacy Vega import flow for relation types will be aligned in a later slice.",
-    relationTypeImportTitle: "Import relation types",
     relationTypeMappingAssociation: "Relation association",
     relationTypeMappingDescription: "Maintain relation type mapping configuration.",
     relationTypeMappingEntry: "Mapping config",

--- a/src/modules/knowledge-network/locales/zh-CN/action-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/action-type.ts
@@ -59,9 +59,6 @@ export const actiontypePart = {
     actionTypeExecutionSubtitle: "维护执行映射、调度计划与执行日志入口。",
     actionTypeExecutionConfigSubtitle: "维护行动类执行来源与参数映射。",
     actionTypeExecutionTitle: "行动类执行配置",
-    actionTypeImportPending:
-      "行动类 JSON 导入将在后续切片对齐 Vega 体验。",
-    actionTypeImportTitle: "导入行动类",
     actionTypeKind: "行动类型",
     actionTypeKindCreate: "添加",
     actionTypeKindDelete: "删除",

--- a/src/modules/knowledge-network/locales/zh-CN/object-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/object-type.ts
@@ -78,9 +78,6 @@ export const objecttypePart = {
     objectTypeEmptyNoSearchResult: "未找到匹配的对象类",
     objectTypeHasIndex: "资源索引状态",
     objectTypeIdPattern: "仅支持小写字母、数字、下划线和连字符。",
-    objectTypeImportPending:
-      "对象类导入流程会在后续切片中按旧 Vega 体验继续补齐。",
-    objectTypeImportTitle: "导入对象类",
     objectTypeIndexed: "资源已建索引",
     objectTypeKeyNotConfigured: "未配置",
     objectTypeLogicAttributeCreateTitle: "添加逻辑属性",

--- a/src/modules/knowledge-network/locales/zh-CN/relation-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/relation-type.ts
@@ -38,9 +38,6 @@ export const relationtypePart = {
     relationTypeEditTitle: "编辑关系类",
     relationTypeEmptyValue: "—",
     relationTypeEmptyNoSearchResult: "未找到匹配的关系类。",
-    relationTypeImportPending:
-      "关系类导入流程会在后续切片中按旧 Vega 体验继续补齐。",
-    relationTypeImportTitle: "导入关系类",
     relationTypeMappingAssociation: "关系关联",
     relationTypeMappingDescription: "维护关系类映射配置。",
     relationTypeMappingEntry: "映射配置",

--- a/src/modules/knowledge-network/scenes/workspace/WorkspaceResourceSection.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/WorkspaceResourceSection.tsx
@@ -22,10 +22,7 @@ import {
   deleteKnowledgeNetworkObjectType,
   deleteKnowledgeNetworkRelationType,
   deleteKnowledgeNetworkTask,
-  importKnowledgeNetworkActionTypes,
   importKnowledgeNetworkConceptGroup,
-  importKnowledgeNetworkObjectTypes,
-  importKnowledgeNetworkRelationTypes,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
 import { useWorkspaceData } from "@/modules/knowledge-network/scenes/workspace/useWorkspaceData";
 
@@ -82,9 +79,6 @@ export function WorkspaceResourceSection({
             void message.success(t("common.success"));
             await data.reloadObjectTypes();
           }}
-          onImport={(payload, importMode) =>
-            importKnowledgeNetworkObjectTypes(networkId, payload, importMode)
-          }
           onRefresh={data.reloadObjectTypes}
         />
       );
@@ -104,9 +98,6 @@ export function WorkspaceResourceSection({
             void message.success(t("common.success"));
             await data.reloadRelationTypes();
           }}
-          onImport={(payload, importMode) =>
-            importKnowledgeNetworkRelationTypes(networkId, payload, importMode)
-          }
           onRefresh={data.reloadRelationTypes}
         />
       );
@@ -126,9 +117,6 @@ export function WorkspaceResourceSection({
             void message.success(t("common.success"));
             await data.reloadActionTypes();
           }}
-          onImport={(payload, importMode) =>
-            importKnowledgeNetworkActionTypes(networkId, payload, importMode)
-          }
           onRefresh={data.reloadActionTypes}
         />
       );


### PR DESCRIPTION
## Summary
- Remove the redundant JSON import action from object type, relation type, and action type list toolbars.
- Remove the corresponding unused callback wiring from the workspace resource section.
- Remove unused Chinese and English copy for the retired list-level import entry.

Closes #221

## Test plan
- [x] `npx tsc -b --pretty false`
- [ ] Manually confirm the three list toolbars retain create, delete, search, and filter behavior without an import action.
- [ ] Confirm concept group and knowledge-network-level import entry points remain available.

Made with [Cursor](https://cursor.com)