### PR TITLE
fix(execution-factory): 详情页头部分区内容改回顶对齐

### DIFF
--- a/src/modules/execution-factory/scenes/toolbox-detail.module.css
+++ b/src/modules/execution-factory/scenes/toolbox-detail.module.css
@@ -264,15 +264,17 @@
   border-bottom: none;
 }
 
-/* 头部分区：内容压到线上方（flex-end），描述那行才紧贴着线而不是让线飘在半空。
-   行距按函数工作台的头部压紧（10 / 8 / 10）——这里是「头部分区」不是普通卡片，
-   照 16 / 14 / 16 的卡片节奏排，两栏中缝就会顶出一条明显偏高的空带。 */
+/* 头部分区：内容顶对齐，与左栏头一致。撑到 96px 的是左栏（标题 + 筛选框），
+   右栏内容只有 72px，多出的那截若压在下面（flex-end），空隙就全落到徽标上方，
+   线紧贴着描述、标题上边反而空一块。留在描述与线之间才是对的。
+
+   行距按函数工作台的头部压紧（10 / 8）——这里是「头部分区」不是普通卡片，
+   照 16 / 14 / 16 的卡片节奏排，两栏中缝会顶出一条明显偏高的空带。 */
 .layoutHeadAligned .section:first-child {
   --detail-meta-header-gap: 8px;
   --detail-meta-subheader-gap: 0px;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
   min-height: var(--entity-rail-head-height);
   padding: 10px 20px;
 }


### PR DESCRIPTION
## 问题

#292 之后，工具箱 / MCP 详情页的头部带子高 96px，这个高度由左栏（标题 + 筛选框）撑起；右栏内容（徽标 + 名字 + 描述）只有 72px。

右栏用了 `justify-content: flex-end` 把内容压在下面，多出的 24px 就全落到 `api` 徽标**上方**——分隔线紧贴着描述、标题上边反而空一块，两栏一个顶对齐一个底对齐，读起来像线的位置没放对。

## 改动

去掉 `flex-end`，右栏与左栏一样顶对齐，空隙留在描述与分隔线之间。

一行 CSS，不涉及逻辑。

（`flex-end` 是从函数工作台照搬的，那边是右栏更高、需要描述贴住线；这两个页面反过来，照搬就错了。）

## 验证

`tsc -b --pretty false`、`eslint.config.typechecked.js --max-warnings 0`（整个 `src/`）、`vitest run` 119 文件 494 用例、`vite build` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)