### PR TITLE
feat(bkn-trace): add studio explorer

### DIFF
--- a/src/app/locales/resources/en-US.ts
+++ b/src/app/locales/resources/en-US.ts
@@ -11,6 +11,7 @@ import { commonEnUS } from "@/app/locales/resources/common/en-US";
 import { shellEnUS } from "@/app/locales/resources/shell/en-US";
 import { accountEnUS } from "@/modules/account/locales/en-US";
 import { apiKeysEnUS } from "@/modules/api-keys/locales/en-US";
+import { bknTraceEnUS } from "@/modules/bkn-trace/locales/en-US";
 import { dataCatalogEnUS } from "@/modules/data-catalog/locales/en-US";
 import { dataConnectEnUS } from "@/modules/data-connect/locales/en-US";
 import { executionFactoryLabEnUS } from "@/modules/execution-factory-lab/locales/en-US";
@@ -32,5 +33,6 @@ export const enUS = {
   ...executionFactoryLabEnUS,
   ...systemAdminEnUS,
   ...apiKeysEnUS,
+  ...bknTraceEnUS,
   ...accountEnUS,
 } as const;

--- a/src/app/locales/resources/zh-CN.ts
+++ b/src/app/locales/resources/zh-CN.ts
@@ -11,6 +11,7 @@ import { commonZhCN } from "@/app/locales/resources/common/zh-CN";
 import { shellZhCN } from "@/app/locales/resources/shell/zh-CN";
 import { accountZhCN } from "@/modules/account/locales/zh-CN";
 import { apiKeysZhCN } from "@/modules/api-keys/locales/zh-CN";
+import { bknTraceZhCN } from "@/modules/bkn-trace/locales/zh-CN";
 import { dataCatalogZhCN } from "@/modules/data-catalog/locales/zh-CN";
 import { dataConnectZhCN } from "@/modules/data-connect/locales/zh-CN";
 import { executionFactoryLabZhCN } from "@/modules/execution-factory-lab/locales/zh-CN";
