### PR TITLE
fix(bkn-studio): skip lookup for synthetic system actors

### DIFF
--- a/src/modules/system-admin/utils/audit-lookup-cache.test.ts
+++ b/src/modules/system-admin/utils/audit-lookup-cache.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUser = vi.hoisted(() => vi.fn());
+
+vi.mock("@/modules/system-admin/services/admin.service", () => ({
+  getUser,
+  listDepartments: vi.fn(),
+  listRoles: vi.fn(),
+}));
+
+import {
+  getCachedUser,
+  hydrateUserLookup,
+  isUserLookupId,
+} from "@/modules/system-admin/utils/audit-lookup-cache";
+
+describe("audit user lookup", () => {
+  beforeEach(() => {
+    getUser.mockReset();
+  });
+
+  it("does not resolve synthetic system actors as users", async () => {
+    expect(isUserLookupId("system:license")).toBe(false);
+    expect(await getCachedUser("system:license")).toBeNull();
+
+    await hydrateUserLookup(["system:license", "u-1"]);
+
+    expect(getUser).toHaveBeenCalledTimes(1);
+    expect(getUser).toHaveBeenCalledWith("u-1");
+  });
+});

--- a/src/modules/system-admin/utils/audit-lookup-cache.ts
+++ b/src/modules/system-admin/utils/audit-lookup-cache.ts
@@ -23,6 +23,11 @@ let departmentsCache: CacheEntry<AdminDepartment[]> | null = null;
 let rolesCache: CacheEntry<AdminRole[]> | null = null;
 const userCache = new Map<string, CacheEntry<AdminUser>>();
 
+/** 审计主体不一定是用户；例如许可证服务使用 system:license 作为 actor。 */
+export function isUserLookupId(id: string) {
+  return Boolean(id.trim()) && !id.trim().startsWith("system:");
+}
+
 function isFresh<T>(entry: CacheEntry<T> | null | undefined) {
   return Boolean(entry && Date.now() - entry.loadedAt < CACHE_TTL_MS);
 }
@@ -53,6 +58,9 @@ export async function getCachedRoles(): Promise<AdminRole[]> {
 }
 
 export async function getCachedUser(id: string): Promise<AdminUser | null> {
+  if (!isUserLookupId(id)) {
+    return null;
+  }
   const cached = userCache.get(id);
   if (isFresh(cached)) {
     return cached!.data;
@@ -67,7 +75,7 @@ export async function getCachedUser(id: string): Promise<AdminUser | null> {
 }
 
 export async function hydrateUserLookup(ids: string[]) {
-  const missing = ids.filter((id) => id && !isFresh(userCache.get(id)));
+  const missing = ids.filter((id) => isUserLookupId(id) && !isFresh(userCache.get(id)));
   if (!missing.length) {
     return;
   }


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] 修复 bkn-studio 登录后错误查询 `system:license` 用户的问题
- [x] 新增系统主体用户查询的回归测试

---

## Why

- Related Issue: 暂无
- Background:

许可证服务使用 `system:license` 作为审计主体，但该主体并不是实际用户。前端当前会将其请求为：

`GET /api/safe/v1/admin/users/system%3Alicense`

该请求没有意义并会返回用户不存在错误。

---

## How

- 在审计用户缓存查询层过滤 `system:*` 主体
- `system:license` 等系统主体不再调用用户详情接口
- 普通用户 ID 的查询逻辑保持不变

- Breaking changes: 无

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

新增回归测试验证：
- `system:license` 不会触发用户查询
- 普通用户 ID 仍会正常查询

本地测试因 pnpm 缓存数据库不可写未能执行。

---

## Risk & Rollback

- Potential risks: 仅影响审计主体到用户信息的解析，不影响真实用户查询
- Rollback plan: 回退本 PR 即可恢复原逻辑

---

## Additional Notes

- 未修改后端 API
- 未涉及数据库、配置或权限变更