### PR TITLE
fix(data-catalog): preserve build task execution semantics

### DIFF
--- a/src/modules/data-catalog/services/build-task.service.test.ts
+++ b/src/modules/data-catalog/services/build-task.service.test.ts
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getMock = vi.hoisted(() => vi.fn());
 const postMock = vi.hoisted(() => vi.fn());
@@ -15,7 +15,7 @@ vi.mock("@/framework/request/http", () => ({
 }));
 
 import {
-	createBuildTask,
+  createBuildTask,
   mapBuildTask,
   snapshotFieldsOf,
 } from "@/modules/data-catalog/services/build-task.service";
@@ -93,6 +93,11 @@ describe("createBuildTask", () => {
       vi.stubEnv("VITE_USE_MOCK", "false");
       getMock.mockReset();
       postMock.mockReset();
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
     });
 
     it("rejects when the created task cannot be retrieved", async () => {

--- a/src/modules/data-catalog/services/build-task.service.test.ts
+++ b/src/modules/data-catalog/services/build-task.service.test.ts
@@ -5,9 +5,17 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+const postMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock, post: postMock },
+}));
 
 import {
+	createBuildTask,
   mapBuildTask,
   snapshotFieldsOf,
 } from "@/modules/data-catalog/services/build-task.service";
@@ -65,5 +73,38 @@ describe("mapBuildTask", () => {
     const task = mapBuildTask({ id: "task-1", mode: "streaming" });
 
     expect(task.executeType).toBeUndefined();
+  });
+});
+
+describe("createBuildTask", () => {
+  it("retains the selected incremental type in mock mode", async () => {
+    const task = await createBuildTask({
+      executeType: "incremental",
+      mode: "batch",
+      resourceId: "mock-incremental-task-resource",
+    });
+
+    expect(task.executeType).toBe("incremental");
+  });
+
+  describe("when using the API", () => {
+    beforeEach(() => {
+      vi.resetModules();
+      vi.stubEnv("VITE_USE_MOCK", "false");
+      getMock.mockReset();
+      postMock.mockReset();
+    });
+
+    it("rejects when the created task cannot be retrieved", async () => {
+      postMock.mockResolvedValue({ data: { id: "task-1" } });
+      getMock.mockResolvedValue({ data: null });
+      const { createBuildTask: createWithAPI } = await import(
+        "@/modules/data-catalog/services/build-task.service"
+      );
+
+      await expect(
+        createWithAPI({ mode: "batch", resourceId: "resource-1" }),
+      ).rejects.toThrow("Created build task task-1 could not be retrieved");
+    });
   });
 });

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -526,6 +526,7 @@ export async function createBuildTask(
       id: `bt-${mockSlug(8)}`,
       resourceId: input.resourceId,
       mode: input.mode,
+      executeType: input.mode === "batch" ? (input.executeType ?? "full") : undefined,
       status: "pending",
       embeddingFields: form.embeddingFields,
       buildKeyFields: form.buildKeyFields,
@@ -551,7 +552,7 @@ export async function createBuildTask(
     return wait(task);
   }
 
-  // 创建仅返回 {id, resource_id, status: "init"},完整任务体再查一次。
+	// 创建仅返回 {id}，完整任务体再查一次。
   // 索引配置由服务端从 resource 派生快照，客户端不再传字段配置。
   const response = await http.post<BackendBuildTask>(
     "/vega-backend/v1/build-tasks",
@@ -564,8 +565,11 @@ export async function createBuildTask(
     },
   );
 
-  const created = await getBuildTask(response.data.id);
-  return created ?? mapBuildTask(response.data);
+	const created = await getBuildTask(response.data.id);
+  if (!created) {
+    throw new Error(`Created build task ${response.data.id} could not be retrieved`);
+  }
+  return created;
 }
 
 export async function pauseBuildTask(id: string) {

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -552,7 +552,7 @@ export async function createBuildTask(
     return wait(task);
   }
 
-	// 创建仅返回 {id}，完整任务体再查一次。
+  // 创建仅返回 {id}，完整任务体再查一次。
   // 索引配置由服务端从 resource 派生快照，客户端不再传字段配置。
   const response = await http.post<BackendBuildTask>(
     "/vega-backend/v1/build-tasks",
@@ -565,7 +565,7 @@ export async function createBuildTask(
     },
   );
 
-	const created = await getBuildTask(response.data.id);
+  const created = await getBuildTask(response.data.id);
   if (!created) {
     throw new Error(`Created build task ${response.data.id} could not be retrieved`);
   }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Data Catalog 任务模型与接口映射保留 batch `execute_type`，并在详情展示。
- [x] 开放增量构建入口；仅 full 任务可选择从头重建。
- [x] mock 创建路径保留执行类型；创建接口仅返回 ID 时，详情读取失败会显式报错。

---

## Why

- Related Issue: [Issue #501](https://github.com/openbkn-ai/bkn-foundry/issues/501)
- Related Feature: 批量构建执行类型持久化
- Background: 前端需要展示、传递并遵循后端持久化后的执行类型与重试约束。

Related to openbkn-ai/bkn-foundry#501

---

## How

- Key implementation points: 映射后端 `execute_type`；incremental 固定续跑；full 支持 `reset=true` 从头构建；测试隔离 API 模式环境变量。
- Breaking changes (API, config, database, etc.): 无。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes: 相关 Vitest 通过；TypeScript 编译通过。

---

## Risk & Rollback

- Potential risks: 前后端部署版本不一致时，旧后端响应会按 full 兼容展示。
- Rollback plan: 回滚前端即可恢复旧交互；后端字段不影响旧客户端。

---

## Additional Notes

- 无。