### PR TITLE
feat(bkn-trace): apply server-derived access profile

### DIFF
--- a/src/app/shell/console-navigation.test.ts
+++ b/src/app/shell/console-navigation.test.ts
@@ -17,10 +17,11 @@ const keys = (items: { key: string }[]) => items.map((item) => item.key);
 const systemGroup = (items: ReturnType<typeof filterNavByPermission>) =>
   items.find((item) => item.key === "system-management");
 
-describe("filterNavByPermission — 系统管理 仅对持有 admin 权限者可见", () => {
-  it("普通用户(无 admin 权限)→ 系统管理整组隐藏", () => {
-    const filtered = filterNavByPermission(consoleNavigation, []);
-    expect(keys(filtered)).not.toContain("system-management");
+describe("filterNavByPermission — 系统管理按功能独立授权", () => {
+  it("普通用户可进入 BKN Trace，记录正文由服务端访问画像裁决", () => {
+    const group = systemGroup(filterNavByPermission(consoleNavigation, []));
+    expect(group).toBeDefined();
+    expect(keys(group!.children ?? [])).toEqual(["bkn-trace"]);
   });
 
   it("超管(全部权限)→ 系统管理可见,4 个子项齐全", () => {
@@ -44,12 +45,15 @@ describe("filterNavByPermission — 系统管理 仅对持有 admin 权限者可
     );
   });
 
-  it("仅持有 admin-audit:view → 系统管理只剩日志管理", () => {
+  it("仅持有 admin-audit:view → 系统管理包含 BKN Trace 和日志管理", () => {
     const group = systemGroup(
       filterNavByPermission(consoleNavigation, ["admin-audit:view"]),
     );
     expect(group).toBeDefined();
-    expect(keys(group!.children ?? [])).toEqual(["log-management"]);
+    expect(keys(group!.children ?? [])).toEqual([
+      "bkn-trace",
+      "log-management",
+    ]);
   });
 
   it("非系统类菜单不受权限过滤影响", () => {

--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -17,6 +17,8 @@ export const bknTraceEnUS = {
       "Inspect runtime traces, evidence chains, business semantic graphs, and snapshot previews by trace id or request id.",
     empty: "Enter a trace id or request id to query.",
     errors: {
+      accessDenied: "No provenance analysis view is available for the current account.",
+      accessProfileFailed: "Unable to load the current provenance access profile. Refresh and try again.",
       missingScope: "Enter a trace id or request id.",
       queryFailed: "Query failed.",
     },

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -16,6 +16,8 @@ export const bknTraceZhCN = {
     description: "按 trace id 或 request id 查看运行链路、证据链、业务语义链和快照预览。",
     empty: "输入 trace id 或 request id 后查询",
     errors: {
+      accessDenied: "当前账号没有可用的溯源分析视图。",
+      accessProfileFailed: "无法获取当前溯源分析权限，请刷新后重试。",
       missingScope: "请输入 trace id 或 request id。",
       queryFailed: "查询失败。",
     },

--- a/src/modules/bkn-trace/module.manifest.ts
+++ b/src/modules/bkn-trace/module.manifest.ts
@@ -8,7 +8,7 @@
 export const bknTraceModuleManifest = {
   id: "bkn-trace",
   name: "BKN Trace",
-  permissions: ["bkn-trace:view"],
+  permissions: [],
   requiresShell: true,
   services: ["agent-observability/v1"],
   supportsEmbedded: false,

--- a/src/modules/bkn-trace/navigation.tsx
+++ b/src/modules/bkn-trace/navigation.tsx
@@ -17,7 +17,6 @@ export const bknTraceNavigation: ConsoleNavContribution = {
       labelKey: "shell.items.bknTrace",
       icon: <BranchesOutlined />,
       path: "/system/bkn-trace",
-      permission: ["bkn-trace:view"],
     },
   ],
 };

--- a/src/modules/bkn-trace/routes.test.tsx
+++ b/src/modules/bkn-trace/routes.test.tsx
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import { consoleNavigation } from "@/app/shell/console-navigation";
 import { runtimeModuleManifests } from "@/framework/runtime/module-manifests";
 import { bknTraceNavigation } from "@/modules/bkn-trace/navigation";
+import { bknTraceModuleManifest } from "@/modules/bkn-trace/module.manifest";
 import { bknTraceRouteContribution } from "@/modules/bkn-trace/routes";
 
 describe("bkn-trace module registration", () => {
@@ -21,6 +22,7 @@ describe("bkn-trace module registration", () => {
       labelKey: "shell.items.bknTrace",
       path: "/system/bkn-trace",
     });
+    expect(bknTraceNavigation.items[0]).not.toHaveProperty("permission");
     expect(
       consoleNavigation
         .flatMap((item) => item.children ?? [])
@@ -30,5 +32,6 @@ describe("bkn-trace module registration", () => {
 
   it("registers permissions in runtime module manifests", () => {
     expect(runtimeModuleManifests.map((manifest) => manifest.id)).toContain("bkn-trace");
+    expect(bknTraceModuleManifest.permissions).toEqual([]);
   });
 });

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
@@ -11,6 +11,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import runStyles from "@/modules/bkn-trace/scenes/BknTraceRunsScene.module.css";
 import { BknTraceExplorerScene } from "@/modules/bkn-trace/scenes/BknTraceExplorerScene";
 import {
+  getAccessProfile,
   getBusinessGraph,
   getEvidenceArtifact,
   getEvidenceChain,
@@ -22,13 +23,17 @@ import {
   getTraceGraph,
 } from "@/modules/bkn-trace/services/trace.service";
 
+const translate = vi.hoisted(() =>
+  (key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? key,
+);
+
 vi.mock("react-i18next", async (importOriginal) => {
   const original = await importOriginal<typeof import("react-i18next")>();
   return {
     ...original,
     useTranslation: () => ({
-      t: (key: string, options?: { defaultValue?: string }) =>
-        options?.defaultValue ?? key,
+      t: translate,
     }),
   };
 });
@@ -37,6 +42,7 @@ vi.mock("@/modules/bkn-trace/services/trace.service", async (importOriginal) => 
   const original = await importOriginal<typeof import("@/modules/bkn-trace/services/trace.service")>();
   return {
     ...original,
+    getAccessProfile: vi.fn(),
     getBusinessGraph: vi.fn(),
     getEvidenceArtifact: vi.fn(),
     getEvidenceChain: vi.fn(),
@@ -67,7 +73,7 @@ const requestSummary = {
   traceCount: 1,
 };
 
-describe("BknTraceExplorerScene", () => {
+describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
   beforeAll(() => {
     window.matchMedia = vi.fn().mockImplementation((query: string) => ({
       addEventListener: vi.fn(),
@@ -83,6 +89,15 @@ describe("BknTraceExplorerScene", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getAccessProfile).mockResolvedValue({
+      accessScopeFingerprint: "sha256:test",
+      businessProvenanceManagedNetworks: false,
+      businessProvenanceOwn: true,
+      globalLogSearch: false,
+      managementAudit: false,
+      securityAudit: false,
+      technicalTrace: true,
+    });
     vi.mocked(getRequestSummaries).mockResolvedValue({
       entries: [requestSummary],
       nextCursor: "cursor-2",
@@ -229,6 +244,24 @@ describe("BknTraceExplorerScene", () => {
     expect(screen.queryByPlaceholderText("bknTrace.placeholders.traceId")).toBeNull();
   });
 
+  it("普通业务用户不显示全局技术 Trace 高级查询入口", async () => {
+    vi.mocked(getAccessProfile).mockResolvedValueOnce({
+      accessScopeFingerprint: "sha256:normal-user",
+      businessProvenanceManagedNetworks: false,
+      businessProvenanceOwn: true,
+      globalLogSearch: false,
+      managementAudit: false,
+      securityAudit: false,
+      technicalTrace: false,
+    });
+
+    render(<BknTraceExplorerScene />);
+
+    await waitFor(() => expect(getAccessProfile).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("bknTrace.tabs.runs")).not.toBeNull();
+    expect(screen.queryByText("bknTrace.tabs.advanced")).toBeNull();
+  });
+
   it("将页面标题和筛选区放在独立布局块中，避免正式壳层压缩标题", async () => {
     render(<BknTraceExplorerScene />);
 
@@ -262,6 +295,7 @@ describe("BknTraceExplorerScene", () => {
   it("从业务运行下钻完整问题、结果、业务语义和关联技术 Trace", async () => {
     render(<BknTraceExplorerScene />);
 
+    await waitFor(() => expect(getRequestSummaries).toHaveBeenCalledWith({ limit: 30 }));
     fireEvent.click(await screen.findByRole("button", { name: /客户 A 的风险为什么上升/ }));
 
     await waitFor(() => expect(getRequestSummary).toHaveBeenCalledWith("req_business_001"));
@@ -322,6 +356,7 @@ describe("BknTraceExplorerScene", () => {
     });
 
     render(<BknTraceExplorerScene />);
+    await waitFor(() => expect(getRequestSummaries).toHaveBeenCalledWith({ limit: 30 }));
     fireEvent.click(await screen.findByRole("button", { name: /客户 A 的风险为什么上升/ }));
 
     await waitFor(() =>

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
@@ -239,8 +239,8 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
     render(<BknTraceExplorerScene />);
 
     await waitFor(() => expect(getRequestSummaries).toHaveBeenCalledWith({ limit: 30 }));
-    expect(screen.getByText("客户 A 的风险为什么上升？")).not.toBeNull();
-    expect(screen.getByText("近 7 天投诉增加，风险等级上升。")).not.toBeNull();
+    expect(await screen.findByText("客户 A 的风险为什么上升？")).not.toBeNull();
+    expect(await screen.findByText("近 7 天投诉增加，风险等级上升。")).not.toBeNull();
     expect(screen.queryByPlaceholderText("bknTrace.placeholders.traceId")).toBeNull();
   });
 

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.tsx
@@ -17,12 +17,13 @@ import {
 } from "@ant-design/icons";
 import { Alert, Button, Descriptions, Empty, Form, Input, Segmented, Spin, Table, Tabs, Tag, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import styles from "@/modules/bkn-trace/scenes/BknTraceExplorerScene.module.css";
 import { BknTraceRunsScene } from "@/modules/bkn-trace/scenes/BknTraceRunsScene";
 import {
+  getAccessProfile,
   getBusinessGraph,
   getEvidenceChain,
   getSnapshotPreview,
@@ -32,6 +33,7 @@ import {
   type EvidenceChain,
   type SnapshotPreview,
   type TraceBusinessNode,
+  type TraceAccessProfile,
   type TraceGraph,
   type TraceGraphNode,
 } from "@/modules/bkn-trace/services/trace.service";
@@ -80,22 +82,54 @@ const propertyKeys = [
 
 export function BknTraceExplorerScene() {
   const { t } = useTranslation();
+  const [accessProfile, setAccessProfile] = useState<TraceAccessProfile>();
+  const [accessError, setAccessError] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    getAccessProfile()
+      .then((profile) => {
+        if (active) setAccessProfile(profile);
+      })
+      .catch(() => {
+        if (active) setAccessError(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (accessError) {
+    return <Alert message={t("bknTrace.errors.accessProfileFailed")} showIcon type="error" />;
+  }
+  if (!accessProfile) {
+    return <Spin />;
+  }
+
+  const items = [];
+  if (accessProfile.businessProvenanceOwn || accessProfile.businessProvenanceManagedNetworks) {
+    items.push({
+      children: <BknTraceRunsScene />,
+      key: "runs",
+      label: t("bknTrace.tabs.runs"),
+    });
+  }
+  if (accessProfile.technicalTrace) {
+    items.push({
+      children: <BknTraceAdvancedExplorerScene />,
+      key: "advanced",
+      label: t("bknTrace.tabs.advanced"),
+    });
+  }
+  if (!items.length) {
+    return <Alert message={t("bknTrace.errors.accessDenied")} showIcon type="warning" />;
+  }
+
   return (
     <Tabs
       className={styles.productTabs}
-      defaultActiveKey="runs"
-      items={[
-        {
-          children: <BknTraceRunsScene />,
-          key: "runs",
-          label: t("bknTrace.tabs.runs"),
-        },
-        {
-          children: <BknTraceAdvancedExplorerScene />,
-          key: "advanced",
-          label: t("bknTrace.tabs.advanced"),
-        },
-      ]}
+      defaultActiveKey={items[0].key}
+      items={items}
     />
   );
 }

--- a/src/modules/bkn-trace/services/trace.service.test.ts
+++ b/src/modules/bkn-trace/services/trace.service.test.ts
@@ -26,6 +26,38 @@ describe("bkn-trace service", () => {
     getMock.mockReset();
   });
 
+  it("fetches the server-derived access profile without client-supplied roles", async () => {
+    getMock.mockResolvedValue({
+      data: {
+        business_provenance_own: true,
+        business_provenance_managed_networks: true,
+        technical_trace: false,
+        security_audit: false,
+        management_audit: false,
+        global_log_search: false,
+        access_scope_fingerprint: "sha256:scope-a",
+      },
+    });
+    const { getAccessProfile } = await import("@/modules/bkn-trace/services/trace.service");
+
+    const profile = await getAccessProfile();
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/agent-observability/v1/access-profile",
+      { headers: { "x-business-domain": "bd_demo" } },
+    );
+    expect(profile).toEqual({
+      accessScopeFingerprint: "sha256:scope-a",
+      businessProvenanceManagedNetworks: true,
+      businessProvenanceOwn: true,
+      globalLogSearch: false,
+      managementAudit: false,
+      securityAudit: false,
+      technicalTrace: false,
+    });
+    expect(getMock.mock.calls.flat().join(" ")).not.toContain("roles");
+  });
+
   it("fetches trace graph through the BKN Trace API", async () => {
     getMock.mockResolvedValue({
       data: {

--- a/src/modules/bkn-trace/services/trace.service.ts
+++ b/src/modules/bkn-trace/services/trace.service.ts
@@ -259,6 +259,26 @@ export type InteractionSummary = {
   traces: TraceExecutionSummary[];
 };
 
+export type TraceAccessProfile = {
+  accessScopeFingerprint: string;
+  businessProvenanceManagedNetworks: boolean;
+  businessProvenanceOwn: boolean;
+  globalLogSearch: boolean;
+  managementAudit: boolean;
+  securityAudit: boolean;
+  technicalTrace: boolean;
+};
+
+type BackendTraceAccessProfile = {
+  access_scope_fingerprint?: string;
+  business_provenance_managed_networks?: boolean;
+  business_provenance_own?: boolean;
+  global_log_search?: boolean;
+  management_audit?: boolean;
+  security_audit?: boolean;
+  technical_trace?: boolean;
+};
+
 export type RequestSummaryQuery = {
   agentOrApp?: string;
   businessDomain?: string;
@@ -509,6 +529,22 @@ type BackendEvidenceArtifact = {
   source_version?: string;
   trace_id?: string;
 };
+
+export async function getAccessProfile(): Promise<TraceAccessProfile> {
+  const response = await http.get<BackendTraceAccessProfile>(
+    `${OBSERVABILITY_API_PREFIX}/access-profile`,
+    { headers: traceHeaders() },
+  );
+  return {
+    accessScopeFingerprint: response.data.access_scope_fingerprint ?? "",
+    businessProvenanceManagedNetworks: Boolean(response.data.business_provenance_managed_networks),
+    businessProvenanceOwn: Boolean(response.data.business_provenance_own),
+    globalLogSearch: Boolean(response.data.global_log_search),
+    managementAudit: Boolean(response.data.management_audit),
+    securityAudit: Boolean(response.data.security_audit),
+    technicalTrace: Boolean(response.data.technical_trace),
+  };
+}
 
 export async function getTraceGraph(traceId: string): Promise<TraceGraph> {
   const response = await http.get<BackendTraceGraph>(


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Load the current BKN Trace access profile from agent-observability
- [x] Show business provenance for own/managed-network scope and technical Trace only for the corresponding capability
- [x] Remove the invented `bkn-trace:view` role/permission from the module manifest and navigation
- [x] Add loading, access-denied, and access-profile failure states with locale coverage

---

## Why

- Related Issue: [openbkn-ai/bkn-foundry#542](https://github.com/openbkn-ai/bkn-foundry/issues/542)
- Related Feature: [Foundry authorization implementation #591](https://github.com/openbkn-ai/bkn-foundry/pull/591)
- Background: Studio must reuse the roles and scopes already defined by OpenBKN and must not infer authorization from client-side role names. The backend remains the enforcement point and only returns page-level capabilities.

---

## How

- Key implementation points: Call `GET /api/agent-observability/v1/access-profile`; gate the business-provenance and advanced technical tabs from returned booleans; keep the menu available to ordinary users so they can access their own records.
- Breaking changes (API, config, database, etc.): Requires the access-profile endpoint introduced by Foundry PR #591. No database or configuration changes. Issue closure is handled by the Foundry PR.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- BKN Trace/navigation target set: 4 files, 21 tests passed with `--maxWorkers=1`
- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod --registry=https://registry.npmjs.org` exited 0; one repository-ignored high-severity advisory was reported
- The default full parallel Vitest run is resource-sensitive on this machine: failures were fixed-timeout tests in unrelated modules. A full single-worker run reached 123/128 files and 545/550 tests; all five remaining failures were unrelated fixed 5/10/15-second timeouts. The changed BKN Trace/navigation target set passes completely.

---

## Risk & Rollback

- Potential risks: If Foundry access-profile resolution is unavailable, the page intentionally fails closed instead of showing stale or over-broad views.
- Rollback plan: Revert this PR; no persisted data or configuration rollback is required.

---

## Additional Notes

- Foundry PR #591 contains `Closes #542`.
- No new OpenBKN role or permission identifier is introduced.