### PR TITLE
fix(data-catalog): hide streaming build entry

### DIFF
--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
+
+import { BuildTaskLaunchPanel, STREAMING_BUILD_ENTRY_ENABLED } from "./BuildTaskLaunchPanel";
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({ message: { success: vi.fn() } }),
+}));
+
+vi.mock("@/modules/data-catalog/services/build-task.service", () => ({
+  BuildTaskConflictError: class BuildTaskConflictError extends Error {},
+  createBuildTask: vi.fn(),
+  listBuildTasks: vi.fn().mockResolvedValue([]),
+  resumeBuildTask: vi.fn(),
+}));
+
+vi.mock("@/modules/model-resources/services/small-model.service", () => ({
+  listSmallModels: vi.fn().mockResolvedValue({ items: [] }),
+}));
+
+const resource: CatalogResource = {
+  catalogId: "catalog-1",
+  category: "table",
+  columnCount: 1,
+  description: "",
+  id: "resource-1",
+  indexConfig: { buildKeyFields: ["id"] },
+  name: "orders",
+  rowCount: 1,
+  schema: [
+    {
+      features: [{ featureType: "vector" }],
+      name: "content",
+      type: "string",
+    },
+  ],
+  sourceIdentifier: "orders",
+  updateTime: "2026-07-27T00:00:00Z",
+  updatedAt: 0,
+};
+
+describe("BuildTaskLaunchPanel", () => {
+  it("hides the streaming-build entry while the feature is disabled", () => {
+    expect(STREAMING_BUILD_ENTRY_ENABLED).toBe(false);
+
+    render(
+      <BuildTaskLaunchPanel
+        active
+        onGoConfigure={vi.fn()}
+        onStarted={vi.fn()}
+        resource={resource}
+      />,
+    );
+
+    expect(screen.getByText("dataCatalog.build.batchLabel")).toBeTruthy();
+    expect(screen.queryByText("dataCatalog.build.streamingLabel")).toBeNull();
+  });
+});

--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
@@ -33,6 +33,9 @@ import type { SmallModel } from "@/modules/model-resources/types/small-model";
 
 import formStyles from "./BuildTaskFormPanel.module.css";
 
+// 流式构建后端能力仍保留，待重新开放时将此开关改为 true 即可恢复入口。
+export const STREAMING_BUILD_ENTRY_ENABLED = false;
+
 export type BuildTaskLaunchPanelProps = {
   active: boolean;
   disabled?: boolean;
@@ -338,35 +341,37 @@ export function BuildTaskLaunchPanel({
             ) : null}
           </div>
 
-          <button
-            className={cx(
-              formStyles.modeCard,
-              formStyles.modeCardSelectable,
-              mode === "streaming" && formStyles.modeCardActive,
-            )}
-            disabled={controlsDisabled}
-            onClick={() => {
-              setMode("streaming");
-              setError(null);
-            }}
-            type="button"
-          >
-            <span
-              aria-hidden
+          {STREAMING_BUILD_ENTRY_ENABLED ? (
+            <button
               className={cx(
-                formStyles.modeCardRadio,
-                mode === "streaming" && formStyles.modeCardRadioChecked,
+                formStyles.modeCard,
+                formStyles.modeCardSelectable,
+                mode === "streaming" && formStyles.modeCardActive,
               )}
-            />
-            <span className={formStyles.modeCardText}>
-              <span className={formStyles.modeCardTitle}>
-                {t("dataCatalog.build.streamingLabel")}
+              disabled={controlsDisabled}
+              onClick={() => {
+                setMode("streaming");
+                setError(null);
+              }}
+              type="button"
+            >
+              <span
+                aria-hidden
+                className={cx(
+                  formStyles.modeCardRadio,
+                  mode === "streaming" && formStyles.modeCardRadioChecked,
+                )}
+              />
+              <span className={formStyles.modeCardText}>
+                <span className={formStyles.modeCardTitle}>
+                  {t("dataCatalog.build.streamingLabel")}
+                </span>
+                <span className={formStyles.modeCardDesc}>
+                  {t("dataCatalog.build.streamingDescription")}
+                </span>
               </span>
-              <span className={formStyles.modeCardDesc}>
-                {t("dataCatalog.build.streamingDescription")}
-              </span>
-            </span>
-          </button>
+            </button>
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Temporarily hide the streaming-build option in the data-catalog build launch panel
- [x] Add a component test that verifies the streaming-build entry is not rendered
- [ ] Docs/doc 1 (not applicable)

---

## Why

- Related Issue: Closes #277
- Related Feature: Data-catalog index build
- Background: The streaming-build capability must not currently be available from the frontend.

---

## How

- Key implementation points: Gate the existing streaming option with `STREAMING_BUILD_ENTRY_ENABLED`, currently set to `false`; retain the underlying service code and a clear restoration path.
- Breaking changes (API, config, database, etc.): None. This only removes the frontend entry.

---

## Testing

- [x] Unit tests passed locally (`pnpm exec vitest --run`)
- [ ] Integration tests passed locally (not applicable; this is a frontend-only display change)
- [ ] Verified in test environment (not performed)

Test notes:

- Added `BuildTaskLaunchPanel` coverage for the hidden entry.
- `pnpm exec tsc -b --pretty false`, `pnpm exec vite build`, ESLint, license-header check, and production dependency audit also passed.

---

## Risk & Rollback

- Potential risks: Users cannot create new streaming build tasks from the UI while the flag is disabled; existing task visibility and backend support remain unchanged.
- Rollback plan: Set `STREAMING_BUILD_ENTRY_ENABLED` to `true` and redeploy the frontend.

---

## Additional Notes

- The production dependency audit reports one existing high-severity vulnerability that is configured as ignored.
- Vite reports existing large-chunk warnings during the production build.