### PR TITLE
fix(data-catalog): 暂时屏蔽增量构建入口

### DIFF
--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx
@@ -10,7 +10,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 
-import { BuildTaskLaunchPanel, STREAMING_BUILD_ENTRY_ENABLED } from "./BuildTaskLaunchPanel";
+import {
+  BuildTaskLaunchPanel,
+  INCREMENTAL_BUILD_ENTRY_ENABLED,
+  STREAMING_BUILD_ENTRY_ENABLED,
+} from "./BuildTaskLaunchPanel";
 
 vi.mock("react-i18next", async (importOriginal) => ({
   ...(await importOriginal<typeof import("react-i18next")>()),
@@ -56,6 +60,7 @@ const resource: CatalogResource = {
 describe("BuildTaskLaunchPanel", () => {
   it("hides the streaming-build entry while the feature is disabled", () => {
     expect(STREAMING_BUILD_ENTRY_ENABLED).toBe(false);
+    expect(INCREMENTAL_BUILD_ENTRY_ENABLED).toBe(false);
 
     render(
       <BuildTaskLaunchPanel
@@ -68,5 +73,6 @@ describe("BuildTaskLaunchPanel", () => {
 
     expect(screen.getByText("dataCatalog.build.batchLabel")).toBeTruthy();
     expect(screen.queryByText("dataCatalog.build.streamingLabel")).toBeNull();
+    expect(screen.queryByText("dataCatalog.build.executeIncremental")).toBeNull();
   });
 });

--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
@@ -35,6 +35,8 @@ import formStyles from "./BuildTaskFormPanel.module.css";
 
 // 流式构建后端能力仍保留，待重新开放时将此开关改为 true 即可恢复入口。
 export const STREAMING_BUILD_ENTRY_ENABLED = false;
+// 执行方式尚未持久化到构建任务历史；修复前仅允许全量构建，避免历史语义不明确。
+export const INCREMENTAL_BUILD_ENTRY_ENABLED = false;
 
 export type BuildTaskLaunchPanelProps = {
   active: boolean;
@@ -202,18 +204,24 @@ export function BuildTaskLaunchPanel({
     return null;
   }
 
-  const executeOptions = [
+  const executeOptions: Array<{
+    description: string;
+    key: BuildExecuteType;
+    label: string;
+  }> = [
     {
       description: t("dataCatalog.build.executeFullDescription"),
-      key: "full" as const,
+      key: "full",
       label: t("dataCatalog.build.executeFull"),
     },
-    {
-      description: t("dataCatalog.build.executeIncrementalDescription"),
-      key: "incremental" as const,
-      label: t("dataCatalog.build.executeIncremental"),
-    },
   ];
+  if (INCREMENTAL_BUILD_ENTRY_ENABLED) {
+    executeOptions.push({
+      description: t("dataCatalog.build.executeIncrementalDescription"),
+      key: "incremental",
+      label: t("dataCatalog.build.executeIncremental"),
+    });
+  }
   const selectedExecuteOption =
     executeOptions.find((option) => option.key === executeType) ?? executeOptions[0];
 

--- a/src/modules/data-catalog/hooks/use-build-task-actions.ts
+++ b/src/modules/data-catalog/hooks/use-build-task-actions.ts
@@ -56,7 +56,7 @@ export function useBuildTaskActions(onRefresh: () => Promise<void> | void) {
   );
 
   const retry = useCallback(
-    async (task: BuildTask, executeType: BuildExecuteType = "incremental") => {
+    async (task: BuildTask, executeType: BuildExecuteType = "full") => {
       const reset = executeType === "full";
       const run = async () => {
         try {

--- a/src/modules/data-catalog/scenes/IndexBuildListScene.tsx
+++ b/src/modules/data-catalog/scenes/IndexBuildListScene.tsx
@@ -10,7 +10,7 @@ import {
   ReloadOutlined,
   UnorderedListOutlined,
 } from "@ant-design/icons";
-import { Alert, Dropdown, Select, Space, Tooltip } from "antd";
+import { Alert, Select, Space, Tooltip } from "antd";
 import type { ColumnsType, TableProps } from "antd/es/table";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -33,7 +33,6 @@ import {
   readIndexBuildListFilters,
 } from "@/modules/data-catalog/lib/index-build-filters";
 import {
-  type BuildExecuteType,
   deleteBuildTask,
   listBuildTaskPage,
 } from "@/modules/data-catalog/services/build-task.service";
@@ -503,26 +502,9 @@ export function IndexBuildListScene() {
             ) : null}
             {record.status === "failed" || record.status === "succeeded" ? (
               <PermissionGate permissions="resource:task_manage">
-                <Dropdown
-                  menu={{
-                    items: [
-                      {
-                        key: "incremental",
-                        label: t("dataCatalog.task.rebuildIncremental"),
-                      },
-                      {
-                        key: "full",
-                        label: t("dataCatalog.task.rebuildFull"),
-                      },
-                    ],
-                    onClick: ({ key }) =>
-                      void handleRetry(record, key as BuildExecuteType),
-                  }}
-                >
-                  <AppButton type="link">
-                    {t("dataCatalog.task.rebuild")}
-                  </AppButton>
-                </Dropdown>
+                <AppButton onClick={() => void handleRetry(record, "full")} type="link">
+                  {t("dataCatalog.task.rebuildFull")}
+                </AppButton>
               </PermissionGate>
             ) : null}
             <PermissionGate permissions="resource:task_manage">


### PR DESCRIPTION
## Summary

- 在创建构建任务界面隐藏增量执行方式，仅保留全量构建
- 任务管理列表的重建操作只允许全量重建
- 资源索引页的失败重建默认改为全量
- 通过开关保留后续恢复增量入口的路径

## Verification

- `pnpm vitest run src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx`
- `pnpm eslint ...`
- `pnpm build`

Closes #283