### PR TITLE
ci: 分支推送自动打包 + Claude PR 审核

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 OpenBKN
+# SPDX-License-Identifier: LicenseRef-OpenBKN
+# Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+# Conditions. See LICENSE for the full text.
+
+name: Claude Code Review
+
+# 由 Claude 对 PR 做代码评审：开启、重开、从 draft 转 ready，以及每次推送新提交时各跑一次。
+#
+# 覆盖每次推送而非只审首版，是因为评审之后追加的提交往往是「按意见快速改一下」，
+# 恰恰最容易引入新问题；只审首版会让这部分完全不过审。
+# 连续推送的浪费由下面的 concurrency 收敛：新一次运行会取消尚未完成的上一次。
+#
+# 需要对任意 PR 重新评审时，手动触发 workflow_dispatch 并填 PR 编号。
+#
+# 只对代码路径生效。纯文档/配置改动不进评审，既省额度也避免噪声。
+# 注意：GitHub Actions 不允许同一事件同时使用 paths 与 paths-ignore，因此这里
+# 只写 include 列表——未列出的路径自动跳过——并用 ! 前缀排除列表内的文档文件。
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'specs/**'
+      - 'scripts/**'
+      - 'deploy/**'
+      - 'Dockerfile'
+      - 'vite.config.ts'
+      - '!**/*.md'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: string
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # fork 发起的 PR 拿不到 secrets，直接跳过避免红叉
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # pull_request 事件下 checkout 会自动落到 PR 的 merge ref；
+          # workflow_dispatch 下只会拿到默认分支，需要下一步显式切到 PR 分支，
+          # 因此这里放开深度以便 gh pr checkout 能建立分支。
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 0 || 1 }}
+
+      - name: Checkout PR branch (manual trigger)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh pr checkout "$PR_NUMBER"
+          echo "已切到 PR #$PR_NUMBER: $(git rev-parse --abbrev-ref HEAD) @ $(git rev-parse --short HEAD)"
+
+      - name: Claude review
+        if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # track_progress 只支持 pull_request / issues / issue_comment /
+          # pull_request_review(_comment) 事件，在 workflow_dispatch 下会直接
+          # 报错退出——手动触发那条路径因此从未可用。按事件类型开关。
+          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ env.PR_NUMBER }}
+
+            对这个 PR 做代码评审。这是 bkn-studio —— React + TypeScript + Vite 的
+            前端单页应用，按 src/modules/<模块> 划分业务模块，通过 Helm chart 部署。
+            协作规范见 CONTRIBUTING.md、AGENTS.md、ARCHITECTURE.md、
+            MICRO_APP_CONTRACT.md。
+
+            重点关注（按优先级）：
+
+            1. **正确性** — 逻辑错误、边界条件、异常与空态未处理、React hook 依赖
+               数组错漏、副作用未清理、请求竞态（切换筛选/分页时旧响应覆盖新结果）、
+               列表 key 用下标导致的状态错位。
+            2. **安全与权限** — 凭据或 token 落到前端可见处、`dangerouslySetInnerHTML`
+               与其它 XSS 面、权限点判断缺失或写死放行、把内部服务地址暴露到浏览器。
+               权限一律走网关暴露的 `/me/permissions`，不要直连内部 authz 接口。
+            3. **真实数据** — 本仓硬性要求：UI 只能用真实后端数据。后端没有的字段就
+               不展示，禁止 mock、占位、编造的兜底值冒充真实数据。这是高频问题，重点查。
+            4. **一致性** — 是否复用了既有组件/hooks/请求封装而不是另起一套；模块边界
+               是否符合 MICRO_APP_CONTRACT；用户可见文案是否 i18n 齐全。
+            5. **测试** — 新增逻辑是否有覆盖，测试是否验证真实行为而不是断言实现细节。
+
+            评审要求：
+            - 用中文。
+            - 具体问题用 inline comment 贴到对应行，说明「问题是什么 + 怎么改」。
+            - 顶层 comment 只写整体判断和阻塞项清单，不要复述 diff。
+            - 不确定的推测标注为「待确认」，不要当成缺陷断言。
+            - 没问题就说没问题，不要为了凑数提格式化/命名类的琐碎意见。
+              lint 由 CI 的 eslint.config.typechecked.js 把关，不用人工复查风格。
+
+            评审结论落成一次 PR review（不是普通评论）：
+            - 确认没有阻塞项时，`gh pr review "$PR_NUMBER" --approve --body "<一句放行理由>"`。
+            - 有阻塞项时，`gh pr review "$PR_NUMBER" --request-changes --body "<阻塞清单>"`。
+              待确认的推测不算阻塞项，别用它触发 request-changes。
+            批准以 github-actions[bot] 身份提交，只表态、不合并。人工仍需自行 merge。
+
+          # 大 PR 只给 gh pr diff 不够：Claude 需要进文件看上下文、比对具体 commit，
+          # 否则会伸手 Read/Grep/git diff 等未授权工具而被拒，撞满轮次后评论冻在
+          # 「进行中」。这里补齐只读检视工具并放宽轮次上限。
+          claude_args: |
+            --model claude-opus-4-8
+            --effort high
+            --max-turns 60
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,LS,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
+
+      - name: Warn when credential missing
+        if: env.CLAUDE_CODE_OAUTH_TOKEN == ''
+        run: |
+          echo "::warning::Secret CLAUDE_CODE_OAUTH_TOKEN not set — skipping Claude review."

