### PR TITLE
chore(execution-factory): 删除调试请求的旧信封推断路径

### DIFF
--- a/src/modules/execution-factory/utils/tool-io.test.ts
+++ b/src/modules/execution-factory/utils/tool-io.test.ts
@@ -8,75 +8,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  buildToolDebugRequest,
   normalizeToolApiSpecResponses,
   parseToolIoSpec,
 } from "@/modules/execution-factory/utils/tool-io";
-
-describe("buildToolDebugRequest", () => {
-  it("splits flat debug input by OpenAPI parameter location", () => {
-    expect(
-      buildToolDebugRequest(
-        {
-          accept: "application/json",
-          customerId: "1001",
-          region: "CN",
-          resourceId: "resource-1",
-          "x-demo-source": "openbkn-manual",
-        },
-        {
-          parameters: [
-            { in: "query", name: "customerId", type: "string" },
-            { in: "query", name: "region", type: "string" },
-            { in: "header", name: "accept", type: "string" },
-            { in: "header", name: "x-demo-source", type: "string" },
-            { in: "path", name: "resourceId", type: "string" },
-          ],
-        },
-      ),
-    ).toEqual({
-      header: {
-        accept: "application/json",
-        "x-demo-source": "openbkn-manual",
-      },
-      query: {
-        customerId: "1001",
-        region: "CN",
-      },
-      path: {
-        resourceId: "resource-1",
-      },
-    });
-  });
-
-  it("preserves explicit query/header/body debug payloads", () => {
-    expect(
-      buildToolDebugRequest({
-        body: { city: "Beijing" },
-        header: { accept: "application/json" },
-        path: { resourceId: 1001 },
-        query: { region: "CN" },
-      }),
-    ).toEqual({
-      body: { city: "Beijing" },
-      header: { accept: "application/json" },
-      path: { resourceId: "1001" },
-      query: { region: "CN" },
-    });
-  });
-
-  it("keeps unknown flat fields in the request body", () => {
-    expect(
-      buildToolDebugRequest(
-        { city: "Beijing", traceId: "debug-1" },
-        { parameters: [{ in: "query", name: "city", type: "string" }] },
-      ),
-    ).toEqual({
-      body: { traceId: "debug-1" },
-      query: { city: "Beijing" },
-    });
-  });
-});
 
 describe("parseToolIoSpec", () => {
   it("normalizes array responses and resolves local schema refs", () => {

--- a/src/modules/execution-factory/utils/tool-io.ts
+++ b/src/modules/execution-factory/utils/tool-io.ts
@@ -6,7 +6,6 @@
  */
 
 import type {
-  ToolDebugInput,
   ToolIoParameter,
   ToolIoSpec,
 } from "@/modules/execution-factory/types/tool";
@@ -217,83 +216,5 @@ export function parseToolIoSpec(metadata?: ApiSpecMetadata): ToolIoSpec | undefi
     requestBodyExample,
     requestBodySchema,
     responses,
-  };
-}
-
-function pickRecord(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-
-  return value as Record<string, unknown>;
-}
-
-function pickStringRecord(value: unknown): Record<string, string> | undefined {
-  const record = pickRecord(value);
-  if (!record) {
-    return undefined;
-  }
-
-  return Object.fromEntries(
-    Object.entries(record).map(([key, item]) => [key, String(item)]),
-  );
-}
-
-function hasStructuredDebugPayload(input: Record<string, unknown>) {
-  return "query" in input || "header" in input || "body" in input || "path" in input;
-}
-
-export function buildToolDebugRequest(
-  input?: Record<string, unknown>,
-  ioSpec?: ToolIoSpec,
-): ToolDebugInput {
-  if (!input) {
-    return {};
-  }
-
-  if (hasStructuredDebugPayload(input)) {
-    return {
-      body: pickRecord(input.body),
-      header: pickRecord(input.header),
-      query: pickRecord(input.query),
-      path: pickStringRecord(input.path),
-    };
-  }
-
-  const body: Record<string, unknown> = {};
-  const header: Record<string, unknown> = {};
-  const query: Record<string, unknown> = {};
-  const path: Record<string, string> = {};
-  const consumedKeys = new Set<string>();
-
-  for (const parameter of ioSpec?.parameters ?? []) {
-    if (!(parameter.name in input)) {
-      continue;
-    }
-
-    consumedKeys.add(parameter.name);
-
-    if (parameter.in === "header") {
-      header[parameter.name] = input[parameter.name];
-    } else if (parameter.in === "query") {
-      query[parameter.name] = input[parameter.name];
-    } else if (parameter.in === "path") {
-      path[parameter.name] = String(input[parameter.name]);
-    } else {
-      body[parameter.name] = input[parameter.name];
-    }
-  }
-
-  for (const [key, value] of Object.entries(input)) {
-    if (!consumedKeys.has(key)) {
-      body[key] = value;
-    }
-  }
-
-  return {
-    ...(Object.keys(body).length > 0 ? { body } : {}),
-    ...(Object.keys(header).length > 0 ? { header } : {}),
-    ...(Object.keys(query).length > 0 ? { query } : {}),
-    ...(Object.keys(path).length > 0 ? { path } : {}),
   };
 }


### PR DESCRIPTION
## 背景

`buildToolDebugRequest` 是调试面板改版前的请求组装入口：拿一坨平铺 JSON，按 `ioSpec.parameters[].in` 猜哪些字段属于 header / query / path，猜不出来的丢进 body；顶层一旦出现 `header` / `query` / `body` / `path`，又整体当成"结构化信封"直接拆开。

#275 之后调试面板已经改成 path / query / header / body 四个独立表单域，统一走 `buildHttpDebugRequest`。全仓库搜下来，没有任何生产代码再调 `buildToolDebugRequest`，只剩它自己的单测在引用。

留着的成本不在死代码本身，而在那条"按字段名猜参数位置"的老路径还摆在导出面上 —— 谁再接上去，就会重新踩 bkn-foundry#216 验收标准 12 那个坑：请求体里有个正常业务字段叫 `header`，整个 body 被误当调试信封拆掉。

## 改动

删除 `src/modules/execution-factory/utils/tool-io.ts` 里的：

- `buildToolDebugRequest`
- `hasStructuredDebugPayload`
- `pickRecord` / `pickStringRecord`（只服务于上面两个）

以及 `tool-io.test.ts` 中对应的 3 个用例。

`parseToolIoSpec`、`normalizeToolApiSpecResponses` 及其用例不动。

## 测试

`vitest run src/modules/execution-factory` 46 文件 218 用例通过；`tsc --noEmit` 与 `eslint.config.typechecked.js --max-warnings 0` 干净。

Refs bkn-foundry#216

🤖 Generated with [Claude Code](https://claude.com/claude-code)