### PR TITLE
fix(data-catalog): correct OpenSearch catalog display

### DIFF
--- a/src/modules/data-catalog/components/CatalogDetailPanel.module.css
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.module.css
@@ -138,6 +138,16 @@
   min-width: 0;
 }
 
+.resourceNameTooltip:global(.ant-tooltip) {
+  max-width: min(720px, calc(100vw - 48px));
+}
+
+.resourceNameTooltip :global(.ant-tooltip-inner) {
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: normal;
+}
+
 .resizableHeader {
   position: relative;
   display: flex;

--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -49,14 +49,22 @@ function indexFilterBucket(key: string) {
   return "failed";
 }
 
-function deriveDisplayName(resource: CatalogResource) {
+function deriveDisplayName(resource: CatalogResource, connectorType: string) {
   const rawName = (resource.name ?? "").trim();
+  const rawIdentifier = (resource.sourceIdentifier ?? "").trim();
+
+  if (connectorType === "opensearch") {
+    if (rawName && rawIdentifier && rawName !== rawIdentifier) {
+      return `${rawName} / ${rawIdentifier}`;
+    }
+    return rawName || rawIdentifier || "-";
+  }
+
   const byName = rawName.includes(".") ? rawName.split(".").filter(Boolean).at(-1) : rawName;
   if (byName) {
     return byName;
   }
 
-  const rawIdentifier = (resource.sourceIdentifier ?? "").trim();
   const fromMatch = rawIdentifier.match(/\bfrom\s+([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+){0,2})/i);
   const candidate = (fromMatch?.[1] ?? rawIdentifier).trim();
   const byIdentifier = candidate.includes(".") ? candidate.split(".").filter(Boolean).at(-1) : candidate;
@@ -69,6 +77,22 @@ function EllipsisText({ text }: { text: string }) {
       <span className={styles.cellEllipsis}>{text}</span>
     </Tooltip>
   );
+}
+
+function getResourceNameTooltip(
+  resource: CatalogResource,
+  connectorType: string,
+  displayName: string,
+) {
+  if (connectorType === "opensearch") {
+    return displayName;
+  }
+
+  if (resource.sourceIdentifier && resource.sourceIdentifier !== resource.name) {
+    return `${resource.name}\n${resource.sourceIdentifier}`;
+  }
+
+  return resource.name || displayName;
 }
 
 type CatalogDetailPanelProps = {
@@ -311,13 +335,13 @@ export function CatalogDetailPanel({
         </div>
       ),
       render: (_, record) => {
-        const tooltip =
-          record.sourceIdentifier && record.sourceIdentifier !== record.name
-            ? `${record.name}\n${record.sourceIdentifier}`
-            : record.name;
-        const displayName = deriveDisplayName(record);
+        const displayName = deriveDisplayName(record, catalog.connectorType);
+        const tooltip = getResourceNameTooltip(record, catalog.connectorType, displayName);
         return (
-          <Tooltip title={tooltip}>
+          <Tooltip
+            overlayClassName={styles.resourceNameTooltip}
+            title={tooltip}
+          >
             <AppButton
               className={styles.ellipsisLink}
               onClick={() => onOpenResource(record.id, "detail")}

--- a/src/modules/data-catalog/components/CatalogTreePanel.tsx
+++ b/src/modules/data-catalog/components/CatalogTreePanel.tsx
@@ -91,11 +91,17 @@ type ScopeGroup = {
   schemas: string[];
 };
 
-function parseScopeGroupsByCatalog(resources: CatalogResource[]) {
+function parseScopeGroupsByCatalog(
+  resources: CatalogResource[],
+  catalogConnectorTypes: Map<string, string>,
+) {
   const groupedByCatalog = new Map<string, Map<string, Set<string>>>();
 
   resources.forEach((item) => {
     if (!item.catalogId) {
+      return;
+    }
+    if (catalogConnectorTypes.get(item.catalogId) === "opensearch") {
       return;
     }
     const raw = (item.sourceIdentifier ?? "").trim();
@@ -172,7 +178,15 @@ export function CatalogTreePanel({
     return resources.find((item) => item.id === selection.id)?.catalogId;
   }, [resources, selection]);
 
-  const scopeGroupsByCatalog = useMemo(() => parseScopeGroupsByCatalog(resources), [resources]);
+  const catalogConnectorTypes = useMemo(
+    () => new Map(catalogs.map((catalog) => [catalog.id, catalog.connectorType])),
+    [catalogs],
+  );
+
+  const scopeGroupsByCatalog = useMemo(
+    () => parseScopeGroupsByCatalog(resources, catalogConnectorTypes),
+    [catalogConnectorTypes, resources],
+  );
 
   const selectedKey = useMemo(() => {
     if (selectedCatalogId && activeDb && activeSchema) {


### PR DESCRIPTION
﻿# Pull Request

## What Changed

Brief description of changes:

- [x] 数据目录左侧树不再把 OpenSearch index 名称按 `.` 拆成虚拟层级。
- [x] OpenSearch 资源名称不再按关系型 `db.table` 规则截短。
- [x] 资源名称列保持单行省略，hover tooltip 加宽展示完整名称。

---

## Why

- Related Issue: #307
- Related Feature: 数据目录 / OpenSearch 资源展示
- Background: OpenSearch 的 index 名称可能包含日期点号，例如 `top_queries-2026.07.22-44539`，这些点号不是数据库/schema 层级。此前左侧树会错误拆层级，右侧资源名称也会被关系型显示规则截短。

---

## How

- Key implementation points:
  - 构建左侧资源 scope 分组时跳过 `connectorType === "opensearch"` 的资源，避免生成假层级。
  - OpenSearch 资源名称使用完整业务名/索引名，不再按 `.` 取最后一段。
  - 名称列仍保持单行展示，超出列宽使用省略号，完整内容放在加宽 tooltip 中。
- Breaking changes (API, config, database, etc.): 无。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `node scripts/check-license-headers.mjs` passed
- `pnpm exec eslint.cmd . --config eslint.config.typechecked.js --max-warnings 0` passed
- `pnpm exec vitest --run src/modules/data-catalog/lib/resource-identifier.test.ts` passed
- `pnpm exec tsc -b --pretty false` passed
- `pnpm exec vite build` passed，存在现有 chunk size / browser compatibility warning
- `pnpm audit --prod` passed，输出 1 个已 ignored 的 high vulnerability
- `pnpm exec vitest --run` 全量本地执行失败在 `src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx` 两个用例；该文件单跑通过，判断为和本次数据目录改动无关的全量并发/时序 flaky。

---

## Risk & Rollback

- Potential risks: 只影响数据目录中 OpenSearch 资源的左树分组和资源名称展示；关系型数据源仍按原层级解析和显示逻辑处理。
- Rollback plan: 回滚本 PR 即恢复原展示逻辑。

---

## Additional Notes

- 本 PR 只提交 OpenSearch 左树和资源名称展示相关 3 个文件，不包含本地 `.tmp-*.json` 临时文件。
