### PR TITLE
fix(knowledge-network): map lowercase action types in list

### DIFF
--- a/src/modules/knowledge-network/services/mappers/action-type-list.test.ts
+++ b/src/modules/knowledge-network/services/mappers/action-type-list.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  mapActionKind,
+  mapActionType,
+  mapConceptGroupDetail,
+} from "@/modules/knowledge-network/services/mappers";
+
+describe("action type list mapper", () => {
+  it("maps backend lowercase action types to frontend action kinds", () => {
+    expect(mapActionKind("add")).toBe("create");
+    expect(mapActionKind("modify")).toBe("update");
+    expect(mapActionKind("delete")).toBe("delete");
+    expect(mapActionKind("notify")).toBe("notify");
+  });
+
+  it("keeps supporting backend uppercase action types", () => {
+    expect(mapActionKind("ADD")).toBe("create");
+    expect(mapActionKind("UPDATE")).toBe("update");
+    expect(mapActionKind("DELETE")).toBe("delete");
+    expect(mapActionKind("NOTIFY")).toBe("notify");
+  });
+
+  it("maps modify records to update for the action type list", () => {
+    expect(
+      mapActionType({
+        action_type: "modify",
+        id: "action-1",
+        name: "Edit order",
+      }).actionKind,
+    ).toBe("update");
+  });
+
+  it("maps concept group action type entries with lowercase backend enums", () => {
+    expect(
+      mapConceptGroupDetail({
+        action_types: [
+          {
+            action_type: "modify",
+            id: "action-1",
+            name: "Edit order",
+          },
+        ],
+        id: "group-1",
+        name: "Order group",
+      }).actionTypes[0]?.actionKind,
+    ).toBe("update");
+  });
+});

--- a/src/modules/knowledge-network/services/mappers/backend-types.ts
+++ b/src/modules/knowledge-network/services/mappers/backend-types.ts
@@ -16,6 +16,16 @@ export type BackendAccountInfo = {
   name?: string | null;
 };
 
+export type BackendActionTypeEnum =
+  | "ADD"
+  | "UPDATE"
+  | "DELETE"
+  | "NOTIFY"
+  | "add"
+  | "modify"
+  | "delete"
+  | "notify";
+
 export type BackendKnowledgeNetwork = {
   code?: string;
   color?: string;
@@ -143,7 +153,17 @@ export type BackendSmallModel = {
 };
 
 export type BackendConceptGroup = {
-  action_types?: BackendObjectType[];
+  action_types?: Array<
+    BackendObjectType & {
+      action_type?: BackendActionTypeEnum;
+      object_type?: {
+        color?: string;
+        icon?: string;
+        id?: string;
+        name?: string;
+      };
+    }
+  >;
   color?: string;
   comment?: string;
   id: string;
@@ -192,7 +212,7 @@ export type BackendActionType = {
     tool_name?: string;
     type?: "manual" | "mcp" | "tool";
   };
-  action_type?: "ADD" | "UPDATE" | "DELETE" | "NOTIFY" | "add" | "modify" | "delete" | "notify";
+  action_type?: BackendActionTypeEnum;
   affect?: {
     comment?: string;
     object_type_id?: string;

--- a/src/modules/knowledge-network/services/mappers/index.ts
+++ b/src/modules/knowledge-network/services/mappers/index.ts
@@ -356,7 +356,7 @@ function mapConceptGroupRelationItem(
 
 function mapConceptGroupActionItem(
   item: BackendObjectType & {
-    action_type?: string;
+    action_type?: BackendActionType["action_type"];
     object_type?: {
       color?: string;
       icon?: string;
@@ -365,11 +365,9 @@ function mapConceptGroupActionItem(
     };
   },
 ): ConceptGroupRelatedItem {
-  const actionKind = item.action_type as KnowledgeNetworkActionTypeKind | undefined;
-
   return {
     ...mapConceptGroupRelatedItem(item),
-    actionKind,
+    actionKind: mapActionKind(item.action_type),
     boundObjectType: mapConceptGroupResourceRef(item.object_type),
   };
 }
@@ -428,12 +426,16 @@ export function mapActionKind(
   value?: BackendActionType["action_type"],
 ): KnowledgeNetworkActionTypeKind {
   switch (value) {
+    case "modify":
     case "UPDATE":
       return "update";
+    case "delete":
     case "DELETE":
       return "delete";
+    case "notify":
     case "NOTIFY":
       return "notify";
+    case "add":
     case "ADD":
     default:
       return "create";


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Fix knowledge-network action type list mapping for lowercase backend enums.
- [x] Add regression coverage for action type list and concept group action entries.
- [ ] Docs/doc 1 - N/A, behavior-only mapper fix.

---

## Why

- Related Issue: Closes #223
- Related Feature: N/A
- Background: The create/edit flow writes lowercase backend `action_type` values such as `add`, `modify`, and `delete`. The action type list mapper only handled uppercase legacy values, so lowercase `modify` fell through to the default `create` kind and displayed as 添加 instead of 编辑.

---

## How

- Key implementation points:
  - Introduced a shared `BackendActionTypeEnum` DTO type covering both uppercase legacy values and lowercase backend contract values.
  - Updated `mapActionKind` to map lowercase `modify`, `delete`, `notify`, and `add` consistently with uppercase values.
  - Updated concept group action entries to call `mapActionKind` instead of casting backend `action_type` directly.
  - Added mapper regression tests for lowercase/uppercase values, list records, and concept group action entries.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment - N/A, no shared test environment was used for this local mapper fix.

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run` (102 files, 434 tests passed)
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` (exits 0; reports 1 high vulnerability ignored by current audit policy)

---

## Risk & Rollback

- Potential risks: Low. The change is limited to frontend DTO typing and backend-to-frontend enum mapping. Unknown or missing action types still default to `create`, preserving previous fallback behavior.
- Rollback plan: Revert this commit to restore the previous list mapper behavior.

---

## Additional Notes

- Vite build still reports existing chunk-size and dynamic/static import warnings unrelated to this change.
- Vitest output still includes existing Ant Design deprecation and jsdom `getComputedStyle` warnings unrelated to this change.