### PR TITLE
fix(data-catalog): show effective field analyzers

### DIFF
--- a/src/modules/data-catalog/components/BuildTaskDetailDrawer.tsx
+++ b/src/modules/data-catalog/components/BuildTaskDetailDrawer.tsx
@@ -44,6 +44,22 @@ function renderFieldList(fields: string[]) {
   );
 }
 
+function renderFulltextAnalyzers(analyzers: Record<string, string>) {
+  const entries = Object.entries(analyzers);
+  if (entries.length === 0) {
+    return "—";
+  }
+  return (
+    <span className={styles.fieldList}>
+      {entries.map(([field, analyzer]) => (
+        <span className={styles.fieldText} key={field}>
+          {field}: {analyzer}
+        </span>
+      ))}
+    </span>
+  );
+}
+
 export function BuildTaskDetailDrawer({
   onClose,
   open,
@@ -194,7 +210,12 @@ export function BuildTaskDetailDrawer({
             </Descriptions.Item>
             {task.fulltextFields.length > 0 ? (
               <Descriptions.Item label={t("dataCatalog.task.fields.fulltextAnalyzer")}>
-                {task.fulltextAnalyzer || "standard"}
+                {renderFulltextAnalyzers(
+                  task.fulltextAnalyzers ??
+                    Object.fromEntries(
+                      task.fulltextFields.map((field) => [field, task.fulltextAnalyzer || "standard"]),
+                    ),
+                )}
               </Descriptions.Item>
             ) : null}
             <Descriptions.Item label={t("dataCatalog.task.fields.embeddingModel")}>

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
@@ -354,6 +354,16 @@ export function IndexConfigFormPanel({
     () => Object.keys(eligibleFulltextAnalyzerGroups).filter((field) => (eligibleFulltextAnalyzerGroups[field]?.length ?? 0) > 0),
     [eligibleFulltextAnalyzerGroups],
   );
+  const fulltextAnalyzerOverrides = useMemo(
+    () =>
+      Object.entries(eligibleFulltextAnalyzerGroups).flatMap(([field, groups]) =>
+        groups
+          .map((feature) => feature.value?.trim())
+          .filter((analyzer): analyzer is string => Boolean(analyzer))
+          .map((analyzer) => `${field}: ${analyzer}`),
+      ),
+    [eligibleFulltextAnalyzerGroups],
+  );
 
   const toggleField = (
     field: string,
@@ -870,6 +880,15 @@ export function IndexConfigFormPanel({
                   <div className={formStyles.fieldHint}>
                     {t("dataCatalog.build.fulltextAnalyzerHint")}
                   </div>
+                  {fulltextAnalyzerOverrides.length > 0 ? (
+                    <Alert
+                      message={t("dataCatalog.build.fulltextAnalyzerOverrides", {
+                        overrides: fulltextAnalyzerOverrides.join(", "),
+                      })}
+                      showIcon
+                      type="info"
+                    />
+                  ) : null}
                 </div>
                 <div className={formStyles.resourceDefaultItem}>
                   <div className={formStyles.resourceDefaultItemHead}>

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -281,6 +281,8 @@ export const dataCatalogEnUS = {
       resourceDefaultsTitle: "Resource Defaults",
       resourceDefaultsHint:
         "Features use these defaults when no override is selected.",
+      fulltextAnalyzerOverrides:
+        "Field analyzers override the default: {{overrides}}. Update them in Field Feature Config or choose Use default.",
       fieldEmbeddingModel: "Embedding Model",
       fieldFulltextAnalyzer: "Analyzer",
       inheritDefaultAnalyzer: "Use default",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -264,6 +264,7 @@ export const dataCatalogZhCN = {
       configCannotBuild: "缺少特征",
       resourceDefaultsTitle: "资源默认配置",
       resourceDefaultsHint: "特征未单独指定时使用默认值。",
+      fulltextAnalyzerOverrides: "字段级分词器覆盖默认值：{{overrides}}。请在字段特征配置中修改或选择“跟随默认”。",
       fieldEmbeddingModel: "Embedding 模型",
       fieldFulltextAnalyzer: "分词器",
       inheritDefaultAnalyzer: "跟随默认",

--- a/src/modules/data-catalog/services/build-task.service.test.ts
+++ b/src/modules/data-catalog/services/build-task.service.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { snapshotFieldsOf } from "@/modules/data-catalog/services/build-task.service";
+
+describe("snapshotFieldsOf", () => {
+  it("retains the effective analyzer for every fulltext field", () => {
+    const snapshot = snapshotFieldsOf({
+      id: "task-1",
+      index_config: {
+        features: {
+          coupon_code: { fulltext: { analyzer: "standard" } },
+          status: { fulltext: { analyzer: "hanlp_index" } },
+        },
+      },
+    });
+
+    expect(snapshot.fulltextAnalyzer).toBe("standard");
+    expect(snapshot.fulltextAnalyzers).toEqual({
+      coupon_code: "standard",
+      status: "hanlp_index",
+    });
+  });
+});

--- a/src/modules/data-catalog/services/build-task.service.test.ts
+++ b/src/modules/data-catalog/services/build-task.service.test.ts
@@ -27,4 +27,22 @@ describe("snapshotFieldsOf", () => {
       status: "hanlp_index",
     });
   });
+
+  it("uses standard for fulltext fields without an analyzer in the snapshot", () => {
+    const snapshot = snapshotFieldsOf({
+      id: "task-1",
+      index_config: {
+        features: {
+          title: { fulltext: {} },
+          status: { fulltext: { config: { analyzer: "hanlp_index" } } },
+        },
+      },
+    });
+
+    expect(snapshot.fulltextAnalyzer).toBe("standard");
+    expect(snapshot.fulltextAnalyzers).toEqual({
+      title: "standard",
+      status: "hanlp_index",
+    });
+  });
 });

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -178,13 +178,11 @@ export function snapshotFieldsOf(item: BackendBuildTask) {
       if (feature.fulltext) {
         fulltextFields.push(fieldName);
         const analyzer =
-          feature.fulltext.analyzer ?? feature.fulltext.config?.analyzer ?? "";
+          feature.fulltext.analyzer ?? feature.fulltext.config?.analyzer ?? "standard";
         if (analyzer && !fulltextAnalyzer) {
           fulltextAnalyzer = analyzer;
         }
-        if (analyzer) {
-          fulltextAnalyzers[fieldName] = analyzer;
-        }
+        fulltextAnalyzers[fieldName] = analyzer;
       }
     }
 
@@ -201,12 +199,10 @@ export function snapshotFieldsOf(item: BackendBuildTask) {
 
   // 兼容旧扁平字段（过渡期 / mock）
   const fulltextFields = splitFields(item.fulltext_fields);
-  const fulltextAnalyzer = item.fulltext_analyzer ?? "";
+  const fulltextAnalyzer = item.fulltext_analyzer || "standard";
   const fulltextAnalyzers: Record<string, string> = {};
-  if (fulltextAnalyzer) {
-    for (const field of fulltextFields) {
-      fulltextAnalyzers[field] = fulltextAnalyzer;
-    }
+  for (const field of fulltextFields) {
+    fulltextAnalyzers[field] = fulltextAnalyzer;
   }
   return {
     buildKeyFields: splitFields(item.build_key_fields),

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -148,7 +148,7 @@ export function embeddingStateOf(task: BuildTask): IndexHealthState {
   );
 }
 
-function snapshotFieldsOf(item: BackendBuildTask) {
+export function snapshotFieldsOf(item: BackendBuildTask) {
   const snapshot = item.index_config;
   if (snapshot?.features || snapshot?.build_key_fields) {
     const embeddingFields: string[] = [];
@@ -156,6 +156,7 @@ function snapshotFieldsOf(item: BackendBuildTask) {
     let embeddingModel = "";
     let modelDimensions = 0;
     let fulltextAnalyzer = "";
+    const fulltextAnalyzers: Record<string, string> = {};
 
     for (const [fieldName, feature] of Object.entries(snapshot.features ?? {})) {
       if (feature.vector) {
@@ -181,6 +182,9 @@ function snapshotFieldsOf(item: BackendBuildTask) {
         if (analyzer && !fulltextAnalyzer) {
           fulltextAnalyzer = analyzer;
         }
+        if (analyzer) {
+          fulltextAnalyzers[fieldName] = analyzer;
+        }
       }
     }
 
@@ -191,17 +195,27 @@ function snapshotFieldsOf(item: BackendBuildTask) {
       modelDimensions,
       fulltextFields,
       fulltextAnalyzer,
+      fulltextAnalyzers,
     };
   }
 
   // 兼容旧扁平字段（过渡期 / mock）
+  const fulltextFields = splitFields(item.fulltext_fields);
+  const fulltextAnalyzer = item.fulltext_analyzer ?? "";
+  const fulltextAnalyzers: Record<string, string> = {};
+  if (fulltextAnalyzer) {
+    for (const field of fulltextFields) {
+      fulltextAnalyzers[field] = fulltextAnalyzer;
+    }
+  }
   return {
     buildKeyFields: splitFields(item.build_key_fields),
     embeddingFields: splitFields(item.embedding_fields),
     embeddingModel: item.embedding_model ?? "",
     modelDimensions: item.model_dimensions ?? 0,
-    fulltextFields: splitFields(item.fulltext_fields),
-    fulltextAnalyzer: item.fulltext_analyzer ?? "",
+    fulltextFields,
+    fulltextAnalyzer,
+    fulltextAnalyzers,
   };
 }
 
@@ -248,6 +262,7 @@ function mapBuildTask(item: BackendBuildTask): BuildTask {
     modelDimensions: snapshot.modelDimensions,
     fulltextFields: snapshot.fulltextFields,
     fulltextAnalyzer: snapshot.fulltextAnalyzer,
+    fulltextAnalyzers: snapshot.fulltextAnalyzers,
     totalCount: item.total_count ?? 0,
     syncedCount: synced,
     vectorizedCount: vectorized,

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -124,6 +124,8 @@ export type BuildTask = {
   /** completed 但向量化没建满（vectorized < synced），索引不可用/部分可用。 */
   embeddingDegraded: boolean;
   fulltextAnalyzer: string;
+  /** 任务快照中每个全文字段最终使用的 analyzer。 */
+  fulltextAnalyzers?: Record<string, string>;
   fulltextFields: string[];
   error: string | null;
   /** 后端 failure_detail：向量化失败的详细原因，tooltip 展开用。 */


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Display the effective analyzer for every full-text field in build-task details.
- [x] Surface field-level analyzer overrides in the index configuration view.
- [x] Add a regression test for mixed field-level analyzers in a task snapshot.
- [ ] Docs/doc 1 — not required; user-facing behavior is self-explanatory in the existing UI.

---

## Why

- Related Issue: [Issue #247](https://github.com/openbkn-ai/bkn-studio/issues/247)
- Related Feature: N/A
- Background: A resource default could display `standard` while a field retained `hanlp_index`, hiding the analyzer actually used by OpenSearch.

---

## How

- Key implementation points: Preserve per-field analyzer values when mapping build-task snapshots; render them in the details drawer; explicitly list override fields under resource defaults.
- Breaking changes (API, config, database, etc.): No API, configuration, or database changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; this change is frontend mapping and UI behavior.
- [ ] Verified in test environment — not performed; no deployment requested.

Test notes:

- Passed license-header check, ESLint with zero warnings, full Vitest suite, TypeScript build, Vite production build, and production dependency audit.

---

## Risk & Rollback

- Potential risks: Existing task payloads without field-level snapshots use the prior task-level analyzer as a compatibility fallback.
- Rollback plan: Revert commit `d2ab9c1` to restore the prior summary-only display.

---

## Additional Notes

- Backend validation is tracked separately in [openbkn-ai/bkn-foundry#468](https://github.com/openbkn-ai/bkn-foundry/pull/468).
- Closes #247.