### PR TITLE
fix(ci): 修掉 Claude 评审被自己进度评论取消

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -49,7 +49,15 @@ on:
         type: string
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  # 按事件类别分组，别把评论事件和 PR 推送混在一组。
+  # claude-code-action（track_progress）在评审跑到一半时会以 bot 身份贴 tracking
+  # comment，那条 comment 触发 issue_comment:created 又排一个同组 run；若共用一组，
+  # cancel-in-progress 会在 job `if` 过滤掉 bot 评论之前，就把正在跑的评审取消掉
+  # ——评审每次贴进度评论那刻自杀，永远跑不到绿。concurrency 在 run 排队时求值，
+  # 早于 job if，所以只能靠分组隔离，if 拦不住取消。
+  # push 之间仍在 -push 组内互相取消（连续推送省额度）；评论事件落 -comment 组，
+  # 取消不到正在跑的 PR 评审。
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}-${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && 'comment' || 'push' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## 问题

`Claude Code Review`（`.github/workflows/automation-claude-review.yml`）在 bkn-studio 上每次 PR 评审几乎必被 `cancelled`，看着像挂了、实为并发自杀。

链条（以 7a0f6ab 为例，其后无新 push）：
```
:06  pull_request run 起，开始评审
:20  claude-code-action(track_progress) 以 bot 身份贴 tracking comment
:24  该 comment 触发 issue_comment:created，同 concurrency group 排新 run = "higher priority waiting request"
:37  cancel-in-progress 顶掉正在跑的 :06（31s）；新 run 再被 job `if` 判成 skipped
```

根因：`pull_request` / `issue_comment` / `pull_request_review_comment` 共用一个 concurrency group + `cancel-in-progress`。**concurrency 在 run 排队时求值，早于 job `if`**，所以 `if` 里过滤 bot 评论只能挡"别重复评审"，挡不住"取消"。评审每次贴进度评论那刻自杀。

不是 30s 超时（job 无 `timeout-minutes`）；31s 是从起跑到自贴 comment 再触发抢占的延迟。

## 修法

concurrency group 按事件类别分：评论事件落 `-comment` 组，取消不到 `-push` 里正在跑的评审；连续 push 仍在 `-push` 组内互相取消（省额度）。bot 评论 run 照旧被 job `if` skip。

```yaml
group: claude-review-${{ ... }}-${{ (issue_comment || pull_request_review_comment) && 'comment' || 'push' }}
```

## 备注

此文件由 bkn-foundry 模板同步。foundry 那份 paths 是 `adp/infra/bkn-safe/deploy` 且**无** issue_comment 触发，不犯此病；但 foundry 模板若会重新生成 studio 副本，需同步此修复以防回退（后续单独处理）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)