### PR TITLE
fix(knowledge-network): hide quarter metric query step

### DIFF
--- a/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.test.tsx
+++ b/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.test.tsx
@@ -59,6 +59,42 @@ afterEach(() => {
 });
 
 describe("MetricDataQueryPanel", () => {
+  it("hides quarter step for trend and proportion query modes", () => {
+    render(
+      <MetricDataQueryPanel
+        metricId="metric-1"
+        metricName="Material count"
+        networkId="network-1"
+      />,
+    );
+
+    const modeLabel = screen.getByText("knowledgeNetwork.metricQueryModeLabel");
+    const modeSelect = modeLabel
+      .closest(".ant-form-item")
+      ?.querySelector(".ant-select-selector");
+
+    expect(modeSelect).toBeTruthy();
+    fireEvent.mouseDown(modeSelect!);
+    fireEvent.click(screen.getByText("knowledgeNetwork.metricQueryMode.trend"));
+
+    const stepLabel = screen.getByText("knowledgeNetwork.metricQueryStepLabel");
+    const stepSelect = stepLabel
+      .closest(".ant-form-item")
+      ?.querySelector(".ant-select-selector");
+
+    expect(stepSelect).toBeTruthy();
+    fireEvent.mouseDown(stepSelect!);
+    expect(screen.queryByText("knowledgeNetwork.metricQueryStep.quarter")).toBeNull();
+    expect(screen.getByText("knowledgeNetwork.metricQueryStep.month")).toBeTruthy();
+
+    fireEvent.mouseDown(modeSelect!);
+    fireEvent.click(screen.getByText("knowledgeNetwork.metricQueryMode.proportion"));
+    fireEvent.mouseDown(stepSelect!);
+
+    expect(screen.queryByText("knowledgeNetwork.metricQueryStep.quarter")).toBeNull();
+    expect(screen.getByText("knowledgeNetwork.metricQueryStep.month")).toBeTruthy();
+  }, 10_000);
+
   it("renders drill-down dimensions with semantic property names", () => {
     const { container } = render(
       <MetricDataQueryPanel

--- a/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.tsx
+++ b/src/modules/knowledge-network/components/metric/MetricDataQueryPanel.tsx
@@ -45,6 +45,8 @@ const CALENDAR_STEP_OPTIONS: MetricQueryCalendarStep[] = [
   "quarter",
   "year",
 ];
+const TREND_AND_PROPORTION_STEP_OPTIONS: MetricQueryCalendarStep[] =
+  CALENDAR_STEP_OPTIONS.filter((value) => value !== "quarter");
 const SAME_PERIOD_METHOD_OPTIONS: MetricSamePeriodMethod[] = ["growth_value", "growth_rate"];
 const SAME_PERIOD_GRANULARITY_OPTIONS: MetricSamePeriodTimeGranularity[] = [
   "day",
@@ -60,6 +62,14 @@ function showStepField(mode: MetricDataQueryMode | undefined) {
 
 function showFillNullField(mode: MetricDataQueryMode | undefined) {
   return mode === "trend" || mode === "sameperiod" || mode === "proportion";
+}
+
+function getCalendarStepOptions(mode: MetricDataQueryMode | undefined) {
+  if (mode === "trend" || mode === "proportion") {
+    return TREND_AND_PROPORTION_STEP_OPTIONS;
+  }
+
+  return CALENDAR_STEP_OPTIONS;
 }
 
 type MetricDataQueryPanelProps = {
@@ -175,6 +185,10 @@ export function MetricDataQueryPanel({
   const [result, setResult] = useState<MetricDataQueryResult | null>(null);
   const queryMode = Form.useWatch("mode", form);
   const timeRange = Form.useWatch("timeRange", form);
+  const calendarStepOptions = useMemo(
+    () => getCalendarStepOptions(queryMode),
+    [queryMode],
+  );
   const propertyDisplayNameMap = useMemo(
     () =>
       new Map(
@@ -235,7 +249,8 @@ export function MetricDataQueryPanel({
           layout="inline"
           onValuesChange={(changed: Partial<MetricDataQueryParams>) => {
             if (changed.mode === "trend" || changed.mode === "proportion") {
-              if (!form.getFieldValue("step")) {
+              const currentStep = form.getFieldValue("step") as MetricQueryCalendarStep | undefined;
+              if (!currentStep || currentStep === "quarter") {
                 form.setFieldValue("step", "day");
               }
             }
@@ -299,7 +314,7 @@ export function MetricDataQueryPanel({
               }
             >
               <Select
-                options={CALENDAR_STEP_OPTIONS.map((value) => ({
+                options={calendarStepOptions.map((value) => ({
                   label: t(`knowledgeNetwork.metricQueryStep.${value}`),
                   value,
                 }))}


### PR DESCRIPTION
﻿# Pull Request

## What Changed

Brief description of changes:

- [x] Knowledge Network metric data query hides the `quarter` step option when query mode is `trend`.
- [x] Knowledge Network metric data query hides the `quarter` step option when query mode is `proportion`.
- [x] Added regression coverage for the trend/proportion step options.

---

## Why

- Related Issue: N/A, requested release branch patch.
- Related Feature: Knowledge Network metric data query.
- Background: Quarter granularity should not be selectable for trend and proportion metric data queries on the release branch.

---

## How

- Key implementation points:
  - Added a filtered calendar step option list for `trend` and `proportion` modes.
  - Reset existing `quarter` form value to `day` when switching into `trend` or `proportion`.
  - Added component test coverage to ensure `quarter` is absent while other valid steps remain available.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally: N/A, UI option filtering only.
- [ ] Verified in test environment: Not run locally.

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run src/modules/knowledge-network/components/metric/MetricDataQueryPanel.test.tsx`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` (exit 0; 1 high vulnerability ignored by existing config)

---

## Risk & Rollback

- Potential risks: Low. The change is scoped to one metric query form select and its mode-switch normalization.
- Rollback plan: Revert commit `16a5c45`.

---

## Additional Notes

- Target branch: `release/0.1.2`.
- Local untracked `.tmp-*` files were intentionally not included.
