### PR TITLE
fix(knowledge-network): resolve action source display names

### DIFF
--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionConfigTable.module.css
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionConfigTable.module.css
@@ -33,6 +33,13 @@
   font-weight: 500;
 }
 
+.loadingSource {
+  align-items: center;
+  color: rgba(0, 0, 0, 0.45);
+  display: inline-flex;
+  gap: 8px;
+}
+
 .propertyCell {
   align-items: center;
   display: inline-flex;

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionConfigTable.module.css
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionConfigTable.module.css
@@ -40,6 +40,10 @@
   gap: 8px;
 }
 
+.unavailableSource {
+  color: rgba(0, 0, 0, 0.45);
+}
+
 .propertyCell {
   align-items: center;
   display: inline-flex;

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionConfigTable.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionConfigTable.tsx
@@ -15,7 +15,7 @@ import { FieldTypeIcon } from "@/modules/knowledge-network/components/object-typ
 import { getKnowledgeNetworkObjectTypeDetail } from "@/modules/knowledge-network/services/knowledge-network.service";
 import {
   needsActionTypeActionSourceDisplayResolution,
-  resolveActionTypeActionSourceDisplay,
+  resolveActionTypeActionSourceDisplayWithTimeout,
 } from "@/modules/knowledge-network/services/action-type-tool.service";
 import type {
   ActionTypeActionSource,
@@ -41,6 +41,7 @@ export function ActionTypeExecutionConfigTable({
   const [resolvedActionSource, setResolvedActionSource] = useState<
     ActionTypeActionSource | undefined
   >(detail.executionConfig.actionSource);
+  const [actionSourceResolutionFailed, setActionSourceResolutionFailed] = useState(false);
   const [isResolvingActionSource, setIsResolvingActionSource] = useState(false);
 
   useEffect(() => {
@@ -69,17 +70,26 @@ export function ActionTypeExecutionConfigTable({
     setResolvedActionSource(actionSource);
 
     if (!actionSource || !needsActionTypeActionSourceDisplayResolution(actionSource)) {
+      setActionSourceResolutionFailed(false);
       setIsResolvingActionSource(false);
       return;
     }
 
     let cancelled = false;
+    setActionSourceResolutionFailed(false);
     setIsResolvingActionSource(true);
     const resolveDisplay = async () => {
       try {
-        const resolved = await resolveActionTypeActionSourceDisplay(actionSource);
+        const resolved = await resolveActionTypeActionSourceDisplayWithTimeout(actionSource);
         if (!cancelled) {
           setResolvedActionSource(resolved);
+          setActionSourceResolutionFailed(
+            needsActionTypeActionSourceDisplayResolution(resolved),
+          );
+        }
+      } catch {
+        if (!cancelled) {
+          setActionSourceResolutionFailed(true);
         }
       } finally {
         if (!cancelled) {
@@ -126,7 +136,10 @@ export function ActionTypeExecutionConfigTable({
     },
   ];
 
-  const sourceLabel = isResolvingActionSource
+  const sourceUnavailable =
+    actionSourceResolutionFailed &&
+    needsActionTypeActionSourceDisplayResolution(resolvedActionSource);
+  const sourceLabel = isResolvingActionSource || sourceUnavailable
     ? ""
     : getActionSourceDisplayName(resolvedActionSource) || detail.executionConfig.sourceName;
 
@@ -141,7 +154,11 @@ export function ActionTypeExecutionConfigTable({
               {t("knowledgeNetwork.actionTypeExecutionSourceResolving")}
             </strong>
           ) : (
-            <strong>{sourceLabel || t("knowledgeNetwork.actionTypeEmptyValue")}</strong>
+            <strong className={sourceUnavailable ? styles.unavailableSource : undefined}>
+              {sourceUnavailable
+                ? t("knowledgeNetwork.actionTypeExecutionSourceUnavailable")
+                : sourceLabel || t("knowledgeNetwork.actionTypeEmptyValue")}
+            </strong>
           )}
         </div>
       </div>

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionConfigTable.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionConfigTable.tsx
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Table } from "antd";
+import { Spin, Table } from "antd";
 import type { TableProps } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -13,7 +13,12 @@ import { useTranslation } from "react-i18next";
 import { getActionSourceDisplayName } from "@/modules/knowledge-network/utils/action-type-execution";
 import { FieldTypeIcon } from "@/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon";
 import { getKnowledgeNetworkObjectTypeDetail } from "@/modules/knowledge-network/services/knowledge-network.service";
+import {
+  needsActionTypeActionSourceDisplayResolution,
+  resolveActionTypeActionSourceDisplay,
+} from "@/modules/knowledge-network/services/action-type-tool.service";
 import type {
+  ActionTypeActionSource,
   ActionTypeDetail,
   ActionTypeExecutionParameter,
 } from "@/modules/knowledge-network/types/knowledge-network";
@@ -33,6 +38,10 @@ export function ActionTypeExecutionConfigTable({
 }: ActionTypeExecutionConfigTableProps) {
   const { t } = useTranslation();
   const [propertyTypeMap, setPropertyTypeMap] = useState<Record<string, string>>({});
+  const [resolvedActionSource, setResolvedActionSource] = useState<
+    ActionTypeActionSource | undefined
+  >(detail.executionConfig.actionSource);
+  const [isResolvingActionSource, setIsResolvingActionSource] = useState(false);
 
   useEffect(() => {
     const loadProperties = async () => {
@@ -54,6 +63,37 @@ export function ActionTypeExecutionConfigTable({
 
     void loadProperties();
   }, [detail.objectTypeId, networkId]);
+
+  useEffect(() => {
+    const actionSource = detail.executionConfig.actionSource;
+    setResolvedActionSource(actionSource);
+
+    if (!actionSource || !needsActionTypeActionSourceDisplayResolution(actionSource)) {
+      setIsResolvingActionSource(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsResolvingActionSource(true);
+    const resolveDisplay = async () => {
+      try {
+        const resolved = await resolveActionTypeActionSourceDisplay(actionSource);
+        if (!cancelled) {
+          setResolvedActionSource(resolved);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsResolvingActionSource(false);
+        }
+      }
+    };
+
+    void resolveDisplay();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [detail.executionConfig.actionSource]);
 
   const rows = useMemo<ParameterRow[]>(
     () =>
@@ -86,16 +126,23 @@ export function ActionTypeExecutionConfigTable({
     },
   ];
 
-  const sourceLabel =
-    getActionSourceDisplayName(detail.executionConfig.actionSource) ||
-    detail.executionConfig.sourceName;
+  const sourceLabel = isResolvingActionSource
+    ? ""
+    : getActionSourceDisplayName(resolvedActionSource) || detail.executionConfig.sourceName;
 
   return (
     <div className={styles.root}>
       <div className={styles.metaRow}>
         <div>
           <span>{t("knowledgeNetwork.actionTypeExecutionSourceLabel")}</span>
-          <strong>{sourceLabel || t("knowledgeNetwork.actionTypeEmptyValue")}</strong>
+          {isResolvingActionSource ? (
+            <strong className={styles.loadingSource}>
+              <Spin size="small" />
+              {t("knowledgeNetwork.actionTypeExecutionSourceResolving")}
+            </strong>
+          ) : (
+            <strong>{sourceLabel || t("knowledgeNetwork.actionTypeEmptyValue")}</strong>
+          )}
         </div>
       </div>
       <Table<ParameterRow>

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "react-i18next";
 import { getKnowledgeNetworkObjectTypeDetail } from "@/modules/knowledge-network/services/knowledge-network.service";
 import {
   needsActionTypeActionSourceDisplayResolution,
-  resolveActionTypeActionSourceDisplay,
+  resolveActionTypeActionSourceDisplayWithTimeout,
   resolveActionTypeToolInputSchema,
 } from "@/modules/knowledge-network/services/action-type-tool.service";
 import type {
@@ -45,8 +45,6 @@ type ActionTypeExecutionEditorProps = {
 
 type DisplayResolutionStatus = "failed" | "idle" | "loading";
 
-const DISPLAY_RESOLUTION_TIMEOUT_MS = 3000;
-
 function buildActionSourceKey(actionSource?: ActionTypeExecutionConfig["actionSource"]) {
   if (!actionSource) {
     return "";
@@ -62,24 +60,6 @@ function buildActionSourceKey(actionSource?: ActionTypeExecutionConfig["actionSo
   return actionSource.boxId && actionSource.toolId
     ? `tool:${actionSource.boxId}:${actionSource.toolId}`
     : "";
-}
-
-async function withDisplayResolutionTimeout<T>(promise: Promise<T>): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error("Action source display resolution timed out")),
-      DISPLAY_RESOLUTION_TIMEOUT_MS,
-    );
-  });
-
-  try {
-    return await Promise.race([promise, timeout]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
 }
 
 export function ActionTypeExecutionEditor({
@@ -217,9 +197,8 @@ export function ActionTypeExecutionEditor({
 
     const resolveDisplay = async () => {
       try {
-        const resolvedSource = await withDisplayResolutionTimeout(
-          resolveActionTypeActionSourceDisplay(actionSource),
-        );
+        const resolvedSource =
+          await resolveActionTypeActionSourceDisplayWithTimeout(actionSource);
         if (cancelled) {
           return;
         }

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
@@ -11,7 +11,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { getKnowledgeNetworkObjectTypeDetail } from "@/modules/knowledge-network/services/knowledge-network.service";
-import { resolveActionTypeToolInputSchema } from "@/modules/knowledge-network/services/action-type-tool.service";
+import {
+  needsActionTypeActionSourceDisplayResolution,
+  resolveActionTypeActionSourceDisplay,
+  resolveActionTypeToolInputSchema,
+} from "@/modules/knowledge-network/services/action-type-tool.service";
 import type {
   ActionTypeExecutionConfig,
   ActionTypeExecutionParameter,
@@ -39,20 +43,43 @@ type ActionTypeExecutionEditorProps = {
   onChange: (value: ActionTypeExecutionConfig) => void;
 };
 
+type DisplayResolutionStatus = "failed" | "idle" | "loading";
+
+const DISPLAY_RESOLUTION_TIMEOUT_MS = 3000;
+
 function buildActionSourceKey(actionSource?: ActionTypeExecutionConfig["actionSource"]) {
   if (!actionSource) {
     return "";
   }
 
   if (actionSource.type === "mcp") {
-    return actionSource.mcpId && actionSource.toolName
-      ? `mcp:${actionSource.mcpId}:${actionSource.toolName}`
+    const toolKey = actionSource.toolId || actionSource.toolName;
+    return actionSource.mcpId && toolKey
+      ? `mcp:${actionSource.mcpId}:${toolKey}`
       : "";
   }
 
   return actionSource.boxId && actionSource.toolId
     ? `tool:${actionSource.boxId}:${actionSource.toolId}`
     : "";
+}
+
+async function withDisplayResolutionTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("Action source display resolution timed out")),
+      DISPLAY_RESOLUTION_TIMEOUT_MS,
+    );
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 export function ActionTypeExecutionEditor({
@@ -65,7 +92,19 @@ export function ActionTypeExecutionEditor({
   const valueRef = useRef(value);
   const onChangeRef = useRef(onChange);
   const loadedSourceKeyRef = useRef("");
+  const resolvedDisplaySourceKeyRef = useRef("");
+  const displayActionSourceRef = useRef<ActionTypeExecutionConfig["actionSource"]>(
+    value.actionSource,
+  );
+  const [displayActionSource, setDisplayActionSource] =
+    useState<ActionTypeExecutionConfig["actionSource"]>(value.actionSource);
   const [inputSchema, setInputSchema] = useState<ActionTypeToolInputParam[]>([]);
+  const [displayResolutionStatus, setDisplayResolutionStatus] =
+    useState<DisplayResolutionStatus>(() =>
+      needsActionTypeActionSourceDisplayResolution(value.actionSource)
+        ? "loading"
+        : "idle",
+    );
   const [schemaLoading, setSchemaLoading] = useState(false);
   const [propertyOptions, setPropertyOptions] = useState<
     Array<{
@@ -80,11 +119,17 @@ export function ActionTypeExecutionEditor({
 
   valueRef.current = value;
   onChangeRef.current = onChange;
+  displayActionSourceRef.current = displayActionSource;
 
   const sourceKey = useMemo(
     () => buildActionSourceKey(value.actionSource),
     [value.actionSource],
   );
+  const sourceNeedsDisplayResolution = needsActionTypeActionSourceDisplayResolution(
+    value.actionSource,
+  );
+  const displaySourceNeedsResolution =
+    needsActionTypeActionSourceDisplayResolution(displayActionSource);
 
   useEffect(() => {
     const loadProperties = async () => {
@@ -112,6 +157,7 @@ export function ActionTypeExecutionEditor({
   useEffect(() => {
     if (!sourceKey || !value.actionSource) {
       loadedSourceKeyRef.current = "";
+      resolvedDisplaySourceKeyRef.current = "";
       setInputSchema([]);
       return;
     }
@@ -141,10 +187,85 @@ export function ActionTypeExecutionEditor({
     void loadSchema();
   }, [sourceKey, value.actionSource]);
 
+  useEffect(() => {
+    const actionSource = valueRef.current.actionSource;
+    if (!sourceKey || !actionSource) {
+      resolvedDisplaySourceKeyRef.current = "";
+      setDisplayActionSource(actionSource);
+      setDisplayResolutionStatus("idle");
+      return;
+    }
+
+    if (!sourceNeedsDisplayResolution) {
+      resolvedDisplaySourceKeyRef.current = sourceKey;
+      setDisplayActionSource(actionSource);
+      setDisplayResolutionStatus("idle");
+      return;
+    }
+
+    if (
+      resolvedDisplaySourceKeyRef.current === sourceKey &&
+      !needsActionTypeActionSourceDisplayResolution(displayActionSourceRef.current)
+    ) {
+      setDisplayResolutionStatus("idle");
+      return;
+    }
+
+    let cancelled = false;
+    setDisplayActionSource(actionSource);
+    setDisplayResolutionStatus("loading");
+
+    const resolveDisplay = async () => {
+      try {
+        const resolvedSource = await withDisplayResolutionTimeout(
+          resolveActionTypeActionSourceDisplay(actionSource),
+        );
+        if (cancelled) {
+          return;
+        }
+
+        const nextSourceName = getActionSourceDisplayName(resolvedSource);
+        const currentSourceName = getActionSourceDisplayName(valueRef.current.actionSource);
+        setDisplayActionSource(resolvedSource);
+        resolvedDisplaySourceKeyRef.current = sourceKey;
+        if (!nextSourceName || nextSourceName === currentSourceName) {
+          setDisplayResolutionStatus(
+            needsActionTypeActionSourceDisplayResolution(resolvedSource)
+              ? "failed"
+              : "idle",
+          );
+          return;
+        }
+
+        onChangeRef.current({
+          ...valueRef.current,
+          actionSource: resolvedSource,
+          sourceName: nextSourceName,
+          sourceType: resolvedSource.type,
+        });
+        setDisplayResolutionStatus("idle");
+      } catch {
+        if (!cancelled) {
+          resolvedDisplaySourceKeyRef.current = sourceKey;
+          setDisplayResolutionStatus("failed");
+        }
+      }
+    };
+
+    void resolveDisplay();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceKey, sourceNeedsDisplayResolution]);
+
   const hasSource = Boolean(getActionSourceDisplayName(value.actionSource) || value.sourceName.trim());
 
   const handleSourceChange = (nextSource: ActionTypeExecutionConfig["actionSource"]) => {
     loadedSourceKeyRef.current = "";
+    resolvedDisplaySourceKeyRef.current = "";
+    setDisplayActionSource(nextSource);
+    setDisplayResolutionStatus("idle");
     setInputSchema([]);
 
     if (!nextSource) {
@@ -168,6 +289,9 @@ export function ActionTypeExecutionEditor({
 
   const handleSourceSelected = (nextSource: NonNullable<ActionTypeExecutionConfig["actionSource"]>) => {
     loadedSourceKeyRef.current = "";
+    resolvedDisplaySourceKeyRef.current = "";
+    setDisplayActionSource(nextSource);
+    setDisplayResolutionStatus("idle");
     setInputSchema([]);
     onChange({
       ...value,
@@ -190,9 +314,15 @@ export function ActionTypeExecutionEditor({
       <div className={styles.operatorSection}>
         <div className={styles.operatorLabel}>{t("knowledgeNetwork.actionTypeOperatorLabel")}</div>
         <ActionTypeSourcePicker
+          loading={displayResolutionStatus === "loading"}
           onChange={handleSourceChange}
           onSourceSelected={handleSourceSelected}
-          value={value.actionSource}
+          unresolved={
+            displayResolutionStatus === "failed" &&
+            sourceNeedsDisplayResolution &&
+            displaySourceNeedsResolution
+          }
+          value={displayActionSource}
         />
       </div>
 

--- a/src/modules/knowledge-network/components/action-type/ActionTypeSourcePicker.module.css
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeSourcePicker.module.css
@@ -46,6 +46,26 @@
   white-space: nowrap;
 }
 
+.loadingValue {
+  align-items: center;
+  color: rgba(0, 0, 0, 0.45);
+  display: inline-flex;
+  flex: 1;
+  gap: 8px;
+  min-width: 0;
+  text-align: left;
+}
+
+.unresolvedValue {
+  color: rgba(0, 0, 0, 0.45);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .suffixIcon {
   color: rgba(0, 0, 0, 0.25);
   flex-shrink: 0;

--- a/src/modules/knowledge-network/components/action-type/ActionTypeSourcePicker.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeSourcePicker.tsx
@@ -6,6 +6,7 @@
  */
 
 import { CloseCircleFilled, DownOutlined } from "@ant-design/icons";
+import { Spin } from "antd";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -17,20 +18,27 @@ import { getActionSourceDisplayName } from "@/modules/knowledge-network/utils/ac
 import styles from "./ActionTypeSourcePicker.module.css";
 
 type ActionTypeSourcePickerProps = {
+  loading?: boolean;
   onSourceSelected?: (source: ActionTypeActionSource) => void;
+  unresolved?: boolean;
   value?: ActionTypeActionSource;
   onChange?: (value?: ActionTypeActionSource) => void;
 };
 
 export function ActionTypeSourcePicker({
+  loading = false,
   onSourceSelected,
+  unresolved = false,
   value,
   onChange,
 }: ActionTypeSourcePickerProps) {
   const { t } = useTranslation();
   const [modalOpen, setModalOpen] = useState(false);
 
-  const displayName = useMemo(() => getActionSourceDisplayName(value), [value]);
+  const displayName = useMemo(
+    () => (loading || unresolved ? "" : getActionSourceDisplayName(value)),
+    [loading, unresolved, value],
+  );
 
   const handleConfirm = (source: ActionTypeActionSource) => {
     onChange?.(source);
@@ -52,7 +60,34 @@ export function ActionTypeSourcePicker({
         role="button"
         tabIndex={0}
       >
-        {displayName ? (
+        {loading ? (
+          <>
+            <span className={styles.loadingValue}>
+              <Spin size="small" />
+              {t("knowledgeNetwork.actionTypeExecutionSourceResolving")}
+            </span>
+            <CloseCircleFilled
+              className={styles.closeIcon}
+              onClick={(event) => {
+                event.stopPropagation();
+                onChange?.(undefined);
+              }}
+            />
+          </>
+        ) : unresolved ? (
+          <>
+            <span className={styles.unresolvedValue}>
+              {t("knowledgeNetwork.actionTypeExecutionSourceUnavailable")}
+            </span>
+            <CloseCircleFilled
+              className={styles.closeIcon}
+              onClick={(event) => {
+                event.stopPropagation();
+                onChange?.(undefined);
+              }}
+            />
+          </>
+        ) : displayName ? (
           <>
             <span className={styles.value} title={displayName}>
               {displayName}

--- a/src/modules/knowledge-network/locales/en-US/action-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/action-type.ts
@@ -116,6 +116,8 @@ export const actiontypePart = {
     actionTypeConditionOperation_exist: "Exists",
     actionTypeConditionOperation_not_exist: "Does not exist",
     actionTypeExecutionSourceLabel: "Execution source",
+    actionTypeExecutionSourceResolving: "Loading",
+    actionTypeExecutionSourceUnavailable: "Execution source unavailable",
     actionTypeExecutionSelectSource: "Select a tool or execution source",
     actionTypeExecutionSelectSourceTitle: "Select execution source",
     actionTypeExecutionMappingHint: "Map tool parameters to bound object data properties.",

--- a/src/modules/knowledge-network/locales/zh-CN/action-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/action-type.ts
@@ -107,6 +107,8 @@ export const actiontypePart = {
     actionTypeConditionOperation_exist: "存在",
     actionTypeConditionOperation_not_exist: "不存在",
     actionTypeExecutionSourceLabel: "执行来源",
+    actionTypeExecutionSourceResolving: "加载中",
+    actionTypeExecutionSourceUnavailable: "执行来源不可用",
     actionTypeExecutionSelectSource: "选择工具或执行来源",
     actionTypeExecutionSelectSourceTitle: "选择执行来源",
     actionTypeExecutionMappingHint: "将工具参数映射到绑定对象的数据属性。",

--- a/src/modules/knowledge-network/services/action-type-tool.service.test.ts
+++ b/src/modules/knowledge-network/services/action-type-tool.service.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const executionFactoryMocks = vi.hoisted(() => ({
+  getMcpMarket: vi.fn(),
+  getToolDetail: vi.fn(),
+  getToolbox: vi.fn(),
+  getToolboxMarket: vi.fn(),
+  listMcpMarket: vi.fn(),
+  listMcpTools: vi.fn(),
+  listToolboxMarket: vi.fn(),
+  listTools: vi.fn(),
+}));
+
+vi.mock("@/modules/execution-factory/services/mcp.service", () => ({
+  getMcpMarket: executionFactoryMocks.getMcpMarket,
+  listMcpMarket: executionFactoryMocks.listMcpMarket,
+  listMcpTools: executionFactoryMocks.listMcpTools,
+}));
+
+vi.mock("@/modules/execution-factory/services/tool.service", () => ({
+  getToolDetail: executionFactoryMocks.getToolDetail,
+  listTools: executionFactoryMocks.listTools,
+}));
+
+vi.mock("@/modules/execution-factory/services/toolbox.service", () => ({
+  getToolbox: executionFactoryMocks.getToolbox,
+  getToolboxMarket: executionFactoryMocks.getToolboxMarket,
+  listToolboxMarket: executionFactoryMocks.listToolboxMarket,
+}));
+
+async function resolveWithMockCatalog(
+  source: Parameters<
+    typeof import("./action-type-tool.service").resolveActionTypeActionSourceDisplay
+  >[0],
+) {
+  const { resolveActionTypeActionSourceDisplay } = await import(
+    "./action-type-tool.service"
+  );
+  const promise = resolveActionTypeActionSourceDisplay(source);
+  await vi.advanceTimersByTimeAsync(200);
+  return promise;
+}
+
+describe("resolveActionTypeActionSourceDisplay", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "true");
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves toolbox and tool names when only persisted IDs are available", async () => {
+    const result = await resolveWithMockCatalog({
+      boxId: "box-risk",
+      toolId: "block_order_tool",
+      type: "tool",
+    });
+
+    expect(result).toMatchObject({
+      boxId: "box-risk",
+      boxName: "Risk Tools",
+      toolId: "block_order_tool",
+      toolName: "Block Order",
+      type: "tool",
+    });
+  });
+
+  it("resolves MCP server name without changing the persisted tool name", async () => {
+    const { MOCK_EXECUTION_FACTORY_CATALOG } = await import(
+      "@/modules/knowledge-network/services/mock/action-type-tool-catalog"
+    );
+    const result = await resolveWithMockCatalog({
+      mcpId: "mcp-filesystem",
+      toolName: "read_file",
+      type: "mcp",
+    });
+
+    expect(result).toMatchObject({
+      mcpId: "mcp-filesystem",
+      mcpName: MOCK_EXECUTION_FACTORY_CATALOG.mcpServers[0]?.mcpName,
+      toolName: "read_file",
+      type: "mcp",
+    });
+  });
+
+  it("keeps IDs as a degraded display when the source cannot be resolved", async () => {
+    const source = {
+      boxId: "missing-box",
+      toolId: "missing-tool",
+      type: "tool" as const,
+    };
+
+    await expect(resolveWithMockCatalog(source)).resolves.toEqual(source);
+  });
+
+  it("falls back to toolbox and tool detail APIs when catalog lists miss persisted IDs", async () => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+
+    executionFactoryMocks.listToolboxMarket.mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 100,
+      total: 0,
+    });
+    executionFactoryMocks.listMcpMarket.mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 100,
+      total: 0,
+    });
+    executionFactoryMocks.listTools.mockResolvedValue({
+      boxId: "box-direct",
+      items: [],
+      page: 1,
+      pageSize: 100,
+      total: 0,
+    });
+    executionFactoryMocks.getToolboxMarket.mockRejectedValue(new Error("not in market"));
+    executionFactoryMocks.getToolbox.mockResolvedValue({
+      boxId: "box-direct",
+      name: "Direct Toolbox",
+      status: "published",
+    });
+    executionFactoryMocks.getToolDetail.mockResolvedValue({
+      name: "Direct Tool",
+      toolId: "tool-direct",
+    });
+
+    const { resolveActionTypeActionSourceDisplay } = await import(
+      "./action-type-tool.service"
+    );
+
+    await expect(
+      resolveActionTypeActionSourceDisplay({
+        boxId: "box-direct",
+        toolId: "tool-direct",
+        type: "tool",
+      }),
+    ).resolves.toMatchObject({
+      boxId: "box-direct",
+      boxName: "Direct Toolbox",
+      toolId: "tool-direct",
+      toolName: "Direct Tool",
+      type: "tool",
+    });
+  });
+});

--- a/src/modules/knowledge-network/services/action-type-tool.service.test.ts
+++ b/src/modules/knowledge-network/services/action-type-tool.service.test.ts
@@ -157,4 +157,31 @@ describe("resolveActionTypeActionSourceDisplay", () => {
       type: "tool",
     });
   });
+
+  it("times out display resolution when action source lookup is slow", async () => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+
+    executionFactoryMocks.getToolbox.mockReturnValue(new Promise(() => {}));
+    executionFactoryMocks.getToolDetail.mockReturnValue(new Promise(() => {}));
+
+    const { resolveActionTypeActionSourceDisplayWithTimeout } = await import(
+      "./action-type-tool.service"
+    );
+
+    const promise = resolveActionTypeActionSourceDisplayWithTimeout(
+      {
+        boxId: "box-timeout",
+        toolId: "tool-timeout",
+        type: "tool",
+      },
+      100,
+    );
+
+    const expectation = expect(promise).rejects.toThrow(
+      "Action source display resolution timed out",
+    );
+    await vi.advanceTimersByTimeAsync(100);
+    await expectation;
+  });
 });

--- a/src/modules/knowledge-network/services/action-type-tool.service.ts
+++ b/src/modules/knowledge-network/services/action-type-tool.service.ts
@@ -40,6 +40,7 @@ import {
 
 /** Backend validates PageSize with a max tag; Vega uses 100. */
 const CATALOG_PAGE_SIZE = 100;
+export const ACTION_TYPE_ACTION_SOURCE_DISPLAY_TIMEOUT_MS = 3000;
 
 type MarketSearchToolBox = {
   box_desc?: string;
@@ -684,6 +685,27 @@ export async function resolveActionTypeActionSourceDisplay(
   }
 
   return actionSource;
+}
+
+export async function resolveActionTypeActionSourceDisplayWithTimeout(
+  actionSource: ActionTypeActionSource,
+  timeoutMs = ACTION_TYPE_ACTION_SOURCE_DISPLAY_TIMEOUT_MS,
+): Promise<ActionTypeActionSource> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("Action source display resolution timed out")),
+      timeoutMs,
+    );
+  });
+
+  try {
+    return await Promise.race([resolveActionTypeActionSourceDisplay(actionSource), timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 export function buildActionSourceFromCatalogSelection(

--- a/src/modules/knowledge-network/services/action-type-tool.service.ts
+++ b/src/modules/knowledge-network/services/action-type-tool.service.ts
@@ -6,9 +6,14 @@
  */
 
 import { http } from "@/framework/request/http";
-import { listMcpMarket, listMcpTools } from "@/modules/execution-factory/services/mcp.service";
+import {
+  getMcpMarket,
+  listMcpMarket,
+  listMcpTools,
+} from "@/modules/execution-factory/services/mcp.service";
 import { getToolDetail, listTools } from "@/modules/execution-factory/services/tool.service";
 import {
+  getToolbox,
   getToolboxMarket,
   listToolboxMarket,
 } from "@/modules/execution-factory/services/toolbox.service";
@@ -537,6 +542,148 @@ export async function resolveActionTypeToolParameters(
   }
 
   return fallback;
+}
+
+export function needsActionTypeActionSourceDisplayResolution(
+  actionSource?: ActionTypeActionSource,
+) {
+  if (!actionSource || actionSource.type === "manual") {
+    return false;
+  }
+
+  if (actionSource.type === "mcp") {
+    return Boolean(
+      actionSource.mcpId &&
+        (!actionSource.mcpName || (actionSource.toolId && !actionSource.toolName)),
+    );
+  }
+
+  return Boolean(
+    actionSource.boxId &&
+      (!actionSource.boxName || (actionSource.toolId && !actionSource.toolName)),
+  );
+}
+
+export async function resolveActionTypeActionSourceDisplay(
+  actionSource: ActionTypeActionSource,
+): Promise<ActionTypeActionSource> {
+  if (!needsActionTypeActionSourceDisplayResolution(actionSource)) {
+    return actionSource;
+  }
+
+  if (actionSource.type === "mcp" && actionSource.mcpId) {
+    let mcpName = actionSource.mcpName;
+    let toolId = actionSource.toolId;
+    let toolName = actionSource.toolName;
+
+    if (!mcpName) {
+      try {
+        const server = await getMcpMarket(actionSource.mcpId);
+        if (server) {
+          mcpName = server.name;
+        }
+      } catch (error) {
+        logServiceFallback(
+          "resolveActionTypeActionSourceDisplay.mcp.detail",
+          error,
+          `mcpId=${actionSource.mcpId}`,
+        );
+      }
+    }
+
+    try {
+      const catalog = await listActionTypeExecutionFactoryCatalog();
+      const server = catalog.mcpServers.find((item) => item.mcpId === actionSource.mcpId);
+      const tools = await loadActionTypeMcpServerTools(actionSource.mcpId);
+      const tool = tools.find(
+        (item) =>
+          item.toolId === actionSource.toolId ||
+          item.toolId === actionSource.toolName ||
+          item.toolName === actionSource.toolName,
+      );
+
+      mcpName ||= server?.mcpName;
+      toolId ||= tool?.toolId;
+      toolName ||= tool?.toolName;
+    } catch (error) {
+      logServiceFallback(
+        "resolveActionTypeActionSourceDisplay.mcp.catalog",
+        error,
+        `mcpId=${actionSource.mcpId} toolId=${actionSource.toolId ?? ""}`,
+      );
+    }
+
+    return {
+      ...actionSource,
+      mcpName,
+      toolId,
+      toolName,
+    };
+  }
+
+  if (actionSource.type === "tool" && actionSource.boxId) {
+    let boxName = actionSource.boxName;
+    let toolName = actionSource.toolName;
+
+    if (!boxName || (actionSource.toolId && !toolName)) {
+      const [toolboxResult, toolResult] = await Promise.allSettled([
+        getToolbox(actionSource.boxId),
+        actionSource.toolId
+          ? getToolDetail(actionSource.boxId, actionSource.toolId)
+          : Promise.resolve(undefined),
+      ]);
+
+      if (toolboxResult.status === "fulfilled" && toolboxResult.value) {
+        boxName ||= toolboxResult.value.name;
+      } else {
+        logServiceFallback(
+          "resolveActionTypeActionSourceDisplay.toolbox.detail",
+          toolboxResult.status === "rejected"
+            ? toolboxResult.reason
+            : new Error("Toolbox detail is empty"),
+          `boxId=${actionSource.boxId}`,
+        );
+      }
+
+      if (toolResult.status === "fulfilled" && toolResult.value) {
+        toolName ||= toolResult.value?.name;
+      } else {
+        logServiceFallback(
+          "resolveActionTypeActionSourceDisplay.tool.detail",
+          toolResult.status === "rejected"
+            ? toolResult.reason
+            : new Error("Tool detail is empty"),
+          `boxId=${actionSource.boxId} toolId=${actionSource.toolId ?? ""}`,
+        );
+      }
+    }
+
+    if (!boxName || (actionSource.toolId && !toolName)) {
+      try {
+        const catalog = await listActionTypeExecutionFactoryCatalog();
+        const box = catalog.toolBoxes.find((item) => item.boxId === actionSource.boxId);
+        const tools = await loadActionTypeToolBoxTools(actionSource.boxId);
+        const tool = tools.find((item) => item.toolId === actionSource.toolId);
+
+        boxName ||= box?.boxName;
+        toolName ||= tool?.toolName;
+      } catch (error) {
+        logServiceFallback(
+          "resolveActionTypeActionSourceDisplay.toolbox.catalog",
+          error,
+          `boxId=${actionSource.boxId} toolId=${actionSource.toolId ?? ""}`,
+        );
+      }
+    }
+
+    return {
+      ...actionSource,
+      boxName,
+      toolName,
+    };
+  }
+
+  return actionSource;
 }
 
 export function buildActionSourceFromCatalogSelection(


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Fix action type execution source display in edit/detail pages so persisted boxId/toolId no longer appears as the visible operator name.
- [x] Add resilient display-name resolution for toolbox/MCP action sources, including direct detail lookup, catalog fallback, and timeout handling.
- [x] Add regression tests for action source display-name resolution.

---

## Why

- Related Issue: Closes #217
- Related Feature: N/A
- Background:
  - Editing an action type could show the persisted `boxId/toolId` path instead of a readable operator name.
  - Hiding the ID behind a loading state exposed another issue: if resolution did not complete or the parent value was not immediately rewritten, the field could stay in loading indefinitely.

---

## How

- Key implementation points:
  - Add `resolveActionTypeActionSourceDisplay` to resolve saved action sources from IDs to readable toolbox/MCP/tool names.
  - Prefer direct detail lookup for toolbox/tool display names, then fall back to catalog/list lookups when detail APIs do not return usable names.
  - Keep edit-form persistence based on the original action source IDs while using a local display source for the picker UI.
  - Use explicit display states: `loading`, resolved, and unavailable, with a 3s timeout to avoid permanent loading.
  - Apply the same display-name resolution to the detail-page execution config summary.
- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` passed with the existing ignored high-severity advisory.

---

## Risk & Rollback

- Potential risks:
  - If the execution factory detail/catalog APIs are unavailable, the picker shows ?execution source unavailable? instead of exposing IDs.
  - Display-name resolution adds a small async lookup when loading legacy saved action sources without names.
- Rollback plan:
  - Revert this PR to restore the previous persisted-ID display behavior.

---

## Additional Notes

- This PR intentionally does not include the currently unstaged `services/mappers/*` changes in the working tree; those are unrelated to #217.
