### PR TITLE
fix(knowledge-network): allow no-input action tools

### DIFF
--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.test.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ActionTypeActionSource,
+  ActionTypeExecutionConfig,
+} from "@/modules/knowledge-network/types/knowledge-network";
+import type { ActionTypeToolInputParam } from "@/modules/knowledge-network/utils/tool-input-params";
+
+const {
+  getKnowledgeNetworkObjectTypeDetail,
+  needsActionTypeActionSourceDisplayResolution,
+  resolveActionTypeActionSourceDisplayWithTimeout,
+  resolveActionTypeToolInputSchema,
+} = vi.hoisted(() => ({
+  getKnowledgeNetworkObjectTypeDetail: vi.fn(),
+  needsActionTypeActionSourceDisplayResolution: vi.fn(),
+  resolveActionTypeActionSourceDisplayWithTimeout: vi.fn(),
+  resolveActionTypeToolInputSchema: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/modules/knowledge-network/services/knowledge-network.service", () => ({
+  getKnowledgeNetworkObjectTypeDetail,
+}));
+
+vi.mock("@/modules/knowledge-network/services/action-type-tool.service", () => ({
+  needsActionTypeActionSourceDisplayResolution,
+  resolveActionTypeActionSourceDisplayWithTimeout,
+  resolveActionTypeToolInputSchema,
+}));
+
+vi.mock("./ActionTypeSourcePicker", () => ({
+  ActionTypeSourcePicker: () => null,
+}));
+
+vi.mock("./ActionTypeToolParamsTable", () => ({
+  ActionTypeToolParamsTable: () => null,
+}));
+
+import { ActionTypeExecutionEditor } from "./ActionTypeExecutionEditor";
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createSource(toolId: string): ActionTypeActionSource {
+  return {
+    boxId: "box-1",
+    boxName: "Demo Box",
+    toolId,
+    toolName: toolId,
+    type: "tool",
+  };
+}
+
+function createExecutionConfig(actionSource: ActionTypeActionSource): ActionTypeExecutionConfig {
+  return {
+    actionSource,
+    parameters: [],
+    sourceName: actionSource.toolName ?? "",
+    sourceType: actionSource.type,
+  };
+}
+
+beforeEach(() => {
+  getKnowledgeNetworkObjectTypeDetail.mockResolvedValue({ dataProperties: [] });
+  needsActionTypeActionSourceDisplayResolution.mockReturnValue(false);
+  resolveActionTypeActionSourceDisplayWithTimeout.mockResolvedValue(undefined);
+  resolveActionTypeToolInputSchema.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ActionTypeExecutionEditor schema loading", () => {
+  it("ignores stale schema responses after the selected source changes", async () => {
+    const noInputSchema = createDeferred<ActionTypeToolInputParam[]>();
+    const requiredInputSchema = createDeferred<ActionTypeToolInputParam[]>();
+    resolveActionTypeToolInputSchema
+      .mockReturnValueOnce(noInputSchema.promise)
+      .mockReturnValueOnce(requiredInputSchema.promise);
+
+    const onChange = vi.fn();
+    const onParameterSchemaStateChange = vi.fn();
+    const { rerender } = render(
+      <ActionTypeExecutionEditor
+        networkId="network-1"
+        objectTypeId="object-type-1"
+        onChange={onChange}
+        onParameterSchemaStateChange={onParameterSchemaStateChange}
+        value={createExecutionConfig(createSource("tool-a"))}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(resolveActionTypeToolInputSchema).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <ActionTypeExecutionEditor
+        networkId="network-1"
+        objectTypeId="object-type-1"
+        onChange={onChange}
+        onParameterSchemaStateChange={onParameterSchemaStateChange}
+        value={createExecutionConfig(createSource("tool-b"))}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(resolveActionTypeToolInputSchema).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      noInputSchema.resolve([]);
+      await noInputSchema.promise;
+    });
+
+    expect(onParameterSchemaStateChange).not.toHaveBeenLastCalledWith({
+      loaded: true,
+      parameterCount: 0,
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      requiredInputSchema.resolve([
+        {
+          key: "amount",
+          name: "amount",
+          required: true,
+          source: "Body",
+          type: "number",
+        },
+      ]);
+      await requiredInputSchema.promise;
+    });
+
+    await waitFor(() => {
+      expect(onParameterSchemaStateChange).toHaveBeenLastCalledWith({
+        loaded: true,
+        parameterCount: 1,
+      });
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parameters: [
+          expect.objectContaining({
+            name: "amount",
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
@@ -41,9 +41,15 @@ type ActionTypeExecutionEditorProps = {
   objectTypeId: string;
   value: ActionTypeExecutionConfig;
   onChange: (value: ActionTypeExecutionConfig) => void;
+  onParameterSchemaStateChange?: (state: ActionTypeExecutionParameterSchemaState) => void;
 };
 
 type DisplayResolutionStatus = "failed" | "idle" | "loading";
+
+export type ActionTypeExecutionParameterSchemaState = {
+  loaded: boolean;
+  parameterCount: number;
+};
 
 function buildActionSourceKey(actionSource?: ActionTypeExecutionConfig["actionSource"]) {
   if (!actionSource) {
@@ -62,15 +68,27 @@ function buildActionSourceKey(actionSource?: ActionTypeExecutionConfig["actionSo
     : "";
 }
 
+function countLeafSchemaParameters(schema: ActionTypeToolInputParam[]): number {
+  return schema.reduce((count, item) => {
+    if (item.children?.length) {
+      return count + countLeafSchemaParameters(item.children);
+    }
+
+    return count + 1;
+  }, 0);
+}
+
 export function ActionTypeExecutionEditor({
   networkId,
   objectTypeId,
   value,
   onChange,
+  onParameterSchemaStateChange,
 }: ActionTypeExecutionEditorProps) {
   const { t } = useTranslation();
   const valueRef = useRef(value);
   const onChangeRef = useRef(onChange);
+  const onParameterSchemaStateChangeRef = useRef(onParameterSchemaStateChange);
   const loadedSourceKeyRef = useRef("");
   const resolvedDisplaySourceKeyRef = useRef("");
   const displayActionSourceRef = useRef<ActionTypeExecutionConfig["actionSource"]>(
@@ -99,6 +117,7 @@ export function ActionTypeExecutionEditor({
 
   valueRef.current = value;
   onChangeRef.current = onChange;
+  onParameterSchemaStateChangeRef.current = onParameterSchemaStateChange;
   displayActionSourceRef.current = displayActionSource;
 
   const sourceKey = useMemo(
@@ -139,6 +158,7 @@ export function ActionTypeExecutionEditor({
       loadedSourceKeyRef.current = "";
       resolvedDisplaySourceKeyRef.current = "";
       setInputSchema([]);
+      onParameterSchemaStateChangeRef.current?.({ loaded: false, parameterCount: 0 });
       return;
     }
 
@@ -148,10 +168,15 @@ export function ActionTypeExecutionEditor({
 
     const loadSchema = async () => {
       setSchemaLoading(true);
+      onParameterSchemaStateChangeRef.current?.({ loaded: false, parameterCount: 0 });
       try {
         const schema = await resolveActionTypeToolInputSchema(value.actionSource!);
         loadedSourceKeyRef.current = sourceKey;
         setInputSchema(schema);
+        onParameterSchemaStateChangeRef.current?.({
+          loaded: true,
+          parameterCount: countLeafSchemaParameters(schema),
+        });
         onChangeRef.current({
           ...valueRef.current,
           parameters: mergeExecutionParametersWithSchema(
@@ -159,6 +184,8 @@ export function ActionTypeExecutionEditor({
             valueRef.current.parameters,
           ),
         });
+      } catch {
+        onParameterSchemaStateChangeRef.current?.({ loaded: false, parameterCount: 0 });
       } finally {
         setSchemaLoading(false);
       }
@@ -246,6 +273,7 @@ export function ActionTypeExecutionEditor({
     setDisplayActionSource(nextSource);
     setDisplayResolutionStatus("idle");
     setInputSchema([]);
+    onParameterSchemaStateChangeRef.current?.({ loaded: false, parameterCount: 0 });
 
     if (!nextSource) {
       onChange({
@@ -272,6 +300,7 @@ export function ActionTypeExecutionEditor({
     setDisplayActionSource(nextSource);
     setDisplayResolutionStatus("idle");
     setInputSchema([]);
+    onParameterSchemaStateChangeRef.current?.({ loaded: false, parameterCount: 0 });
     onChange({
       ...value,
       actionSource: nextSource,

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
@@ -166,11 +166,17 @@ export function ActionTypeExecutionEditor({
       return;
     }
 
+    let cancelled = false;
+
     const loadSchema = async () => {
       setSchemaLoading(true);
       onParameterSchemaStateChangeRef.current?.({ loaded: false, parameterCount: 0 });
       try {
         const schema = await resolveActionTypeToolInputSchema(value.actionSource!);
+        if (cancelled) {
+          return;
+        }
+
         loadedSourceKeyRef.current = sourceKey;
         setInputSchema(schema);
         onParameterSchemaStateChangeRef.current?.({
@@ -185,13 +191,23 @@ export function ActionTypeExecutionEditor({
           ),
         });
       } catch {
+        if (cancelled) {
+          return;
+        }
+
         onParameterSchemaStateChangeRef.current?.({ loaded: false, parameterCount: 0 });
       } finally {
-        setSchemaLoading(false);
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
       }
     };
 
     void loadSchema();
+
+    return () => {
+      cancelled = true;
+    };
   }, [sourceKey, value.actionSource]);
 
   useEffect(() => {

--- a/src/modules/knowledge-network/scenes/ActionTypeExecutionScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeExecutionScene.tsx
@@ -19,6 +19,7 @@ import {
   normalizeActionTypeExecutionConfig,
   validateActionTypeExecutionConfig,
 } from "@/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor";
+import type { ActionTypeExecutionParameterSchemaState } from "@/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
 import {
   getKnowledgeNetworkActionTypeDetail,
@@ -43,6 +44,11 @@ export function ActionTypeExecutionScene() {
   const [executionValue, setExecutionValue] = useState<ActionTypeExecutionConfig>(
     createDefaultActionTypeExecutionConfig(),
   );
+  const [executionSchemaState, setExecutionSchemaState] =
+    useState<ActionTypeExecutionParameterSchemaState>({
+      loaded: false,
+      parameterCount: 0,
+    });
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -86,7 +92,10 @@ export function ActionTypeExecutionScene() {
       return;
     }
 
-    const validationError = validateActionTypeExecutionConfig(t, executionValue);
+    const validationError = validateActionTypeExecutionConfig(t, executionValue, {
+      allowEmptyParameters:
+        executionSchemaState.loaded && executionSchemaState.parameterCount === 0,
+    });
     if (validationError) {
       void message.error(validationError);
       return;
@@ -140,6 +149,7 @@ export function ActionTypeExecutionScene() {
           <ActionTypeExecutionEditor
             networkId={networkId}
             objectTypeId={detail?.objectTypeId ?? ""}
+            onParameterSchemaStateChange={setExecutionSchemaState}
             onChange={setExecutionValue}
             value={executionValue}
           />

--- a/src/modules/knowledge-network/scenes/ActionTypeFormScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeFormScene.tsx
@@ -18,6 +18,7 @@ import {
   normalizeActionTypeExecutionConfig,
   validateActionTypeExecutionConfig,
 } from "@/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor";
+import type { ActionTypeExecutionParameterSchemaState } from "@/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor";
 import { ActionTypeConditionEditor } from "@/modules/knowledge-network/components/action-type/ActionTypeConditionEditor";
 import { normalizeActionTypeCondition } from "@/modules/knowledge-network/utils/action-type-execution";
 import { RelationTypeObjectTypeSelect } from "@/modules/knowledge-network/components/relation-type/RelationTypeObjectTypeSelect";
@@ -90,6 +91,11 @@ export function ActionTypeFormScene({ mode }: ActionTypeFormSceneProps) {
   const [executionValue, setExecutionValue] = useState<ActionTypeExecutionConfig>(
     createDefaultActionTypeExecutionConfig(),
   );
+  const [executionSchemaState, setExecutionSchemaState] =
+    useState<ActionTypeExecutionParameterSchemaState>({
+      loaded: false,
+      parameterCount: 0,
+    });
   const [pageTitle, setPageTitle] = useState(
     mode === "edit"
       ? t("knowledgeNetwork.actionTypeEditTitle")
@@ -271,7 +277,10 @@ export function ActionTypeFormScene({ mode }: ActionTypeFormSceneProps) {
       }
     }
 
-    const validationError = validateActionTypeExecutionConfig(t, executionValue);
+    const validationError = validateActionTypeExecutionConfig(t, executionValue, {
+      allowEmptyParameters:
+        executionSchemaState.loaded && executionSchemaState.parameterCount === 0,
+    });
     if (validationError) {
       void message.error(validationError);
       return;
@@ -476,6 +485,7 @@ export function ActionTypeFormScene({ mode }: ActionTypeFormSceneProps) {
             (basicForm.getFieldValue("objectTypeId") as string | undefined) ??
             ""
           }
+          onParameterSchemaStateChange={setExecutionSchemaState}
           onChange={setExecutionValue}
           value={executionValue}
         />

--- a/src/modules/knowledge-network/utils/action-type-execution.test.ts
+++ b/src/modules/knowledge-network/utils/action-type-execution.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ActionTypeExecutionConfig } from "@/modules/knowledge-network/types/knowledge-network";
+
+import { validateActionTypeExecutionConfig } from "./action-type-execution";
+
+const t = (key: string) => key;
+
+function createExecutionConfig(
+  patch: Partial<ActionTypeExecutionConfig> = {},
+): ActionTypeExecutionConfig {
+  return {
+    actionSource: {
+      boxId: "box-1",
+      boxName: "Demo Box",
+      toolId: "tool-1",
+      toolName: "No Input Tool",
+      type: "tool",
+    },
+    parameters: [],
+    sourceName: "Demo Box/No Input Tool",
+    sourceType: "tool",
+    ...patch,
+  };
+}
+
+describe("validateActionTypeExecutionConfig", () => {
+  it("keeps requiring an execution source", () => {
+    expect(
+      validateActionTypeExecutionConfig(t, createExecutionConfig({
+        actionSource: undefined,
+        sourceName: "",
+      })),
+    ).toBe("knowledgeNetwork.actionTypeExecutionSourceNameRequired");
+  });
+
+  it("allows empty parameters when the selected tool has no input schema", () => {
+    expect(
+      validateActionTypeExecutionConfig(t, createExecutionConfig(), {
+        allowEmptyParameters: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps rejecting empty parameters when the selected tool requires mappings", () => {
+    expect(validateActionTypeExecutionConfig(t, createExecutionConfig())).toBe(
+      "knowledgeNetwork.actionTypeExecutionParameterRequired",
+    );
+  });
+
+  it("accepts configured dynamic input parameters", () => {
+    expect(
+      validateActionTypeExecutionConfig(
+        t,
+        createExecutionConfig({
+          parameters: [{ name: "order_id", valueFrom: "input" }],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps rejecting incomplete constant or property mappings", () => {
+    expect(
+      validateActionTypeExecutionConfig(
+        t,
+        createExecutionConfig({
+          parameters: [{ name: "status", valueFrom: "const", value: "" }],
+        }),
+      ),
+    ).toBe("knowledgeNetwork.actionTypeExecutionParameterRequired");
+  });
+});

--- a/src/modules/knowledge-network/utils/action-type-execution.ts
+++ b/src/modules/knowledge-network/utils/action-type-execution.ts
@@ -86,9 +86,14 @@ export function normalizeActionTypeCondition(
   };
 }
 
+export type ActionTypeExecutionValidationOptions = {
+  allowEmptyParameters?: boolean;
+};
+
 export function validateActionTypeExecutionConfig(
   t: (key: string) => string,
   value: ActionTypeExecutionConfig,
+  options: ActionTypeExecutionValidationOptions = {},
 ): string | null {
   const sourceLabel =
     getActionSourceDisplayName(value.actionSource) || value.sourceName.trim();
@@ -110,7 +115,7 @@ export function validateActionTypeExecutionConfig(
     return Boolean(item.value?.trim() || item.sourcePropertyName?.trim());
   });
 
-  if (validParameters.length === 0) {
+  if (validParameters.length === 0 && !options.allowEmptyParameters) {
     return t("knowledgeNetwork.actionTypeExecutionParameterRequired");
   }
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Allow action types to save with an empty execution parameter list when the selected tool schema is loaded and has no input parameters.
- [x] Keep existing validation for missing execution source, schema-not-loaded cases, and tools that still require parameter mappings.
- [x] Add focused regression tests for action execution config validation.

---

## Why

- Related Issue: Closes #216
- Related Feature: N/A
- Background:
  - No-input tools render an empty parameter table, but the previous save validation always required at least one valid parameter mapping.
  - This blocked saving action types for tools whose OpenAPI/MCP input schema is legitimately empty.

---

## How

- Key implementation points:
  - `validateActionTypeExecutionConfig` now accepts `allowEmptyParameters`.
  - `ActionTypeExecutionEditor` reports whether parameter schema has loaded and how many leaf input parameters exist.
  - The create/edit and execution-config save scenes only allow empty parameters when schema loading succeeded and the leaf parameter count is zero.
- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` passed with the existing ignored high-severity advisory.

---

## Risk & Rollback

- Potential risks:
  - If schema loading fails, empty parameter lists remain blocked to avoid treating unknown schemas as no-input tools.
- Rollback plan:
  - Revert this PR to restore the previous validation behavior.

---

## Additional Notes

- No backend API or persisted payload shape changes.