### PR TITLE
feat(execution-factory): 技能包文件预览换成高亮编辑器 + Markdown 双视图

### DIFF
--- a/src/framework/ui/common/MarkdownText.module.css
+++ b/src/framework/ui/common/MarkdownText.module.css
@@ -101,6 +101,63 @@
   font-weight: 600;
 }
 
+/* 整篇文档（技能包 SKILL.md 之类）：卡片描述那档字号读一屏正文太挤，正文和标题
+   各放大一档，段距同步放开。圆角归零——站点面板全是方角，只有这块圆着会很跳。 */
+.doc {
+  font-size: 14px;
+  line-height: 1.75;
+  color: var(--color-text-primary);
+}
+.doc p,
+.doc ul,
+.doc ol,
+.doc pre,
+.doc blockquote,
+.doc table {
+  margin-bottom: 12px;
+}
+.doc h1,
+.doc h2,
+.doc h3,
+.doc h4 {
+  margin: 20px 0 10px;
+}
+.doc h1 {
+  font-size: 20px;
+}
+.doc h2 {
+  font-size: 17px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--color-divider);
+}
+.doc h3 {
+  font-size: 15px;
+}
+.doc h4 {
+  font-size: 14px;
+}
+.doc code {
+  border-radius: 0;
+  font-size: 13px;
+}
+.doc pre {
+  padding: 12px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 0;
+  background: var(--color-bg-page);
+}
+.doc pre code {
+  font-size: 13px;
+}
+.doc table {
+  font-size: 13px;
+}
+.doc th,
+.doc td {
+  border-color: var(--color-border);
+  padding: 6px 10px;
+}
+
 /* 深色容器（antd 黑底 tooltip 等）配色覆盖。 */
 .dark a {
   color: #91caff;

--- a/src/framework/ui/common/MarkdownText.tsx
+++ b/src/framework/ui/common/MarkdownText.tsx
@@ -16,6 +16,11 @@ type MarkdownTextProps = {
   text: string;
   /** dark = 深色容器（如 antd 默认黑底 tooltip）下的配色。 */
   tone?: "dark" | "light";
+  /**
+   * compact = 卡片 / tooltip 里的一段描述（默认）；document = 整篇文档
+   * （技能包的 SKILL.md），正文和标题各放大一档，方角对齐站点其余面板。
+   */
+  variant?: "compact" | "document";
 };
 
 /**
@@ -26,8 +31,14 @@ export const MarkdownText = memo(function MarkdownText({
   className,
   text,
   tone = "light",
+  variant = "compact",
 }: MarkdownTextProps) {
-  const classes = [styles.md, tone === "dark" ? styles.dark : "", className]
+  const classes = [
+    styles.md,
+    tone === "dark" ? styles.dark : "",
+    variant === "document" ? styles.doc : "",
+    className,
+  ]
     .filter(Boolean)
     .join(" ");
   return (

--- a/src/modules/execution-factory/components/CodeEditor.tsx
+++ b/src/modules/execution-factory/components/CodeEditor.tsx
@@ -60,16 +60,34 @@ function defineTheme(monaco: Monaco) {
   });
 }
 
-export type CodeEditorLanguage = "json" | "python";
+/**
+ * 可编辑场景只用到 json / python；其余是只读预览（技能包文件）要认的语法，
+ * 全部来自本地打包的 monaco-editor，不额外拉包。
+ */
+export type CodeEditorLanguage =
+  | "css"
+  | "html"
+  | "ini"
+  | "javascript"
+  | "json"
+  | "markdown"
+  | "plaintext"
+  | "python"
+  | "shell"
+  | "sql"
+  | "typescript"
+  | "xml"
+  | "yaml";
 
 /** 挂在这个 URI 上的 JSON 文档会用下面注册的 schema 做补全与校验。 */
 const EVENT_MODEL_PATH = "bkn-function-event.json";
 
 // Python 缩进是语法的一部分，2 空格会写出不符合社区习惯的代码。
-const TAB_SIZE_BY_LANGUAGE: Record<CodeEditorLanguage, number> = {
-  json: 2,
+const TAB_SIZE_BY_LANGUAGE: Partial<Record<CodeEditorLanguage, number>> = {
   python: 4,
 };
+
+const DEFAULT_TAB_SIZE = 2;
 
 type CodeEditorProps = {
   /** 内容持续追加时（流式生成）跟随滚动到最后一行，否则每次 setValue 都会跳回顶部。 */
@@ -148,7 +166,14 @@ export function CodeEditor({
         onMount={(editor) => {
           editorRef.current = editor;
         }}
-        options={{ ...EDITOR_OPTIONS, readOnly, tabSize: TAB_SIZE_BY_LANGUAGE[language] }}
+        options={{
+          ...EDITOR_OPTIONS,
+          // 只读时光标和当前行高亮是噪音：读者点不动，闪烁的竖线只会让人以为能改。
+          domReadOnly: readOnly,
+          renderLineHighlight: readOnly ? "none" : EDITOR_OPTIONS.renderLineHighlight,
+          readOnly,
+          tabSize: TAB_SIZE_BY_LANGUAGE[language] ?? DEFAULT_TAB_SIZE,
+        }}
         path={language === "json" && jsonSchema ? EVENT_MODEL_PATH : undefined}
         theme={THEME_NAME}
         value={value}

--- a/src/modules/execution-factory/components/EntityListRail.module.css
+++ b/src/modules/execution-factory/components/EntityListRail.module.css
@@ -27,6 +27,24 @@
   border-bottom: 1px solid var(--entity-rail-head-border, var(--color-border));
 }
 
+/* 单行头：标题和筛选框同排。右栏头只有一行内容时用它，两栏的头部分隔线才落在
+   同一 y 上，又不必在矮的那侧垫一大片空白。 */
+.headInline {
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+}
+
+.headInline .title {
+  flex: none;
+}
+
+.headInline :global(.ant-input-affix-wrapper) {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .title {
   display: flex;
   align-items: center;

--- a/src/modules/execution-factory/components/EntityListRail.tsx
+++ b/src/modules/execution-factory/components/EntityListRail.tsx
@@ -61,6 +61,8 @@ type EntityListRailProps = {
   emptyText?: ReactNode;
   /** 固定底栏，不跟着列表滚（函数工作台的「新建函数」）。 */
   footer?: ReactNode;
+  /** inline = 标题和筛选框同排（右栏头也只有一行时用，两条头线才对得上）。 */
+  headLayout?: "inline" | "stacked";
   icon?: ReactNode;
   items?: EntityListRailItem[];
   onSelect?: (id: string) => void;
@@ -90,6 +92,7 @@ export function EntityListRail({
   children,
   emptyText,
   footer,
+  headLayout = "stacked",
   icon,
   items = [],
   onSelect,
@@ -111,7 +114,11 @@ export function EntityListRail({
 
   return (
     <div className={styles.rail}>
-      <div className={styles.head}>
+      <div
+        className={
+          headLayout === "inline" ? `${styles.head} ${styles.headInline}` : styles.head
+        }
+      >
         <div className={styles.title}>
           {icon}
           <span>{title}</span>

--- a/src/modules/execution-factory/components/SkillFilePreview.tsx
+++ b/src/modules/execution-factory/components/SkillFilePreview.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { Alert, Empty, Segmented, Spin } from "antd";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { AppButton } from "@/framework/ui/common/AppButton";
+import { MarkdownText } from "@/framework/ui/common/MarkdownText";
+import { CodeEditor } from "@/modules/execution-factory/components/CodeEditor";
+import {
+  isMarkdownSkillFile,
+  resolveSkillFileLanguage,
+} from "@/modules/execution-factory/utils/skill-file-preview";
+
+import styles from "./skill-file-preview.module.css";
+
+type SkillFilePreviewMode = "rendered" | "source";
+
+type SkillFilePreviewProps = {
+  /** 二进制文件的下载直链；给了就渲染下载态。 */
+  downloadUrl?: string;
+  errorMessage?: string | null;
+  loading?: boolean;
+  relPath?: string;
+  /** 文本正文。undefined = 还没选文件 / 拿不到正文。 */
+  text?: string;
+};
+
+/**
+ * 技能包单个文件的预览面板（标题栏 + 正文）。以前是一块裸 `<pre>`：没有语法高亮、
+ * 没有行号，Markdown 也只能看源码，跟函数工作台那侧的编辑器完全不是一套东西。
+ *
+ * 现在按文件类型分流：Markdown 默认渲染、可切原文；其余文本按后缀高亮（复用全站
+ * 同一个 Monaco 只读编辑器）；二进制退回下载。模式开关只在 Markdown 出现——其它
+ * 类型没有第二种看法，摆个只有一个选项的开关是噪音。
+ */
+export function SkillFilePreview({
+  downloadUrl,
+  errorMessage,
+  loading = false,
+  relPath,
+  text,
+}: SkillFilePreviewProps) {
+  const { t } = useTranslation();
+  const isMarkdown = isMarkdownSkillFile(relPath);
+  const [mode, setMode] = useState<SkillFilePreviewMode>("rendered");
+
+  // 换文件时回到默认视图：在 A.md 里切到「原文」，不该让接着点开的 B.md 也是原文。
+  useEffect(() => {
+    setMode("rendered");
+  }, [relPath]);
+
+  const showModeSwitch = isMarkdown && !loading && !errorMessage && text !== undefined;
+  const body = renderBody();
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.head}>
+        <div className={styles.headMain}>
+          <span className={styles.title}>{t("executionFactory.skillFilePreviewTitle")}</span>
+          {relPath ? <span className={styles.path}>{relPath}</span> : null}
+        </div>
+        {showModeSwitch ? (
+          <Segmented<SkillFilePreviewMode>
+            onChange={setMode}
+            options={[
+              { label: t("executionFactory.skillFilePreviewRendered"), value: "rendered" },
+              { label: t("executionFactory.skillFilePreviewSource"), value: "source" },
+            ]}
+            size="small"
+            value={mode}
+          />
+        ) : null}
+      </div>
+      <div className={styles.body}>{body}</div>
+    </div>
+  );
+
+  function renderBody() {
+    if (loading) {
+      return (
+        <div className={styles.placeholder}>
+          <Spin />
+        </div>
+      );
+    }
+
+    if (errorMessage) {
+      return <Alert message={errorMessage} showIcon type="error" />;
+    }
+
+    if (downloadUrl) {
+      return (
+        <div className={styles.placeholder}>
+          <Empty description={t("executionFactory.skillFilePreviewBinaryHint")}>
+            <AppButton href={downloadUrl} rel="noreferrer" target="_blank" type="link">
+              {t("executionFactory.skillFilePreviewDownloadLink")}
+            </AppButton>
+          </Empty>
+        </div>
+      );
+    }
+
+    if (text === undefined) {
+      return (
+        <div className={styles.placeholder}>
+          <Empty description={t("executionFactory.skillFilePreviewSelectHint")} />
+        </div>
+      );
+    }
+
+    if (isMarkdown && mode === "rendered") {
+      return (
+        <div className={styles.markdown}>
+          <MarkdownText text={text} variant="document" />
+        </div>
+      );
+    }
+
+    return (
+      <div className={styles.code}>
+        <CodeEditor
+          height="fill"
+          language={resolveSkillFileLanguage(relPath)}
+          readOnly
+          value={text}
+        />
+      </div>
+    );
+  }
+}

--- a/src/modules/execution-factory/components/SkillFileTreeView.tsx
+++ b/src/modules/execution-factory/components/SkillFileTreeView.tsx
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { FileOutlined, FolderOpenOutlined, FolderOutlined } from "@ant-design/icons";
+import { FileOutlined, FolderOutlined } from "@ant-design/icons";
 import { Tree } from "antd";
 import type { DataNode } from "antd/es/tree";
 import { useEffect, useMemo, useState, type CSSProperties, type Key, type ReactNode } from "react";
@@ -29,6 +29,16 @@ export type SkillFileTreeViewProps = {
   style?: CSSProperties;
 };
 
+/** 文件名右侧的定宽徽标：大写扩展名。无扩展名（LICENSE、Dockerfile）就不画。 */
+function resolveFileBadge(relPath?: string): string {
+  if (!relPath?.includes(".")) {
+    return "";
+  }
+
+  const extension = relPath.slice(relPath.lastIndexOf(".") + 1);
+  return extension.length > 0 && extension.length <= 5 ? extension.toUpperCase() : "";
+}
+
 function toTreeDataNodes(
   nodes: SkillFileTreeNode[],
   options: { showFileMeta: boolean },
@@ -38,15 +48,23 @@ function toTreeDataNodes(
       const meta = options.showFileMeta
         ? [node.file?.mimeType, formatSkillFileSize(node.file?.size)].filter(Boolean).join(" · ")
         : "";
+      const badge = resolveFileBadge(node.file?.relPath ?? node.title);
 
+      // 文件行画成卡片：与工具 / 函数列表栏同一套观感（名字 + 右侧徽标 + 次行元信息）。
+      // 目录行保持轻量的一行，层级才不会被一摞卡片盖过去。
       return {
         key: node.key,
         isLeaf: true,
         selectable: true,
-        icon: <FileOutlined />,
         title: (
-          <span className={styles.leaf}>
-            <span className={styles.title}>{node.title}</span>
+          <span className={styles.card}>
+            <span className={styles.cardTop}>
+              <FileOutlined className={styles.fileIcon} />
+              <span className={styles.title} title={node.file?.relPath ?? node.title}>
+                {node.title}
+              </span>
+              {badge ? <span className={styles.badge}>{badge}</span> : null}
+            </span>
             {meta ? <span className={styles.meta}>{meta}</span> : null}
           </span>
         ),
@@ -57,9 +75,14 @@ function toTreeDataNodes(
       key: node.key,
       isLeaf: false,
       selectable: false,
-      icon: ({ expanded }: { expanded?: boolean }) =>
-        expanded ? <FolderOpenOutlined /> : <FolderOutlined />,
-      title: <span className={styles.title}>{node.title}</span>,
+      title: (
+        <span className={styles.folder}>
+          <FolderOutlined className={styles.folderIcon} />
+          <span className={styles.folderName} title={node.key}>
+            {node.title}
+          </span>
+        </span>
+      ),
       children: toTreeDataNodes(node.children ?? [], options),
     };
   });
@@ -97,7 +120,6 @@ export function SkillFileTreeView({
         }
       }}
       selectedKeys={selectedPath ? [selectedPath] : []}
-      showIcon
       style={style}
       treeData={treeData}
     />

--- a/src/modules/execution-factory/components/skill-file-preview.module.css
+++ b/src/modules/execution-factory/components/skill-file-preview.module.css
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/* 右栏整块：头部定高、正文吃掉剩余高度并自己滚，页面本身不跟着长。 */
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+/* 头部按内容高：左栏的标题 + 筛选框天然更高，硬凑成同高会在这侧顶出一大片空白。
+   两栏各画各的底线，不追求落在同一 y 上。 */
+.head {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 48px;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.headMain {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.title {
+  flex: none;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+/* 路径是「当前在看哪个文件」，等宽字与文件树里的文件名同一套观感。 */
+.path {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-family: var(
+    --font-mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Consolas,
+    "Liberation Mono",
+    monospace
+  );
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  padding: 16px 20px;
+}
+
+/* Monaco 自己带滚动条，外层不要再套一层 overflow，否则两条滚动条会打架。 */
+.code {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* 渲染态的正文行长不设上限会横跨整屏，读一行要甩一次头；72em 是常规正文档。 */
+.markdown {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  max-width: 72em;
+}
+
+.placeholder {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+}

--- a/src/modules/execution-factory/components/skill-file-tree-view.module.css
+++ b/src/modules/execution-factory/components/skill-file-tree-view.module.css
@@ -5,31 +5,137 @@
  * Conditions. See LICENSE for the full text.
  */
 
+/* 文件行画成卡片（与工具 / 函数列表栏同一套：名字 + 右侧徽标 + 次行元信息），
+   目录行是轻量的一行。卡片自己带边框和选中态，所以 antd 那层节点背景全部清掉，
+   否则会在卡片外再套一块灰底。 */
 .tree {
   background: transparent;
 }
 
+.tree :global(.ant-tree-treenode) {
+  width: 100%;
+  padding: 0 0 8px !important;
+  align-items: stretch;
+}
+
+/* 每层缩进从默认 24px 压到 14px：深目录（refs/api/v1/…）在 320px 侧栏里
+   一层吃掉 24px，三层之后文件名就只剩几个字。 */
+.tree :global(.ant-tree-indent-unit) {
+  width: 14px;
+}
+
+.tree :global(.ant-tree-switcher) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 30px;
+  color: var(--color-text-muted);
+}
+
+/* 叶子节点没有展开箭头，antd 仍占一格空位；不清掉的话根目录下的文件卡片会比
+   头部的标题 / 筛选框窄一截、左缘也对不齐。 */
+.tree :global(.ant-tree-switcher-noop) {
+  width: 0;
+}
+
 .tree :global(.ant-tree-node-content-wrapper) {
+  min-width: 0;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  transition: none;
+}
+
+.tree :global(.ant-tree-title) {
+  display: block;
   min-width: 0;
 }
 
-.leaf {
+/* 目录行：一行、无边框，纯粹交代层级。 */
+.folder {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  height: 30px;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.folderIcon {
+  flex: none;
+  color: var(--color-text-muted);
+}
+
+.folderName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* 文件卡片：边框 + 方角，与 EntityListRail 的 .item 同规格（10/12 比列表卡略紧，
+   因为这里每行左边还要让出缩进）。 */
+.card {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 8px;
   min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
+}
+
+.tree :global(.ant-tree-node-content-wrapper:hover) .card {
+  border-color: var(--color-primary-border);
+}
+
+.tree :global(.ant-tree-node-selected) .card {
+  border-color: var(--color-primary-600);
+  box-shadow: 0 0 0 1px var(--color-primary-border);
+}
+
+.cardTop {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  line-height: 20px;
+}
+
+.fileIcon {
+  flex: none;
+  color: var(--color-text-muted);
 }
 
 .title {
+  flex: 1;
   overflow: hidden;
-  color: rgba(0, 0, 0, 0.88);
+  color: var(--color-text-primary);
+  font-size: 13px;
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.meta {
-  color: rgba(0, 0, 0, 0.45);
-  font-size: 12px;
+/* 扩展名徽标：与列表卡右下角的小标签同一档，浅底细框，不跟文件名抢注意力。 */
+.badge {
+  flex: none;
+  padding: 0 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-fill-quaternary, #f5f5f5);
+  color: var(--color-text-secondary);
+  font-size: 11px;
   line-height: 18px;
+  white-space: nowrap;
+}
+
+.meta {
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/modules/execution-factory/locales/en-US.ts
+++ b/src/modules/execution-factory/locales/en-US.ts
@@ -706,6 +706,8 @@ export const executionFactoryEnUS = {
     skillFilePreviewBinaryHint: "This file is binary and cannot be previewed inline. Use the link below to download it.",
     skillFilePreviewDownloadLink: "Open download link",
     skillFilePreviewSelectHint: "Select a file on the left to preview its contents.",
+    skillFilePreviewRendered: "Preview",
+    skillFilePreviewSource: "Source",
     skillMarketDetailTitle: "Market SKILL Detail",
     skillContentTitle: "SKILL.md Content",
     skillContentEmpty: "No SKILL content available.",

--- a/src/modules/execution-factory/locales/zh-CN.ts
+++ b/src/modules/execution-factory/locales/zh-CN.ts
@@ -698,6 +698,8 @@ export const executionFactoryZhCN = {
     skillFilePreviewBinaryHint: "该文件为二进制格式，暂不支持在线预览，可通过下方链接下载查看。",
     skillFilePreviewDownloadLink: "打开下载链接",
     skillFilePreviewSelectHint: "请从左侧选择一个文件进行预览。",
+    skillFilePreviewRendered: "预览",
+    skillFilePreviewSource: "原文",
     skillMarketDetailTitle: "市场 SKILL 详情",
     skillContentTitle: "SKILL.md 内容",
     skillContentEmpty: "暂无 SKILL 内容。",

--- a/src/modules/execution-factory/scenes/SkillDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/SkillDetailScene.tsx
@@ -29,6 +29,7 @@ import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { DetailBasicInfoButton } from "@/modules/execution-factory/components/DetailBasicInfoButton";
 import { EntityListRail } from "@/modules/execution-factory/components/EntityListRail";
+import { SkillFilePreview } from "@/modules/execution-factory/components/SkillFilePreview";
 import { SkillFileTreeView } from "@/modules/execution-factory/components/SkillFileTreeView";
 import { SkillHistoryDrawer } from "@/modules/execution-factory/components/SkillHistoryDrawer";
 import {
@@ -369,6 +370,7 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
                 {/* 与工具 / 函数 / MCP 三处列表栏同一套外壳；文件树有层级，压平成
                     卡片就没了，所以走 EntityListRail 的自绘出口。 */}
                 <EntityListRail
+                  headLayout="inline"
                   icon={<FileTextOutlined />}
                   search={{
                     onChange: setRailKeyword,
@@ -396,44 +398,19 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
                   )}
                 </EntityListRail>
               </Sider>
-              <Content className={styles.content}>
-                {selectedFile ? (
-                  <div className={styles.ioPanel}>
-                    <div className={styles.ioHeader}>
-                      <span>{t("executionFactory.skillFilePreviewTitle")}</span>
-                      <span className={styles.infoValue}>{selectedFile.relPath}</span>
-                    </div>
-                    {previewLoading ? (
-                      <div className={styles.emptyWrap}>
-                        <Spin />
-                      </div>
-                    ) : previewError ? (
-                      <Alert message={previewError} showIcon type="error" />
-                    ) : preview?.kind === "text" ? (
-                      <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>{preview.content}</pre>
-                    ) : preview?.kind === "binary" ? (
-                      <Empty description={t("executionFactory.skillFilePreviewBinaryHint")}>
-                        <AppButton href={preview.url} rel="noreferrer" target="_blank" type="link">
-                          {t("executionFactory.skillFilePreviewDownloadLink")}
-                        </AppButton>
-                      </Empty>
-                    ) : (
-                      <Empty description={t("executionFactory.skillFilePreviewSelectHint")} />
-                    )}
-                  </div>
-                ) : (
-                  <div className={styles.emptyWrap}>
-                    <Empty description={t("executionFactory.skillFilePreviewSelectHint")} />
-                  </div>
-                )}
+              <Content className={`${styles.content} ${styles.contentFill}`}>
+                <SkillFilePreview
+                  downloadUrl={preview?.kind === "binary" ? preview.url : undefined}
+                  errorMessage={previewError}
+                  loading={previewLoading}
+                  relPath={selectedFile?.relPath}
+                  text={preview?.kind === "text" ? preview.content : undefined}
+                />
               </Content>
             </Layout>
           ) : content?.content ? (
-            <div className={styles.ioPanel}>
-              <div className={styles.ioHeader}>
-                <span>{t("executionFactory.skillContentTitle")}</span>
-              </div>
-              <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>{content.content}</pre>
+            <div className={`${styles.layout} ${styles.contentFill}`}>
+              <SkillFilePreview relPath="SKILL.md" text={content.content} />
             </div>
           ) : (
             <div className={styles.emptyWrap}>

--- a/src/modules/execution-factory/scenes/toolbox-detail.module.css
+++ b/src/modules/execution-factory/scenes/toolbox-detail.module.css
@@ -273,6 +273,14 @@
   background: var(--color-bg-surface) !important;
 }
 
+/* 单块面板铺满右栏（技能包的文件预览）：里面是 Monaco / 长文档，自己管滚动，
+   外层再滚一层就会出现两条滚动条。 */
+.contentFill {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 /* 工作区按水平线分区，不再一块一个卡片（对齐函数工作台的 .fnHead / .editor / .console）。 */
 .section,
 .ioPanel {

--- a/src/modules/execution-factory/utils/skill-file-preview.test.ts
+++ b/src/modules/execution-factory/utils/skill-file-preview.test.ts
@@ -8,8 +8,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  isMarkdownSkillFile,
   isTextPreviewableSkillFile,
   resolveSkillFileFetchUrl,
+  resolveSkillFileLanguage,
 } from "@/modules/execution-factory/utils/skill-file-preview";
 
 describe("skill-file-preview", () => {
@@ -47,5 +49,19 @@ describe("skill-file-preview", () => {
     expect(isTextPreviewableSkillFile("text/markdown", "refs/guide.md")).toBe(true);
     expect(isTextPreviewableSkillFile(undefined, "scripts/run.py")).toBe(true);
     expect(isTextPreviewableSkillFile("application/zip", "archive.bin")).toBe(false);
+  });
+
+  it("maps file extensions to monaco languages", () => {
+    expect(resolveSkillFileLanguage("scripts/pick_substitute.py")).toBe("python");
+    expect(resolveSkillFileLanguage("SKILL.md")).toBe("markdown");
+    expect(resolveSkillFileLanguage("config/app.YAML")).toBe("yaml");
+    expect(resolveSkillFileLanguage("Makefile")).toBe("plaintext");
+    expect(resolveSkillFileLanguage("data.unknownext")).toBe("plaintext");
+    expect(resolveSkillFileLanguage()).toBe("plaintext");
+  });
+
+  it("flags markdown files for the rendered/source toggle", () => {
+    expect(isMarkdownSkillFile("refs/guide.markdown")).toBe(true);
+    expect(isMarkdownSkillFile("scripts/run.py")).toBe(false);
   });
 });

--- a/src/modules/execution-factory/utils/skill-file-preview.ts
+++ b/src/modules/execution-factory/utils/skill-file-preview.ts
@@ -35,6 +35,12 @@ const TEXT_EXTENSIONS = new Set([
   ".csv",
 ]);
 
+/** 后缀（含点）；没有后缀返回空串。Dockerfile 这类无后缀文件走文件名匹配。 */
+function getExtension(relPath: string): string {
+  const lowerPath = relPath.toLowerCase();
+  return lowerPath.includes(".") ? lowerPath.slice(lowerPath.lastIndexOf(".")) : "";
+}
+
 export function isTextPreviewableSkillFile(mimeType?: string, relPath?: string): boolean {
   const normalizedMime = mimeType?.toLowerCase();
   if (normalizedMime) {
@@ -50,9 +56,60 @@ export function isTextPreviewableSkillFile(mimeType?: string, relPath?: string):
     return false;
   }
 
-  const lowerPath = relPath.toLowerCase();
-  const extension = lowerPath.includes(".") ? lowerPath.slice(lowerPath.lastIndexOf(".")) : "";
-  return TEXT_EXTENSIONS.has(extension);
+  return TEXT_EXTENSIONS.has(getExtension(relPath));
+}
+
+/** 后缀 → Monaco 语言 id。这些语法都在本地打包的 monaco-editor 里，不额外拉包。 */
+const LANGUAGE_BY_EXTENSION: Record<string, SkillFileLanguage> = {
+  ".md": "markdown",
+  ".markdown": "markdown",
+  ".json": "json",
+  ".yaml": "yaml",
+  ".yml": "yaml",
+  ".py": "python",
+  ".js": "javascript",
+  ".jsx": "javascript",
+  ".ts": "typescript",
+  ".tsx": "typescript",
+  ".sh": "shell",
+  ".bash": "shell",
+  ".zsh": "shell",
+  ".sql": "sql",
+  ".xml": "xml",
+  ".html": "html",
+  ".htm": "html",
+  ".css": "css",
+  ".toml": "ini",
+  ".ini": "ini",
+  ".cfg": "ini",
+};
+
+export type SkillFileLanguage =
+  | "css"
+  | "html"
+  | "ini"
+  | "javascript"
+  | "json"
+  | "markdown"
+  | "plaintext"
+  | "python"
+  | "shell"
+  | "sql"
+  | "typescript"
+  | "xml"
+  | "yaml";
+
+/** 高亮按后缀判，认不出来的按纯文本渲染——猜错语言比不高亮更难读。 */
+export function resolveSkillFileLanguage(relPath?: string): SkillFileLanguage {
+  if (!relPath) {
+    return "plaintext";
+  }
+
+  return LANGUAGE_BY_EXTENSION[getExtension(relPath)] ?? "plaintext";
+}
+
+export function isMarkdownSkillFile(relPath?: string): boolean {
+  return resolveSkillFileLanguage(relPath) === "markdown";
 }
 
 /**

--- a/src/modules/knowledge-network/components/network/KnowledgeNetworkCard.tsx
+++ b/src/modules/knowledge-network/components/network/KnowledgeNetworkCard.tsx
@@ -9,7 +9,7 @@ import { DeploymentUnitOutlined, EllipsisOutlined } from "@ant-design/icons";
 import { Dropdown, Tooltip, type MenuProps } from "antd";
 import { useTranslation } from "react-i18next";
 
-import { MarkdownText } from "@/modules/knowledge-network/components/shared/MarkdownText";
+import { MarkdownText } from "@/framework/ui/common/MarkdownText";
 import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
 
 import styles from "./KnowledgeNetworkCard.module.css";

--- a/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.tsx
@@ -29,7 +29,7 @@ import { AppButton } from "@/framework/ui/common/AppButton";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { ObjectAuthorizeDrawer } from "@/modules/system-admin/components/ObjectAuthorizeDrawer";
 import { OverviewOntologyBlock } from "@/modules/knowledge-network/components/preview/OverviewOntologyBlock";
-import { MarkdownText } from "@/modules/knowledge-network/components/shared/MarkdownText";
+import { MarkdownText } from "@/framework/ui/common/MarkdownText";
 import { renderResourceIcon } from "@/modules/knowledge-network/components/shared/ResourceIconSelect";
 import type {
   KnowledgeNetworkRecord,


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `execution-factory`：技能详情文件预览重做（新增 `SkillFilePreview` + `skill-file-preview.module.css`），Markdown 渲染/原文双视图，其余文本按后缀 Monaco 高亮，二进制退回下载
- [x] `execution-factory`：`CodeEditor` 语言联合从 `json | python` 放宽到技能包常见的十余种，只读态关掉光标与当前行高亮
- [x] `framework/ui/common`：`MarkdownText`（含 css module）从 `modules/knowledge-network/components/shared` 迁入，新增 `variant="document"`
- [x] `execution-factory`：文件树行改画成卡片（图标 + 文件名 + 扩展名徽标 + 次行 `mime · 大小`，选中蓝框），目录行保持一行，缩进 24px → 14px
- [x] `execution-factory`：`EntityListRail` 新增 `headLayout="inline"`，技能详情两栏头部各自一行、底线同 y
- [x] i18n：`skillFilePreviewRendered` / `skillFilePreviewSource` 中英各一条
- [ ] 文档：无

---

## Why

- Related Issue: 无（用户在会话中直接反馈「skill 预览风格太丑、要和其他页面对齐」「markdown 支持看原文和 preview」「代码也要高亮」）
- Related Feature: 承接 #292（技能包文件栏并入 EntityListRail）
- 背景：技能详情右栏此前是一块裸 `<pre style="white-space:pre-wrap">`——没有语法高亮、没有行号，Markdown 只能看源码，与函数工作台那侧的 Monaco 编辑器完全不是一套观感；左栏文件行是 antd Tree 默认样式，选中后一整块灰底压在浅灰侧栏上，且根级行比头部的标题 / 筛选框窄一截。

---

## How

- 关键实现点：
  - 预览按文件类型分流：`isMarkdownSkillFile` 决定是否出「预览 / 原文」Segmented；`resolveSkillFileLanguage` 按后缀映射 Monaco 语言，认不出走 `plaintext`（猜错语言比不高亮更难读）。语法全部来自本地打包的 `monaco-editor`，不新增依赖、不走 CDN。
  - 切换文件时 `mode` 重置回 `rendered`，A.md 切到原文不会带到 B.md。
  - `MarkdownText` 提到 framework 共享层，`document` 变体只改排版尺度（14px 正文、标题放大一档、方角、h2 下划线、行长封顶 72em），`compact` 行为不变，原两处调用同步改导入。
  - 文件树：叶子节点的展开箭头空位（`.ant-tree-switcher-noop`）宽度归零，根级卡片才与头部左右缘齐平；每层缩进压到 14px，`refs/api/v1/…` 这类深目录在 320px 侧栏里仍读得下。
  - 两栏头部不再互相凑高度：左栏标题与筛选框同排（`headLayout="inline"`），右栏预览头也是一行，两条底线自然同 y，矮的一侧不必垫空白。
- Breaking changes：无。`CodeEditor` 只是放宽语言联合（旧调用 `json` / `python` 不受影响）；`MarkdownText` 是内部组件迁移，无对外契约变化。
- 模块注册相关：未修改 `locales` 之外的注册面——`navigation.tsx` / `routes.tsx` / `module.manifest.ts` 均未改动；`locales` 仅新增两条预览视图文案（中英各一）；不影响其他智能体整合方式。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（本仓无该层；e2e 需 Playwright 环境，未在本机跑）
- [x] Verified in test environment（本地 dev server + 无头 Chrome 实测）

Test notes：

```
node scripts/check-license-headers.mjs                                   # 通过
pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0 # 0 warning
pnpm exec vitest --run                                                    # 116 文件 / 485 测试全过
pnpm exec tsc -b --pretty false                                           # 通过
pnpm exec vite build                                                      # 通过
pnpm audit --prod                                                         # 1 high，仓库既有忽略项，非本次引入
pnpm test:execution-factory                                               # 48 文件 / 236 测试全过
```

新增单测覆盖 `resolveSkillFileLanguage`（后缀映射、大小写、无后缀、未知后缀回退）与 `isMarkdownSkillFile`。

无头 Chrome 实测四种形态：Markdown 渲染态、Markdown 原文态、`.py` 高亮、深目录树（`refs/api/v1/*`、`scripts/helpers/*`，用临时 mock 造的层级，验证后已还原）。

---

## Risk & Rollback

- 潜在风险：
  - 纯前端展示层改动，不碰接口与数据写入；预览仍走原有 `previewSkillManagementFile`，请求时序与竞态处理未变。
  - Monaco 只读实例数增加（每次只挂一个），大文件预览的内存 / 首帧成本略高于 `<pre>`；技能包文件通常在几十 KB 量级，实测无卡顿。
  - `MarkdownText` 迁移影响 knowledge-network 两处调用（网络卡片 tooltip、工作台概览），`compact` 默认样式未改，视觉不变。
  - 未引入 `rehype-raw` / `dangerouslySetInnerHTML`，Markdown 渲染无新增 XSS 面。
- 回滚方案：单 commit（`78e307e`），`git revert` 即可全量退回；无数据迁移、无配置变更。

---

## Additional Notes

- 自动评审（`automation-claude-review.yml`）结论：无阻塞项。
- CI：`ci-quality`、`ci-smoke`、`L1 vitest (execution-factory)`、`release-studio build verify`、`security-scan`、`secret scan`、`dependency review` 均通过。
