### PR TITLE
fix(auth): 全量放行改按资源通配判定，不再按 is_admin (#134)

### DIFF
--- a/src/framework/auth/current-user.test.ts
+++ b/src/framework/auth/current-user.test.ts
@@ -58,18 +58,60 @@ describe("fetchCurrentUser — 权限来源不可用时 fail-closed", () => {
     expect(user.permissions).toEqual([]);
   });
 
-  it("is_admin → 放行全部已注册权限", async () => {
+  it("资源通配(超级管理员) → 放行全部已注册权限", async () => {
     mockGet.mockImplementation((url: string) =>
       url === "/safe/v1/me"
         ? meOk({ id: "root" })
-        : meOk({ is_admin: true, permissions: [] }),
+        : meOk({
+            is_admin: true,
+            // 超管的实际响应形态(实测 14.103.77.23):折叠成单行资源通配。
+            permissions: [{ operations: ["*"], resource: { id: "*", type: "*" } }],
+          }),
     );
 
     const fetchCurrentUser = await importFetchCurrentUser();
     const user = await fetchCurrentUser();
 
+    expect(user.isAdmin).toBe(true);
     expect(user.permissions).toContain("admin-audit:view");
     expect(user.permissions).toContain("admin-license:view");
+  });
+
+  // 后端 CanAdmin 判的是 safe_admin:console:manage,三员角色都持有,所以 is_admin
+  // 对三员一律为 true。若按它放行全部权限,按点位控制入口的门禁在三员身上就失效了
+  // (审计员会看到授权/撤权按钮,点下去才被后端 403)。
+  it("is_admin=true 但无资源通配(三员角色) → 只给实际持有的点位", async () => {
+    mockGet.mockImplementation((url: string) =>
+      url === "/safe/v1/me"
+        ? meOk({ id: "u-audit", roles: ["audit"] })
+        : meOk({
+            is_admin: true,
+            // 审计管理员的实际响应形态(实测 14.103.77.23)。
+            permissions: [
+              { operations: ["view"], resource: { id: "*", type: "admin-audit" } },
+              { operations: ["view"], resource: { id: "*", type: "admin-user" } },
+              { operations: ["view"], resource: { id: "*", type: "admin-dept" } },
+              { operations: ["view"], resource: { id: "*", type: "admin-role" } },
+              { operations: ["view"], resource: { id: "*", type: "admin-authz" } },
+            ],
+          }),
+    );
+
+    const fetchCurrentUser = await importFetchCurrentUser();
+    const user = await fetchCurrentUser();
+
+    expect(user.isAdmin).toBe(true);
+    expect(user.permissions).toContain("admin-audit:view");
+    expect(user.permissions).toContain("admin-authz:view");
+    expect(user.permissions).toContain("admin-role:view");
+    // 授权面的写点位一个都不该有。
+    expect(user.permissions).not.toContain("admin-authz:grant");
+    expect(user.permissions).not.toContain("admin-authz:revoke");
+    expect(user.permissions).not.toContain("admin-role:members");
+    expect(user.permissions).not.toContain("admin-role:permissions");
+    // 其他模块的写权限同样不该被 is_admin 顺带放行。
+    expect(user.permissions).not.toContain("admin-user:create");
+    expect(user.permissions).not.toContain("admin-license:manage");
   });
 
   it("两个请求都失败 → 完全 fail-closed", async () => {

--- a/src/framework/auth/current-user.ts
+++ b/src/framework/auth/current-user.ts
@@ -55,8 +55,17 @@ export const anonymousRuntimeUser: RuntimeUser = {
  * 登录后拉取当前用户身份 + 权限,组装成 RuntimeUser。
  *
  * bkn-safe 下发的是 `<resource_type>:<operation>`,与各模块 manifest 声明的权限点并非
- * 同一套命名,需经 permission-map 翻译(见该文件注释)。is_admin(超级管理员/admin)
- * 放行全部已注册权限。
+ * 同一套命名,需经 permission-map 翻译(见该文件注释)。
+ *
+ * 全量放行的判据是**资源通配授权**(`*:*` 行),不是 `is_admin`。两者不等价:
+ * `is_admin` 来自后端 CanAdmin,判的是 `safe_admin:console:manage`——「可以进管理
+ * API 面」,系统/安全/审计三员角色都持有它。若按 is_admin 放行全部权限,三员就都
+ * 拿到全量权限点,按点位控制入口的门禁在他们身上直接失效(实测 14.103.77.23:三员
+ * 的 /me/permissions 均为 is_admin=true,而 permissions 只含各自那几行)。超级管理员
+ * 才持有资源通配,其 /me/permissions 折叠成单行 `{type:"*",id:"*",ops:["*"]}`。
+ *
+ * is_admin 仍然有用:它是 ADMIN_ONLY_SUFFIXES(跨租户运维页)的判据,与执行工厂后端
+ * CheckAdminPermission 同口径,所以照常传给 deriveStudioPermissions。
  *
  * 两个请求各自独立降级(allSettled),互不牵连:身份拿不到不影响权限,权限拿不到
  * 一律按无权限处理。permissions 拉取失败绝不放行任何权限(fail-closed)——避免因为
@@ -81,15 +90,18 @@ export async function fetchCurrentUser(): Promise<RuntimeUser> {
     permResult.status === "fulfilled" ? permResult.value.data : {};
 
   const safeGrants = flattenSafeGrants(perm.permissions);
+  const isAdmin = Boolean(perm.is_admin);
+  // 资源通配 = 超级管理员,对每一类资源的每个操作都成立,没有逐点推导的必要。
+  const hasResourceWildcard = safeGrants.has("*:*");
 
   return {
     businessDomainId: null,
     id: me.id ?? null,
-    isAdmin: Boolean(perm.is_admin),
+    isAdmin,
     name: me.name || me.account || me.id || null,
     roles: me.roles ?? [],
-    permissions: perm.is_admin
+    permissions: hasResourceWildcard
       ? [...defaultDevPermissions]
-      : deriveStudioPermissions(defaultDevPermissions, safeGrants, false),
+      : deriveStudioPermissions(defaultDevPermissions, safeGrants, isAdmin),
   };
 }


### PR DESCRIPTION
#290 合并后在测试服 14.103.77.23 上实测发现的问题，与 #134 直接相关。

## 现象

三员角色（系统 / 安全 / 审计）的 `/me/permissions` 都返回 `is_admin: true`。实测响应：

```
-- 超级管理员 admin --
{"is_admin":true,"permissions":[{"operations":["*"],"resource":{"id":"*","type":"*"}}]}

-- 审计管理员 --
{"is_admin":true,"permissions":[
  {"operations":["view"],"resource":{"id":"*","type":"admin-audit"}},
  {"operations":["view"],"resource":{"id":"*","type":"admin-user"}},
  {"operations":["view"],"resource":{"id":"*","type":"admin-dept"}},
  {"operations":["view"],"resource":{"id":"*","type":"admin-role"}},
  {"operations":["view"],"resource":{"id":"*","type":"admin-authz"}}]}
```

原因在后端语义：`CanAdmin` 判的是 `safe_admin:console:manage`，含义是「可以进管理 API 面」，三员角色都持有它。它从来不是「拥有一切」。

而 `fetchCurrentUser` 里 `perm.is_admin ? [...defaultDevPermissions] : derive(...)` —— 见 `is_admin` 为真就放行全部已注册权限。于是 #134 刚落地的点位门禁在三员身上直接失效：审计管理员会看到授权、撤权、角色成员、角色权限配置的按钮，点下去才被后端 403 拦住。

后端拦得住（三员权限矩阵在测试服 20/20 实测通过，含 403/204/400 与审计 `_outcome.removed`），所以这不是越权漏洞，但「前端按细粒度权限点控制入口」这条要求在三员身上等于没生效——而三员正是 #134 要划清边界的那三个角色。

## 改法

全量放行的判据换成真正的**资源通配授权**（`*:*` 行）：

```ts
const hasResourceWildcard = safeGrants.has("*:*");
permissions: hasResourceWildcard
  ? [...defaultDevPermissions]
  : deriveStudioPermissions(defaultDevPermissions, safeGrants, isAdmin),
```

超级管理员的 `/me/permissions` 折叠成单行 `{type:"*",id:"*",ops:["*"]}`（上面实测确认），走全量分支；三员只有各自那几行，推导出各自实际持有的点位。

`is_admin` 保留并照常传给 `deriveStudioPermissions` —— 它是 `ADMIN_ONLY_SUFFIXES`（跨租户运维页，如 `sandbox-runtime:view`）的判据，与执行工厂后端 `CheckAdminPermission` 同口径。此前 else 分支写死 `false`，三员是靠 `is_admin` 走全量分支才拿到这类页面；现在按其真实语义传入，这部分行为不变。

顺带说明：`permission-map` 里 `safeGrantsCover` 处理的类型级通配只对执行工厂前缀生效，`admin-*` 点位走的是直接同名匹配，不受本改动影响。

## 测试

`current-user.test.ts` 的 `is_admin → 放行全部` 用例改写成两个，基准数据用上面的实测响应形态：

- 超管单行资源通配 → 全量权限（含 `admin-audit:view`、`admin-license:view`）
- `is_admin=true` 但无通配（审计员五行 view）→ 只有 view 类点位；`admin-authz:grant/revoke`、`admin-role:members/permissions` 四个写点位一个都没有；`admin-user:create`、`admin-license:manage` 这类其他模块写权限同样没有

全量 485 个测试通过，`tsc -b`、`eslint`、`license:check` 均通过。

Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
