### PR TITLE
enhancement(execution-factory): 统一导入工具箱 OpenAPI 编排入口

### DIFF
--- a/src/modules/execution-factory/components/create-menu/ImportResourceModal.test.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportResourceModal.test.tsx
@@ -135,15 +135,22 @@ vi.mock("@/modules/execution-factory/services/category.service", () => ({
   ),
 }));
 
-const { createToolbox, registerOperator } = vi.hoisted(() => ({
-  createToolbox: vi.fn(() => Promise.resolve({ boxId: "box-1" })),
+const { registerOpenApiImport, registerOperator } = vi.hoisted(() => ({
+  registerOpenApiImport: vi.fn(() =>
+    Promise.resolve({
+      boxId: "box-1",
+      toolIds: ["tool-1"],
+      successCount: 1,
+      failureCount: 0,
+    }),
+  ),
   registerOperator: vi.fn<(input: { openapiSpec?: string }) => Promise<{ operatorId: string }>>(
     () => Promise.resolve({ operatorId: "op-1" }),
   ),
 }));
 
-vi.mock("@/modules/execution-factory/services/toolbox.service", () => ({
-  createToolbox,
+vi.mock("@/modules/execution-factory/services/import-openapi.service", () => ({
+  registerOpenApiImport,
 }));
 
 vi.mock("@/modules/execution-factory/services/operator.service", () => ({
@@ -218,7 +225,7 @@ describe("ImportResourceModal", () => {
     expect(await screen.findByDisplayValue("示例工具箱_API")).toBeTruthy();
   });
 
-  it("submits a normalized toolbox name when creating from OpenAPI", async () => {
+  it("submits a normalized toolbox name via registerOpenApiImport", async () => {
     render(
       <ImportResourceModal activeTab="toolbox" onClose={vi.fn()} onSuccess={vi.fn()} open />,
     );
@@ -232,11 +239,34 @@ describe("ImportResourceModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Import" }));
 
     await waitFor(() => {
-      expect(createToolbox).toHaveBeenCalledWith(
+      expect(registerOpenApiImport).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: "示例工具箱_API",
+          openapiSpec: spacedTitleSpec,
+          toolboxMode: "new",
+          toolboxName: "示例工具箱_API",
+          serviceUrl: "https://example.com",
+          category: "other_category",
         }),
       );
+    });
+    expect(registerOperator).not.toHaveBeenCalled();
+  });
+
+  it("does not call registerOpenApiImport when toolbox Service URL is cleared", async () => {
+    render(
+      <ImportResourceModal activeTab="toolbox" onClose={vi.fn()} onSuccess={vi.fn()} open />,
+    );
+
+    await screen.findByDisplayValue("http://127.0.0.1:9000");
+    fireEvent.click(screen.getByRole("button", { name: "Load OpenAPI" }));
+    await screen.findByDisplayValue("https://example.com");
+
+    const serviceUrlInput = screen.getByLabelText("Service URL");
+    fireEvent.change(serviceUrlInput, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    await waitFor(() => {
+      expect(registerOpenApiImport).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/execution-factory/components/create-menu/ImportResourceModal.test.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportResourceModal.test.tsx
@@ -271,8 +271,10 @@ describe("ImportResourceModal", () => {
       failureCount: 2,
     });
 
+    const onClose = vi.fn();
+    const onSuccess = vi.fn();
     render(
-      <ImportResourceModal activeTab="toolbox" onClose={vi.fn()} onSuccess={vi.fn()} open />,
+      <ImportResourceModal activeTab="toolbox" onClose={onClose} onSuccess={onSuccess} open />,
     );
 
     await screen.findByDisplayValue("http://127.0.0.1:9000");
@@ -284,6 +286,28 @@ describe("ImportResourceModal", () => {
       expect(messageWarning).toHaveBeenCalledWith("Imported 1 tool(s), 2 failed");
     });
     expect(messageSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows success toast and invokes callbacks when all tools import", async () => {
+    const onClose = vi.fn();
+    const onSuccess = vi.fn();
+    render(
+      <ImportResourceModal activeTab="toolbox" onClose={onClose} onSuccess={onSuccess} open />,
+    );
+
+    await screen.findByDisplayValue("http://127.0.0.1:9000");
+    fireEvent.click(screen.getByRole("button", { name: "Load OpenAPI" }));
+    await screen.findByDisplayValue("https://example.com");
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    await waitFor(() => {
+      expect(messageSuccess).toHaveBeenCalledWith("Imported");
+    });
+    expect(messageWarning).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 
   it("does not call registerOpenApiImport when toolbox Service URL is cleared", async () => {

--- a/src/modules/execution-factory/components/create-menu/ImportResourceModal.test.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportResourceModal.test.tsx
@@ -68,7 +68,7 @@ const relativeServerSpec = JSON.stringify({
 
 let nextOpenApiSpec = spacedTitleSpec;
 
-const translate = (key: string) => {
+const translate = (key: string, options?: Record<string, string | number>) => {
   const labels: Record<string, string> = {
     "common.required": "Required",
     "executionFactory.category": "Category",
@@ -80,6 +80,8 @@ const translate = (key: string) => {
     "executionFactory.importResourceTitle.toolbox": "Import toolbox",
     "executionFactory.importResourceTitle.operator": "Import operator",
     "executionFactory.importSuccess": "Imported",
+    "executionFactory.importOpenApiCapabilityPartial":
+      "Imported {{success}} tool(s), {{failed}} failed",
     "executionFactory.importOpenApiFileRequired": "OpenAPI required",
     "executionFactory.importOpenApiServiceUrlRequired": "Service URL required",
     "executionFactory.importOpenApiMissingServerManual": "Missing servers",
@@ -88,7 +90,13 @@ const translate = (key: string) => {
     "executionFactory.businessIntro.impexOpenApiOperator": "Intro",
   };
 
-  return labels[key] ?? key;
+  let text = labels[key] ?? key;
+  if (options) {
+    for (const [name, value] of Object.entries(options)) {
+      text = text.replaceAll(`{{${name}}}`, String(value));
+    }
+  }
+  return text;
 };
 
 Object.defineProperty(window, "matchMedia", {
@@ -115,8 +123,10 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-const { messageError } = vi.hoisted(() => ({
+const { messageError, messageSuccess, messageWarning } = vi.hoisted(() => ({
   messageError: vi.fn(),
+  messageSuccess: vi.fn(),
+  messageWarning: vi.fn(),
 }));
 
 vi.mock("@/framework/context/use-app-services", () => ({
@@ -124,7 +134,8 @@ vi.mock("@/framework/context/use-app-services", () => ({
     message: {
       error: messageError,
       info: vi.fn(),
-      success: vi.fn(),
+      success: messageSuccess,
+      warning: messageWarning,
     },
   }),
 }));
@@ -250,6 +261,29 @@ describe("ImportResourceModal", () => {
       );
     });
     expect(registerOperator).not.toHaveBeenCalled();
+  });
+
+  it("warns when registerOpenApiImport reports partial tool failures", async () => {
+    registerOpenApiImport.mockResolvedValueOnce({
+      boxId: "box-1",
+      toolIds: ["tool-1"],
+      successCount: 1,
+      failureCount: 2,
+    });
+
+    render(
+      <ImportResourceModal activeTab="toolbox" onClose={vi.fn()} onSuccess={vi.fn()} open />,
+    );
+
+    await screen.findByDisplayValue("http://127.0.0.1:9000");
+    fireEvent.click(screen.getByRole("button", { name: "Load OpenAPI" }));
+    await screen.findByDisplayValue("https://example.com");
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    await waitFor(() => {
+      expect(messageWarning).toHaveBeenCalledWith("Imported 1 tool(s), 2 failed");
+    });
+    expect(messageSuccess).not.toHaveBeenCalled();
   });
 
   it("does not call registerOpenApiImport when toolbox Service URL is cleared", async () => {

--- a/src/modules/execution-factory/components/create-menu/ImportResourceModal.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportResourceModal.tsx
@@ -366,40 +366,43 @@ export function ImportResourceModal({
             openapiSpec: normalizedOpenapiSpec,
             category: values.category as OperatorCategory,
           });
+          void message.success(t("executionFactory.importSuccess"));
         } else {
           // Share the same toolbox OpenAPI pipeline as「添加能力 → 导入 OpenAPI」.
-          await registerOpenApiImport({
+          const result = await registerOpenApiImport({
             openapiSpec,
             toolboxMode: "new",
             toolboxName: resolvedName,
             category: values.category,
             serviceUrl,
           });
+          if (result.failureCount > 0) {
+            void message.warning(
+              t("executionFactory.importOpenApiCapabilityPartial", {
+                success: result.successCount,
+                failed: result.failureCount,
+              }),
+            );
+          } else {
+            void message.success(t("executionFactory.importSuccess"));
+          }
         }
 
-      } else {
-
-        const values = await adpForm.validateFields();
-
-        const uploadFile = readUploadFile(adpFileList);
-
-
-
-        if (!uploadFile) {
-
-          void message.info(t("executionFactory.importAdpFileRequired"));
-
-          return;
-
-        }
-
-
-
-        await importComponentFile(impexType, uploadFile, values.mode);
-
+        onSuccess?.();
+        onClose();
+        return;
       }
 
+      const values = await adpForm.validateFields();
 
+      const uploadFile = readUploadFile(adpFileList);
+
+      if (!uploadFile) {
+        void message.info(t("executionFactory.importAdpFileRequired"));
+        return;
+      }
+
+      await importComponentFile(impexType, uploadFile, values.mode);
 
       void message.success(t("executionFactory.importSuccess"));
 

--- a/src/modules/execution-factory/components/create-menu/ImportResourceModal.tsx
+++ b/src/modules/execution-factory/components/create-menu/ImportResourceModal.tsx
@@ -29,10 +29,10 @@ import { listOperatorCategories } from "@/modules/execution-factory/services/cat
 
 import { importComponentFile } from "@/modules/execution-factory/services/impex.service";
 
+import { registerOpenApiImport } from "@/modules/execution-factory/services/import-openapi.service";
+
 import { registerOperator } from "@/modules/execution-factory/services/operator.service";
 import type { OperatorCategory } from "@/modules/execution-factory/types/operator";
-
-import { createToolbox } from "@/modules/execution-factory/services/toolbox.service";
 
 import type { ImpexComponentType, ImpexImportMode } from "@/modules/execution-factory/types/impex";
 
@@ -346,9 +346,6 @@ export function ImportResourceModal({
           return;
         }
 
-        const normalizedText = normalizeOpenApiDocumentText(openapiSpec);
-        const normalizedOpenapiSpec = rewriteOpenApiServerUrl(normalizedText, serviceUrl);
-
         const hints = extractOpenApiMetadataHints(openapiSpec);
 
         const fallbackName =
@@ -358,6 +355,11 @@ export function ImportResourceModal({
           normalizeGeneratedCapabilityName(values.name) || fallbackName;
 
         if (activeTab === "operator") {
+          // Operator registration keeps its own path; only rewrite servers here.
+          const normalizedOpenapiSpec = rewriteOpenApiServerUrl(
+            normalizeOpenApiDocumentText(openapiSpec),
+            serviceUrl,
+          );
           await registerOperator({
             metadataType: "openapi",
             name: resolvedName,
@@ -365,12 +367,13 @@ export function ImportResourceModal({
             category: values.category as OperatorCategory,
           });
         } else {
-          await createToolbox({
-            name: resolvedName,
+          // Share the same toolbox OpenAPI pipeline as「添加能力 → 导入 OpenAPI」.
+          await registerOpenApiImport({
+            openapiSpec,
+            toolboxMode: "new",
+            toolboxName: resolvedName,
             category: values.category,
-            metadataType: "openapi",
             serviceUrl,
-            openapiSpec: normalizedOpenapiSpec,
           });
         }
 

--- a/src/modules/execution-factory/services/import-openapi.service.test.ts
+++ b/src/modules/execution-factory/services/import-openapi.service.test.ts
@@ -143,6 +143,34 @@ describe("registerOpenApiImport", () => {
     expect(vi.mocked(createToolbox).mock.calls[0]?.[0].name).toBe("示例工具箱_API");
   });
 
+  it("creates an empty toolbox then imports tools (no openapi data on create)", async () => {
+    await registerOpenApiImport({
+      openapiSpec: petstoreSpec,
+      serviceUrl: "https://petstore3.swagger.io/api/v3",
+      toolboxName: "Swagger_Petstore_OpenAPI_3_0",
+      category: "animals",
+      toolboxMode: "new",
+    });
+
+    expect(createToolbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Swagger_Petstore_OpenAPI_3_0",
+        category: "animals",
+        metadataType: "openapi",
+        serviceUrl: "https://petstore3.swagger.io/api/v3",
+      }),
+    );
+    const createArg = vi.mocked(createToolbox).mock.calls[0]?.[0];
+    expect(createArg).toBeDefined();
+    expect(createArg).not.toHaveProperty("openapiSpec");
+
+    expect(importOpenApiTools).toHaveBeenCalledWith(
+      "box-1",
+      expect.any(String),
+      undefined,
+    );
+  });
+
   it("truncates generated toolbox descriptions before creating a toolbox", async () => {
     await registerOpenApiImport({
       openapiSpec: petstoreSpec,


### PR DESCRIPTION
## Summary
- `ImportResourceModal` 工具箱 OpenAPI 导入改为调用 `registerOpenApiImport`，与「添加能力 → 导入 OpenAPI」共用同一编排（校验 / normalize / rewrite servers & summaries / 空箱 + `importOpenApiTools`）。
- 补强单测：Modal 断言走 `registerOpenApiImport` 且缺 Service URL 不提交；服务层断言新建时 `createToolbox` 不带 `openapiSpec`。
- Closes #239

## Test plan
- [ ] `npx vitest run src/modules/execution-factory/components/create-menu/ImportResourceModal.test.tsx src/modules/execution-factory/services/import-openapi.service.test.ts`
- [ ] UI：能力管理 → **导入** → OpenAPI 上传合法 fixture，确认创建工具箱并导入工具
- [ ] UI：`+ 添加能力` → **导入 OpenAPI**，同一份文档结果一致（servers / operation summary）
- [ ] 故意清空 Service URL，导入按钮应被拦住且不发创建请求

Made with [Cursor](https://cursor.com)