@@ -32,6 +33,7 @@ export const zhCN = {
   ...modelResourcesZhCN,
   ...systemAdminZhCN,
   ...apiKeysZhCN,
+  ...bknTraceZhCN,
   ...accountZhCN,
   executionFactoryLab: {
     ...executionFactoryLabZhCN.executionFactoryLab,

--- a/src/app/router/module-routes.ts
+++ b/src/app/router/module-routes.ts
@@ -10,6 +10,7 @@ import type { RouteObject } from "react-router-dom";
 import type { AppRouteContribution } from "@/app/router/types";
 import { accountRouteContribution } from "@/modules/account/routes";
 import { apiKeysRouteContribution } from "@/modules/api-keys/routes";
+import { bknTraceRouteContribution } from "@/modules/bkn-trace/routes";
 import { dataCatalogRouteContribution } from "@/modules/data-catalog/routes";
 import { dataConnectRouteContribution } from "@/modules/data-connect/routes";
 import { executionFactoryLabRouteContribution } from "@/modules/execution-factory-lab/routes";
@@ -25,6 +26,7 @@ const routeContributions: AppRouteContribution[] = [
   executionFactoryRouteContribution,
   modelResourcesRouteContribution,
   executionFactoryLabRouteContribution,
+  bknTraceRouteContribution,
   systemAdminRouteContribution,
   apiKeysRouteContribution,
   accountRouteContribution,

--- a/src/app/shell/console-navigation.tsx
+++ b/src/app/shell/console-navigation.tsx
@@ -11,6 +11,7 @@ import type {
   ConsoleNavItem,
 } from "@/app/shell/navigation/types";
 import { hasPermissions } from "@/framework/permission/has-permissions";
+import { bknTraceNavigation } from "@/modules/bkn-trace/navigation";
 import { dataCatalogNavigation } from "@/modules/data-catalog/navigation";
 import { dataConnectNavigation } from "@/modules/data-connect/navigation";
 import { executionFactoryLabNavigation } from "@/modules/execution-factory-lab/navigation";
@@ -25,6 +26,7 @@ const navigationContributions: ConsoleNavContribution[] = [
   executionFactoryNavigation,
   modelResourcesNavigation,
   executionFactoryLabNavigation,
+  bknTraceNavigation,
 ];
 
 export type { ConsoleNavItem } from "@/app/shell/navigation/types";

--- a/src/framework/runtime/module-manifests.ts
+++ b/src/framework/runtime/module-manifests.ts
@@ -6,6 +6,7 @@
  */
 
 import { dataCatalogModuleManifest } from "@/modules/data-catalog/module.manifest";
+import { bknTraceModuleManifest } from "@/modules/bkn-trace/module.manifest";
 import { dataConnectModuleManifest } from "@/modules/data-connect/module.manifest";
 import { executionFactoryLabModuleManifest } from "@/modules/execution-factory-lab/module.manifest";
 import { executionFactoryModuleManifest } from "@/modules/execution-factory/module.manifest";
@@ -20,6 +21,7 @@ export const runtimeModuleManifests = [
   executionFactoryModuleManifest,
   modelResourcesModuleManifest,
   executionFactoryLabModuleManifest,
+  bknTraceModuleManifest,
   systemAdminModuleManifest,
 ] as const;
 

--- a/src/modules/bkn-trace/index.ts
+++ b/src/modules/bkn-trace/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export { bknTraceModuleManifest } from "@/modules/bkn-trace/module.manifest";

--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export const bknTraceEnUS = {
+  bknTrace: {
+    actions: {
+      query: "Query",
+    },
+    description:
+      "Inspect runtime traces, evidence chains, business semantic graphs, and snapshot previews by trace id or request id.",
+    empty: "Enter a trace id or request id to query.",
+    errors: {
+      missingScope: "Enter a trace id or request id.",
+      queryFailed: "Query failed.",
+    },
+    metrics: {
+      businessEdges: "Business edges",
+      businessNodes: "Business nodes",
+      businessRefs: "Business refs",
+      claims: "Claims",
+      evidenceRefs: "Evidence refs",
+      spans: "Spans",
+    },
+    partial: "The current result is partial",
+    placeholders: {
+      requestId: "request id",
+      traceId: "trace id",
+    },
+    scope: {
+      request: "Request",
+      trace: "Trace",
+    },
+    sections: {
+      businessGraph: "Business Semantic Graph",
+      evidenceChain: "Evidence Chain",
+      snapshot: "Snapshot Preview",
+      traceGraph: "Trace Graph",
+      visibility: "Visibility",
+    },
+    title: "BKN Trace",
+    traceGraphRequestOnly: "Trace Graph is only available for trace-id queries.",
+  },
+} as const;

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export const bknTraceZhCN = {
+  bknTrace: {
+    actions: {
+      query: "查询",
+    },
+    description: "按 trace id 或 request id 查看运行链路、证据链、业务语义链和快照预览。",
+    empty: "输入 trace id 或 request id 后查询",
+    errors: {
+      missingScope: "请输入 trace id 或 request id。",
+      queryFailed: "查询失败。",
+    },
+    metrics: {
+      businessEdges: "业务边",
+      businessNodes: "业务节点",
+      businessRefs: "业务引用",
+      claims: "结论",
+      evidenceRefs: "证据引用",
+      spans: "Span",
+    },
+    partial: "当前结果不完整",
+    placeholders: {
+      requestId: "request id",
+      traceId: "trace id",
+    },
+    scope: {
+      request: "Request",
+      trace: "Trace",
+    },
+    sections: {
+      businessGraph: "业务语义链",
+      evidenceChain: "证据链",
+      snapshot: "快照预览",
+      traceGraph: "调用链",
+      visibility: "可见性",
+    },
+    title: "BKN Trace",
+    traceGraphRequestOnly: "request id 查询不返回调用链",
+  },
+} as const;

--- a/src/modules/bkn-trace/module.manifest.ts
+++ b/src/modules/bkn-trace/module.manifest.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export const bknTraceModuleManifest = {
+  id: "bkn-trace",
+  name: "BKN Trace",
+  permissions: ["bkn-trace:view"],
+  requiresShell: true,
+  services: ["agent-observability/v1"],
+  supportsEmbedded: false,
+  supportsReadOnly: true,
+  scenes: [
+    {
+      id: "bkn-trace.explorer",
+      exportName: "BknTraceExplorerScene",
+      description: "Inspect Trace Graph, Evidence Chain, Business Graph, and Snapshot Preview.",
+      inputs: [
+        { name: "traceId", required: false, type: "string" },
+        { name: "requestId", required: false, type: "string" },
+      ],
+    },
+  ],
+} as const;

--- a/src/modules/bkn-trace/navigation.tsx
+++ b/src/modules/bkn-trace/navigation.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { BranchesOutlined } from "@ant-design/icons";
+
+import type { ConsoleNavContribution } from "@/app/shell/navigation/types";
+
+export const bknTraceNavigation: ConsoleNavContribution = {
+  parentKey: "system-management",
+  items: [
+    {
+      key: "bkn-trace",
+      labelKey: "shell.items.traceai",
+      icon: <BranchesOutlined />,
+      path: "/bkn-trace",
+      permission: ["bkn-trace:view"],
+    },
+  ],
+};

--- a/src/modules/bkn-trace/pages/BknTraceExplorerPage.tsx
+++ b/src/modules/bkn-trace/pages/BknTraceExplorerPage.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { BknTraceExplorerScene } from "@/modules/bkn-trace/scenes/BknTraceExplorerScene";
+
+export function BknTraceExplorerPage() {
+  return <BknTraceExplorerScene />;
+}

--- a/src/modules/bkn-trace/routes.test.tsx
+++ b/src/modules/bkn-trace/routes.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { consoleNavigation } from "@/app/shell/console-navigation";
+import { runtimeModuleManifests } from "@/framework/runtime/module-manifests";
+import { bknTraceNavigation } from "@/modules/bkn-trace/navigation";
+import { bknTraceRouteContribution } from "@/modules/bkn-trace/routes";
+
+describe("bkn-trace module registration", () => {
+  it("contributes a shell route and navigation item", () => {
+    expect(bknTraceRouteContribution.moduleId).toBe("bkn-trace");
+    expect(bknTraceRouteContribution.routes.map((route) => route.path)).toContain("bkn-trace");
+    expect(bknTraceNavigation.items[0]).toMatchObject({
+      key: "bkn-trace",
+      labelKey: "shell.items.traceai",
+      path: "/bkn-trace",
+    });
+    expect(
+      consoleNavigation
+        .flatMap((item) => item.children ?? [])
+        .map((item) => item.key),
+    ).toContain("bkn-trace");
+  });
+
+  it("registers permissions in runtime module manifests", () => {
+    expect(runtimeModuleManifests.map((manifest) => manifest.id)).toContain("bkn-trace");
+  });
+});

--- a/src/modules/bkn-trace/routes.tsx
+++ b/src/modules/bkn-trace/routes.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { lazy, Suspense, type ReactNode } from "react";
+import type { RouteObject } from "react-router-dom";
+
+import { RouteLoading } from "@/app/router/RouteLoading";
+import type { AppRouteContribution } from "@/app/router/types";
+
+const BknTraceExplorerPage = lazy(async () => {
+  const module = await import("@/modules/bkn-trace/pages/BknTraceExplorerPage");
+  return { default: module.BknTraceExplorerPage };
+});
+
+function withRouteLoading(element: ReactNode) {
+  return <Suspense fallback={<RouteLoading />}>{element}</Suspense>;
+}
+
+export const bknTraceRoutes: RouteObject[] = [
+  {
+    path: "bkn-trace",
+    handle: {
+      console: {
+        descriptionKey: "bknTrace.description",
+        menuKey: "bkn-trace",
+        titleKey: "bknTrace.title",
+      },
+    },
+    element: withRouteLoading(<BknTraceExplorerPage />),
+  },
+];
+
+export const bknTraceRouteContribution: AppRouteContribution = {
+  moduleId: "bkn-trace",
+  routes: bknTraceRoutes,
+};

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.module.css
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.module.css
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+.scene {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 100%;
+  padding: 24px;
+}
+
+.toolbar {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.title {
+  margin-bottom: 4px;
+}
+
+.queryForm {
+  justify-content: flex-end;
+}
+
+.scopeInput {
+  width: min(420px, 54vw);
+}
+
+.alert {
+  max-width: 100%;
+}
+
+.empty {
+  margin-top: 96px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #edf0f5;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 900px) {
+  .toolbar {
+    flex-direction: column;
+  }
+
+  .queryForm {
+    justify-content: flex-start;
+  }
+
+  .scopeInput {
+    width: min(100%, 420px);
+  }
+
+  .metrics,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.tsx
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Empty,
+  Form,
+  Input,
+  Segmented,
+  Space,
+  Spin,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import styles from "@/modules/bkn-trace/scenes/BknTraceExplorerScene.module.css";
+import {
+  getBusinessGraph,
+  getEvidenceChain,
+  getSnapshotPreview,
+  getTraceGraph,
+  type BusinessGraph,
+  type EvidenceChain,
+  type SnapshotPreview,
+  type TraceGraph,
+  type TraceGraphNode,
+} from "@/modules/bkn-trace/services/trace.service";
+
+type ScopeMode = "request" | "trace";
+
+type TraceExplorerState = {
+  businessGraph?: BusinessGraph;
+  evidenceChain?: EvidenceChain;
+  snapshotPreview?: SnapshotPreview;
+  traceGraph?: TraceGraph;
+};
+
+const spanColumns: ColumnsType<TraceGraphNode> = [
+  { dataIndex: "name", key: "name", title: "Span" },
+  { dataIndex: "serviceName", key: "serviceName", title: "Service" },
+  { dataIndex: "kind", key: "kind", title: "Kind", width: 120 },
+  {
+    dataIndex: "status",
+    key: "status",
+    render: (status: string) => <Tag color={status === "error" ? "red" : "green"}>{status}</Tag>,
+    title: "Status",
+    width: 120,
+  },
+  {
+    dataIndex: "durationNano",
+    key: "durationNano",
+    render: (value: number) => `${Math.round(value / 1_000_000)} ms`,
+    title: "Duration",
+    width: 120,
+  },
+];
+
+export function BknTraceExplorerScene() {
+  const { t } = useTranslation();
+  const [scopeMode, setScopeMode] = useState<ScopeMode>("trace");
+  const [traceId, setTraceId] = useState("");
+  const [requestId, setRequestId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<TraceExplorerState>({});
+
+  const effectiveScope = useMemo(() => {
+    const trimmedTraceId = traceId.trim();
+    const trimmedRequestId = requestId.trim();
+    if (scopeMode === "request" && trimmedRequestId) {
+      return { requestId: trimmedRequestId, limit: 100 };
+    }
+    if (scopeMode === "trace" && trimmedTraceId) {
+      return { traceId: trimmedTraceId, limit: 100 };
+    }
+    return null;
+  }, [requestId, scopeMode, traceId]);
+
+  async function handleQuery() {
+    if (!effectiveScope) {
+      setError(t("bknTrace.errors.missingScope"));
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const [traceGraph, evidenceChain, businessGraph, snapshotPreview] =
+        effectiveScope.traceId
+          ? await Promise.all([
+              getTraceGraph(effectiveScope.traceId),
+              getEvidenceChain(effectiveScope),
+              getBusinessGraph(effectiveScope),
+              getSnapshotPreview(effectiveScope),
+            ])
+          : await Promise.all([
+              Promise.resolve(undefined),
+              getEvidenceChain(effectiveScope),
+              getBusinessGraph(effectiveScope),
+              getSnapshotPreview(effectiveScope),
+            ]);
+      setState({ businessGraph, evidenceChain, snapshotPreview, traceGraph });
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : t("bknTrace.errors.queryFailed"));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const visibility = state.evidenceChain?.visibilitySummary ?? state.businessGraph?.visibilitySummary;
+  const partialReason = [
+    ...(state.traceGraph?.partialReason ?? []),
+    ...(state.evidenceChain?.partialReason ?? []),
+    ...(state.businessGraph?.partialReason ?? []),
+    ...(state.snapshotPreview?.partialReason ?? []),
+  ];
+
+  return (
+    <div className={styles.scene}>
+      <section className={styles.toolbar}>
+        <div>
+          <Typography.Title level={3} className={styles.title}>
+            {t("bknTrace.title")}
+          </Typography.Title>
+          <Typography.Text type="secondary">{t("bknTrace.description")}</Typography.Text>
+        </div>
+        <Form layout="inline" className={styles.queryForm}>
+          <Form.Item>
+            <Segmented
+              value={scopeMode}
+              onChange={(value) => setScopeMode(value as ScopeMode)}
+              options={[
+                { label: t("bknTrace.scope.trace"), value: "trace" },
+                { label: t("bknTrace.scope.request"), value: "request" },
+              ]}
+            />
+          </Form.Item>
+          {scopeMode === "trace" ? (
+            <Form.Item>
+              <Input
+                className={styles.scopeInput}
+                onChange={(event) => setTraceId(event.target.value)}
+                placeholder={t("bknTrace.placeholders.traceId")}
+                value={traceId}
+              />
+            </Form.Item>
+          ) : (
+            <Form.Item>
+              <Input
+                className={styles.scopeInput}
+                onChange={(event) => setRequestId(event.target.value)}
+                placeholder={t("bknTrace.placeholders.requestId")}
+                value={requestId}
+              />
+            </Form.Item>
+          )}
+          <Form.Item>
+            <Button type="primary" loading={loading} onClick={() => void handleQuery()}>
+              {t("bknTrace.actions.query")}
+            </Button>
+          </Form.Item>
+        </Form>
+      </section>
+
+      {error ? <Alert className={styles.alert} type="error" message={error} showIcon /> : null}
+
+      <Spin spinning={loading}>
+        {!state.evidenceChain && !state.traceGraph ? (
+          <Empty className={styles.empty} description={t("bknTrace.empty")} />
+        ) : (
+          <div className={styles.content}>
+            <section className={styles.metrics}>
+              <Statistic title={t("bknTrace.metrics.spans")} value={state.traceGraph?.page.nodeCount ?? 0} />
+              <Statistic title={t("bknTrace.metrics.claims")} value={state.evidenceChain?.data.claims.length ?? 0} />
+              <Statistic title={t("bknTrace.metrics.evidenceRefs")} value={state.evidenceChain?.data.evidenceRefs.length ?? 0} />
+              <Statistic title={t("bknTrace.metrics.businessNodes")} value={state.businessGraph?.data.nodes.length ?? 0} />
+            </section>
+
+            {partialReason.length ? (
+              <Alert
+                className={styles.alert}
+                type="warning"
+                message={t("bknTrace.partial")}
+                description={
+                  <Space wrap>
+                    {[...new Set(partialReason)].map((reason) => (
+                      <Tag key={reason}>{reason}</Tag>
+                    ))}
+                  </Space>
+                }
+                showIcon
+              />
+            ) : null}
+
+            <section className={styles.panel}>
+              <Typography.Title level={5}>{t("bknTrace.sections.traceGraph")}</Typography.Title>
+              {state.traceGraph ? (
+                <Table
+                  columns={spanColumns}
+                  dataSource={state.traceGraph.data.nodes}
+                  pagination={false}
+                  rowKey="spanId"
+                  size="small"
+                />
+              ) : (
+                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("bknTrace.traceGraphRequestOnly")} />
+              )}
+            </section>
+
+            <section className={styles.grid}>
+              <div className={styles.panel}>
+                <Typography.Title level={5}>{t("bknTrace.sections.evidenceChain")}</Typography.Title>
+                <Descriptions column={1} size="small">
+                  <Descriptions.Item label={t("bknTrace.metrics.claims")}>
+                    {state.evidenceChain?.data.claims.length ?? 0}
+                  </Descriptions.Item>
+                  <Descriptions.Item label={t("bknTrace.metrics.evidenceRefs")}>
+                    {state.evidenceChain?.data.evidenceRefs.length ?? 0}
+                  </Descriptions.Item>
+                  <Descriptions.Item label={t("bknTrace.metrics.businessRefs")}>
+                    {state.evidenceChain?.data.businessRefs.length ?? 0}
+                  </Descriptions.Item>
+                </Descriptions>
+              </div>
+              <div className={styles.panel}>
+                <Typography.Title level={5}>{t("bknTrace.sections.visibility")}</Typography.Title>
+                <Descriptions column={1} size="small">
+                  <Descriptions.Item label="authorized">{visibility?.authorizedRefCount ?? 0}</Descriptions.Item>
+                  <Descriptions.Item label="redacted">{visibility?.redactedRefCount ?? 0}</Descriptions.Item>
+                  <Descriptions.Item label="hidden">{visibility?.hiddenRefCount ?? 0}</Descriptions.Item>
+                  <Descriptions.Item label="unresolved">{visibility?.unresolvedRefCount ?? 0}</Descriptions.Item>
+                </Descriptions>
+              </div>
+              <div className={styles.panel}>
+                <Typography.Title level={5}>{t("bknTrace.sections.businessGraph")}</Typography.Title>
+                <Descriptions column={1} size="small">
+                  <Descriptions.Item label={t("bknTrace.metrics.businessNodes")}>
+                    {state.businessGraph?.data.nodes.length ?? 0}
+                  </Descriptions.Item>
+                  <Descriptions.Item label={t("bknTrace.metrics.businessEdges")}>
+                    {state.businessGraph?.data.edges.length ?? 0}
+                  </Descriptions.Item>
+                </Descriptions>
+              </div>
+              <div className={styles.panel}>
+                <Typography.Title level={5}>{t("bknTrace.sections.snapshot")}</Typography.Title>
+                <Descriptions column={1} size="small">
+                  <Descriptions.Item label="mode">
+                    {state.snapshotPreview?.snapshotRef.mode ?? "-"}
+                  </Descriptions.Item>
+                  <Descriptions.Item label="snapshot">
+                    {state.snapshotPreview?.snapshotRef.snapshotId ?? "-"}
+                  </Descriptions.Item>
+                </Descriptions>
+              </div>
+            </section>
+          </div>
+        )}
+      </Spin>
+    </div>
+  );
+}

--- a/src/modules/bkn-trace/services/trace.service.test.ts
+++ b/src/modules/bkn-trace/services/trace.service.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock },
+}));
+
+describe("bkn-trace service", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getMock.mockReset();
+  });
+
+  it("fetches trace graph through the BKN Trace API", async () => {
+    getMock.mockResolvedValue({
+      data: {
+        trace_id: "trace_001",
+        status: "ok",
+        duration_nano: 120,
+        partial: false,
+        partial_reason: [],
+        page: { node_count: 1, edge_count: 0, truncated: false },
+        data: { nodes: [], edges: [] },
+      },
+    });
+    const { getTraceGraph } = await import("@/modules/bkn-trace/services/trace.service");
+
+    const result = await getTraceGraph("trace_001");
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/agent-observability/v1/traces/trace_001/trace-graph",
+    );
+    expect(result.traceId).toBe("trace_001");
+    expect(result.status).toBe("ok");
+  });
+
+  it("fetches request-scoped evidence views without raw OpenSearch access", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          trace_id: "trace_001",
+          "bkn.request.id": "req_001",
+          partial: false,
+          partial_reason: [],
+          visibility_summary: {
+            authorized_ref_count: 1,
+            redacted_ref_count: 0,
+            hidden_ref_count: 0,
+            omitted_ref_count: 0,
+            unresolved_ref_count: 0,
+          },
+          page: { node_count: 1, edge_count: 0, truncated: false },
+          data: { claims: [], evidence_refs: [], business_refs: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          trace_id: "trace_001",
+          "bkn.request.id": "req_001",
+          partial: false,
+          partial_reason: [],
+          visibility_summary: {
+            authorized_ref_count: 1,
+            redacted_ref_count: 0,
+            hidden_ref_count: 0,
+            omitted_ref_count: 0,
+            unresolved_ref_count: 0,
+          },
+          page: { node_count: 1, edge_count: 0, truncated: false },
+          data: { nodes: [], edges: [] },
+        },
+      });
+    const { getEvidenceChain, getBusinessGraph } = await import(
+      "@/modules/bkn-trace/services/trace.service"
+    );
+
+    await getEvidenceChain({ requestId: "req_001", limit: 50 });
+    await getBusinessGraph({ requestId: "req_001", limit: 50 });
+
+    expect(getMock).toHaveBeenNthCalledWith(
+      1,
+      "/agent-observability/v1/traces/by-request",
+      { params: { request_id: "req_001", limit: 50 } },
+    );
+    expect(getMock).toHaveBeenNthCalledWith(
+      2,
+      "/agent-observability/v1/traces/by-request/business-graph",
+      { params: { request_id: "req_001", limit: 50 } },
+    );
+    expect(getMock.mock.calls.flat().join(" ")).not.toContain("_search");
+  });
+});

