### PR TITLE
fix(ci): 修掉评论触发的 Claude 复评自我取消

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -49,15 +49,19 @@ on:
         type: string
 
 concurrency:
-  # 按事件类别分组，别把评论事件和 PR 推送混在一组。
-  # claude-code-action（track_progress）在评审跑到一半时会以 bot 身份贴 tracking
-  # comment，那条 comment 触发 issue_comment:created 又排一个同组 run；若共用一组，
-  # cancel-in-progress 会在 job `if` 过滤掉 bot 评论之前，就把正在跑的评审取消掉
-  # ——评审每次贴进度评论那刻自杀，永远跑不到绿。concurrency 在 run 排队时求值，
-  # 早于 job if，所以只能靠分组隔离，if 拦不住取消。
-  # push 之间仍在 -push 组内互相取消（连续推送省额度）；评论事件落 -comment 组，
-  # 取消不到正在跑的 PR 评审。
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}-${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && 'comment' || 'push' }}
+  # 按事件类别分组，别把评论事件和 PR 推送混在一组。concurrency 在 run 排队时求值，
+  # 早于 job if，所以隔离只能靠分组，if 拦不住取消。
+  #
+  # push（含 opened/synchronize/…）落 -push 组、cancel-in-progress 生效：连续推送时
+  # 新 run 取消未完成的旧 run，省额度。
+  #
+  # 评论事件（issue_comment / pull_request_review_comment）每条按 comment.id 各自成组。
+  # 否则 claude-code-action（track_progress）在评论触发的复评跑到一半时以 bot 身份贴
+  # tracking comment，那条 comment 又触发 issue_comment、排进同一 -comment 组，
+  # cancel-in-progress 在 job if 过滤掉 bot 评论之前就把正在跑的复评取消了——评论触发的
+  # 复评每次贴进度评论那刻自杀（#243 的「作者回帖复评后放行」因此永远补不上 approve）。
+  # 按 comment.id 分组后每条评论各自独立、互不取消，bot 的进度评论也顶不掉正在跑的复评。
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}-${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && format('comment-{0}', github.event.comment.id) || 'push' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## 问题

#245 把评论事件挪出 \`-push\` 组，保住了 **PR-push 代码评审**（每次提交那条），已生效。

但 **评论触发的复评**（#243 为审批门禁加的「作者回帖 → 复评 → 放行」）仍共用一个 \`-comment\` 组：这类复评跑到一半时，claude-code-action(track_progress) 会以 bot 身份贴 tracking comment，那条 comment 又触发 \`issue_comment:created\` 排进同一 \`-comment\` 组，\`cancel-in-progress\` 在 job \`if\` 过滤掉 bot 评论**之前**就把正在跑的复评取消了（concurrency 在 run 排队时求值，早于 job if）。

结果：**评论触发的复评每次贴进度评论那刻自杀**，#243 的「作者回帖后放行」永远补不上 approve。表现为 PR 上一堆 \`Cancelled\` 的 \`issue_comment\` run。

> 注：PR-push 代码评审不受影响（#245 已隔离），\`197bcd3\` 等 push 评审正常 success。

## 修法

评论事件按 \`comment.id\` 各自成组 → 每条评论独立、互不取消，bot 进度评论也顶不掉正在跑的复评。push 事件保持 \`-push\` 组 + \`cancel-in-progress\`（新提交取代旧评审，不变）。

\`\`\`yaml
group: claude-review-${{ ... }}-${{ (issue_comment || pull_request_review_comment) && format('comment-{0}', github.event.comment.id) || 'push' }}
\`\`\`

## 备注

- 只改 studio 副本；foundry 模板那份无 issue_comment 触发，不犯此病。
- 本 PR 只动 \`.github/**\`，不触发代码评审。合并到 main 后对后续 PR 生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)