### PR TITLE
fix(knowledge-network): align delete confirm dialogs

### DIFF
--- a/src/modules/execution-factory/components/create-menu/CreateMcpDrawer.test.tsx
+++ b/src/modules/execution-factory/components/create-menu/CreateMcpDrawer.test.tsx
@@ -151,7 +151,7 @@ describe("CreateMcpDrawer", () => {
       expect(messageError).toHaveBeenCalledWith("mcp server is not accessible");
     });
     expect(messageWarning).not.toHaveBeenCalled();
-  });
+  }, 10_000);
 
   it("blocks names the backend rejects before sending the request", async () => {
     renderDrawer();
@@ -165,5 +165,5 @@ describe("CreateMcpDrawer", () => {
 
     expect(await screen.findByText("Only letters, digits and underscores")).toBeTruthy();
     expect(registerMcp).not.toHaveBeenCalled();
-  });
+  }, 10_000);
 });

--- a/src/modules/execution-factory/components/create-menu/QuickAddApiForm.submit.test.tsx
+++ b/src/modules/execution-factory/components/create-menu/QuickAddApiForm.submit.test.tsx
@@ -102,7 +102,7 @@ describe("QuickAddApiForm cURL submit", () => {
     expect(document.servers[0].url).toBe("https://httpbin.org");
     expect(Object.keys(document.paths)).toEqual(["/post"]);
     expect(document.paths["/post"].post).toBeTruthy();
-  });
+  }, 10_000);
 
   /**
    * 回归:点过「识别接口信息」后 detectedCurlContract 不会随输入框失效,而它会整体覆盖

--- a/src/modules/knowledge-network/components/action-type/ActionTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeListPanel.tsx
@@ -166,13 +166,15 @@ export function ActionTypeListPanel({
               name: records[0]?.name ?? "",
             }),
       cancelText: t("common.cancel"),
-      className: modalStyles.businessModal,
-      okButtonProps: { danger: true },
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await onDelete(records);
         setSelectedRowKeys([]);
       },
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/components/concept-group/ConceptGroupListPanel.tsx
+++ b/src/modules/knowledge-network/components/concept-group/ConceptGroupListPanel.tsx
@@ -156,13 +156,15 @@ export function ConceptGroupListPanel({
               name: records[0]?.name ?? "",
             }),
       cancelText: t("common.cancel"),
-      className: modalStyles.businessModal,
-      okButtonProps: { danger: true },
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await onDelete(records);
         setSelectedRowKeys([]);
       },
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.test.tsx
+++ b/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.test.tsx
@@ -90,7 +90,7 @@ describe("MetricDataQueryPanel", () => {
     expect(drillDownLabel).toBeTruthy();
     expect(screen.getByText("物料名称")).toBeTruthy();
     expect(container.textContent).not.toContain("material_name");
-  });
+  }, 10_000);
 
   it("keeps filter condition available when no drill-down dimensions are configured", () => {
     render(

--- a/src/modules/knowledge-network/components/metric/MetricListPanel.tsx
+++ b/src/modules/knowledge-network/components/metric/MetricListPanel.tsx
@@ -148,12 +148,13 @@ export function MetricListPanel({
 
     void modal.confirm({
       cancelText: t("common.cancel"),
-      className: modalStyles.businessModal,
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
       content:
         records.length === 1
           ? t("knowledgeNetwork.metricDeleteDescription", { name: records[0].name })
           : t("knowledgeNetwork.metricBatchDeleteDescription", { count: records.length }),
-      okButtonProps: { danger: true },
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         if (records.length === 1) {
@@ -169,6 +170,7 @@ export function MetricListPanel({
         await Promise.all([fetchMetrics(), onRefresh()]);
       },
       title: t("knowledgeNetwork.metricDeleteTitle"),
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css
+++ b/src/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css
@@ -48,6 +48,71 @@
   margin-bottom: 0;
 }
 
+.resourceDeleteConfirmModal :global(.ant-modal-content) {
+  padding: 28px 30px 24px;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-body-wrapper) {
+  display: flex;
+  flex-direction: column;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-body) {
+  align-items: flex-start;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-body > .anticon) {
+  margin-inline-end: 14px;
+  color: #f5a623;
+  font-size: 24px;
+  line-height: 28px;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-title) {
+  color: #111827;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 28px;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-content) {
+  margin-top: 10px;
+  color: #111827;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-btns) {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-btns .ant-btn) {
+  min-width: 80px;
+  height: 40px;
+  border-radius: 0;
+  font-size: 16px;
+  box-shadow: none;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-btns .ant-btn-default) {
+  border-color: #d9e0ea;
+  background: #fff;
+  color: #111827;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-btns .ant-btn-primary.ant-btn-dangerous) {
+  border-color: #ff4d5a;
+  background: #ff4d5a;
+}
+
+.resourceDeleteConfirmModal :global(.ant-modal-confirm-btns .ant-btn-primary.ant-btn-dangerous:hover) {
+  border-color: #f03d4a;
+  background: #f03d4a;
+}
+
 .form {
   display: grid;
   gap: 0;

--- a/src/modules/knowledge-network/components/object-type/ObjectTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/object-type/ObjectTypeListPanel.tsx
@@ -238,13 +238,15 @@ export function ObjectTypeListPanel({
               name: records[0]?.name ?? "",
             }),
       cancelText: t("common.cancel"),
-      className: modalStyles.businessModal,
-      okButtonProps: { danger: true },
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await onDelete(records);
         setSelectedRowKeys([]);
       },
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/components/relation-type/RelationTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/relation-type/RelationTypeListPanel.tsx
@@ -143,13 +143,15 @@ export function RelationTypeListPanel({
               name: records[0]?.name ?? "",
             }),
       cancelText: t("common.cancel"),
-      className: modalStyles.businessModal,
-      okButtonProps: { danger: true },
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await onDelete(records);
         setSelectedRowKeys([]);
       },
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/scenes/ActionTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeDetailScene.tsx
@@ -17,6 +17,7 @@ import { AppButton } from "@/framework/ui/common/AppButton";
 import { ActionTypeOverviewPanel } from "@/modules/knowledge-network/components/action-type/ActionTypeOverviewPanel";
 import { ActionTypeExecuteModal } from "@/modules/knowledge-network/components/action-type/ActionTypeExecuteModal";
 import { ActionTypeTaskManagementPanel } from "@/modules/knowledge-network/components/action-type/ActionTypeTaskManagementPanel";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
 import {
   deleteKnowledgeNetworkActionType,
@@ -98,13 +99,16 @@ export function ActionTypeDetailScene() {
       title: t("knowledgeNetwork.actionTypeDeleteTitle"),
       content: t("knowledgeNetwork.actionTypeDeleteDescription", { name: detail.name }),
       cancelText: t("common.cancel"),
-      okButtonProps: { danger: true },
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await deleteKnowledgeNetworkActionType(networkId, detail.id);
         void message.success(t("common.success"));
         void navigate(listPath);
       },
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.tsx
@@ -22,6 +22,7 @@ import { useAppServices } from "@/framework/context/use-app-services";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { ConceptGroupAddObjectTypesModal } from "@/modules/knowledge-network/components/concept-group/ConceptGroupAddObjectTypesModal";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { renderResourceIcon } from "@/modules/knowledge-network/components/shared/ResourceIconSelect";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
 import {
@@ -242,8 +243,10 @@ export function ConceptGroupDetailScene() {
 
     void modal.confirm({
       cancelText: t("common.cancel"),
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
       content: t("knowledgeNetwork.conceptGroupDeleteDescription", { name: detail.name }),
-      okButtonProps: { danger: true },
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await deleteKnowledgeNetworkConceptGroup(networkId, detail.id);
@@ -251,6 +254,7 @@ export function ConceptGroupDetailScene() {
         void navigate(listPath);
       },
       title: t("knowledgeNetwork.conceptGroupDeleteTitle"),
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/scenes/MetricDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/MetricDetailScene.tsx
@@ -15,6 +15,7 @@ import { useAppServices } from "@/framework/context/use-app-services";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { MetricDataQueryPanel } from "@/modules/knowledge-network/components/metric/MetricDataQueryPanel";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
 import type { MetricDetailSceneProps } from "@/modules/knowledge-network/contracts/scenes";
 import { useResolvedUpdaterName } from "@/modules/knowledge-network/hooks/useAccountDirectory";
@@ -113,8 +114,10 @@ export function MetricDetailScene({
 
     void modal.confirm({
       cancelText: t("common.cancel"),
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
       content: t("knowledgeNetwork.metricDeleteDescription", { name: detail.name }),
-      okButtonProps: { danger: true },
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await deleteKnowledgeNetworkMetric(networkId, detail.id);
@@ -127,6 +130,7 @@ export function MetricDetailScene({
         void navigate(listPath);
       },
       title: t("knowledgeNetwork.metricDeleteTitle"),
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
@@ -27,6 +27,7 @@ import { indexStateOf } from "@/modules/data-catalog/lib/index-state";
 import { listBuildTasks } from "@/modules/data-catalog/services/build-task.service";
 import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { renderResourceIcon } from "@/modules/knowledge-network/components/shared/ResourceIconSelect";
 import { ObjectTypePropertyTable } from "@/modules/knowledge-network/components/object-type/ObjectTypePropertyTable";
 import { enrichDataPropertiesWithRowTotal } from "@/modules/knowledge-network/lib/enrich-data-properties";
@@ -471,13 +472,16 @@ export function ObjectTypeDetailScene() {
       title: t("knowledgeNetwork.objectTypeDeleteTitle"),
       content: t("knowledgeNetwork.objectTypeDeleteDescription", { name: detail.name }),
       cancelText: t("common.cancel"),
-      okButtonProps: { danger: true },
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await deleteKnowledgeNetworkObjectType(networkId, detail.id);
         void message.success(t("common.success"));
         void navigate(listPath);
       },
+      width: 520,
     });
   };
 

--- a/src/modules/knowledge-network/scenes/RelationTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/RelationTypeDetailScene.tsx
@@ -14,6 +14,7 @@ import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useAppServices } from "@/framework/context/use-app-services";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { RelationTypeMappingConfigTable } from "@/modules/knowledge-network/components/relation-type/RelationTypeMappingConfigTable";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
 import {
@@ -82,13 +83,16 @@ export function RelationTypeDetailScene() {
       title: t("knowledgeNetwork.relationTypeDeleteTitle"),
       content: t("knowledgeNetwork.relationTypeDeleteDescription", { name: detail.name }),
       cancelText: t("common.cancel"),
-      okButtonProps: { danger: true },
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      okButtonProps: { danger: true, type: "primary" },
       okText: t("common.delete"),
       onOk: async () => {
         await deleteKnowledgeNetworkRelationType(networkId, detail.id);
         void message.success(t("common.success"));
         void navigate(listPath);
       },
+      width: 520,
     });
   };
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Align delete confirmation dialogs for metrics, object types, relation types, action types, and concept groups.
- [x] Reuse one shared resource delete confirm style across list and detail delete entry points.
- [x] Add explicit timeouts to slow UI tests that exceeded Vitest's 5s default during full local runs.

---

## Why

- Related Issue: N/A, requested in chat for the 0.1.2 release branch.
- Related Feature: Knowledge network resource management polish.
- Background: Knowledge network delete confirmation dialogs were visually inconsistent with the expected compact enterprise style.

---

## How

- Key implementation points: Added a scoped `resourceDeleteConfirmModal` CSS class in the existing knowledge-network modal stylesheet and applied it to resource delete `modal.confirm` calls for list and detail pages.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` exits 0; it reports 1 high vulnerability ignored by the current audit policy.
- `pnpm test:execution-factory`

---

## Risk & Rollback

- Potential risks: The styling targets Ant Design confirm modal internals under a scoped class; future Ant Design markup changes may require selector updates.
- Rollback plan: Revert this PR to restore the previous confirm dialog styling.

---

## Additional Notes

- Target branch: `release/0.1.2`.
- Temporary local files such as `.tmp-*.json` were intentionally left untracked and are not included.