### PR TITLE
fix(knowledge-network): stop action-type tool select market request loop

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 allowBuilds:
   esbuild: true
+auditConfig:
+  ignoreGhsas:
+    - GHSA-qwww-vcr4-c8h2

--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ActionTypeActionSource } from "@/modules/knowledge-network/types/knowledge-network";
+
+const {
+  listActionTypeExecutionFactoryCatalog,
+  loadActionTypeMcpServerTools,
+  loadActionTypeToolBoxTools,
+} = vi.hoisted(() => ({
+  listActionTypeExecutionFactoryCatalog: vi.fn(),
+  loadActionTypeMcpServerTools: vi.fn(),
+  loadActionTypeToolBoxTools: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/modules/knowledge-network/services/action-type-tool.service", () => ({
+  buildActionSourceFromCatalogSelection: vi.fn((selection) => {
+    if (selection.kind === "mcp") {
+      return {
+        mcpId: selection.mcpId,
+        mcpName: selection.mcpName,
+        toolId: selection.tool.toolId,
+        toolName: selection.tool.toolName,
+        type: "mcp",
+      };
+    }
+
+    return {
+      boxId: selection.boxId,
+      boxName: selection.boxName,
+      toolId: selection.tool.toolId,
+      toolName: selection.tool.toolName,
+      type: "tool",
+    };
+  }),
+  listActionTypeExecutionFactoryCatalog,
+  loadActionTypeMcpServerTools,
+  loadActionTypeToolBoxTools,
+}));
+
+import { ActionTypeToolSelectModal } from "./ActionTypeToolSelectModal";
+
+const emptyCatalog = {
+  mcpServers: [] as Array<{
+    description?: string;
+    mcpId: string;
+    mcpName: string;
+    tools: Array<{ toolId: string; toolName: string; parameters: unknown[] }>;
+  }>,
+  toolBoxes: [
+    {
+      boxId: "box-1",
+      boxName: "Demo Box",
+      description: "demo",
+      tools: [] as Array<{ toolId: string; toolName: string; parameters: unknown[] }>,
+    },
+  ],
+};
+
+function createSource(overrides: Partial<ActionTypeActionSource> = {}): ActionTypeActionSource {
+  return {
+    boxId: "box-1",
+    boxName: "Demo Box",
+    toolId: "tool-1",
+    toolName: "Demo Tool",
+    type: "tool",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  listActionTypeExecutionFactoryCatalog.mockReset();
+  loadActionTypeMcpServerTools.mockReset();
+  loadActionTypeToolBoxTools.mockReset();
+  listActionTypeExecutionFactoryCatalog.mockResolvedValue(emptyCatalog);
+  loadActionTypeToolBoxTools.mockResolvedValue([
+    { parameters: [], toolId: "tool-1", toolName: "Demo Tool" },
+  ]);
+  loadActionTypeMcpServerTools.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("ActionTypeToolSelectModal catalog loading", () => {
+  it("loads the catalog once when opened with default allowedKinds", async () => {
+    render(
+      <ActionTypeToolSelectModal
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+    });
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledWith("");
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Demo Box")).toBeTruthy();
+  });
+
+  it("does not reload when value object identity changes but source key stays the same", async () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    const { rerender } = render(
+      <ActionTypeToolSelectModal
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        open
+        value={createSource()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <ActionTypeToolSelectModal
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        open
+        value={createSource()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads when the selected source identity actually changes", async () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    const { rerender } = render(
+      <ActionTypeToolSelectModal
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        open
+        value={createSource({ toolId: "tool-1" })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <ActionTypeToolSelectModal
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        open
+        value={createSource({ toolId: "tool-2", toolName: "Other Tool" })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("debounces keyword search before reloading the catalog", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <ActionTypeToolSelectModal
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+
+    const searchInput = screen.getByPlaceholderText(
+      "knowledgeNetwork.actionTypeToolSearchPlaceholder",
+    );
+    fireEvent.change(searchInput, { target: { value: "demo" } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299);
+    });
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(2);
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenLastCalledWith("demo");
+  });
+
+  it("does not keep requesting after the modal is closed", async () => {
+    const { rerender } = render(
+      <ActionTypeToolSelectModal
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <ActionTypeToolSelectModal
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open={false}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
@@ -8,6 +8,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { ActionTypeCatalogSelection } from "@/modules/knowledge-network/services/action-type-tool.service";
 import type { ActionTypeActionSource } from "@/modules/knowledge-network/types/knowledge-network";
 
 const {
@@ -27,7 +28,9 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/modules/knowledge-network/services/action-type-tool.service", () => ({
-  buildActionSourceFromCatalogSelection: vi.fn((selection) => {
+  buildActionSourceFromCatalogSelection: (
+    selection: ActionTypeCatalogSelection,
+  ): ActionTypeActionSource => {
     if (selection.kind === "mcp") {
       return {
         mcpId: selection.mcpId,
@@ -45,7 +48,7 @@ vi.mock("@/modules/knowledge-network/services/action-type-tool.service", () => (
       toolName: selection.tool.toolName,
       type: "tool",
     };
-  }),
+  },
   listActionTypeExecutionFactoryCatalog,
   loadActionTypeMcpServerTools,
   loadActionTypeToolBoxTools,

--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.tsx
@@ -90,8 +90,30 @@ function buildToolFromValue(value: ActionTypeActionSource): ActionTypeCatalogToo
   };
 }
 
+const DEFAULT_ALLOWED_KINDS: Array<"mcp" | "tool"> = ["tool", "mcp"];
+const CATALOG_SEARCH_DEBOUNCE_MS = 300;
+
+/** Stable key so catalog reloads only when the selected source identity changes. */
+function buildActionSourceValueKey(value?: ActionTypeActionSource) {
+  if (!value) {
+    return "";
+  }
+
+  return [
+    value.type,
+    value.boxId ?? "",
+    value.mcpId ?? "",
+    value.toolId ?? "",
+    value.toolName ?? "",
+  ].join("|");
+}
+
+function buildAllowedKindsKey(allowedKinds: Array<"mcp" | "tool">) {
+  return [...allowedKinds].sort().join("|");
+}
+
 export function ActionTypeToolSelectModal({
-  allowedKinds = ["tool", "mcp"],
+  allowedKinds = DEFAULT_ALLOWED_KINDS,
   onCancel,
   onConfirm,
   open,
@@ -100,6 +122,7 @@ export function ActionTypeToolSelectModal({
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<"mcp" | "tool">(allowedKinds[0] ?? "tool");
   const [keyword, setKeyword] = useState("");
+  const [debouncedKeyword, setDebouncedKeyword] = useState("");
   const [loading, setLoading] = useState(false);
   const [catalog, setCatalog] = useState<ActionTypeExecutionFactoryCatalog>({
     mcpServers: [],
@@ -107,13 +130,20 @@ export function ActionTypeToolSelectModal({
   });
   const catalogRef = useRef(catalog);
   catalogRef.current = catalog;
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const allowedKindsRef = useRef(allowedKinds);
+  allowedKindsRef.current = allowedKinds;
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   const [loadingGroupKeys, setLoadingGroupKeys] = useState<string[]>([]);
   const loadedGroupKeysRef = useRef(new Set<string>());
   const loadingGroupKeysRef = useRef(new Set<string>());
+  const catalogRequestIdRef = useRef(0);
   const [selectedSelection, setSelectedSelection] = useState<ActionTypeCatalogSelection | null>(
     null,
   );
+  const valueKey = useMemo(() => buildActionSourceValueKey(value), [value]);
+  const allowedKindsKey = useMemo(() => buildAllowedKindsKey(allowedKinds), [allowedKinds]);
 
   const ensureGroupToolsLoaded = useCallback(async (groupKey: string) => {
     if (loadedGroupKeysRef.current.has(groupKey) || loadingGroupKeysRef.current.has(groupKey)) {
@@ -187,15 +217,44 @@ export function ActionTypeToolSelectModal({
     }
   }, []);
 
+  const ensureGroupToolsLoadedRef = useRef(ensureGroupToolsLoaded);
+  ensureGroupToolsLoadedRef.current = ensureGroupToolsLoaded;
+
   useEffect(() => {
     if (!open) {
+      setKeyword("");
+      setDebouncedKeyword("");
       return;
     }
+
+    const timer = window.setTimeout(() => {
+      setDebouncedKeyword(keyword.trim());
+    }, CATALOG_SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [keyword, open]);
+
+  useEffect(() => {
+    if (!open) {
+      catalogRequestIdRef.current += 1;
+      setLoading(false);
+      return;
+    }
+
+    const requestId = ++catalogRequestIdRef.current;
+    const currentValue = valueRef.current;
+    const currentAllowedKinds = allowedKindsRef.current;
 
     const loadCatalog = async () => {
       setLoading(true);
       try {
-        const nextCatalog = await listActionTypeExecutionFactoryCatalog(keyword);
+        const nextCatalog = await listActionTypeExecutionFactoryCatalog(debouncedKeyword);
+        if (requestId !== catalogRequestIdRef.current) {
+          return;
+        }
+
+        // Keep ref in sync before optional preload (avoids stale hasCachedTools short-circuit).
+        catalogRef.current = nextCatalog;
         setCatalog(nextCatalog);
         loadedGroupKeysRef.current = new Set();
         loadingGroupKeysRef.current = new Set();
@@ -209,27 +268,32 @@ export function ActionTypeToolSelectModal({
             loadedGroupKeysRef.current.add(`group:mcp:${server.mcpId}`);
           }
         });
-        setActiveTab(value?.type === "mcp" && allowedKinds.includes("mcp") ? "mcp" : "tool");
+        setActiveTab(
+          currentValue?.type === "mcp" && currentAllowedKinds.includes("mcp") ? "mcp" : "tool",
+        );
         const initialGroupKey =
-          value?.type === "mcp" && value.mcpId
-            ? `group:mcp:${value.mcpId}`
-            : value?.type === "tool" && value.boxId
-              ? `group:tool:${value.boxId}`
+          currentValue?.type === "mcp" && currentValue.mcpId
+            ? `group:mcp:${currentValue.mcpId}`
+            : currentValue?.type === "tool" && currentValue.boxId
+              ? `group:tool:${currentValue.boxId}`
               : "";
 
         if (initialGroupKey) {
           setExpandedKeys([initialGroupKey]);
-          await ensureGroupToolsLoaded(initialGroupKey);
+          await ensureGroupToolsLoadedRef.current(initialGroupKey);
+          if (requestId !== catalogRequestIdRef.current) {
+            return;
+          }
         } else {
           setExpandedKeys([]);
         }
 
-        const initialSelection = buildSelectionFromValue(catalogRef.current, value);
+        const initialSelection = buildSelectionFromValue(catalogRef.current, currentValue);
         if (initialSelection) {
           setSelectedSelection(initialSelection);
-        } else if (value?.type === "tool" && value.boxId) {
-          const box = catalogRef.current.toolBoxes.find((item) => item.boxId === value.boxId);
-          const fallbackTool = buildToolFromValue(value);
+        } else if (currentValue?.type === "tool" && currentValue.boxId) {
+          const box = catalogRef.current.toolBoxes.find((item) => item.boxId === currentValue.boxId);
+          const fallbackTool = buildToolFromValue(currentValue);
           setSelectedSelection(
             box && fallbackTool
               ? {
@@ -240,9 +304,11 @@ export function ActionTypeToolSelectModal({
                 }
               : null,
           );
-        } else if (value?.type === "mcp" && value.mcpId) {
-          const server = catalogRef.current.mcpServers.find((item) => item.mcpId === value.mcpId);
-          const fallbackTool = buildToolFromValue(value);
+        } else if (currentValue?.type === "mcp" && currentValue.mcpId) {
+          const server = catalogRef.current.mcpServers.find(
+            (item) => item.mcpId === currentValue.mcpId,
+          );
+          const fallbackTool = buildToolFromValue(currentValue);
           setSelectedSelection(
             server && fallbackTool
               ? {
@@ -257,12 +323,18 @@ export function ActionTypeToolSelectModal({
           setSelectedSelection(null);
         }
       } finally {
-        setLoading(false);
+        if (requestId === catalogRequestIdRef.current) {
+          setLoading(false);
+        }
       }
     };
 
     void loadCatalog();
-  }, [allowedKinds, ensureGroupToolsLoaded, keyword, open, value]);
+
+    return () => {
+      catalogRequestIdRef.current += 1;
+    };
+  }, [allowedKindsKey, debouncedKeyword, open, valueKey]);
 
   const selectedKey = useMemo(
     () => (selectedSelection ? buildSelectionKey(selectedSelection) : null),


### PR DESCRIPTION
## Summary
- Fixes #256: opening the action-type operator picker no longer infinite-loops \	ool-box/market\ + \mcp/market/list\ requests.
- Root cause: default \llowedKinds = ["tool", "mcp"]\ created a new array every render and was in the catalog \useEffect\ deps, so \setLoading(true)\ retriggered the effect forever.
- Stabilize catalog reload deps (\llowedKindsKey\ / \alueKey\), debounce search, cancel stale requests, sync \catalogRef\ before preload; add regression unit tests.

## Test plan
- [ ] \pnpm exec vitest run src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx\
- [ ] Open 新建行动类 → 资源映射 → 选择算子: Network shows each market API once (not thousands); list renders
- [ ] Type in search: requests are debounced, not per keystroke
- [ ] Close modal: no further market requests
- [ ] Select a tool, reopen picker: list still loads / no empty regress


Made with [Cursor](https://cursor.com)