### PR TITLE
chore(vitest): 排除 .claude/worktrees 下的仓库副本

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,6 +69,9 @@ export default defineConfig(({ mode }) => {
       exclude: [
         "**/node_modules/**",
         "**/dist/**",
+        // Claude Code 的 git worktree 挂在 .claude/worktrees/ 下，是整仓副本。收进来
+        // 会拿别的分支的测试跑本仓代码（alias @ 恒指根 src），红得没有意义。
+        "**/.claude/**",
         // Playwright e2e specs run via `pnpm test:execution-factory:e2e`, not
         // vitest. They import @playwright/test, so collecting them here fails.
         "tests/e2e/**",


### PR DESCRIPTION
## 问题

Claude Code 的 git worktree 挂在 `.claude/worktrees/` 下，每个都是整仓副本。vitest 的 `exclude` 没排掉它们，本地 `pnpm exec vitest --run` 会把这些副本的测试一起收进来，实测 **152 files failed**，两种炸法：

- **单测红**：alias `@` 恒指根目录 `src`（`path.resolve(projectRoot, "./src")`），副本里旧分支的测试断言跑的却是当前仓库代码，版本对不上必然失败。
- **收集失败**：`tests/e2e/**` 是根相对路径，匹配不到 `.claude/worktrees/*/tests/e2e/**`，那些 Playwright spec 被 vitest 收走后 import `@playwright/test` 当场报错。

## 影响面

只影响本地全量跑，CI 干净：

- CI 无影响 —— `.claude/` 在 `.gitignore` 里，从不进提交，CI checkout 没这目录
- `tsc` 无影响 —— `tsconfig.app.json` 的 `include` 只有 `src`
- `eslint` 无影响 —— flat config 默认不下钻点目录

代价是本地全量结果没有参考价值，得手工挑路径才能看出真实红绿。

## 改动

`vite.config.ts` 的 `test.exclude` 加一条 `**/.claude/**`。

## 验证

本地 `vitest run` 从「152 files failed | 490 passed」变为 **111 files / 459 tests 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)