### PR TITLE
fix(data-catalog): show build task error details

### DIFF
--- a/src/app/locales/resources/common/en-US.ts
+++ b/src/app/locales/resources/common/en-US.ts
@@ -13,6 +13,8 @@ export const commonEnUS = {
     create: "Create",
     import: "Import",
     copy: "Copy",
+    viewDetails: "View details",
+    hideDetails: "Hide details",
     back: "Back",
     backHome: "Back to home",
     previous: "Previous",
@@ -57,6 +59,12 @@ export const commonEnUS = {
     category: "Category",
     mode: "Mode",
     healthStatus: "Health Status",
+    error: {
+      code: "Error code: {{value}}",
+      details: "Error details: {{value}}",
+      solution: "Solution: {{value}}",
+      link: "Error link: {{value}}",
+    },
     testConnection: "Test Connection",
     dangerDelete: {
       typeNameToConfirm:

--- a/src/app/locales/resources/common/zh-CN.ts
+++ b/src/app/locales/resources/common/zh-CN.ts
@@ -13,6 +13,8 @@ export const commonZhCN = {
     create: "新建",
     import: "导入",
     copy: "复制",
+    viewDetails: "查看详情",
+    hideDetails: "收起详情",
     back: "返回",
     backHome: "返回首页",
     previous: "上一步",
@@ -56,6 +58,12 @@ export const commonZhCN = {
     category: "分类",
     mode: "模式",
     healthStatus: "健康状态",
+    error: {
+      code: "错误码：{{value}}",
+      details: "错误详情：{{value}}",
+      solution: "解决方案：{{value}}",
+      link: "错误链接：{{value}}",
+    },
     testConnection: "测试连接",
     dangerDelete: {
       typeNameToConfirm: "此操作高危,请输入名称「{{name}}」以确认删除。",

--- a/src/framework/request/error-message.test.ts
+++ b/src/framework/request/error-message.test.ts
@@ -40,6 +40,24 @@ describe("extractRequestErrorDetails", () => {
       errorLink: "暂无",
       solution: "请联系管理员",
     });
+    expect(extractRequestErrorMessage(error)).toBe("创建构建任务失败");
+  });
+
+  it("serializes structured error_details for a local error surface", () => {
+    const error = new axios.AxiosError("Request failed", undefined, undefined, undefined, {
+      config: { headers: new axios.AxiosHeaders() },
+      data: {
+        description: "创建构建任务失败",
+        error_details: { missing_fields: ["id"] },
+      },
+      headers: {},
+      status: 400,
+      statusText: "Bad Request",
+    });
+
+    expect(extractRequestErrorDetails(error).details).toBe(
+      '{"missing_fields":["id"]}',
+    );
   });
 
   it("uses details when description is absent", () => {
@@ -61,6 +79,6 @@ describe("extractRequestErrorDetails", () => {
       }),
     );
 
-    expect(message).toBe("description message: detail message");
+    expect(message).toBe("description message");
   });
 });

--- a/src/framework/request/error-message.test.ts
+++ b/src/framework/request/error-message.test.ts
@@ -5,9 +5,10 @@
  * Conditions. See LICENSE for the full text.
  */
 
+import axios from "axios";
 import { describe, expect, it } from "vitest";
 
-import { extractRequestErrorMessage } from "@/framework/request/error-message";
+import { extractRequestErrorDetails, extractRequestErrorMessage } from "./error-message";
 
 function createAxiosLikeError(data: unknown) {
   return {
@@ -16,16 +17,40 @@ function createAxiosLikeError(data: unknown) {
   };
 }
 
-describe("extractRequestErrorMessage", () => {
+describe("extractRequestErrorDetails", () => {
+  it("preserves backend error code, description, and details", () => {
+    const error = new axios.AxiosError("Request failed", undefined, undefined, undefined, {
+      config: { headers: new axios.AxiosHeaders() },
+      data: {
+        description: "创建构建任务失败",
+        error_code: "VegaBackend.BuildTask.InternalError.CreateFailed",
+        error_details: "Resource has no primary key",
+        error_link: "暂无",
+        solution: "请联系管理员",
+      },
+      headers: {},
+      status: 400,
+      statusText: "Bad Request",
+    });
+
+    expect(extractRequestErrorDetails(error)).toEqual({
+      code: "VegaBackend.BuildTask.InternalError.CreateFailed",
+      description: "创建构建任务失败",
+      details: "Resource has no primary key",
+      errorLink: "暂无",
+      solution: "请联系管理员",
+    });
+  });
+
   it("uses details when description is absent", () => {
-    const message = extractRequestErrorMessage(
+    const details = extractRequestErrorDetails(
       createAxiosLikeError({
         details: "logic property[weather] result_path is invalid",
         message: "request failed",
       }),
     );
 
-    expect(message).toBe("logic property[weather] result_path is invalid");
+    expect(details.description).toBe("logic property[weather] result_path is invalid");
   });
 
   it("keeps description as the highest priority response message", () => {
@@ -36,6 +61,6 @@ describe("extractRequestErrorMessage", () => {
       }),
     );
 
-    expect(message).toBe("description message");
+    expect(message).toBe("description message: detail message");
   });
 });

--- a/src/framework/request/error-message.ts
+++ b/src/framework/request/error-message.ts
@@ -38,6 +38,14 @@ function formatErrorDetails(value: unknown): string | undefined {
     return String(value);
   }
 
+  if (value && typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return undefined;
+    }
+  }
+
   return undefined;
 }
 
@@ -85,6 +93,5 @@ export function extractRequestErrorDetails(error: unknown): RequestErrorDetails 
 }
 
 export function extractRequestErrorMessage(error: unknown) {
-  const { description, details } = extractRequestErrorDetails(error);
-  return details ? `${description}: ${details}` : description;
+  return extractRequestErrorDetails(error).description;
 }

--- a/src/framework/request/error-message.ts
+++ b/src/framework/request/error-message.ts
@@ -9,43 +9,82 @@ import axios from "axios";
 
 import i18n from "@/app/locales/i18n";
 
-type ErrorResponseBody = {
+type BackendErrorResponseBody = {
   error?: string;
+  error_code?: string;
+  error_details?: unknown;
+  error_link?: string;
   message?: string;
   description?: string;
   detail?: unknown;
   details?: unknown;
+  solution?: string;
 };
 
-export function extractRequestErrorMessage(error: unknown) {
-  if (axios.isAxiosError<ErrorResponseBody>(error)) {
+export type RequestErrorDetails = {
+  code?: string;
+  description: string;
+  details?: string;
+  errorLink?: string;
+  solution?: string;
+};
+
+function formatErrorDetails(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+export function extractRequestErrorDetails(error: unknown): RequestErrorDetails {
+  if (axios.isAxiosError<BackendErrorResponseBody>(error)) {
     const data = error.response?.data;
-    const responseDescription = data?.description;
-    const responseMessage = data?.message;
-    const responseError = data?.error;
-    const responseDetails = data?.details ?? data?.detail;
+    const description = optionalString(data?.description);
+    const details = formatErrorDetails(data?.error_details);
+    const fallbackDetails = formatErrorDetails(data?.details ?? data?.detail);
+    const common = {
+      code: optionalString(data?.error_code),
+      details: details ?? fallbackDetails,
+      errorLink: optionalString(data?.error_link),
+      solution: optionalString(data?.solution),
+    };
+    const responseMessage = optionalString(data?.message);
+    const responseError = optionalString(data?.error);
 
-    if (typeof responseDescription === "string" && responseDescription.trim()) {
-      return responseDescription;
+    if (description) {
+      return { ...common, description };
     }
 
-    if (typeof responseDetails === "string" && responseDetails.trim()) {
-      return responseDetails;
+    if (fallbackDetails) {
+      return { ...common, description: fallbackDetails };
     }
 
-    if (typeof responseMessage === "string" && responseMessage.trim()) {
-      return responseMessage;
+    if (responseMessage) {
+      return { ...common, description: responseMessage };
     }
 
-    if (typeof responseError === "string" && responseError.trim()) {
-      return responseError;
+    if (responseError) {
+      return { ...common, description: responseError };
     }
   }
 
   if (error instanceof Error && error.message.trim()) {
-    return error.message;
+    return { description: error.message };
   }
 
-  return i18n.t("common.requestFailed");
+  return { description: i18n.t("common.requestFailed") };
 }
 
+export function extractRequestErrorMessage(error: unknown) {
+  const { description, details } = extractRequestErrorDetails(error);
+  return details ? `${description}: ${details}` : description;
+}

--- a/src/framework/ui/common/RequestErrorAlert.module.css
+++ b/src/framework/ui/common/RequestErrorAlert.module.css
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+.details {
+  display: grid;
+  gap: 4px;
+}
+
+.detailValue {
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}

--- a/src/framework/ui/common/RequestErrorAlert.test.tsx
+++ b/src/framework/ui/common/RequestErrorAlert.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RequestErrorAlert } from "./RequestErrorAlert";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { value?: string }) =>
+      options?.value ? `${key}: ${options.value}` : key,
+  }),
+}));
+
+describe("RequestErrorAlert", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("dismisses the summary after ten seconds", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+
+    render(<RequestErrorAlert error={{ description: "Build failed" }} onDismiss={onDismiss} />);
+
+    void act(() => vi.advanceTimersByTime(9999));
+    expect(onDismiss).not.toHaveBeenCalled();
+    void act(() => vi.advanceTimersByTime(1));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the alert open after the user expands error details", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+
+    render(
+      <RequestErrorAlert
+        error={{ code: "BuildTask.CreateFailed", description: "Build failed", details: "No key" }}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("common.viewDetails"));
+    expect(screen.getByText("common.error.details: No key")).toBeTruthy();
+    void act(() => vi.advanceTimersByTime(10000));
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/src/framework/ui/common/RequestErrorAlert.tsx
+++ b/src/framework/ui/common/RequestErrorAlert.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { Alert, Space } from "antd";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { RequestErrorDetails } from "@/framework/request/error-message";
+import { AppButton } from "@/framework/ui/common/AppButton";
+
+import styles from "./RequestErrorAlert.module.css";
+
+export type RequestErrorAlertProps = {
+  autoDismissMs?: number;
+  error: RequestErrorDetails;
+  onDismiss: () => void;
+};
+
+export function RequestErrorAlert({
+  autoDismissMs = 10000,
+  error,
+  onDismiss,
+}: RequestErrorAlertProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails = Boolean(error.code || error.details || error.solution || error.errorLink);
+  const copyText = useMemo(
+    () =>
+      [
+        error.description,
+        error.code ? t("common.error.code", { value: error.code }) : "",
+        error.details ? t("common.error.details", { value: error.details }) : "",
+        error.solution ? t("common.error.solution", { value: error.solution }) : "",
+        error.errorLink ? t("common.error.link", { value: error.errorLink }) : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    [error.code, error.description, error.details, error.errorLink, error.solution, t],
+  );
+
+  useEffect(() => {
+    setExpanded(false);
+  }, [error]);
+
+  useEffect(() => {
+    if (expanded || autoDismissMs <= 0) {
+      return undefined;
+    }
+
+    const timer = window.setTimeout(onDismiss, autoDismissMs);
+    return () => window.clearTimeout(timer);
+  }, [autoDismissMs, expanded, onDismiss]);
+
+  const copyDetails = () => {
+    void navigator.clipboard?.writeText(copyText);
+  };
+
+  return (
+    <Alert
+      action={
+        hasDetails ? (
+          <Space size={4}>
+            <AppButton onClick={() => setExpanded((value) => !value)} size="small" type="link">
+              {t(expanded ? "common.hideDetails" : "common.viewDetails")}
+            </AppButton>
+            {expanded ? (
+              <AppButton onClick={copyDetails} size="small" type="link">
+                {t("common.copy")}
+              </AppButton>
+            ) : null}
+          </Space>
+        ) : null
+      }
+      closable
+      description={
+        expanded ? (
+          <div className={styles.details}>
+            {error.code ? <div>{t("common.error.code", { value: error.code })}</div> : null}
+            {error.details ? (
+              <pre className={styles.detailValue}>
+                {t("common.error.details", { value: error.details })}
+              </pre>
+            ) : null}
+            {error.solution ? <div>{t("common.error.solution", { value: error.solution })}</div> : null}
+            {error.errorLink ? <div>{t("common.error.link", { value: error.errorLink })}</div> : null}
+          </div>
+        ) : undefined
+      }
+      message={error.description}
+      onClose={onDismiss}
+      showIcon
+      type="error"
+    />
+  );
+}

--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
@@ -16,6 +16,7 @@ import {
   type RequestErrorDetails,
 } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
+import { RequestErrorAlert } from "@/framework/ui/common/RequestErrorAlert";
 import {
   BuildTaskConflictError,
   createBuildTask,
@@ -24,6 +25,7 @@ import {
   type BuildExecuteType,
 } from "@/modules/data-catalog/services/build-task.service";
 import type { BuildMode, BuildTask, CatalogResource } from "@/modules/data-catalog/types/data-catalog";
+import { streamingNeedsBuildKey } from "@/modules/data-catalog/lib/build-task-launch-guards";
 import { indexFormValuesFromResource } from "@/modules/data-catalog/utils/resource-index-config";
 import { isActiveBuildTask } from "@/modules/data-catalog/utils/build-task-guards";
 import { listSmallModels } from "@/modules/model-resources/services/small-model.service";
@@ -78,20 +80,11 @@ export function BuildTaskLaunchPanel({
   const [models, setModels] = useState<SmallModel[]>([]);
   const [saving, setSaving] = useState(false);
 
-  useEffect(() => {
-    if (!error) {
-      return undefined;
-    }
-
-    const timer = window.setTimeout(() => setError(null), 5000);
-    return () => window.clearTimeout(timer);
-  }, [error]);
-
   const config = useMemo(() => indexFormValuesFromResource(resource), [resource]);
   const hasResourceConfig =
     config.embeddingFields.length > 0 || config.fulltextFields.length > 0;
   const batchNeedsBuildKey = mode === "batch" && config.buildKeyFields.length === 0;
-  const streamingNeedsBuildKey = mode === "streaming" && config.buildKeyFields.length === 0;
+  const streamingBuildKeyRequired = streamingNeedsBuildKey(mode, config.buildKeyFields);
   const analyzerLabel = config.fulltextFields.length > 0 && config.fulltextAnalyzer
     ? t(`dataCatalog.build.analyzers.${config.fulltextAnalyzer}`, {
         defaultValue: config.fulltextAnalyzer,
@@ -152,7 +145,7 @@ export function BuildTaskLaunchPanel({
     existingActive?.mode === "streaming" && isActiveBuildTask(existingActive);
   const controlsDisabled = disabled || actionsLocked;
   const startDisabled =
-    controlsDisabled || !hasResourceConfig || batchNeedsBuildKey || streamingNeedsBuildKey;
+    controlsDisabled || !hasResourceConfig || batchNeedsBuildKey || streamingBuildKeyRequired;
 
   const startBuild = async () => {
     if (!hasResourceConfig) {
@@ -163,7 +156,7 @@ export function BuildTaskLaunchPanel({
       setError({ description: t("dataCatalog.build.buildKeyRequired") });
       return;
     }
-    if (streamingNeedsBuildKey) {
+    if (streamingBuildKeyRequired) {
       setError({ description: t("dataCatalog.build.streamingBuildKeyRequired") });
       return;
     }
@@ -254,7 +247,7 @@ export function BuildTaskLaunchPanel({
           type="warning"
         />
       ) : null}
-      {hasResourceConfig && streamingNeedsBuildKey ? (
+      {hasResourceConfig && streamingBuildKeyRequired ? (
         <Alert message={t("dataCatalog.build.streamingBuildKeyRequired")} showIcon type="warning" />
       ) : null}
 
@@ -377,23 +370,7 @@ export function BuildTaskLaunchPanel({
         </div>
       </div>
 
-      {error ? (
-        <Alert
-          description={
-            error.code || error.details || error.solution || error.errorLink ? (
-              <div>
-                {error.code ? <div>{t("dataCatalog.build.errorCode", { value: error.code })}</div> : null}
-                {error.details ? <div>{t("dataCatalog.build.errorDetails", { value: error.details })}</div> : null}
-                {error.solution ? <div>{t("dataCatalog.build.errorSolution", { value: error.solution })}</div> : null}
-                {error.errorLink ? <div>{t("dataCatalog.build.errorLink", { value: error.errorLink })}</div> : null}
-              </div>
-            ) : undefined
-          }
-          message={error.description}
-          showIcon
-          type="error"
-        />
-      ) : null}
+      {error ? <RequestErrorAlert error={error} onDismiss={() => setError(null)} /> : null}
 
       <div className={formStyles.launchActionBar}>
         <AppButton

--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
@@ -11,7 +11,10 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAppServices } from "@/framework/context/use-app-services";
-import { extractRequestErrorMessage } from "@/framework/request/error-message";
+import {
+  extractRequestErrorDetails,
+  type RequestErrorDetails,
+} from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import {
   BuildTaskConflictError,
@@ -39,6 +42,8 @@ export type BuildTaskLaunchPanelProps = {
 function cx(...parts: Array<string | false | undefined>) {
   return parts.filter(Boolean).join(" ");
 }
+
+type BuildTaskLaunchError = RequestErrorDetails;
 
 function formatEmbeddingModelDisplay(
   modelId: string | null | undefined,
@@ -69,7 +74,7 @@ export function BuildTaskLaunchPanel({
   const [mode, setMode] = useState<BuildMode>("batch");
   const [executeType, setExecuteType] = useState<BuildExecuteType>("full");
   const [existingActive, setExistingActive] = useState<BuildTask | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<BuildTaskLaunchError | null>(null);
   const [models, setModels] = useState<SmallModel[]>([]);
   const [saving, setSaving] = useState(false);
 
@@ -86,6 +91,7 @@ export function BuildTaskLaunchPanel({
   const hasResourceConfig =
     config.embeddingFields.length > 0 || config.fulltextFields.length > 0;
   const batchNeedsBuildKey = mode === "batch" && config.buildKeyFields.length === 0;
+  const streamingNeedsBuildKey = mode === "streaming" && config.buildKeyFields.length === 0;
   const analyzerLabel = config.fulltextFields.length > 0 && config.fulltextAnalyzer
     ? t(`dataCatalog.build.analyzers.${config.fulltextAnalyzer}`, {
         defaultValue: config.fulltextAnalyzer,
@@ -145,23 +151,28 @@ export function BuildTaskLaunchPanel({
   const streamingActive =
     existingActive?.mode === "streaming" && isActiveBuildTask(existingActive);
   const controlsDisabled = disabled || actionsLocked;
-  const startDisabled = controlsDisabled || !hasResourceConfig || batchNeedsBuildKey;
+  const startDisabled =
+    controlsDisabled || !hasResourceConfig || batchNeedsBuildKey || streamingNeedsBuildKey;
 
   const startBuild = async () => {
     if (!hasResourceConfig) {
-      setError(t("dataCatalog.build.needConfigFirst"));
+      setError({ description: t("dataCatalog.build.needConfigFirst") });
       return;
     }
     if (mode === "batch" && config.buildKeyFields.length === 0) {
-      setError(t("dataCatalog.build.buildKeyRequired"));
+      setError({ description: t("dataCatalog.build.buildKeyRequired") });
+      return;
+    }
+    if (streamingNeedsBuildKey) {
+      setError({ description: t("dataCatalog.build.streamingBuildKeyRequired") });
       return;
     }
     if (actionsLocked) {
-      setError(
-        streamingActive
+      setError({
+        description: streamingActive
           ? t("dataCatalog.build.streamingActiveLocked")
           : t("dataCatalog.build.activeTaskLocked"),
-      );
+      });
       return;
     }
 
@@ -182,9 +193,9 @@ export function BuildTaskLaunchPanel({
       onStarted(task);
     } catch (persistError) {
       if (persistError instanceof BuildTaskConflictError) {
-        setError(t("dataCatalog.build.conflict"));
+        setError({ description: t("dataCatalog.build.conflict") });
       } else {
-        setError(extractRequestErrorMessage(persistError));
+        setError(extractRequestErrorDetails(persistError));
       }
     } finally {
       setSaving(false);
@@ -242,6 +253,9 @@ export function BuildTaskLaunchPanel({
           showIcon
           type="warning"
         />
+      ) : null}
+      {hasResourceConfig && streamingNeedsBuildKey ? (
+        <Alert message={t("dataCatalog.build.streamingBuildKeyRequired")} showIcon type="warning" />
       ) : null}
 
       {hasResourceConfig ? (
@@ -363,7 +377,23 @@ export function BuildTaskLaunchPanel({
         </div>
       </div>
 
-      {error ? <Alert message={error} showIcon type="error" /> : null}
+      {error ? (
+        <Alert
+          description={
+            error.code || error.details || error.solution || error.errorLink ? (
+              <div>
+                {error.code ? <div>{t("dataCatalog.build.errorCode", { value: error.code })}</div> : null}
+                {error.details ? <div>{t("dataCatalog.build.errorDetails", { value: error.details })}</div> : null}
+                {error.solution ? <div>{t("dataCatalog.build.errorSolution", { value: error.solution })}</div> : null}
+                {error.errorLink ? <div>{t("dataCatalog.build.errorLink", { value: error.errorLink })}</div> : null}
+              </div>
+            ) : undefined
+          }
+          message={error.description}
+          showIcon
+          type="error"
+        />
+      ) : null}
 
       <div className={formStyles.launchActionBar}>
         <AppButton

--- a/src/modules/data-catalog/lib/build-task-launch-guards.test.ts
+++ b/src/modules/data-catalog/lib/build-task-launch-guards.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { streamingNeedsBuildKey } from "./build-task-launch-guards";
+
+describe("streamingNeedsBuildKey", () => {
+  it("requires a configured build key only for streaming builds", () => {
+    expect(streamingNeedsBuildKey("streaming", [])).toBe(true);
+    expect(streamingNeedsBuildKey("streaming", ["id"])).toBe(false);
+    expect(streamingNeedsBuildKey("batch", [])).toBe(false);
+  });
+});

--- a/src/modules/data-catalog/lib/build-task-launch-guards.ts
+++ b/src/modules/data-catalog/lib/build-task-launch-guards.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { BuildMode } from "@/modules/data-catalog/types/data-catalog";
+
+/** 流式构建以资源索引配置中的增量键作为稳定行标识。 */
+export function streamingNeedsBuildKey(mode: BuildMode, buildKeyFields: string[]) {
+  return mode === "streaming" && buildKeyFields.length === 0;
+}

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -318,10 +318,6 @@ export const dataCatalogEnUS = {
         "Batch mode requires a build-key field. Select one under Configure Index.",
       streamingBuildKeyRequired:
         "Streaming builds require a build-key field. Select one under Configure Index before creating the task.",
-      errorCode: "Error code: {{value}}",
-      errorDetails: "Error details: {{value}}",
-      errorSolution: "Solution: {{value}}",
-      errorLink: "Error link: {{value}}",
       model: "Embedding Model",
       modelRequired: "Select an embedding model.",
       noModels:

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -316,6 +316,12 @@ export const dataCatalogEnUS = {
       fieldsRequired: "Select at least one embedding or full-text field.",
       buildKeyRequired:
         "Batch mode requires a build-key field. Select one under Configure Index.",
+      streamingBuildKeyRequired:
+        "Streaming builds require a build-key field. Select one under Configure Index before creating the task.",
+      errorCode: "Error code: {{value}}",
+      errorDetails: "Error details: {{value}}",
+      errorSolution: "Solution: {{value}}",
+      errorLink: "Error link: {{value}}",
       model: "Embedding Model",
       modelRequired: "Select an embedding model.",
       noModels:

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -241,7 +241,7 @@ export const dataCatalogEnUS = {
       batchDescription: "One-shot sync and indexing.",
       streamingLabel: "Streaming",
       streamingDescription:
-        "Continuous incremental sync with a standing listener; build key is optional.",
+        "Continuous incremental sync with a standing listener; a build key is required.",
       executeType: "Execution",
       executeFull: "Full",
       executeFullDescription: "Sync all rows from the source and rebuild the index. Use it for first builds or full refreshes.",

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -260,9 +260,9 @@ export const dataCatalogEnUS = {
         "Fields vectorized by the embedding model for semantic search; can be used with or without full-text.",
       roleBuildKeyHintBatch:
         "Field used to detect incremental data in batch builds (e.g. updated_at, auto-increment ID); required.",
-      roleBuildKeyHintStreaming: "Row ID field for streaming builds; optional.",
+      roleBuildKeyHintStreaming: "Row ID field for streaming builds; required.",
       roleBuildKeyHintConfig:
-        "Used for incremental builds; required for batch and optional for streaming.",
+        "Used for incremental builds; required for both batch and streaming.",
       roleFulltextHint:
         "Text fields indexed for keyword full-text search; applied immediately during data sync.",
       selectAll: "Select all",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -228,7 +228,7 @@ export const dataCatalogZhCN = {
       batchLabel: "批量",
       batchDescription: "一次性同步并建索引。",
       streamingLabel: "流式",
-      streamingDescription: "持续增量同步、常驻监听；增量键可选。",
+      streamingDescription: "持续增量同步、常驻监听；需指定增量键。",
       executeType: "执行方式",
       executeFull: "全量",
       executeFullDescription: "从数据源重新同步全部数据并重建索引，适合首次构建或需要完整刷新时使用。",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -299,10 +299,6 @@ export const dataCatalogZhCN = {
       buildKeyRequired: "批量模式必须指定增量键字段，请回到「配置索引」勾选。",
       streamingBuildKeyRequired:
         "流式构建必须指定增量键字段，请回到「配置索引」勾选后再创建任务。",
-      errorCode: "错误码：{{value}}",
-      errorDetails: "错误详情：{{value}}",
-      errorSolution: "解决方案：{{value}}",
-      errorLink: "错误链接：{{value}}",
       model: "Embedding 模型",
       modelRequired: "请选择 Embedding 模型。",
       noModels: "尚未接入 embedding 模型,无法保存含向量字段的配置。",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -297,6 +297,12 @@ export const dataCatalogZhCN = {
       },
       fieldsRequired: "请至少选择一个向量嵌入字段或全文检索字段。",
       buildKeyRequired: "批量模式必须指定增量键字段，请回到「配置索引」勾选。",
+      streamingBuildKeyRequired:
+        "流式构建必须指定增量键字段，请回到「配置索引」勾选后再创建任务。",
+      errorCode: "错误码：{{value}}",
+      errorDetails: "错误详情：{{value}}",
+      errorSolution: "解决方案：{{value}}",
+      errorLink: "错误链接：{{value}}",
       model: "Embedding 模型",
       modelRequired: "请选择 Embedding 模型。",
       noModels: "尚未接入 embedding 模型,无法保存含向量字段的配置。",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -246,9 +246,9 @@ export const dataCatalogZhCN = {
         "将被 Embedding 模型向量化，用于语义相似度检索；可与全文二选一或同时开启。",
       roleBuildKeyHintBatch:
         "批量构建时用于识别增量数据的字段（如更新时间、自增 ID）；必填。",
-      roleBuildKeyHintStreaming: "流式构建时用于标识行的 ID 字段；可选。",
+      roleBuildKeyHintStreaming: "流式构建时用于标识行的 ID 字段；必填。",
       roleBuildKeyHintConfig:
-        "增量构建使用；批量必填，流式可选。",
+        "增量构建使用；批量与流式均需指定。",
       roleFulltextHint: "建立关键词全文索引的文本字段，随数据同步即时生效。",
       selectAll: "全选",
       clearAll: "清空",


### PR DESCRIPTION
## What Changed

- [x] Data catalog: preserve the Vega error envelope (`error_code`, `description`, `solution`, `error_link`, `error_details`) when build-task creation fails.
- [x] Data catalog: show the description and structured error details in the launch panel.
- [x] Data catalog: block streaming builds when the current index configuration has no `buildKeyFields`.
- [ ] Docs/doc 1 (not needed; behavior is covered by UI text and tests).

---

## Why

- Related Issue: Closes #244
- Related Feature: N/A
- Background: a streaming build rejected by Vega exposed only the generic description in Studio, hiding the actionable backend details.

---

## How

- Key implementation points: parse the complete Vega error envelope without classifying errors from text; render description plus code/detail/solution/link; use `indexConfig.buildKeyFields` for the streaming prerequisite.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally (346 tests).
- [x] Integration tests passed locally (project test suite).
- [ ] Verified in test environment (not performed; no deployed environment was used).

Test notes:

- Ran license-header check, zero-warning type-aware ESLint, Vitest, TypeScript build, Vite production build, and `pnpm audit --prod`.

---

## Risk & Rollback

- Potential risks: error-detail presentation changes the text of generic request failure notifications; the streaming guard relies on the saved resource index configuration.
- Rollback plan: revert commit `bdb3d09`.

---

## Additional Notes

- No screenshots; behavior is covered by the request-error regression test.