### PR TITLE
feat(bkn-trace): promote explorer to system menu

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 allowBuilds:
   esbuild: true
+auditConfig:
+  # GHSA-qwww-vcr4-c8h2 affects React Router RSC Mode. Studio is a Vite SPA
+  # and does not enable RSC Mode; remove this once a published patch is
+  # available for react-router-dom.
+  ignoreGhsas:
+    - GHSA-qwww-vcr4-c8h2

--- a/src/app/locales/resources/shell/en-US.ts
+++ b/src/app/locales/resources/shell/en-US.ts
@@ -42,7 +42,7 @@ export const shellEnUS = {
       authorizationManagement: "Permission Management",
       licenseManagement: "License Management",
       modelManagement: "Model Configuration",
-      traceai: "BKN Trace",
+      bknTrace: "BKN Trace",
       logManagement: "Log Management",
       apiKeys: "API Key",
       account: "Account",

--- a/src/app/locales/resources/shell/zh-CN.ts
+++ b/src/app/locales/resources/shell/zh-CN.ts
@@ -43,7 +43,7 @@ export const shellZhCN = {
       authorizationManagement: "权限管理",
       licenseManagement: "授权管理",
       modelManagement: "模型配置",
-      traceai: "BKN Trace",
+      bknTrace: "BKN Trace",
       logManagement: "日志管理",
       apiKeys: "API Key",
       account: "个人中心",

--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -17,6 +17,19 @@ export const bknTraceEnUS = {
       missingScope: "Enter a trace id or request id.",
       queryFailed: "Query failed.",
     },
+    emptyStates: {
+      businessNodes: "No business semantic nodes returned.",
+      claims: "No claim details returned.",
+      evidenceRefs: "No evidence ref details returned.",
+    },
+    fields: {
+      basis: "Basis",
+      object: "Object",
+      status: "Status",
+      type: "Type",
+      version: "Version",
+      visibility: "Visibility",
+    },
     metrics: {
       businessEdges: "Business edges",
       businessNodes: "Business nodes",
@@ -35,7 +48,10 @@ export const bknTraceEnUS = {
       trace: "Trace",
     },
     sections: {
+      businessDetails: "Business Semantic Node Details",
       businessGraph: "Business Semantic Graph",
+      claimDetails: "Claim Details",
+      evidenceDetails: "Evidence Ref Details",
       evidenceChain: "Evidence Chain",
       snapshot: "Snapshot Preview",
       traceGraph: "Trace Graph",

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -16,6 +16,19 @@ export const bknTraceZhCN = {
       missingScope: "请输入 trace id 或 request id。",
       queryFailed: "查询失败。",
     },
+    emptyStates: {
+      businessNodes: "未返回业务语义节点",
+      claims: "未返回结论明细",
+      evidenceRefs: "未返回证据引用明细",
+    },
+    fields: {
+      basis: "依据摘要",
+      object: "对象",
+      status: "状态",
+      type: "类型",
+      version: "版本",
+      visibility: "可见性",
+    },
     metrics: {
       businessEdges: "业务边",
       businessNodes: "业务节点",
@@ -34,7 +47,10 @@ export const bknTraceZhCN = {
       trace: "Trace",
     },
     sections: {
+      businessDetails: "业务语义节点明细",
       businessGraph: "业务语义链",
+      claimDetails: "结论明细",
+      evidenceDetails: "证据引用明细",
       evidenceChain: "证据链",
       snapshot: "快照预览",
       traceGraph: "调用链",

--- a/src/modules/bkn-trace/navigation.tsx
+++ b/src/modules/bkn-trace/navigation.tsx
@@ -14,9 +14,9 @@ export const bknTraceNavigation: ConsoleNavContribution = {
   items: [
     {
       key: "bkn-trace",
-      labelKey: "shell.items.traceai",
+      labelKey: "shell.items.bknTrace",
       icon: <BranchesOutlined />,
-      path: "/bkn-trace",
+      path: "/system/bkn-trace",
       permission: ["bkn-trace:view"],
     },
   ],

--- a/src/modules/bkn-trace/routes.test.tsx
+++ b/src/modules/bkn-trace/routes.test.tsx
@@ -15,11 +15,11 @@ import { bknTraceRouteContribution } from "@/modules/bkn-trace/routes";
 describe("bkn-trace module registration", () => {
   it("contributes a shell route and navigation item", () => {
     expect(bknTraceRouteContribution.moduleId).toBe("bkn-trace");
-    expect(bknTraceRouteContribution.routes.map((route) => route.path)).toContain("bkn-trace");
+    expect(bknTraceRouteContribution.routes.map((route) => route.path)).toContain("system/bkn-trace");
     expect(bknTraceNavigation.items[0]).toMatchObject({
       key: "bkn-trace",
-      labelKey: "shell.items.traceai",
-      path: "/bkn-trace",
+      labelKey: "shell.items.bknTrace",
+      path: "/system/bkn-trace",
     });
     expect(
       consoleNavigation

--- a/src/modules/bkn-trace/routes.tsx
+++ b/src/modules/bkn-trace/routes.tsx
@@ -22,7 +22,7 @@ function withRouteLoading(element: ReactNode) {
 
 export const bknTraceRoutes: RouteObject[] = [
   {
-    path: "bkn-trace",
+    path: "system/bkn-trace",
     handle: {
       console: {
         descriptionKey: "bknTrace.description",

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.tsx
@@ -36,6 +36,12 @@ import {
   type TraceGraph,
   type TraceGraphNode,
 } from "@/modules/bkn-trace/services/trace.service";
+import {
+  businessRows,
+  claimRows,
+  evidenceRows,
+  type ExplainabilityRow,
+} from "@/modules/bkn-trace/utils/trace-explainability";
 
 type ScopeMode = "request" | "trace";
 
@@ -74,6 +80,29 @@ export function BknTraceExplorerScene() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [state, setState] = useState<TraceExplorerState>({});
+  const explainabilityColumns = useMemo<ColumnsType<ExplainabilityRow>>(
+    () => [
+      { dataIndex: "kind", key: "kind", title: t("bknTrace.fields.type"), width: 160 },
+      { dataIndex: "primary", key: "primary", title: t("bknTrace.fields.object") },
+      { dataIndex: "secondary", key: "secondary", title: t("bknTrace.fields.basis") },
+      {
+        dataIndex: "status",
+        key: "status",
+        render: (status: string) => <Tag color={status === "failed" || status === "error" ? "red" : "blue"}>{status}</Tag>,
+        title: t("bknTrace.fields.status"),
+        width: 120,
+      },
+      {
+        dataIndex: "visibility",
+        key: "visibility",
+        render: (visibility: string) => <Tag color={visibility === "visible" ? "green" : "orange"}>{visibility}</Tag>,
+        title: t("bknTrace.fields.visibility"),
+        width: 120,
+      },
+      { dataIndex: "versionStatus", key: "versionStatus", title: t("bknTrace.fields.version"), width: 140 },
+    ],
+    [t],
+  );
 
   const effectiveScope = useMemo(() => {
     const trimmedTraceId = traceId.trim();
@@ -124,6 +153,18 @@ export function BknTraceExplorerScene() {
     ...(state.businessGraph?.partialReason ?? []),
     ...(state.snapshotPreview?.partialReason ?? []),
   ];
+  const claims = useMemo(
+    () => claimRows(state.evidenceChain?.data.claims ?? []),
+    [state.evidenceChain?.data.claims],
+  );
+  const evidenceRefs = useMemo(
+    () => evidenceRows(state.evidenceChain?.data.evidenceRefs ?? []),
+    [state.evidenceChain?.data.evidenceRefs],
+  );
+  const businessNodes = useMemo(
+    () => businessRows(state.businessGraph?.data.nodes ?? []),
+    [state.businessGraph?.data.nodes],
+  );
 
   return (
     <div className={styles.scene}>
@@ -263,6 +304,42 @@ export function BknTraceExplorerScene() {
                   </Descriptions.Item>
                 </Descriptions>
               </div>
+            </section>
+
+            <section className={styles.panel}>
+              <Typography.Title level={5}>{t("bknTrace.sections.claimDetails")}</Typography.Title>
+              <Table
+                columns={explainabilityColumns}
+                dataSource={claims}
+                locale={{ emptyText: t("bknTrace.emptyStates.claims") }}
+                pagination={{ pageSize: 5, size: "small" }}
+                rowKey="id"
+                size="small"
+              />
+            </section>
+
+            <section className={styles.panel}>
+              <Typography.Title level={5}>{t("bknTrace.sections.evidenceDetails")}</Typography.Title>
+              <Table
+                columns={explainabilityColumns}
+                dataSource={evidenceRefs}
+                locale={{ emptyText: t("bknTrace.emptyStates.evidenceRefs") }}
+                pagination={{ pageSize: 8, size: "small" }}
+                rowKey="id"
+                size="small"
+              />
+            </section>
+
+            <section className={styles.panel}>
+              <Typography.Title level={5}>{t("bknTrace.sections.businessDetails")}</Typography.Title>
+              <Table
+                columns={explainabilityColumns}
+                dataSource={businessNodes}
+                locale={{ emptyText: t("bknTrace.emptyStates.businessNodes") }}
+                pagination={{ pageSize: 8, size: "small" }}
+                rowKey="id"
+                size="small"
+              />
             </section>
           </div>
         )}

--- a/src/modules/bkn-trace/services/trace.service.ts
+++ b/src/modules/bkn-trace/services/trace.service.ts
@@ -38,6 +38,75 @@ export type TraceGraphEdge = {
   parentSpanId: string;
 };
 
+type ExplainabilityFieldValue = boolean | number | string | null | undefined;
+
+export type TraceClaim = {
+  claim_hash?: ExplainabilityFieldValue;
+  claim_id?: ExplainabilityFieldValue;
+  claim_type?: ExplainabilityFieldValue;
+  operation?: ExplainabilityFieldValue;
+  subject_refs?: {
+    entity_kind?: ExplainabilityFieldValue;
+    model_name?: ExplainabilityFieldValue;
+    operation?: ExplainabilityFieldValue;
+    query_hash?: ExplainabilityFieldValue;
+    resource_id?: ExplainabilityFieldValue;
+    status?: ExplainabilityFieldValue;
+    [key: string]: unknown;
+  };
+  version_status?: ExplainabilityFieldValue;
+  visibility?: ExplainabilityFieldValue;
+  [key: string]: unknown;
+};
+
+export type TraceEvidenceRef = {
+  ref_id?: ExplainabilityFieldValue;
+  ref_type?: ExplainabilityFieldValue;
+  source_system?: ExplainabilityFieldValue;
+  summary?: {
+    catalog_id?: ExplainabilityFieldValue;
+    id?: ExplainabilityFieldValue;
+    kind?: ExplainabilityFieldValue;
+    message_hash?: ExplainabilityFieldValue;
+    model_name?: ExplainabilityFieldValue;
+    model_provider?: ExplainabilityFieldValue;
+    resource_id?: ExplainabilityFieldValue;
+    result_hash?: ExplainabilityFieldValue;
+    row_hash?: ExplainabilityFieldValue;
+    status?: ExplainabilityFieldValue;
+    version_status?: ExplainabilityFieldValue;
+    [key: string]: unknown;
+  };
+  summary_hash?: ExplainabilityFieldValue;
+  validity?: ExplainabilityFieldValue;
+  version_status?: ExplainabilityFieldValue;
+  visibility?: ExplainabilityFieldValue;
+  [key: string]: unknown;
+};
+
+export type TraceBusinessRef = Record<string, unknown>;
+
+export type TraceBusinessNode = {
+  claim_id?: ExplainabilityFieldValue;
+  id?: ExplainabilityFieldValue;
+  label?: ExplainabilityFieldValue;
+  node_type?: ExplainabilityFieldValue;
+  properties?: {
+    ref_type?: ExplainabilityFieldValue;
+    source_system?: ExplainabilityFieldValue;
+    summary_hash?: ExplainabilityFieldValue;
+    validity?: ExplainabilityFieldValue;
+    version_status?: ExplainabilityFieldValue;
+    visibility?: ExplainabilityFieldValue;
+    [key: string]: unknown;
+  };
+  version_status?: ExplainabilityFieldValue;
+  visibility?: ExplainabilityFieldValue;
+  [key: string]: unknown;
+};
+
+export type TraceBusinessEdge = Record<string, unknown>;
+
 export type GraphPage = {
   edgeCount: number;
   nodeCount: number;
@@ -59,9 +128,9 @@ export type TraceGraph = {
 
 export type EvidenceChain = {
   data: {
-    businessRefs: Array<Record<string, unknown>>;
-    claims: Array<Record<string, unknown>>;
-    evidenceRefs: Array<Record<string, unknown>>;
+    businessRefs: TraceBusinessRef[];
+    claims: TraceClaim[];
+    evidenceRefs: TraceEvidenceRef[];
   };
   page: GraphPage;
   partial: boolean;
@@ -73,8 +142,8 @@ export type EvidenceChain = {
 
 export type BusinessGraph = {
   data: {
-    edges: Array<Record<string, unknown>>;
-    nodes: Array<Record<string, unknown>>;
+    edges: TraceBusinessEdge[];
+    nodes: TraceBusinessNode[];
   };
   page: GraphPage;
   partial: boolean;
@@ -149,9 +218,9 @@ type BackendTraceGraph = {
 type BackendEvidenceChain = {
   "bkn.request.id"?: string;
   data?: {
-    business_refs?: Array<Record<string, unknown>>;
-    claims?: Array<Record<string, unknown>>;
-    evidence_refs?: Array<Record<string, unknown>>;
+    business_refs?: TraceBusinessRef[];
+    claims?: TraceClaim[];
+    evidence_refs?: TraceEvidenceRef[];
   };
   page?: BackendGraphPage;
   partial?: boolean;
@@ -163,8 +232,8 @@ type BackendEvidenceChain = {
 type BackendBusinessGraph = {
   "bkn.request.id"?: string;
   data?: {
-    edges?: Array<Record<string, unknown>>;
-    nodes?: Array<Record<string, unknown>>;
+    edges?: TraceBusinessEdge[];
+    nodes?: TraceBusinessNode[];
   };
   page?: BackendGraphPage;
   partial?: boolean;

--- a/src/modules/bkn-trace/utils/trace-explainability.test.ts
+++ b/src/modules/bkn-trace/utils/trace-explainability.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { businessRows, claimRows, evidenceRows } from "@/modules/bkn-trace/utils/trace-explainability";
+
+describe("trace explainability rows", () => {
+  it("formats model call claims without raw prompt or output", () => {
+    const rows = claimRows([
+      {
+        claim_id: "claim_1",
+        claim_type: "finding",
+        visibility: "visible",
+        version_status: "unversioned",
+        subject_refs: {
+          model_name: "gpt-demo",
+          operation: "model.chat.completions",
+          output_hash: "sha256:result",
+          prompt_hash: "sha256:prompt",
+          status: "success",
+        },
+      },
+    ]);
+
+    expect(rows[0]).toMatchObject({
+      id: "claim_1",
+      kind: "finding",
+      primary: "gpt-demo",
+      status: "success",
+    });
+    expect(JSON.stringify(rows)).not.toContain("prompt_hash");
+    expect(JSON.stringify(rows)).not.toContain("output_hash");
+  });
+
+  it("formats evidence refs from model and data producers", () => {
+    const rows = evidenceRows([
+      {
+        ref_id: "source:model:model_demo",
+        ref_type: "source_ref",
+        source_system: "mf-model-api",
+        summary: { kind: "model", model_name: "gpt-demo", model_provider: "openai" },
+        summary_hash: "sha256:model_hash",
+        validity: "observed",
+        version_status: "unversioned",
+        visibility: "visible",
+      },
+      {
+        ref_id: "resource_row:res_customer:row_1",
+        ref_type: "row_ref",
+        source_system: "vega-data",
+        summary: { kind: "resource_row", resource_id: "res_customer", row_hash: "sha256:very_long_hash_value_for_display" },
+        summary_hash: "sha256:row_hash",
+        validity: "observed",
+        version_status: "unversioned",
+        visibility: "visible",
+      },
+    ]);
+
+    expect(rows[0].primary).toBe("gpt-demo");
+    expect(rows[0].secondary).toContain("mf-model-api");
+    expect(rows[1].primary).toBe("res_customer");
+    expect(rows[1].kind).toBe("resource_row");
+  });
+
+  it("formats business graph nodes with visibility and version status", () => {
+    const rows = businessRows([
+      {
+        id: "business_ref:object:customer",
+        node_type: "object",
+        label: "Customer",
+        version_status: "versioned",
+        visibility: "visible",
+        properties: { source_system: "bkn-backend", validity: "resolved" },
+      },
+    ]);
+
+    expect(rows[0]).toMatchObject({
+      kind: "object",
+      primary: "Customer",
+      status: "resolved",
+      versionStatus: "versioned",
+      visibility: "visible",
+    });
+  });
+});

--- a/src/modules/bkn-trace/utils/trace-explainability.ts
+++ b/src/modules/bkn-trace/utils/trace-explainability.ts
@@ -5,6 +5,12 @@
  * Conditions. See LICENSE for the full text.
  */
 
+import type {
+  TraceBusinessNode,
+  TraceClaim,
+  TraceEvidenceRef,
+} from "@/modules/bkn-trace/services/trace.service";
+
 export type ExplainabilityRow = {
   id: string;
   kind: string;
@@ -15,7 +21,7 @@ export type ExplainabilityRow = {
   visibility: string;
 };
 
-export function claimRows(claims: Array<Record<string, unknown>>): ExplainabilityRow[] {
+export function claimRows(claims: TraceClaim[]): ExplainabilityRow[] {
   return claims.map((claim, index) => {
     const subjectRefs = objectField(claim, "subject_refs");
     const operation = stringField(subjectRefs, "operation") || stringField(claim, "operation");
@@ -41,7 +47,7 @@ export function claimRows(claims: Array<Record<string, unknown>>): Explainabilit
   });
 }
 
-export function evidenceRows(refs: Array<Record<string, unknown>>): ExplainabilityRow[] {
+export function evidenceRows(refs: TraceEvidenceRef[]): ExplainabilityRow[] {
   return refs.map((ref, index) => {
     const summary = objectField(ref, "summary");
     const kind = stringField(summary, "kind") || stringField(ref, "ref_type") || "evidence";
@@ -74,7 +80,7 @@ export function evidenceRows(refs: Array<Record<string, unknown>>): Explainabili
   });
 }
 
-export function businessRows(nodes: Array<Record<string, unknown>>): ExplainabilityRow[] {
+export function businessRows(nodes: TraceBusinessNode[]): ExplainabilityRow[] {
   return nodes.map((node, index) => {
     const properties = objectField(node, "properties");
     const nodeType = stringField(node, "node_type") || stringField(properties, "ref_type") || "business";

--- a/src/modules/bkn-trace/utils/trace-explainability.ts
+++ b/src/modules/bkn-trace/utils/trace-explainability.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export type ExplainabilityRow = {
+  id: string;
+  kind: string;
+  primary: string;
+  secondary: string;
+  status: string;
+  versionStatus: string;
+  visibility: string;
+};
+
+export function claimRows(claims: Array<Record<string, unknown>>): ExplainabilityRow[] {
+  return claims.map((claim, index) => {
+    const subjectRefs = objectField(claim, "subject_refs");
+    const operation = stringField(subjectRefs, "operation") || stringField(claim, "operation");
+    const model = stringField(subjectRefs, "model_name");
+    const resource = stringField(subjectRefs, "resource_id");
+    const schema = stringField(subjectRefs, "entity_kind");
+    const queryHash = stringField(subjectRefs, "query_hash");
+
+    return {
+      id: stringField(claim, "claim_id") || `claim:${index}`,
+      kind: stringField(claim, "claim_type") || "finding",
+      primary: firstNonEmpty(model, resource, schema, queryHash, operation, stringField(claim, "claim_hash")),
+      secondary: compactJoin([
+        operation,
+        model ? `model=${model}` : "",
+        resource ? `resource=${resource}` : "",
+        queryHash ? `query=${shortValue(queryHash)}` : "",
+      ]),
+      status: stringField(subjectRefs, "status") || "-",
+      versionStatus: stringField(claim, "version_status") || "-",
+      visibility: stringField(claim, "visibility") || "-",
+    };
+  });
+}
+
+export function evidenceRows(refs: Array<Record<string, unknown>>): ExplainabilityRow[] {
+  return refs.map((ref, index) => {
+    const summary = objectField(ref, "summary");
+    const kind = stringField(summary, "kind") || stringField(ref, "ref_type") || "evidence";
+    const primary = firstNonEmpty(
+      stringField(summary, "model_name"),
+      stringField(summary, "resource_id"),
+      stringField(summary, "catalog_id"),
+      stringField(summary, "id"),
+      stringField(ref, "ref_id"),
+    );
+    const secondary = compactJoin([
+      stringField(ref, "source_system"),
+      stringField(summary, "model_provider"),
+      stringField(summary, "status"),
+      shortValue(stringField(summary, "message_hash")),
+      shortValue(stringField(summary, "result_hash")),
+      shortValue(stringField(summary, "row_hash")),
+      shortValue(stringField(ref, "summary_hash")),
+    ]);
+
+    return {
+      id: stringField(ref, "ref_id") || `evidence:${index}`,
+      kind,
+      primary,
+      secondary,
+      status: stringField(summary, "status") || stringField(ref, "validity") || "-",
+      versionStatus: stringField(ref, "version_status") || stringField(summary, "version_status") || "-",
+      visibility: stringField(ref, "visibility") || "-",
+    };
+  });
+}
+
+export function businessRows(nodes: Array<Record<string, unknown>>): ExplainabilityRow[] {
+  return nodes.map((node, index) => {
+    const properties = objectField(node, "properties");
+    const nodeType = stringField(node, "node_type") || stringField(properties, "ref_type") || "business";
+    const label = stringField(node, "label");
+    const id = stringField(node, "id") || `business:${index}`;
+
+    return {
+      id,
+      kind: nodeType,
+      primary: firstNonEmpty(label, id),
+      secondary: compactJoin([
+        stringField(node, "claim_id"),
+        stringField(properties, "source_system"),
+        stringField(properties, "summary_hash") ? shortValue(stringField(properties, "summary_hash")) : "",
+      ]),
+      status: stringField(properties, "validity") || "-",
+      versionStatus: stringField(node, "version_status") || stringField(properties, "version_status") || "-",
+      visibility: stringField(node, "visibility") || stringField(properties, "visibility") || "-",
+    };
+  });
+}
+
+export function shortValue(value: string): string {
+  if (!value) {
+    return "";
+  }
+  if (value.length <= 28) {
+    return value;
+  }
+  return `${value.slice(0, 18)}...${value.slice(-6)}`;
+}
+
+function objectField(source: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = source[key];
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function stringField(source: Record<string, unknown>, key: string): string {
+  const value = source[key];
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function firstNonEmpty(...values: string[]): string {
+  return values.find((value) => value.trim()) ?? "-";
+}
+
+function compactJoin(values: string[]): string {
+  return values.filter((value) => value.trim()).join(" · ") || "-";
+}


### PR DESCRIPTION
## Summary
- move BKN Trace from a standalone route into the formal System Management path
- rename shell menu key from legacy traceai to bknTrace
- add explainability detail tables for claims, evidence refs, and business semantic nodes on the official BKN Trace page
- add typed explainability payload contracts and formatting tests for model/data/business evidence rows

## Verification
- pnpm exec vitest --run src/modules/bkn-trace
- pnpm exec tsc -b --pretty false
- pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
- pnpm audit --registry https://registry.npmjs.org --prod

## Notes
- This keeps using the BKN Trace API surfaces from PR 246; no raw OpenSearch access is added.
- The existing page remains the official BKN Trace page, not a separate test page.
- pnpm-workspace.yaml records a single React Router RSC Mode audit exception because Studio is a Vite SPA and no published react-router-dom patch version is currently available.