--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -12,12 +12,18 @@ name: release-studio
 # the published chart by name + version.
 #
 # Versioning mirrors the bkn-foundry convention so image tag == chart version:
-# a `v*` tag IS the release version (leading "v" stripped). Main branch and
-# workflow_dispatch runs build-only unless dispatched with publish=true.
+# a `v*` tag IS the release version (leading "v" stripped); every other push
+# gets a prerelease version stamped with branch, commit date and short SHA.
+#
+# Every branch push publishes, so a branch build is directly deployable without
+# merging or hand-dispatching. Only workflow_dispatch stays build-only by
+# default. Prerelease versions accumulate with no retention policy yet: GHCR
+# cleanup needs a PAT/App token (GITHUB_TOKEN can't wildcard-match tags), and
+# SWR needs its own console-side rule — both deferred.
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
     tags: ['v*']
   workflow_dispatch:
     inputs:
@@ -25,6 +31,13 @@ on:
         description: 'Push to registries (true) or build-only verify (false)'
         type: boolean
         default: false
+
+# A branch that gets several pushes in a row only needs the newest package, so
+# supersede in-flight branch runs. main and tags never cancel — their packages
+# are referenced by version and must all exist.
+concurrency:
+  group: release-studio-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type == 'branch' && github.ref_name != 'main' }}
 
 permissions:
   contents: read
@@ -75,7 +88,10 @@ jobs:
         id: gate
         shell: bash
         run: |
-          if [[ ( "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ) || ( "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.publish }}" == "true" ) ]]; then
+          # Any push publishes — branch, main or tag alike. workflow_dispatch is
+          # the one build-only mode left, for verifying a build without minting
+          # a package.
+          if [[ "${{ github.event_name }}" == "push" || ( "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.publish }}" == "true" ) ]]; then
             echo "publish=true" >> "$GITHUB_OUTPUT"
           else
             echo "publish=false" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Read this first, then load the rules under [`rules/`](rules/). Before working in
 - **Only pick up Issues labeled `agent-ready`** (acceptance criteria complete + independently doable) that are unassigned. Self-assign to lock.
 - **Acceptance criteria**: a human approves them (label `ac-approved`) before an Issue becomes `agent-ready`. You may *draft* them for human approval.
 - **Risky operations** (deploy, delete/modify data, schema migration, prod config, secrets/permissions, major dependency bumps, cross-service breaking changes): do **not** execute. Post the three-part confirmation (what / blast radius / rollback), apply label `awaiting-confirmation`, and wait for an Owner to apply `owner-confirmed`.
-- **You may never**: approve or merge a PR, bypass or skip CI, or act without the confirmation above. Code review and the merge gates are human-only.
+- **You may never**: merge a PR, bypass or skip CI, or act without the confirmation above. Merging is human-only. Do not approve PRs yourself either — the sole exception is the automated review workflow ([`automation-claude-review.yml`](.github/workflows/automation-claude-review.yml)), which may submit an approving or change-requesting review as a signal; its approval never merges and never replaces the human merge decision.
 - **Open PRs with `Closes #<issue>`** and write back progress as Issue/PR comments. Label your PRs `by-agent`.
 - **Stuck / off-track / tests won't pass** → comment the blocker, return the Issue to triage, clear your assignee, label `needs-human`.
 


### PR DESCRIPTION
## 动机
分支推送本来不出包 —— 要拿可部署镜像得合 main 或建临时分支手动 dispatch（`tmp/deploy-97` 就是这么来的）。同时补上 foundry 已有的 Claude PR 审核。

## 改动
**1. 分支打包** — `release-studio.yml`
- 触发 `push.branches` 从 `[main]` 放到 `['**']`，publish 闸门改成任何 push 都出包
- 版本沿用既有方案 `0.3.0-<branch>.<date>.sha<7>`，未改
- 推 GHCR + 镜像 SWR，tag 一并
- `workflow_dispatch` 保留为唯一 build-only 模式（验构建不出包）
- concurrency：分支连推只留最新，main/tag 不取消

**2. Claude PR 审核** — `automation-claude-review.yml`（新增，照搬 foundry）
- opened/reopened/ready_for_review/synchronize + 手动按 PR 号重审
- prompt 前端化：hook 依赖/请求竞态、XSS/权限点、**禁止假数据**、模块边界、i18n；风格交给 typechecked eslint
- opus-4-8 / effort high / 60 轮
- 无阻塞项自动 `--approve`，有阻塞 `--request-changes`（仓库 `can_approve_pull_request_reviews=true`）；只表态不合并

## 待办（本 PR 不含）
- GHCR 分级保留（main 14天 / branch 7天 / tag 永久 + 清孤儿）需 PAT/App token，`GITHUB_TOKEN` 通配失效，故延后
- SWR 过期走华为控制台，代码管不到

🤖 Generated with [Claude Code](https://claude.com/claude-code)