### PR TITLE
fix(runtime): lazy load monaco editor

### DIFF
--- a/src/framework/monaco/MonacoEditor.tsx
+++ b/src/framework/monaco/MonacoEditor.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { lazy, Suspense, type ReactNode } from "react";
+import type { EditorProps } from "@monaco-editor/react";
+
+import { ensureMonacoSetup } from "@/framework/monaco/ensure";
+
+const MonacoEditorImpl = lazy(async () => {
+  await ensureMonacoSetup();
+  const module = await import("@monaco-editor/react");
+
+  return { default: module.default };
+});
+
+type MonacoEditorProps = EditorProps & {
+  fallback?: ReactNode;
+};
+
+export function MonacoEditor({ fallback = null, ...props }: MonacoEditorProps) {
+  return (
+    <Suspense fallback={fallback}>
+      <MonacoEditorImpl {...props} />
+    </Suspense>
+  );
+}

--- a/src/framework/monaco/ensure.ts
+++ b/src/framework/monaco/ensure.ts
@@ -5,8 +5,10 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import "@/app/locales/i18n";
-import "@/styles/global.css";
-import { startStandaloneApp } from "@/framework/runtime/bootstrap";
+let monacoSetupPromise: Promise<void> | undefined;
 
-startStandaloneApp();
+export function ensureMonacoSetup() {
+  monacoSetupPromise ??= import("@/framework/monaco/setup").then(() => undefined);
+
+  return monacoSetupPromise;
+}

--- a/src/modules/execution-factory/components/CodeEditor.tsx
+++ b/src/modules/execution-factory/components/CodeEditor.tsx
@@ -5,8 +5,10 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import Editor, { type Monaco, type OnMount } from "@monaco-editor/react";
+import type { Monaco, OnMount } from "@monaco-editor/react";
 import { useCallback, useEffect, useRef } from "react";
+
+import { MonacoEditor } from "@/framework/monaco/MonacoEditor";
 
 import styles from "./JsonEditor.module.css";
 
@@ -154,12 +156,13 @@ export function CodeEditor({
 
   return (
     <div className={`${styles.editorBorder} ${height === "fill" ? styles.editorFill : ""}`}>
-      <Editor
+      <MonacoEditor
         beforeMount={(monaco) => {
           monacoRef.current = monaco;
           defineTheme(monaco);
           applyJsonSchema(monaco);
         }}
+        fallback={<div style={{ height: height === "fill" ? "100%" : height }} />}
         height={height === "fill" ? "100%" : height}
         language={language}
         onChange={(next) => onChange?.(next ?? "")}

--- a/src/modules/execution-factory/scenes/FunctionWorkbenchScene.status.test.tsx
+++ b/src/modules/execution-factory/scenes/FunctionWorkbenchScene.status.test.tsx
@@ -116,7 +116,7 @@ describe("FunctionWorkbenchScene status wiring", () => {
     render(<FunctionWorkbenchScene boxId="box-1" />);
 
     // 保存按钮在代码区工具条里，要等选中函数、编辑区渲染出来才有。
-    fireEvent.click(await screen.findByText("common.save"));
+    fireEvent.click(await screen.findByText("common.save", undefined, { timeout: 5_000 }));
 
     await waitFor(() => {
       expect(createTool).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe("FunctionWorkbenchScene status wiring", () => {
 
     render(<FunctionWorkbenchScene boxId="box-1" />);
 
-    fireEvent.click(await screen.findByText("common.save"));
+    fireEvent.click(await screen.findByText("common.save", undefined, { timeout: 5_000 }));
 
     await waitFor(() => {
       expect(updateToolStatus).toHaveBeenCalledWith("box-1", ["tool-new"], "enabled");

--- a/src/modules/model-resources/components/models/AdaptationCodeEditor.tsx
+++ b/src/modules/model-resources/components/models/AdaptationCodeEditor.tsx
@@ -5,8 +5,10 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import Editor, { type OnMount } from "@monaco-editor/react";
+import type { OnMount } from "@monaco-editor/react";
 import { useEffect, useRef, useState } from "react";
+
+import { MonacoEditor } from "@/framework/monaco/MonacoEditor";
 
 import styles from "./AdaptationCodeEditor.module.css";
 
@@ -75,9 +77,10 @@ export function AdaptationCodeEditor({
       {showPlaceholder && placeholder ? (
         <div className={styles.placeholder}>{placeholder}</div>
       ) : null}
-      <Editor
+      <MonacoEditor
         className={`${styles.editor}${readOnly ? ` ${styles.editorReadOnly}` : ""}`}
         defaultLanguage="python"
+        fallback={<div style={{ height }} />}
         height={height}
         onChange={handleChange}
         onMount={handleMount}

--- a/src/modules/model-resources/components/models/api-guide/ModelApiGuideMonacoEditor.tsx
+++ b/src/modules/model-resources/components/models/api-guide/ModelApiGuideMonacoEditor.tsx
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import Editor from "@monaco-editor/react";
+import { MonacoEditor } from "@/framework/monaco/MonacoEditor";
 
 import styles from "./ModelApiGuideMonacoEditor.module.css";
 
@@ -48,9 +48,10 @@ export function ModelApiGuideMonacoEditor({
   value,
 }: ModelApiGuideMonacoEditorProps) {
   return (
-    <Editor
+    <MonacoEditor
       className={styles.editor}
       defaultLanguage={language}
+      fallback={<div style={{ height }} />}
       height={height}
       options={READONLY_EDITOR_OPTIONS}
       value={value}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Lazy-load Monaco setup and @monaco-editor/react through a shared wrapper.
- [x] Remove global Monaco setup from the app bootstrap path.
- [x] Update execution factory and model resource Monaco editor usages.

---

## Why

- Related Issue: Closes #296
- Related Feature: 0.1.2 release stabilization
- Background: Monaco was loaded during app bootstrap, increasing first-load cost even on pages that do not use code editors.

---

## How

- Key implementation points: Added a cached ensureMonacoSetup() dynamic import and a Suspense-backed MonacoEditor wrapper. Existing editors now import the wrapper instead of @monaco-editor/react directly.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- node scripts/check-license-headers.mjs
- pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
- pnpm exec vitest --run
- pnpm exec tsc -b --pretty false
- pnpm exec vite build
- pnpm audit --prod (exit 0; existing high vulnerability is ignored by policy)
- pnpm test:execution-factory

---

## Risk & Rollback

- Potential risks: Editors show an empty placeholder while Monaco chunks are loading; pages using editors rely on Suspense fallback during first editor mount.
- Rollback plan: Revert this PR to restore eager Monaco setup import and direct editor imports.

---

## Additional Notes

- Direct push to release/0.1.2 was rejected because the branch is protected, so this PR targets release/0.1.2.