--- a/src/modules/bkn-trace/services/trace.service.ts
+++ b/src/modules/bkn-trace/services/trace.service.ts
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { http } from "@/framework/request/http";
+
+const TRACE_API_PREFIX = "/agent-observability/v1/traces";
+
+export type VisibilitySummary = {
+  authorizedRefCount: number;
+  hiddenRefCount: number;
+  omittedRefCount: number;
+  redactedRefCount: number;
+  unauthorizedRefCount: number;
+  unresolvedRefCount: number;
+};
+
+export type TraceGraphNode = {
+  durationNano: number;
+  endNano: number;
+  errorMessage?: string;
+  kind: string;
+  name: string;
+  parentSpanId?: string;
+  serviceName?: string;
+  spanId: string;
+  startNano: number;
+  status: string;
+};
+
+export type TraceGraphEdge = {
+  childSpanId: string;
+  edgeType: string;
+  id: string;
+  parentSpanId: string;
+};
+
+export type GraphPage = {
+  edgeCount: number;
+  nodeCount: number;
+  truncated: boolean;
+};
+
+export type TraceGraph = {
+  data: {
+    edges: TraceGraphEdge[];
+    nodes: TraceGraphNode[];
+  };
+  durationNano: number;
+  page: GraphPage;
+  partial: boolean;
+  partialReason: string[];
+  status: string;
+  traceId: string;
+};
+
+export type EvidenceChain = {
+  data: {
+    businessRefs: Array<Record<string, unknown>>;
+    claims: Array<Record<string, unknown>>;
+    evidenceRefs: Array<Record<string, unknown>>;
+  };
+  page: GraphPage;
+  partial: boolean;
+  partialReason: string[];
+  requestId: string;
+  traceId: string;
+  visibilitySummary: VisibilitySummary;
+};
+
+export type BusinessGraph = {
+  data: {
+    edges: Array<Record<string, unknown>>;
+    nodes: Array<Record<string, unknown>>;
+  };
+  page: GraphPage;
+  partial: boolean;
+  partialReason: string[];
+  requestId: string;
+  traceId: string;
+  visibilitySummary: VisibilitySummary;
+};
+
+export type SnapshotPreview = {
+  manifest: Record<string, unknown>;
+  partial: boolean;
+  partialReason: string[];
+  requestId: string;
+  snapshotRef: {
+    mode: string;
+    snapshotId?: string;
+    uri?: string;
+  };
+  traceId: string;
+  visibilitySummary: VisibilitySummary;
+};
+
+export type TraceQueryScope =
+  | { limit?: number; requestId: string; traceId?: never }
+  | { limit?: number; requestId?: never; traceId: string };
+
+type BackendVisibilitySummary = {
+  authorized_ref_count?: number;
+  hidden_ref_count?: number;
+  omitted_ref_count?: number;
+  redacted_ref_count?: number;
+  unauthorized_ref_count?: number;
+  unresolved_ref_count?: number;
+};
+
+type BackendGraphPage = {
+  edge_count?: number;
+  node_count?: number;
+  truncated?: boolean;
+};
+
+type BackendTraceGraph = {
+  data?: {
+    edges?: Array<{
+      child_span_id?: string;
+      edge_type?: string;
+      id?: string;
+      parent_span_id?: string;
+    }>;
+    nodes?: Array<{
+      duration_nano?: number;
+      end_nano?: number;
+      error_message?: string;
+      kind?: string;
+      name?: string;
+      parent_span_id?: string;
+      service_name?: string;
+      span_id?: string;
+      start_nano?: number;
+      status?: string;
+    }>;
+  };
+  duration_nano?: number;
+  page?: BackendGraphPage;
+  partial?: boolean;
+  partial_reason?: string[];
+  status?: string;
+  trace_id?: string;
+};
+
+type BackendEvidenceChain = {
+  "bkn.request.id"?: string;
+  data?: {
+    business_refs?: Array<Record<string, unknown>>;
+    claims?: Array<Record<string, unknown>>;
+    evidence_refs?: Array<Record<string, unknown>>;
+  };
+  page?: BackendGraphPage;
+  partial?: boolean;
+  partial_reason?: string[];
+  trace_id?: string;
+  visibility_summary?: BackendVisibilitySummary;
+};
+
+type BackendBusinessGraph = {
+  "bkn.request.id"?: string;
+  data?: {
+    edges?: Array<Record<string, unknown>>;
+    nodes?: Array<Record<string, unknown>>;
+  };
+  page?: BackendGraphPage;
+  partial?: boolean;
+  partial_reason?: string[];
+  trace_id?: string;
+  visibility_summary?: BackendVisibilitySummary;
+};
+
+type BackendSnapshotPreview = {
+  "bkn.request.id"?: string;
+  manifest?: Record<string, unknown>;
+  partial?: boolean;
+  partial_reason?: string[];
+  snapshot_ref?: {
+    mode?: string;
+    snapshot_id?: string;
+    uri?: string;
+  };
+  trace_id?: string;
+  visibility_summary?: BackendVisibilitySummary;
+};
+
+export async function getTraceGraph(traceId: string): Promise<TraceGraph> {
+  const response = await http.get<BackendTraceGraph>(
+    `${TRACE_API_PREFIX}/${encodeURIComponent(traceId)}/trace-graph`,
+  );
+  return mapTraceGraph(response.data);
+}
+
+export async function getEvidenceChain(scope: TraceQueryScope): Promise<EvidenceChain> {
+  const response = await http.get<BackendEvidenceChain>(targetPath(scope, "evidence-chain"), {
+    params: targetParams(scope),
+  });
+  return mapEvidenceChain(response.data);
+}
+
+export async function getBusinessGraph(scope: TraceQueryScope): Promise<BusinessGraph> {
+  const response = await http.get<BackendBusinessGraph>(targetPath(scope, "business-graph"), {
+    params: targetParams(scope),
+  });
+  return mapBusinessGraph(response.data);
+}
+
+export async function getSnapshotPreview(scope: TraceQueryScope): Promise<SnapshotPreview> {
+  const response = await http.get<BackendSnapshotPreview>(targetPath(scope, "snapshot-preview"), {
+    params: targetParams(scope),
+  });
+  return mapSnapshotPreview(response.data);
+}
+
+function targetPath(
+  scope: TraceQueryScope,
+  subresource: "business-graph" | "evidence-chain" | "snapshot-preview",
+) {
+  if (scope.traceId) {
+    return `${TRACE_API_PREFIX}/${encodeURIComponent(scope.traceId)}/${subresource}`;
+  }
+  return subresource === "evidence-chain"
+    ? `${TRACE_API_PREFIX}/by-request`
+    : `${TRACE_API_PREFIX}/by-request/${subresource}`;
+}
+
+function targetParams(scope: TraceQueryScope) {
+  const params: Record<string, number | string> = {};
+  if (scope.requestId) {
+    params.request_id = scope.requestId;
+  }
+  if (scope.limit !== undefined) {
+    params.limit = scope.limit;
+  }
+  return Object.keys(params).length ? params : undefined;
+}
+
+function mapPage(page?: BackendGraphPage): GraphPage {
+  return {
+    edgeCount: page?.edge_count ?? 0,
+    nodeCount: page?.node_count ?? 0,
+    truncated: Boolean(page?.truncated),
+  };
+}
+
+function mapVisibility(summary?: BackendVisibilitySummary): VisibilitySummary {
+  return {
+    authorizedRefCount: summary?.authorized_ref_count ?? 0,
+    hiddenRefCount: summary?.hidden_ref_count ?? 0,
+    omittedRefCount: summary?.omitted_ref_count ?? 0,
+    redactedRefCount: summary?.redacted_ref_count ?? 0,
+    unauthorizedRefCount: summary?.unauthorized_ref_count ?? 0,
+    unresolvedRefCount: summary?.unresolved_ref_count ?? 0,
+  };
+}
+
+function mapTraceGraph(data: BackendTraceGraph): TraceGraph {
+  return {
+    data: {
+      edges: (data.data?.edges ?? []).map((edge) => ({
+        childSpanId: edge.child_span_id ?? "",
+        edgeType: edge.edge_type ?? "",
+        id: edge.id ?? "",
+        parentSpanId: edge.parent_span_id ?? "",
+      })),
+      nodes: (data.data?.nodes ?? []).map((node) => ({
+        durationNano: node.duration_nano ?? 0,
+        endNano: node.end_nano ?? 0,
+        errorMessage: node.error_message,
+        kind: node.kind ?? "",
+        name: node.name ?? "",
+        parentSpanId: node.parent_span_id,
+        serviceName: node.service_name,
+        spanId: node.span_id ?? "",
+        startNano: node.start_nano ?? 0,
+        status: node.status ?? "ok",
+      })),
+    },
+    durationNano: data.duration_nano ?? 0,
+    page: mapPage(data.page),
+    partial: Boolean(data.partial),
+    partialReason: data.partial_reason ?? [],
+    status: data.status ?? "unknown",
+    traceId: data.trace_id ?? "",
+  };
+}
+
+function mapEvidenceChain(data: BackendEvidenceChain): EvidenceChain {
+  return {
+    data: {
+      businessRefs: data.data?.business_refs ?? [],
+      claims: data.data?.claims ?? [],
+      evidenceRefs: data.data?.evidence_refs ?? [],
+    },
+    page: mapPage(data.page),
+    partial: Boolean(data.partial),
+    partialReason: data.partial_reason ?? [],
+    requestId: data["bkn.request.id"] ?? "",
+    traceId: data.trace_id ?? "",
+    visibilitySummary: mapVisibility(data.visibility_summary),
+  };
+}
+
+function mapBusinessGraph(data: BackendBusinessGraph): BusinessGraph {
+  return {
+    data: {
+      edges: data.data?.edges ?? [],
+      nodes: data.data?.nodes ?? [],
+    },
+    page: mapPage(data.page),
+    partial: Boolean(data.partial),
+    partialReason: data.partial_reason ?? [],
+    requestId: data["bkn.request.id"] ?? "",
+    traceId: data.trace_id ?? "",
+    visibilitySummary: mapVisibility(data.visibility_summary),
+  };
+}
+
+function mapSnapshotPreview(data: BackendSnapshotPreview): SnapshotPreview {
+  return {
+    manifest: data.manifest ?? {},
+    partial: Boolean(data.partial),
+    partialReason: data.partial_reason ?? [],
+    requestId: data["bkn.request.id"] ?? "",
+    snapshotRef: {
+      mode: data.snapshot_ref?.mode ?? "preview",
+      snapshotId: data.snapshot_ref?.snapshot_id,
+      uri: data.snapshot_ref?.uri,
+    },
+    traceId: data.trace_id ?? "",
+    visibilitySummary: mapVisibility(data.visibility_summary),
+  };
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add BKN Trace Studio module with route, navigation, manifest, and i18n resources.
- [x] Add BKN Trace Explorer scene for trace graph, evidence chain, business graph, and snapshot preview queries.
- [x] Add service tests and module registration tests to lock API paths and shell integration.

---

## Why

- Related Issue: BKN Trace phase three Studio surface.
- Related Feature: BKN Trace core service and Studio visualization / management.
- Background: Studio should consume normalized BKN Trace APIs and must not query OpenSearch directly.

---

## How

- Key implementation points:
  - New `src/modules/bkn-trace` module follows the existing module contribution pattern.
  - Service layer calls `/agent-observability/v1/traces/...` normalized APIs only.
  - Explorer supports trace-id and request-id scoped queries; request-id mode intentionally omits Trace Graph because the backend Trace Graph endpoint is trace-id scoped.
  - Visibility and partial reasons are surfaced without exposing hidden raw data.
- Breaking changes (API, config, database, etc.): None. Additive Studio module.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` failed because npmmirror has no audit endpoint; reran `pnpm audit --prod --registry=https://registry.npmjs.org` and it passed.

---

## Risk & Rollback

- Potential risks: Backend deployments without BKN Trace phase three APIs will show normal request errors when users query the explorer.
- Rollback plan: Revert this additive module commit.

---

## Additional Notes

- Depends functionally on BKN Trace core API work in openbkn-ai/bkn-foundry#435 and SDK surface work in openbkn-ai/bkn-sdk#23, but Studio does not import SDK directly.
