### PR TITLE
fix(ci): use Helm-compatible release chart versions

### DIFF
--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -73,6 +73,11 @@ jobs:
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             # Tag push (e.g. v0.1.0) cuts a release: the tag IS the version.
             VERSION="${GITHUB_REF_NAME#v}"
+          elif [[ "${GITHUB_REF_NAME}" == release/* ]]; then
+            # Release branches use a stable, Helm-compatible version:
+            # release/0.1.2 -> 0.1.2-release.
+            RELEASE_VERSION="${GITHUB_REF_NAME#release/}"
+            VERSION="${RELEASE_VERSION}-release"
           else
             SANITIZED="$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"
             # Embed the commit date (Asia/Shanghai, fixed-width 14 digits) so the version


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Feature/module 1
- [ ] Feature/module 2
- [ ] Docs/doc 1

Updated `.github/workflows/release-studio.yml` so release branches use Helm-compatible versions:

- `release/0.1.2` → `0.1.2-release`
- `release/0.1.3` → `0.1.3-release`

The resolved version is used consistently for the Docker image tag, Helm chart version, `appVersion`, and chart image tag.

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background:

  The previous release-branch version format was not a valid Helm SemVer. This caused `helm lint` and `helm package` to fail.

---

## How

- Key implementation points:
  - Added explicit handling for `release/*` branches.
  - Extracted the release version from the branch name.
  - Appended `-release` to produce a valid Chart version.
  - Kept tag builds unchanged: `v0.1.2` → `0.1.2`.
  - Kept other branch builds using the existing timestamp/SHA prerelease format.

- Breaking changes (API, config, database, etc.):

  None.

---

## Testing

- [ ] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Verified `release/0.1.2` resolves to `0.1.2-release`.
- Verified `release/0.1.3` resolves to `0.1.3-release`.
- Ran `helm lint` successfully.
- Ran `helm package` successfully and generated `bkn-studio-0.1.2-release.tgz`.

---

## Risk & Rollback

- Potential risks:
  - Consumers referencing the previous release-branch chart version format will need to use the new `0.1.2-release` format.

- Rollback plan:
  - Revert this commit to restore the previous version-resolution behavior.

---

## Additional Notes

- This change only affects release branch builds.
- Versioned tag builds and non-release branch builds are unchanged.