### PR TITLE
fix(studio): avoid full task metadata loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,18 @@ Read this first, then load the rules under [`rules/`](rules/). Before working in
 - Conventional Commits: `type(scope): subject` (`feat` / `fix` / `chore` / `refactor` / `docs` / `test`; scope = service name).
 - Branch from the Issue's "Create a branch"; one PR per Issue, kept small.
 - Branch names must use a valid type prefix and at most two path segments after it: `<type>/<description>`, `<type>/<issue-number>-<description>`, or `<type>/<module>/<description>`; segments start with lowercase letters or digits and may contain `-`, `.`, or `_`.
+
+## Mandatory pre-commit CI checks
+
+Before **every** commit, run the same quality checks enforced by `.github/workflows/ci-quality.yml`. Do not commit if any command fails or emits warnings where CI requires zero warnings:
+
+```bash
+node scripts/check-license-headers.mjs
+pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
+pnpm exec vitest --run
+pnpm exec tsc -b --pretty false
+pnpm exec vite build
+pnpm audit --prod
+```
+
+For changes under `src/modules/execution-factory/**`, also run `pnpm test:execution-factory`, matching the path-scoped CI workflow. Report every command run and any CI-only check that was not practical to run locally.

--- a/src/modules/data-catalog/components/BuildTaskDetailDrawer.tsx
+++ b/src/modules/data-catalog/components/BuildTaskDetailDrawer.tsx
@@ -178,7 +178,7 @@ export function BuildTaskDetailDrawer({
           <h3 className={styles.sectionTitle}>{t("dataCatalog.task.modalTitle")}</h3>
           <Descriptions bordered className={styles.descriptionBlock} column={1} size="small">
             <Descriptions.Item label={t("dataCatalog.build.resource")}>
-              {resource?.name ?? task.resourceId}
+              {resource?.name ?? task.resourceName ?? task.resourceId}
             </Descriptions.Item>
             <Descriptions.Item label={t("dataCatalog.task.fields.resourceId")}>
               {task.resourceId}

--- a/src/modules/data-catalog/scenes/IndexBuildListScene.tsx
+++ b/src/modules/data-catalog/scenes/IndexBuildListScene.tsx
@@ -28,7 +28,6 @@ import { BuildProgress } from "@/modules/data-catalog/components/BuildProgress";
 import { BuildStatusTag } from "@/modules/data-catalog/components/BuildStatusTag";
 import { BuildTaskDetailDrawer } from "@/modules/data-catalog/components/BuildTaskDetailDrawer";
 import { useBuildTaskActions } from "@/modules/data-catalog/hooks/use-build-task-actions";
-import { resourceGateOf } from "@/modules/data-catalog/lib/index-state";
 import {
   applyIndexBuildListFilters,
   readIndexBuildListFilters,
@@ -39,16 +38,18 @@ import {
   listBuildTaskPage,
 } from "@/modules/data-catalog/services/build-task.service";
 import { subscribeMockDb } from "@/modules/data-catalog/services/mock-db";
-import { listCatalogResources } from "@/modules/data-catalog/services/resource.service";
+import {
+  getCatalogResource,
+  listCatalogResourcePage,
+} from "@/modules/data-catalog/services/resource.service";
 import type {
   BuildMode,
   BuildTask,
   BuildTaskOrderBy,
   BuildTaskPageQuery,
   BuildTaskStatus,
-  CatalogResource,
 } from "@/modules/data-catalog/types/data-catalog";
-import { catalogListAllQuery, listCatalogs } from "@/shared/catalog";
+import { getCatalog, listCatalogs } from "@/shared/catalog";
 import type { CatalogRecord } from "@/shared/catalog";
 
 import sceneStyles from "./IndexBuildListScene.module.css";
@@ -104,8 +105,10 @@ export function IndexBuildListScene() {
   );
 
   const [tasks, setTasks] = useState<BuildTask[]>([]);
-  const [resources, setResources] = useState<CatalogResource[]>([]);
-  const [catalogs, setCatalogs] = useState<CatalogRecord[]>([]);
+  const [catalogOptions, setCatalogOptions] = useState<CatalogRecord[]>([]);
+  const [resourceOptions, setResourceOptions] = useState<{ label: string; value: string }[]>([]);
+  const [catalogSearch, setCatalogSearch] = useState("");
+  const [resourceSearch, setResourceSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
@@ -145,18 +148,13 @@ export function IndexBuildListScene() {
     [listFilters, searchParams, setSearchParams],
   );
 
-  const loadData = useCallback(async () => {
+  const loadTasks = useCallback(async () => {
+    setLoading(true);
     setLoadError(null);
     try {
-      const [taskResult, resourceResult, catalogResult] = await Promise.all([
-        listBuildTaskPage(taskQuery),
-        listCatalogResources(),
-        listCatalogs(catalogListAllQuery()),
-      ]);
+      const taskResult = await listBuildTaskPage(taskQuery);
       setTasks(taskResult.items);
       setTotal(taskResult.total);
-      setResources(resourceResult);
-      setCatalogs(catalogResult.items);
     } catch (error) {
       setLoadError(extractRequestErrorMessage(error));
     } finally {
@@ -164,8 +162,8 @@ export function IndexBuildListScene() {
     }
   }, [taskQuery]);
 
-  // 轮询只刷新当前页任务;资源/连接等静态数据进页和手动刷新时才拉
-  const loadTasks = useCallback(async () => {
+  // 轮询只刷新当前页任务，避免随着资源量增加而放大请求量。
+  const refreshTasksSilently = useCallback(async () => {
     try {
       const result = await listBuildTaskPage(taskQuery);
       setTasks(result.items);
@@ -176,10 +174,10 @@ export function IndexBuildListScene() {
   }, [taskQuery]);
 
   useEffect(() => {
-    void loadData();
-  }, [loadData]);
+    void loadTasks();
+  }, [loadTasks]);
 
-  useEffect(() => subscribeMockDb(() => void loadData()), [loadData]);
+  useEffect(() => subscribeMockDb(() => void loadTasks()), [loadTasks]);
 
   const hasActive = useMemo(
     () =>
@@ -200,37 +198,62 @@ export function IndexBuildListScene() {
       if (document.hidden) {
         return;
       }
-      void loadTasks();
+      void refreshTasksSilently();
     }, 10_000);
     return () => window.clearInterval(timer);
-  }, [hasActive, loadTasks]);
+  }, [hasActive, refreshTasksSilently]);
 
-  const resourceMap = useMemo(
-    () => new Map(resources.map((resource) => [resource.id, resource])),
-    [resources],
-  );
-  const catalogMap = useMemo(
-    () => new Map(catalogs.map((catalog) => [catalog.id, catalog])),
-    [catalogs],
-  );
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void listCatalogs({ keyword: catalogSearch, page: 1, pageSize: 50, type: "all" })
+        .then((result) => setCatalogOptions(result.items))
+        .catch(() => setCatalogOptions([]));
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [catalogSearch]);
 
-  const resourceOptions = useMemo(() => {
-    const filteredResources = listFilters.catalogId
-      ? resources.filter((resource) => resource.catalogId === listFilters.catalogId)
-      : resources;
-    return filteredResources.map((resource) => ({
-      label: resource.name,
-      value: resource.id,
-    }));
-  }, [listFilters.catalogId, resources]);
+  useEffect(() => {
+    if (!listFilters.catalogId) {
+      setResourceOptions([]);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      void listCatalogResourcePage({
+        catalogId: listFilters.catalogId,
+        keyword: resourceSearch,
+        limit: 50,
+        offset: 0,
+      })
+        .then((result) =>
+          setResourceOptions(result.items.map((resource) => ({ label: resource.name, value: resource.id }))),
+        )
+        .catch(() => setResourceOptions([]));
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [listFilters.catalogId, resourceSearch]);
+
+  useEffect(() => {
+    if (!listFilters.catalogId || catalogOptions.some((item) => item.id === listFilters.catalogId)) {
+      return;
+    }
+    void getCatalog(listFilters.catalogId).then((catalog) => {
+      if (catalog) setCatalogOptions((items) => [catalog, ...items]);
+    }).catch(() => undefined);
+  }, [catalogOptions, listFilters.catalogId]);
+
+  useEffect(() => {
+    if (!listFilters.resourceId || resourceOptions.some((item) => item.value === listFilters.resourceId)) {
+      return;
+    }
+    void getCatalogResource(listFilters.resourceId).then((resource) => {
+      if (resource) {
+        setResourceOptions((items) => [{ label: resource.name, value: resource.id }, ...items]);
+      }
+    }).catch(() => undefined);
+  }, [listFilters.resourceId, resourceOptions]);
 
   const { pauseOrResume: handlePauseResume, remove: handleDelete, retry: handleRetry } =
-    useBuildTaskActions(loadData);
-
-  const gateOf = (task: BuildTask) => {
-    const resource = resourceMap.get(task.resourceId);
-    return resourceGateOf(resource ? (catalogMap.get(resource.catalogId) ?? null) : null);
-  };
+    useBuildTaskActions(loadTasks);
 
   const handleBatchDelete = () => {
     const targets = tasks.filter((task) => selectedKeys.includes(task.id));
@@ -260,7 +283,7 @@ export function IndexBuildListScene() {
           message.success(t("common.success"));
         }
         setSelectedKeys([]);
-        await loadData();
+        await loadTasks();
       },
     });
   };
@@ -351,11 +374,11 @@ export function IndexBuildListScene() {
       title: t("dataCatalog.resource.catalog"),
       width: 180,
       render: (value: string | undefined, record) => {
-        const catalogId = value ?? resourceMap.get(record.resourceId)?.catalogId;
+        const catalogId = value ?? record.catalogId;
         if (!catalogId) {
           return "-";
         }
-        const label = catalogMap.get(catalogId)?.name ?? catalogId;
+        const label = record.catalogName ?? catalogId;
         return (
           <Tooltip title={label}>
             <button
@@ -391,15 +414,14 @@ export function IndexBuildListScene() {
           />
         </div>
       ),
-      render: (value: string) => {
-        const resource = resourceMap.get(value);
-        const label = resource?.name ?? value;
-        return resource ? (
+      render: (value: string, record) => {
+        const label = record.resourceName ?? value;
+        return value ? (
           <Tooltip title={label}>
             <button
               className={sceneStyles.textLink}
               onClick={() => {
-                void navigate(`/data-directory/resource/${resource.id}?tab=index`);
+                void navigate(`/data-directory/resource/${value}?tab=index`);
               }}
               type="button"
             >
@@ -472,7 +494,6 @@ export function IndexBuildListScene() {
             record.status === "paused" ? (
               <PermissionGate permissions="resource:task_manage">
                 <AppButton
-                  disabled={record.status === "paused" && !gateOf(record).ok}
                   onClick={() => void handlePauseResume(record)}
                   type="link"
                 >
@@ -483,7 +504,6 @@ export function IndexBuildListScene() {
             {record.status === "failed" || record.status === "succeeded" ? (
               <PermissionGate permissions="resource:task_manage">
                 <Dropdown
-                  disabled={!gateOf(record).ok}
                   menu={{
                     items: [
                       {
@@ -499,7 +519,7 @@ export function IndexBuildListScene() {
                       void handleRetry(record, key as BuildExecuteType),
                   }}
                 >
-                  <AppButton disabled={!gateOf(record).ok} type="link">
+                  <AppButton type="link">
                     {t("dataCatalog.task.rebuild")}
                   </AppButton>
                 </Dropdown>
@@ -520,7 +540,7 @@ export function IndexBuildListScene() {
     <section className={sceneStyles.contentSurface}>
       <div className={taskPanelStyles.operationBar}>
         <Space>
-            <AppButton icon={<ReloadOutlined />} onClick={() => void loadData()}>
+            <AppButton icon={<ReloadOutlined />} onClick={() => void loadTasks()}>
               {t("common.refresh")}
             </AppButton>
             <PermissionGate permissions="resource:task_manage">
@@ -540,24 +560,32 @@ export function IndexBuildListScene() {
             <Select
               allowClear
               className={taskPanelStyles.select}
+              filterOption={false}
               onChange={(value) => {
+                setResourceSearch("");
                 updateListFilters({
                   catalogId: value ?? undefined,
                   resourceId: undefined,
                 });
               }}
-              options={catalogs.map((catalog) => ({ label: catalog.name, value: catalog.id }))}
+              onSearch={setCatalogSearch}
+              options={catalogOptions.map((catalog) => ({ label: catalog.name, value: catalog.id }))}
               placeholder={t("dataCatalog.resource.catalog")}
+              showSearch
               value={listFilters.catalogId ?? null}
             />
             <Select
               allowClear
               className={taskPanelStyles.select}
+              disabled={!listFilters.catalogId && !listFilters.resourceId}
+              filterOption={false}
               onChange={(value) => {
                 updateListFilters({ resourceId: value ?? undefined });
               }}
+              onSearch={setResourceSearch}
               options={resourceOptions}
               placeholder={t("dataCatalog.build.resource")}
+              showSearch
               value={listFilters.resourceId ?? null}
             />
             <Select
@@ -598,7 +626,7 @@ export function IndexBuildListScene() {
         {loadError ? (
           <Alert
             action={
-              <AppButton onClick={() => void loadData()} type="link">
+              <AppButton onClick={() => void loadTasks()} type="link">
                 {t("common.retry")}
               </AppButton>
             }
@@ -646,7 +674,7 @@ export function IndexBuildListScene() {
         <BuildTaskDetailDrawer
           onClose={() => setDetailTask(null)}
           open
-          resource={resourceMap.get(detailTask.resourceId) ?? null}
+          resource={null}
           task={detailTask}
         />
       ) : null}

--- a/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
+++ b/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
@@ -8,7 +8,7 @@
 import { DeleteOutlined, ExclamationCircleOutlined, FilterOutlined, ReloadOutlined, UnorderedListOutlined } from "@ant-design/icons";
 import { Alert, Descriptions, Drawer, Popover, Select, Space, Tag } from "antd";
 import type { ColumnsType, TableProps } from "antd/es/table";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
@@ -34,9 +34,9 @@ import type {
   DataConnectDiscoverTaskStatus,
   DataConnectDiscoverTaskTriggerType,
 } from "@/modules/data-connect/types/discover";
-import { listCatalogResources } from "@/modules/data-catalog/services/resource.service";
+import { listCatalogResourcePage } from "@/modules/data-catalog/services/resource.service";
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
-import { catalogListAllQuery, catalogListPhysicalQuery, listCatalogs } from "@/shared/catalog";
+import { listCatalogs } from "@/shared/catalog";
 import type { CatalogRecord } from "@/shared/catalog";
 
 import styles from "./TaskManagementTaskPanels.module.css";
@@ -47,7 +47,9 @@ type SemanticTask = {
   id: string;
   scope: "catalog" | "resource";
   catalogId: string;
+  catalogName?: string;
   resourceId?: string;
+  resourceName?: string;
   status: SemanticTaskStatus;
   applyMode: string;
   agentId: string;
@@ -213,6 +215,7 @@ export function DiscoverTaskListPanel() {
   const navigate = useNavigate();
   const [tasks, setTasks] = useState<DataConnectDiscoverTask[]>([]);
   const [catalogs, setCatalogs] = useState<CatalogRecord[]>([]);
+  const [catalogKeyword, setCatalogKeyword] = useState("");
   const [catalogId, setCatalogId] = useState<string>();
   const [status, setStatus] = useState<DataConnectDiscoverTaskStatus>();
   const [strategy, setStrategy] = useState<DataConnectDiscoverStrategy>();
@@ -231,22 +234,18 @@ export function DiscoverTaskListPanel() {
     setLoading(true);
     setError(null);
     try {
-      const [taskResult, catalogResult] = await Promise.all([
-        listDataConnectDiscoverTasks({
-          catalogId,
-          page,
-          pageSize,
-          status,
-          strategy,
-          triggerType,
-          sort,
-          direction,
-        }),
-        listCatalogs(catalogListPhysicalQuery()),
-      ]);
+      const taskResult = await listDataConnectDiscoverTasks({
+        catalogId,
+        page,
+        pageSize,
+        status,
+        strategy,
+        triggerType,
+        sort,
+        direction,
+      });
       setTasks(taskResult.items);
       setTotal(taskResult.total);
-      setCatalogs(catalogResult.items);
     } catch (loadError) {
       setError(extractRequestErrorMessage(loadError));
     } finally {
@@ -255,7 +254,12 @@ export function DiscoverTaskListPanel() {
   }, [catalogId, direction, page, pageSize, sort, status, strategy, triggerType]);
 
   useEffect(() => void load(), [load]);
-  const catalogNameMap = useMemo(() => new Map(catalogs.map((item) => [item.id, item.name])), [catalogs]);
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void listCatalogs({ keyword: catalogKeyword, page: 1, pageSize: 50, type: "physical" }).then((result) => setCatalogs(result.items));
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [catalogKeyword]);
   const active = tasks.some((item) => item.status === "pending" || item.status === "running");
   useEffect(() => {
     if (!active) return;
@@ -297,8 +301,8 @@ export function DiscoverTaskListPanel() {
       dataIndex: "catalogId",
       title: t("dataCatalog.resource.catalog"),
       width: 180,
-      render: (value: string) => {
-        const catalogName = catalogNameMap.get(value);
+      render: (value: string, record) => {
+        const catalogName = record.catalogName;
         return catalogName ? (
           <button
             className={styles.textLink}
@@ -331,7 +335,7 @@ export function DiscoverTaskListPanel() {
 
   return <TaskPanel>
     <div className={styles.operationBar}><Space className={styles.toolbarActions}><AppButton icon={<ReloadOutlined />} onClick={() => void load()}>{t("common.refresh")}</AppButton><PermissionGate permissions="catalog:task_manage"><AppButton danger disabled={selectedKeys.length === 0} icon={<DeleteOutlined />} onClick={handleBatchDelete}>{selectedKeys.length > 0 ? `${t("dataCatalog.task.batchDelete")} (${selectedKeys.length})` : t("dataCatalog.task.batchDelete")}</AppButton></PermissionGate></Space><Space className={styles.toolbarFilters}>
-      <Select allowClear className={styles.select} options={catalogs.map((item) => ({ label: item.name, value: item.id }))} placeholder={t("dataCatalog.resource.catalog")} value={catalogId} onChange={(value) => { setCatalogId(value); setPage(1); }} />
+      <Select allowClear className={styles.select} filterOption={false} onSearch={setCatalogKeyword} options={catalogs.map((item) => ({ label: item.name, value: item.id }))} placeholder={t("dataCatalog.resource.catalog")} showSearch value={catalogId} onChange={(value) => { setCatalogId(value); setPage(1); }} />
       <Select allowClear className={styles.select} options={["full_sync", "create_only", "cleanup_only"].map((value) => ({ label: t(`dataConnect.discoverStrategies.${value}`), value }))} placeholder={t("dataCatalog.taskManagement.columns.strategy")} value={strategy} onChange={(value) => { setStrategy(value); setPage(1); }} />
       <Select allowClear className={styles.select} options={["manual", "scheduled"].map((value) => ({ label: t(`dataConnect.discoverTriggerTypes.${value}`), value }))} placeholder={t("dataCatalog.taskManagement.columns.trigger")} value={triggerType} onChange={(value) => { setTriggerType(value); setPage(1); }} />
       <Select allowClear className={styles.select} options={["pending", "running", "completed", "failed"].map((value) => ({ label: t(`dataConnect.discoverTaskStatuses.${value}`), value }))} placeholder={t("common.status")} value={status} onChange={(value) => { setStatus(value); setPage(1); }} />
@@ -339,7 +343,7 @@ export function DiscoverTaskListPanel() {
     <TaskTable error={error} loading={loading} data={tasks} columns={columns} emptyTitle={t("dataCatalog.taskManagement.discover.empty")} onRetry={load} onTableChange={handleTableChange} selectedKeys={selectedKeys} onSelectionChange={setSelectedKeys} />
     <Pagination page={page} pageSize={pageSize} total={total} onChange={(nextPage, nextSize) => { setPage(nextPage); setPageSize(nextSize); }} />
     {detailTask ? <TaskDetailDrawer failureReason={detailTask.status === "failed" ? detailTask.message : undefined} onClose={() => setDetailTask(null)} status={t(`dataConnect.discoverTaskStatuses.${detailTask.status}`)} statusClass={detailTask.status === "failed" ? sharedStyles.taskFailed : detailTask.status === "completed" ? sharedStyles.taskSucceeded : sharedStyles.taskRunning} taskId={detailTask.id}>
-      <Descriptions.Item label={t("dataCatalog.resource.catalog")}>{catalogNameMap.get(detailTask.catalogId) ?? detailTask.catalogId}</Descriptions.Item>
+      <Descriptions.Item label={t("dataCatalog.resource.catalog")}>{detailTask.catalogName ?? detailTask.catalogId}</Descriptions.Item>
       <Descriptions.Item label={t("dataCatalog.taskManagement.columns.strategy")}>{t(`dataConnect.discoverStrategies.${detailTask.strategy}`)}</Descriptions.Item>
       <Descriptions.Item label={t("dataCatalog.taskManagement.columns.trigger")}>{t(`dataConnect.discoverTriggerTypes.${detailTask.triggerType}`)}</Descriptions.Item>
       <Descriptions.Item label={t("common.status")}>{t(`dataConnect.discoverTaskStatuses.${detailTask.status}`)}</Descriptions.Item>
@@ -380,7 +384,7 @@ async function listSemanticTasks(page: number, pageSize: number, filters: Semant
     });
   }
 
-  const response = await http.get<ListResponse<{ id: string; scope: "catalog" | "resource"; catalog_id: string; resource_id?: string; status: SemanticTaskStatus; apply_mode?: string; agent_id: string; confidence?: number; applied?: boolean; create_time?: number; failure_detail?: string }>>("/vega-backend/v1/semantic-understanding-tasks", {
+  const response = await http.get<ListResponse<{ id: string; scope: "catalog" | "resource"; catalog_id: string; catalog_name?: string; resource_id?: string; resource_name?: string; status: SemanticTaskStatus; apply_mode?: string; agent_id: string; confidence?: number; applied?: boolean; create_time?: number; failure_detail?: string }>>("/vega-backend/v1/semantic-understanding-tasks", {
     params: {
       direction: filters.direction ?? "desc",
       limit: pageSize,
@@ -394,7 +398,7 @@ async function listSemanticTasks(page: number, pageSize: number, filters: Semant
       applied: filters.applied,
     },
   });
-  return { items: response.data.entries.map((item) => ({ id: item.id, scope: item.scope, catalogId: item.catalog_id, resourceId: item.resource_id, status: item.status, applyMode: item.apply_mode ?? "fill_empty", agentId: item.agent_id, confidence: item.confidence ?? 0, applied: item.applied ?? false, createTime: item.create_time ?? 0, failureDetail: item.failure_detail })), total: response.data.total_count };
+  return { items: response.data.entries.map((item) => ({ id: item.id, scope: item.scope, catalogId: item.catalog_id, catalogName: item.catalog_name, resourceId: item.resource_id, resourceName: item.resource_name, status: item.status, applyMode: item.apply_mode ?? "fill_empty", agentId: item.agent_id, confidence: item.confidence ?? 0, applied: item.applied ?? false, createTime: item.create_time ?? 0, failureDetail: item.failure_detail })), total: response.data.total_count };
 }
 
 async function deleteSemanticTask(id: string) {
@@ -414,6 +418,8 @@ export function SemanticUnderstandingTaskListPanel() {
   const [tasks, setTasks] = useState<SemanticTask[]>([]);
   const [catalogs, setCatalogs] = useState<CatalogRecord[]>([]);
   const [resources, setResources] = useState<CatalogResource[]>([]);
+  const [catalogKeyword, setCatalogKeyword] = useState("");
+  const [resourceKeyword, setResourceKeyword] = useState("");
   const [page, setPage] = useState(1); const [pageSize, setPageSize] = useState(10); const [total, setTotal] = useState(0);
   const [scope, setScope] = useState<SemanticTask["scope"]>();
   const [catalogId, setCatalogId] = useState<string>();
@@ -426,14 +432,21 @@ export function SemanticUnderstandingTaskListPanel() {
   const [loading, setLoading] = useState(true); const [error, setError] = useState<string | null>(null);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [detailTask, setDetailTask] = useState<SemanticTask | null>(null);
-  const load = useCallback(async () => { setLoading(true); setError(null); try { const [taskResult, catalogResult, resourceResult] = await Promise.all([listSemanticTasks(page, pageSize, { scope, catalogId, resourceId, status, applyMode, applied, sort, direction }), listCatalogs(catalogListAllQuery()), listCatalogResources()]); setTasks(taskResult.items); setTotal(taskResult.total); setCatalogs(catalogResult.items); setResources(resourceResult); } catch (loadError) { setError(extractRequestErrorMessage(loadError)); } finally { setLoading(false); } }, [applied, applyMode, catalogId, direction, page, pageSize, resourceId, scope, sort, status]);
+  const load = useCallback(async () => { setLoading(true); setError(null); try { const taskResult = await listSemanticTasks(page, pageSize, { scope, catalogId, resourceId, status, applyMode, applied, sort, direction }); setTasks(taskResult.items); setTotal(taskResult.total); } catch (loadError) { setError(extractRequestErrorMessage(loadError)); } finally { setLoading(false); } }, [applied, applyMode, catalogId, direction, page, pageSize, resourceId, scope, sort, status]);
   useEffect(() => void load(), [load]);
-  const catalogNameMap = useMemo(() => new Map(catalogs.map((item) => [item.id, item.name])), [catalogs]);
-  const resourceNameMap = useMemo(() => new Map(resources.map((item) => [item.id, item.name])), [resources]);
-  const resourceOptions = useMemo(
-    () => resources.filter((item) => !catalogId || item.catalogId === catalogId).map((item) => ({ label: item.name, value: item.id })),
-    [catalogId, resources],
-  );
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void listCatalogs({ keyword: catalogKeyword, page: 1, pageSize: 50, type: "all" }).then((result) => setCatalogs(result.items));
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [catalogKeyword]);
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void listCatalogResourcePage({ catalogId, keyword: resourceKeyword, limit: 50, offset: 0 }).then((result) => setResources(result.items));
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [catalogId, resourceKeyword]);
+  const resourceOptions = resources.map((item) => ({ label: item.name, value: item.id }));
   const active = tasks.some((item) => item.status === "pending" || item.status === "running");
   useEffect(() => { if (!active) return; const timer = window.setInterval(() => !document.hidden && void load(), 10_000); return () => window.clearInterval(timer); }, [active, load]);
   const handleBatchDelete = () => {
@@ -471,13 +484,13 @@ export function SemanticUnderstandingTaskListPanel() {
       title: t("dataCatalog.resource.catalog"),
       width: 180,
       ellipsis: true,
-      render: (value: string) => (
+      render: (value: string, record) => (
         <button
           className={styles.textLink}
           onClick={() => void navigate(`/data-directory/catalog/${value}`)}
           type="button"
         >
-          {catalogNameMap.get(value) ?? value}
+          {record.catalogName ?? value}
         </button>
       ),
     },
@@ -486,14 +499,14 @@ export function SemanticUnderstandingTaskListPanel() {
       title: t("dataCatalog.build.resource"),
       width: 200,
       ellipsis: true,
-      render: (value?: string) =>
+      render: (value: string | undefined, record) =>
         value ? (
           <button
             className={styles.textLink}
             onClick={() => void navigate(`/data-directory/resource/${value}`)}
             type="button"
           >
-            {resourceNameMap.get(value) ?? value}
+            {record.resourceName ?? value}
           </button>
         ) : (
           "-"
@@ -537,14 +550,14 @@ export function SemanticUnderstandingTaskListPanel() {
     : t("dataCatalog.taskManagement.moreFilters");
   const advancedFilters = <Space direction="vertical" size={12}><Select allowClear className={styles.select} options={["catalog", "resource"].map((value) => ({ label: t(`dataCatalog.taskManagement.scope.${value}`), value }))} placeholder={t("dataCatalog.taskManagement.columns.scope")} value={scope} onChange={(value) => { setScope(value); if (value === "catalog") setResourceId(undefined); setPage(1); }} /><Select allowClear className={styles.select} options={["dry_run", "fill_empty", "force"].map((value) => ({ label: t(`dataCatalog.taskManagement.applyMode.${value === "dry_run" ? "dryRun" : value === "fill_empty" ? "fillEmpty" : "force"}`), value }))} placeholder={t("dataCatalog.taskManagement.columns.applyMode")} value={applyMode} onChange={(value) => { setApplyMode(value); setPage(1); }} /><Select allowClear className={styles.select} options={[true, false].map((value) => ({ label: t(value ? "dataCatalog.taskManagement.applied.applied" : "dataCatalog.taskManagement.applied.notApplied"), value }))} placeholder={t("dataCatalog.taskManagement.columns.applied")} value={applied} onChange={(value) => { setApplied(value); setPage(1); }} /><AppButton disabled={advancedFilterCount === 0} type="link" onClick={() => { setScope(undefined); setApplyMode(undefined); setApplied(undefined); setPage(1); }}>{t("dataCatalog.taskManagement.clearAdvancedFilters")}</AppButton></Space>;
   return <TaskPanel><div className={styles.operationBar}><Space className={styles.toolbarActions}><AppButton icon={<ReloadOutlined />} onClick={() => void load()}>{t("common.refresh")}</AppButton><PermissionGate permissions="catalog:task_manage"><AppButton danger disabled={selectedKeys.length === 0} icon={<DeleteOutlined />} onClick={handleBatchDelete}>{selectedKeys.length > 0 ? `${t("dataCatalog.task.batchDelete")} (${selectedKeys.length})` : t("dataCatalog.task.batchDelete")}</AppButton></PermissionGate></Space><Space className={styles.toolbarFilters}>
-    <Select allowClear className={styles.select} options={catalogs.map((item) => ({ label: item.name, value: item.id }))} placeholder={t("dataCatalog.resource.catalog")} value={catalogId} onChange={(value) => { setCatalogId(value); setResourceId(undefined); setPage(1); }} />
-    <Select allowClear className={styles.select} disabled={scope === "catalog"} options={resourceOptions} placeholder={t("dataCatalog.build.resource")} value={resourceId} onChange={(value) => { setResourceId(value); setPage(1); }} />
+    <Select allowClear className={styles.select} filterOption={false} onSearch={setCatalogKeyword} options={catalogs.map((item) => ({ label: item.name, value: item.id }))} placeholder={t("dataCatalog.resource.catalog")} showSearch value={catalogId} onChange={(value) => { setCatalogId(value); setResourceId(undefined); setPage(1); }} />
+    <Select allowClear className={styles.select} disabled={scope === "catalog"} filterOption={false} onSearch={setResourceKeyword} options={resourceOptions} placeholder={t("dataCatalog.build.resource")} showSearch value={resourceId} onChange={(value) => { setResourceId(value); setPage(1); }} />
     <Select allowClear className={styles.select} options={["pending", "running", "succeeded", "failed"].map((value) => ({ label: t(`dataCatalog.taskManagement.semanticStatus.${value}`), value }))} placeholder={t("common.status")} value={status} onChange={(value) => { setStatus(value); setPage(1); }} />
     <Popover content={advancedFilters} trigger="click"><AppButton icon={<FilterOutlined />}>{moreFiltersLabel}</AppButton></Popover>
   </Space></div><TaskTable error={error} loading={loading} data={tasks} columns={columns} emptyTitle={t("dataCatalog.taskManagement.semantic.empty")} onRetry={load} onTableChange={handleTableChange} selectedKeys={selectedKeys} onSelectionChange={setSelectedKeys} /><Pagination page={page} pageSize={pageSize} total={total} onChange={(nextPage, nextSize) => { setPage(nextPage); setPageSize(nextSize); }} />{detailTask ? <TaskDetailDrawer failureReason={detailTask.status === "failed" ? detailTask.failureDetail : undefined} onClose={() => setDetailTask(null)} status={t(`dataCatalog.taskManagement.semanticStatus.${detailTask.status}`)} statusClass={detailTask.status === "failed" ? sharedStyles.taskFailed : detailTask.status === "succeeded" ? sharedStyles.taskSucceeded : sharedStyles.taskRunning} taskId={detailTask.id}>
     <Descriptions.Item label={t("dataCatalog.taskManagement.columns.scope")}>{t(`dataCatalog.taskManagement.scope.${detailTask.scope}`)}</Descriptions.Item>
-    <Descriptions.Item label={t("dataCatalog.resource.catalog")}>{catalogNameMap.get(detailTask.catalogId) ?? detailTask.catalogId}</Descriptions.Item>
-    <Descriptions.Item label={t("dataCatalog.build.resource")}>{detailTask.resourceId ? resourceNameMap.get(detailTask.resourceId) ?? detailTask.resourceId : "-"}</Descriptions.Item>
+    <Descriptions.Item label={t("dataCatalog.resource.catalog")}>{detailTask.catalogName ?? detailTask.catalogId}</Descriptions.Item>
+    <Descriptions.Item label={t("dataCatalog.build.resource")}>{detailTask.resourceId ? detailTask.resourceName ?? detailTask.resourceId : "-"}</Descriptions.Item>
     <Descriptions.Item label={t("common.status")}>{t(`dataCatalog.taskManagement.semanticStatus.${detailTask.status}`)}</Descriptions.Item>
     <Descriptions.Item label={t("dataCatalog.taskManagement.columns.applyMode")}>{detailTask.applyMode === "dry_run" ? t("dataCatalog.taskManagement.applyMode.dryRun") : detailTask.applyMode === "force" ? t("dataCatalog.taskManagement.applyMode.force") : t("dataCatalog.taskManagement.applyMode.fillEmpty")}</Descriptions.Item>
     <Descriptions.Item label={t("dataCatalog.taskManagement.columns.confidence")}>{`${Math.round(detailTask.confidence * 100)}%`}</Descriptions.Item>

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -51,6 +51,7 @@ type BackendBuildTaskIndexConfig = {
 type BackendBuildTask = {
   build_key_fields?: string | string[];
   catalog_id?: string;
+  catalog_name?: string;
   create_time?: number;
   embedding_fields?: string | string[];
   embedding_model?: string;
@@ -64,6 +65,7 @@ type BackendBuildTask = {
   mode?: string;
   model_dimensions?: number;
   resource_id?: string;
+  resource_name?: string;
   status?: string;
   synced_count?: number;
   total_count?: number;
@@ -234,7 +236,9 @@ function mapBuildTask(item: BackendBuildTask): BuildTask {
   return {
     id: item.id,
     catalogId: item.catalog_id,
+    catalogName: item.catalog_name,
     resourceId: item.resource_id ?? "",
+    resourceName: item.resource_name,
     mode,
     status,
     embeddingFields: snapshot.embeddingFields,

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -115,6 +115,8 @@ export type BuildTask = {
   buildKeyFields: string[];
   /** 后端任务记录所属 Catalog；mock 旧数据可缺省并由数据资源回填。 */
   catalogId?: string;
+  /** 任务列表关联返回的 catalog 展示字段，避免列表页再全量加载 catalog。 */
+  catalogName?: string;
   createTime: string;
   createdAt: number;
   embeddingFields: string[];
@@ -136,6 +138,8 @@ export type BuildTask = {
   mode: BuildMode;
   modelDimensions: number;
   resourceId: string;
+  /** 任务列表关联返回的资源名称，避免列表页再全量加载 resources。 */
+  resourceName?: string;
   status: BuildTaskStatus;
   syncedCount: number;
   totalCount: number;

--- a/src/modules/data-connect/components/DataConnectDiscoverTaskDrawer.tsx
+++ b/src/modules/data-connect/components/DataConnectDiscoverTaskDrawer.tsx
@@ -60,6 +60,7 @@ export function DataConnectDiscoverTaskDrawer({
   }, [open, taskId]);
 
   const catalogName =
+    task?.catalogName ??
     catalogs.find((item) => item.id === task?.catalogId)?.name ??
     task?.catalogId ??
     "-";

--- a/src/modules/data-connect/components/DiscoverScheduleFormModal.tsx
+++ b/src/modules/data-connect/components/DiscoverScheduleFormModal.tsx
@@ -25,6 +25,7 @@ type DiscoverScheduleFormModalProps = {
   initialValue?: DataConnectDiscoverSchedule | null;
   mode: "create" | "edit";
   onCancel: () => void;
+  onCatalogSearch?: (keyword: string) => void;
   onSubmit: (payload: DiscoverScheduleFormModalSubmitPayload) => Promise<void>;
   open: boolean;
   submitting: boolean;
@@ -65,6 +66,7 @@ export function DiscoverScheduleFormModal({
   initialValue,
   mode,
   onCancel,
+  onCatalogSearch,
   onSubmit,
   open,
   submitting,
@@ -165,11 +167,12 @@ export function DiscoverScheduleFormModal({
             >
               <Select
                 disabled={catalogLocked}
+                filterOption={false}
+                onSearch={onCatalogSearch}
                 options={catalogs.map((item) => ({
                   label: item.name,
                   value: item.id,
                 }))}
-                optionFilterProp="label"
                 placeholder={t("dataConnect.discoverCatalogFilterPlaceholder")}
                 showSearch
               />

--- a/src/modules/data-connect/scenes/DataConnectDiscoverScene.tsx
+++ b/src/modules/data-connect/scenes/DataConnectDiscoverScene.tsx
@@ -22,7 +22,7 @@ import { AppTable } from "@/framework/ui/common/AppTable";
 import { EmptyStatePanel } from "@/framework/ui/common/EmptyStatePanel";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { TableSurface } from "@/framework/ui/common/TableSurface";
-import { catalogListPhysicalQuery, listCatalogs } from "@/shared/catalog";
+import { listCatalogs } from "@/shared/catalog";
 import {
   createDataConnectDiscoverSchedule,
   deleteDataConnectDiscoverTask,
@@ -77,6 +77,8 @@ export function DataConnectDiscoverScene({
   const [activeTab, setActiveTab] = useState<DiscoverPageTab>("schedules");
   const [keyword, setKeyword] = useState("");
   const debouncedKeyword = useDebouncedValue(keyword.trim());
+  const [catalogKeyword, setCatalogKeyword] = useState("");
+  const debouncedCatalogKeyword = useDebouncedValue(catalogKeyword.trim());
   const [selectedCatalogId, setSelectedCatalogId] = useState<string | undefined>(catalogId);
   const [enabledFilter, setEnabledFilter] =
     useState<EnabledFilterValue>("all");
@@ -138,14 +140,19 @@ export function DataConnectDiscoverScene({
     setCatalogError(null);
 
     try {
-      const result = await listCatalogs(catalogListPhysicalQuery());
+      const result = await listCatalogs({
+        keyword: debouncedCatalogKeyword,
+        page: 1,
+        pageSize: 50,
+        type: "physical",
+      });
       setCatalogs(result.items);
     } catch (error) {
       setCatalogError(extractRequestErrorMessage(error));
     } finally {
       setLoadingCatalogs(false);
     }
-  }, []);
+  }, [debouncedCatalogKeyword]);
 
   const loadSchedules = useCallback(async () => {
     setLoadingSchedules(true);
@@ -590,7 +597,8 @@ export function DataConnectDiscoverScene({
           setSchedulePage(1);
           setTaskPage(1);
         }}
-        optionFilterProp="label"
+        filterOption={false}
+        onSearch={setCatalogKeyword}
         options={[
           ...(catalogLocked ? [] : [{ label: t("dataConnect.categoryAll"), value: "" }]),
           ...catalogs.map((item) => ({
@@ -906,6 +914,7 @@ export function DataConnectDiscoverScene({
             setScheduleModalState(null);
             setEditingSchedule(null);
           }}
+          onCatalogSearch={setCatalogKeyword}
           onSubmit={handleScheduleSubmit}
           open
           submitting={scheduleModalSubmitting}

--- a/src/modules/data-connect/services/discover.service.ts
+++ b/src/modules/data-connect/services/discover.service.ts
@@ -27,6 +27,7 @@ type BackendAccountInfo = {
 
 type BackendDiscoverSchedule = {
   catalog_id: string;
+  catalog_name?: string;
   create_time?: number;
   creator?: BackendAccountInfo;
   cron_expr: string;
@@ -44,6 +45,7 @@ type BackendDiscoverSchedule = {
 
 type BackendDiscoverTask = {
   catalog_id: string;
+  catalog_name?: string;
   create_time?: number;
   creator?: BackendAccountInfo;
   finish_time?: number;
@@ -213,6 +215,7 @@ function mapSchedule(item: BackendDiscoverSchedule): DataConnectDiscoverSchedule
     id: item.id,
     name: item.name,
     catalogId: item.catalog_id,
+    catalogName: item.catalog_name,
     cronExpr: item.cron_expr,
     startTime: formatTimestamp(item.start_time),
     startTimeValue: item.start_time,
@@ -235,6 +238,7 @@ function mapTask(item: BackendDiscoverTask): DataConnectDiscoverTask {
   return {
     id: item.id,
     catalogId: item.catalog_id,
+    catalogName: item.catalog_name,
     scheduleId: item.schedule_id ?? "",
     strategy: normalizeStrategy(item.strategy),
     triggerType: normalizeTriggerType(item.trigger_type),

--- a/src/modules/data-connect/types/discover.ts
+++ b/src/modules/data-connect/types/discover.ts
@@ -21,6 +21,7 @@ export type DataConnectDiscoverTaskSort = "create_time" | "default";
 
 export type DataConnectDiscoverSchedule = {
   catalogId: string;
+  catalogName?: string;
   createTime: string;
   creatorName: string;
   cronExpr: string;
@@ -42,6 +43,7 @@ export type DataConnectDiscoverSchedule = {
 
 export type DataConnectDiscoverTask = {
   catalogId: string;
+  catalogName?: string;
   createTime: string;
   creatorName: string;
   finishTime: string;

--- a/src/shared/catalog/catalog.service.test.ts
+++ b/src/shared/catalog/catalog.service.test.ts
@@ -13,6 +13,11 @@ vi.mock("@/framework/request/http", () => ({
   http: { get: getMock },
 }));
 
+function lastParams(): Record<string, unknown> {
+  const call = getMock.mock.calls.at(-1) as [string, { params?: Record<string, unknown> }] | undefined;
+  return call?.[1]?.params ?? {};
+}
+
 describe("catalog.service · listCatalogs", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -30,9 +35,7 @@ describe("catalog.service · listCatalogs", () => {
 
     await listCatalogs({ keyword: "", page: 1, pageSize: 50, type: "physical" });
 
-    expect(getMock).toHaveBeenCalledWith("/vega-backend/v1/catalogs", {
-      params: expect.objectContaining({ type: "physical" }),
-    });
+    expect(lastParams()).toMatchObject({ type: "physical" });
   });
 
   it("omits the type filter when all catalog types are requested", async () => {
@@ -40,8 +43,6 @@ describe("catalog.service · listCatalogs", () => {
 
     await listCatalogs({ keyword: "", page: 1, pageSize: 50, type: "all" });
 
-    expect(getMock).toHaveBeenCalledWith("/vega-backend/v1/catalogs", {
-      params: expect.objectContaining({ type: undefined }),
-    });
+    expect(lastParams()).toMatchObject({ type: undefined });
   });
 });

--- a/src/shared/catalog/catalog.service.test.ts
+++ b/src/shared/catalog/catalog.service.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock },
+}));
+
+describe("catalog.service · listCatalogs", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    getMock.mockReset();
+    getMock.mockResolvedValue({ data: { entries: [], total_count: 0 } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("passes the physical type to Vega before pagination", async () => {
+    const { listCatalogs } = await import("@/shared/catalog/catalog.service");
+
+    await listCatalogs({ keyword: "", page: 1, pageSize: 50, type: "physical" });
+
+    expect(getMock).toHaveBeenCalledWith("/vega-backend/v1/catalogs", {
+      params: expect.objectContaining({ type: "physical" }),
+    });
+  });
+
+  it("omits the type filter when all catalog types are requested", async () => {
+    const { listCatalogs } = await import("@/shared/catalog/catalog.service");
+
+    await listCatalogs({ keyword: "", page: 1, pageSize: 50, type: "all" });
+
+    expect(getMock).toHaveBeenCalledWith("/vega-backend/v1/catalogs", {
+      params: expect.objectContaining({ type: undefined }),
+    });
+  });
+});

--- a/src/shared/catalog/catalog.service.ts
+++ b/src/shared/catalog/catalog.service.ts
@@ -57,6 +57,7 @@ export async function listCatalogs(query: CatalogListQuery): Promise<CatalogList
       name: query.keyword.trim() || undefined,
       offset: (query.page - 1) * query.pageSize,
       sort: "update_time",
+      type: query.type === "all" ? undefined : query.type,
     },
   });
 


### PR DESCRIPTION
## Summary
- Render task catalog/resource names returned by the backend instead of loading all catalogs and resources on every task-list refresh.
- Use debounced, remote catalog/resource selectors capped at 50 results for build, discover, semantic-understanding, and discover-schedule flows.
- Map discover task and schedule catalog names in Studio clients.

## Validation
- `pnpm exec tsc -b --pretty false`
- Relevant ESLint checks

Closes #235