### PR TITLE
fix(knowledge-network): 工具型逻辑属性确定无反应 (#261)

### DIFF
--- a/src/modules/knowledge-network/components/object-type/logic-attribute/ObjectTypeLogicAttributeEditDrawer.tsx
+++ b/src/modules/knowledge-network/components/object-type/logic-attribute/ObjectTypeLogicAttributeEditDrawer.tsx
@@ -30,9 +30,12 @@ import {
   LOGIC_ATTRIBUTE_TYPE_OPTIONS,
   PARAMETER_SOURCE_OPTIONS,
   VALUE_FROM_OPTIONS,
+  asOptionalString,
   buildToolLogicParameterSettings,
   extractLeafParams,
   isEmptyExceptZero,
+  isToolLogicBindingComplete,
+  readLogicAttributeToolBinding,
 } from "./constants";
 import {
   listObjectTypeLogicMetricModels,
@@ -88,10 +91,6 @@ type LogicAttributeFormValues = {
 
 function createParameterId() {
   return `param-${Math.random().toString(36).slice(2, 10)}`;
-}
-
-function asOptionalString(value: unknown) {
-  return typeof value === "string" ? value : undefined;
 }
 
 export function ObjectTypeLogicAttributeEditDrawer({
@@ -405,11 +404,21 @@ export function ObjectTypeLogicAttributeEditDrawer({
     if (!type) {
       return;
     }
-    const formValues = form.getFieldsValue();
-    if (
-      (type !== "tool" && !resourceId) ||
-      (type === "tool" && (!formValues.boxId || !formValues.toolId))
-    ) {
+    // Ant Design 5: getFieldsValue() only returns registered fields by default.
+    // boxId/toolId/resourceName are kept via hidden Form.Items; true still covers
+    // any store values set before registration during the same tick.
+    const formValues = form.getFieldsValue(true) as LogicAttributeFormValues;
+    const toolBinding = readLogicAttributeToolBinding({
+      boxId: formValues.boxId,
+      resourceName: formValues.resourceName,
+      toolId: formValues.toolId,
+    });
+    if (type !== "tool" && !resourceId) {
+      void message.error(t("knowledgeNetwork.pleaseSelect"));
+      return;
+    }
+    if (type === "tool" && !isToolLogicBindingComplete(toolBinding)) {
+      void message.error(t("knowledgeNetwork.objectTypeLogicToolSelect"));
       return;
     }
     if (type === "tool" && settingList.length > 0 && validateParams()) {
@@ -420,16 +429,16 @@ export function ObjectTypeLogicAttributeEditDrawer({
     const resourceName =
       type === "metric"
         ? metricModelList.find((item) => item.id === resourceId)?.name
-        : formValues.resourceName;
+        : toolBinding.resourceName;
 
     onOk({
       comment: formValues.comment,
       dataSource: {
-        boxId: formValues.boxId,
+        boxId: toolBinding.boxId,
         id: type === "tool" ? undefined : resourceId,
         name: resourceName ?? "",
         resultPath: formValues.resultPath,
-        toolId: formValues.toolId,
+        toolId: toolBinding.toolId,
         type,
       },
       displayName: formValues.displayName ?? "",
@@ -585,6 +594,16 @@ export function ObjectTypeLogicAttributeEditDrawer({
       width={1000}
     >
       <Form form={form} layout="vertical">
+        {/* Register tool binding fields so getFieldsValue() includes them (antd 5). */}
+        <Form.Item hidden name="boxId">
+          <Input />
+        </Form.Item>
+        <Form.Item hidden name="toolId">
+          <Input />
+        </Form.Item>
+        <Form.Item hidden name="resourceName">
+          <Input />
+        </Form.Item>
         <Row gutter={16}>
           <Col span={6}>
             <Form.Item
@@ -648,7 +667,10 @@ export function ObjectTypeLogicAttributeEditDrawer({
           </Col>
           <Col span={6}>
             {type === "tool" ? (
-              <Form.Item label={t("knowledgeNetwork.objectTypeLogicAttributeResource")}>
+              <Form.Item
+                label={t("knowledgeNetwork.objectTypeLogicAttributeResource")}
+                required
+              >
                 <Input
                   onClick={() => setToolSelectorOpen(true)}
                   placeholder={t("knowledgeNetwork.objectTypeLogicToolSelect")}

--- a/src/modules/knowledge-network/components/object-type/logic-attribute/constants.test.ts
+++ b/src/modules/knowledge-network/components/object-type/logic-attribute/constants.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import { buildToolLogicParameterSettings } from "./constants";
+import {
+  buildToolLogicParameterSettings,
+  isToolLogicBindingComplete,
+  readLogicAttributeToolBinding,
+} from "./constants";
 
 describe("buildToolLogicParameterSettings", () => {
   it("merges saved tool parameter mappings into the input schema", () => {
@@ -94,5 +98,36 @@ describe("buildToolLogicParameterSettings", () => {
         valueFrom: "const",
       },
     ]);
+  });
+});
+
+describe("readLogicAttributeToolBinding", () => {
+  it("treats antd default getFieldsValue() shape (no boxId/toolId) as incomplete", () => {
+    // Reproduces #261: tool name may be visible while registered-only values omit binding ids.
+    const registeredOnly = {
+      displayName: "Risk Score",
+      name: "risk_score",
+      type: "tool",
+    };
+
+    expect(isToolLogicBindingComplete(readLogicAttributeToolBinding(registeredOnly))).toBe(false);
+  });
+
+  it("accepts complete tool binding when boxId and toolId are present", () => {
+    const allValues = {
+      boxId: "box-1",
+      displayName: "Risk Score",
+      name: "risk_score",
+      resourceName: "Demo Tool",
+      toolId: "tool-1",
+      type: "tool",
+    };
+
+    expect(readLogicAttributeToolBinding(allValues)).toEqual({
+      boxId: "box-1",
+      resourceName: "Demo Tool",
+      toolId: "tool-1",
+    });
+    expect(isToolLogicBindingComplete(readLogicAttributeToolBinding(allValues))).toBe(true);
   });
 });

--- a/src/modules/knowledge-network/components/object-type/logic-attribute/constants.ts
+++ b/src/modules/knowledge-network/components/object-type/logic-attribute/constants.ts
@@ -46,6 +46,36 @@ export function isEmptyExceptZero(value: unknown) {
   return value === undefined || value === null || value === "";
 }
 
+export function asOptionalString(value: unknown) {
+  return typeof value === "string" ? value : undefined;
+}
+
+export type LogicAttributeToolBinding = {
+  boxId?: string;
+  resourceName?: string;
+  toolId?: string;
+};
+
+/**
+ * Read tool binding from Ant Design form values.
+ * Callers must pass values that include unregistered store fields
+ * (`getFieldsValue(true)` or registered hidden `Form.Item`s). Default
+ * `getFieldsValue()` omits `boxId`/`toolId` and looks like a silent no-op submit.
+ */
+export function readLogicAttributeToolBinding(
+  formValues: Record<string, unknown>,
+): LogicAttributeToolBinding {
+  return {
+    boxId: asOptionalString(formValues.boxId),
+    resourceName: asOptionalString(formValues.resourceName),
+    toolId: asOptionalString(formValues.toolId),
+  };
+}
+
+export function isToolLogicBindingComplete(binding: LogicAttributeToolBinding) {
+  return Boolean(binding.boxId && binding.toolId);
+}
+
 export function deduplicateByName<T extends { name: string }>(items: T[]) {
   const map = new Map<string, T>();
   items.forEach((item) => {


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Fix tool-type logic attribute submit silently no-op (Ant Design Form unregistered `boxId`/`toolId`)
- [x] Register hidden form fields + read via `getFieldsValue(true)`
- [x] Show error when tool is not selected; add regression unit tests

Closes #261

---

## Why

- Related Issue: [Issue #261](https://github.com/openbkn-ai/bkn-studio/issues/261)
- Background: Adding a tool-type logic property and clicking OK appeared to do nothing because `getFieldsValue()` omitted unregistered `boxId`/`toolId`, then submit returned silently.

---

## How

- Key implementation points:
  - Hidden `Form.Item`s for `boxId` / `toolId` / `resourceName`
  - Submit uses `getFieldsValue(true)` + `readLogicAttributeToolBinding` / `isToolLogicBindingComplete`
  - Missing tool binding shows `message.error` instead of silent return
- Breaking changes (API, config, database, etc.): None

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
- `pnpm exec vitest --run src/modules/knowledge-network/components/object-type/logic-attribute/constants.test.ts` (4 passed)
- eslint on touched files with `--max-warnings 0`

---

## Risk & Rollback

- Potential risks: Low; frontend form submit path only for tool-type logic properties
- Rollback plan: Revert this PR

---

## Additional Notes

- Metric-type logic property path unchanged (`resourceId` already registered)