### PR TITLE
feat(knowledge-network): add metric query analysis dimension support

### DIFF
--- a/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.tsx
+++ b/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.tsx
@@ -81,6 +81,35 @@ function parseNumericValue(value: string | number | undefined) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function resolveBarChartColumns(result: MetricDataQueryResult) {
+  const reservedKeys = new Set([
+    "value",
+    "current",
+    "timestamp",
+    "growthValue",
+    "growthRate",
+    "metric",
+    "dimension",
+  ]);
+  const columnKeys = result.columns.map((column) => column.key);
+  const valueKey = columnKeys.find((key) => key === "value" || key === "current") ?? "value";
+  const labelKeys = columnKeys.filter((key) => !reservedKeys.has(key));
+
+  return { labelKeys, valueKey };
+}
+
+function formatBarLabel(
+  row: Record<string, string | number>,
+  labelKeys: string[],
+  index: number,
+) {
+  if (labelKeys.length === 0) {
+    return String(row.timestamp ?? row.dimension ?? index + 1);
+  }
+
+  return labelKeys.map((key) => String(row[key] ?? "--")).join(" / ");
+}
+
 function renderVisualResult(result: MetricDataQueryResult, metricName: string) {
   if (result.visualHint === "instant-card") {
     const value = result.rows[0]?.value ?? "--";
@@ -93,8 +122,7 @@ function renderVisualResult(result: MetricDataQueryResult, metricName: string) {
   }
 
   if (result.visualHint === "trend-bars" || result.visualHint === "proportion-bars") {
-    const labelKey = result.columns[0]?.key ?? "label";
-    const valueKey = result.columns[1]?.key ?? "value";
+    const { labelKeys, valueKey } = resolveBarChartColumns(result);
     const maxValue = Math.max(
       ...result.rows.map((row) => parseNumericValue(row[valueKey])),
       1,
@@ -103,7 +131,7 @@ function renderVisualResult(result: MetricDataQueryResult, metricName: string) {
     return (
       <div className={styles.barList}>
         {result.rows.map((row, index) => {
-          const label = String(row[labelKey] ?? index);
+          const label = formatBarLabel(row, labelKeys, index);
           const value = parseNumericValue(row[valueKey]);
           const width = `${Math.max((value / maxValue) * 100, 4)}%`;
 

--- a/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.tsx
+++ b/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.tsx
@@ -60,6 +60,7 @@ function showFillNullField(mode: MetricDataQueryMode | undefined) {
 }
 
 type MetricDataQueryPanelProps = {
+  analysisDimensionOptions?: string[];
   embedded?: boolean;
   metricId: string;
   metricName: string;
@@ -124,6 +125,7 @@ function renderVisualResult(result: MetricDataQueryResult, metricName: string) {
 }
 
 export function MetricDataQueryPanel({
+  analysisDimensionOptions = [],
   embedded = false,
   metricId,
   metricName,
@@ -284,6 +286,23 @@ export function MetricDataQueryPanel({
                 <InputNumber min={1} max={12} style={{ width: 90 }} />
               </Form.Item>
             </Space>
+          ) : null}
+          {analysisDimensionOptions.length > 0 ? (
+            <Form.Item
+              label={t("knowledgeNetwork.metricQueryAnalysisDimensions")}
+              name="analysisDimensions"
+            >
+              <Select
+                allowClear
+                mode="multiple"
+                options={analysisDimensionOptions.map((value) => ({
+                  label: value,
+                  value,
+                }))}
+                placeholder={t("knowledgeNetwork.metricQueryAnalysisDimensionsPlaceholder")}
+                style={{ minWidth: 220 }}
+              />
+            </Form.Item>
           ) : null}
           <Form.Item label={t("knowledgeNetwork.metricQueryLimit")} name="limit">
             <InputNumber min={1} max={1000} style={{ width: 100 }} />

--- a/src/modules/knowledge-network/locales/en-US/metric.ts
+++ b/src/modules/knowledge-network/locales/en-US/metric.ts
@@ -74,6 +74,8 @@ export const metricPart = {
     metricOrderByProperty: "Sort property",
     metricOrderByPropertyPlaceholder: "Select sort property",
     metricOrderDesc: "Descending",
+    metricQueryAnalysisDimensions: "Analysis dimensions",
+    metricQueryAnalysisDimensionsPlaceholder: "Select drill-down dimensions",
     metricQueryDuration: "Query took {{duration}} ms",
     metricQueryEmpty: "Run a query to see results.",
     metricQueryFillNull: "Fill null values",

--- a/src/modules/knowledge-network/locales/zh-CN/metric.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/metric.ts
@@ -72,6 +72,8 @@ export const metricPart = {
     metricOrderByProperty: "排序属性",
     metricOrderByPropertyPlaceholder: "选择排序属性",
     metricOrderDesc: "降序",
+    metricQueryAnalysisDimensions: "分析维度",
+    metricQueryAnalysisDimensionsPlaceholder: "选择下钻维度",
     metricQueryDuration: "查询耗时 {{duration}} ms",
     metricQueryEmpty: "请先执行查询。",
     metricQueryFillNull: "填充空值",

--- a/src/modules/knowledge-network/scenes/MetricDataQueryScene.tsx
+++ b/src/modules/knowledge-network/scenes/MetricDataQueryScene.tsx
@@ -85,7 +85,12 @@ export function MetricDataQueryScene({
       subtitle={t("knowledgeNetwork.metricDataQueryDescription")}
       title={t("knowledgeNetwork.metricDataQueryTitle", { name: detail.name })}
     >
-      <MetricDataQueryPanel metricId={detail.id} metricName={detail.name} networkId={networkId} />
+      <MetricDataQueryPanel
+        analysisDimensionOptions={detail.calculationFormula.analysisDimensions ?? []}
+        metricId={detail.id}
+        metricName={detail.name}
+        networkId={networkId}
+      />
     </KnowledgeNetworkResourceConfigShell>
   );
 }

--- a/src/modules/knowledge-network/scenes/MetricDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/MetricDetailScene.tsx
@@ -324,6 +324,7 @@ export function MetricDetailScene({
             </div>
           ) : (
             <MetricDataQueryPanel
+              analysisDimensionOptions={detail.calculationFormula.analysisDimensions ?? []}
               embedded
               metricId={detail.id}
               metricName={detail.name}

--- a/src/modules/knowledge-network/services/metric.service.test.ts
+++ b/src/modules/knowledge-network/services/metric.service.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { normalizeMetricDataResponse } from "@/modules/knowledge-network/services/metric.service";
+
+describe("normalizeMetricDataResponse", () => {
+  it("expands multi-series trend rows with prefixed dimension columns", () => {
+    const result = normalizeMetricDataResponse(
+      {
+        datas: [
+          {
+            labels: { warehouse_id: "WH001", item_code: "PART-1" },
+            time_strs: ["2024-01-01"],
+            values: [120],
+          },
+          {
+            labels: { warehouse_id: "WH002", item_code: "PART-2" },
+            time_strs: ["2024-01-01"],
+            values: [98],
+          },
+        ],
+      },
+      "trend",
+    );
+
+    expect(result.columns.map((column) => column.key)).toEqual([
+      "dim_warehouse_id",
+      "dim_item_code",
+      "timestamp",
+      "value",
+    ]);
+    expect(result.rows[0]).toMatchObject({
+      dim_item_code: "PART-1",
+      dim_warehouse_id: "WH001",
+      value: 120,
+    });
+    expect(result.rows[1]).toMatchObject({
+      dim_item_code: "PART-2",
+      dim_warehouse_id: "WH002",
+      value: 98,
+    });
+    expect(result.visualHint).toBe("trend-bars");
+  });
+
+  it("keeps reserved metric fields when a dimension property collides with value", () => {
+    const result = normalizeMetricDataResponse(
+      {
+        datas: [
+          {
+            labels: { value: "WH001", warehouse_id: "WH001" },
+            values: [42],
+          },
+        ],
+      },
+      "instant",
+    );
+
+    expect(result.rows[0]).toMatchObject({
+      dim_value: "WH001",
+      dim_warehouse_id: "WH001",
+      value: 42,
+    });
+  });
+});

--- a/src/modules/knowledge-network/services/metric.service.ts
+++ b/src/modules/knowledge-network/services/metric.service.ts
@@ -407,6 +407,12 @@ function buildMetricDataQueryPayload(params: MetricDataQueryParams) {
 
 type BackendMetricDataSeries = NonNullable<BackendMetricDataResponse["datas"]>[number];
 
+const METRIC_DIMENSION_COLUMN_PREFIX = "dim_";
+
+function toMetricDimensionColumnKey(propertyName: string) {
+  return `${METRIC_DIMENSION_COLUMN_PREFIX}${propertyName}`;
+}
+
 function normalizeLabelRecord(
   labels: BackendMetricDataSeries["labels"],
 ): Record<string, string | number> {
@@ -414,7 +420,9 @@ function normalizeLabelRecord(
     return {};
   }
 
-  return Object.fromEntries(Object.entries(labels));
+  return Object.fromEntries(
+    Object.entries(labels).map(([key, value]) => [toMetricDimensionColumnKey(key), value]),
+  );
 }
 
 function collectLabelKeys(datas: BackendMetricDataSeries[]): string[] {
@@ -426,7 +434,7 @@ function collectLabelKeys(datas: BackendMetricDataSeries[]): string[] {
     }
 
     for (const key of Object.keys(labels)) {
-      keys.add(key);
+      keys.add(toMetricDimensionColumnKey(key));
     }
   }
 
@@ -460,7 +468,7 @@ function resolveSeriesTimes(item: BackendMetricDataSeries) {
   return [];
 }
 
-function normalizeMetricDataResponse(
+export function normalizeMetricDataResponse(
   data: BackendMetricDataResponse | MetricDataQueryResult,
   mode: MetricDataQueryParams["mode"],
 ): MetricDataQueryResult {
@@ -555,8 +563,12 @@ function normalizeMetricDataResponse(
       for (let index = 0; index < values.length; index += 1) {
         rows.push({
           ...labelRecord,
-          growthRate: item.growth_rates?.[index] ?? "",
-          growthValue: item.growth_values?.[index] ?? "",
+          ...(mode === "sameperiod"
+            ? {
+                growthRate: item.growth_rates?.[index] ?? "",
+                growthValue: item.growth_values?.[index] ?? "",
+              }
+            : {}),
           timestamp: times[index] == null ? "--" : formatMetricTimeLabel(times[index]),
           [valueKey]: values[index] ?? "--",
         });

--- a/src/modules/knowledge-network/services/metric.service.ts
+++ b/src/modules/knowledge-network/services/metric.service.ts
@@ -398,7 +398,66 @@ function buildMetricDataQueryPayload(params: MetricDataQueryParams) {
     };
   }
 
+  if (params.analysisDimensions?.length) {
+    payload.analysis_dimensions = params.analysisDimensions;
+  }
+
   return payload;
+}
+
+type BackendMetricDataSeries = NonNullable<BackendMetricDataResponse["datas"]>[number];
+
+function normalizeLabelRecord(
+  labels: BackendMetricDataSeries["labels"],
+): Record<string, string | number> {
+  if (!labels || Array.isArray(labels)) {
+    return {};
+  }
+
+  return Object.fromEntries(Object.entries(labels));
+}
+
+function collectLabelKeys(datas: BackendMetricDataSeries[]): string[] {
+  const keys = new Set<string>();
+  for (const item of datas) {
+    const labels = item.labels;
+    if (!labels || Array.isArray(labels)) {
+      continue;
+    }
+
+    for (const key of Object.keys(labels)) {
+      keys.add(key);
+    }
+  }
+
+  return [...keys];
+}
+
+function hasAnalysisLabels(datas: BackendMetricDataSeries[]): boolean {
+  return datas.some((item) => {
+    const labels = item.labels;
+    if (!labels) {
+      return false;
+    }
+
+    if (Array.isArray(labels)) {
+      return labels.length > 0;
+    }
+
+    return Object.keys(labels).length > 0;
+  });
+}
+
+function resolveSeriesTimes(item: BackendMetricDataSeries) {
+  if (item.time_strs && item.time_strs.length > 0) {
+    return item.time_strs;
+  }
+
+  if (item.times && item.times.length > 0) {
+    return item.times;
+  }
+
+  return [];
 }
 
 function normalizeMetricDataResponse(
@@ -409,7 +468,8 @@ function normalizeMetricDataResponse(
     return data;
   }
 
-  const firstData = data.datas?.[0];
+  const datas = data.datas ?? [];
+  const firstData = datas[0];
   if (!firstData) {
     return {
       columns: [],
@@ -418,19 +478,52 @@ function normalizeMetricDataResponse(
     };
   }
 
+  const durationMs = data.overall_ms ?? data.vega_duration_ms;
+  const multiSeries = datas.length > 1 || hasAnalysisLabels(datas);
+  const labelKeys = multiSeries ? collectLabelKeys(datas) : [];
+
   if (mode === "instant") {
+    if (multiSeries) {
+      return {
+        columns: [
+          ...labelKeys.map((key) => ({ key, title: key })),
+          { key: "value", title: "Value" },
+        ],
+        durationMs,
+        rows: datas.map((item) => ({
+          ...normalizeLabelRecord(item.labels),
+          value: item.values?.[0] ?? "--",
+        })),
+      };
+    }
+
     return {
       columns: [
         { key: "metric", title: "Metric" },
         { key: "value", title: "Value" },
       ],
-      durationMs: data.overall_ms ?? data.vega_duration_ms,
+      durationMs,
       rows: [{ metric: "value", value: firstData.values?.[0] ?? "--" }],
       visualHint: "instant-card",
     };
   }
 
   if (mode === "proportion") {
+    if (multiSeries) {
+      return {
+        columns: [
+          ...labelKeys.map((key) => ({ key, title: key })),
+          { key: "value", title: "Value" },
+        ],
+        durationMs,
+        rows: datas.map((item) => ({
+          ...normalizeLabelRecord(item.labels),
+          value: item.proportions?.[0] ?? item.values?.[0] ?? "--",
+        })),
+        visualHint: "proportion-bars",
+      };
+    }
+
     const labels = Array.isArray(firstData.labels)
       ? firstData.labels
       : Object.values(firstData.labels ?? {});
@@ -441,7 +534,7 @@ function normalizeMetricDataResponse(
         { key: "dimension", title: "Dimension" },
         { key: "value", title: "Value" },
       ],
-      durationMs: data.overall_ms ?? data.vega_duration_ms,
+      durationMs,
       rows: values.map((value, index) => ({
         dimension: labels[index] ?? `Item ${index + 1}`,
         value,
@@ -450,12 +543,48 @@ function normalizeMetricDataResponse(
     };
   }
 
-  const times =
-    firstData.time_strs && firstData.time_strs.length > 0
-      ? firstData.time_strs
-      : firstData.times && firstData.times.length > 0
-        ? firstData.times
-        : [];
+  if (multiSeries) {
+    const valueKey = mode === "sameperiod" ? "current" : "value";
+    const rows: Array<Record<string, string | number>> = [];
+
+    for (const item of datas) {
+      const labelRecord = normalizeLabelRecord(item.labels);
+      const times = resolveSeriesTimes(item);
+      const values = item.values ?? [];
+
+      for (let index = 0; index < values.length; index += 1) {
+        rows.push({
+          ...labelRecord,
+          growthRate: item.growth_rates?.[index] ?? "",
+          growthValue: item.growth_values?.[index] ?? "",
+          timestamp: times[index] == null ? "--" : formatMetricTimeLabel(times[index]),
+          [valueKey]: values[index] ?? "--",
+        });
+      }
+    }
+
+    return {
+      columns:
+        mode === "sameperiod"
+          ? [
+              ...labelKeys.map((key) => ({ key, title: key })),
+              { key: "timestamp", title: "Timestamp" },
+              { key: "current", title: "Current" },
+              { key: "growthValue", title: "Growth value" },
+              { key: "growthRate", title: "Growth rate" },
+            ]
+          : [
+              ...labelKeys.map((key) => ({ key, title: key })),
+              { key: "timestamp", title: "Timestamp" },
+              { key: "value", title: "Value" },
+            ],
+      durationMs,
+      rows,
+      visualHint: "trend-bars",
+    };
+  }
+
+  const times = resolveSeriesTimes(firstData);
   const valueKey = mode === "sameperiod" ? "current" : "value";
 
   return {
@@ -471,7 +600,7 @@ function normalizeMetricDataResponse(
             { key: "timestamp", title: "Timestamp" },
             { key: "value", title: "Value" },
           ],
-    durationMs: data.overall_ms ?? data.vega_duration_ms,
+    durationMs,
     rows: (firstData.values ?? []).map((value, index) => ({
       growthRate: firstData.growth_rates?.[index] ?? "",
       growthValue: firstData.growth_values?.[index] ?? "",

--- a/src/modules/knowledge-network/types/metric.ts
+++ b/src/modules/knowledge-network/types/metric.ts
@@ -172,6 +172,7 @@ export type MetricDataQueryTimeRange =
   | "custom";
 
 export type MetricDataQueryParams = {
+  analysisDimensions?: string[];
   customEndTime?: unknown;
   customStartTime?: unknown;
   fillNull?: boolean;


### PR DESCRIPTION
## What Changed

- [x] Metric data query payload sends `analysis_dimensions`
- [x] Metric query panel adds analysis dimension multi-select from metric definition
- [x] Query result normalization renders multi-series rows with dimension labels

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#436
- Background: Studio could not request or display metric drill-down dimensions even after backend support is added.

---

## How

- Extend `MetricDataQueryParams` and `buildMetricDataQueryPayload` with `analysis_dimensions`.
- Pass metric definition analysis dimensions into `MetricDataQueryPanel` from detail/query scenes.
- Flatten multi-series API responses into table rows with dimension columns.
- Breaking changes: none.

---

## Testing

- [x] Unit tests passed locally (n/a for this UI/service slice)
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
- `npx tsc -b` passed locally.
- End-to-end verification depends on deploying openbkn-ai/bkn-foundry PR for #436.

---

## Risk & Rollback

- Potential risks: low; UI only appears when a metric defines analysis dimensions.
- Rollback plan: revert this PR.

---

## Additional Notes

- Depends on backend fix in openbkn-ai/bkn-foundry#436 for end-to-end drill-down behavior.

Made with [Cursor](https://cursor.com)