### PR TITLE
fix(knowledge-network): require action type execution tool selection

### DIFF
--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.module.css
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.module.css
@@ -14,6 +14,16 @@
   max-width: 640px;
 }
 
+.operatorFormItem {
+  margin-bottom: 0;
+}
+
+.operatorFormItem :global(.ant-form-item-label > label) {
+  color: rgba(0, 0, 0, 0.88);
+  font-size: 14px;
+  height: 22px;
+}
+
 .operatorLabel {
   color: rgba(0, 0, 0, 0.88);
   font-size: 14px;

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.test.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { act, cleanup, render, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   ActionTypeActionSource,
@@ -81,6 +81,22 @@ function createExecutionConfig(actionSource: ActionTypeActionSource): ActionType
     sourceType: actionSource.type,
   };
 }
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    value: vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    })),
+    writable: true,
+  });
+});
 
 beforeEach(() => {
   getKnowledgeNetworkObjectTypeDetail.mockResolvedValue({ dataProperties: [] });

--- a/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor.tsx
@@ -7,6 +7,7 @@
 
 /* eslint-disable react-refresh/only-export-components */
 
+import { Form } from "antd";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -30,6 +31,8 @@ import { getActionSourceDisplayName } from "@/modules/knowledge-network/utils/ac
 import styles from "./ActionTypeExecutionEditor.module.css";
 
 export {
+  ACTION_TYPE_EXECUTION_PARAMETER_REQUIRED_KEY,
+  ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY,
   cloneActionTypeExecutionConfig,
   createDefaultActionTypeExecutionConfig,
   normalizeActionTypeExecutionConfig,
@@ -39,6 +42,7 @@ export {
 type ActionTypeExecutionEditorProps = {
   networkId: string;
   objectTypeId: string;
+  sourceError?: string | null;
   value: ActionTypeExecutionConfig;
   onChange: (value: ActionTypeExecutionConfig) => void;
   onParameterSchemaStateChange?: (state: ActionTypeExecutionParameterSchemaState) => void;
@@ -81,6 +85,7 @@ function countLeafSchemaParameters(schema: ActionTypeToolInputParam[]): number {
 export function ActionTypeExecutionEditor({
   networkId,
   objectTypeId,
+  sourceError,
   value,
   onChange,
   onParameterSchemaStateChange,
@@ -336,18 +341,26 @@ export function ActionTypeExecutionEditor({
   return (
     <div className={styles.panel}>
       <div className={styles.operatorSection}>
-        <div className={styles.operatorLabel}>{t("knowledgeNetwork.actionTypeOperatorLabel")}</div>
-        <ActionTypeSourcePicker
-          loading={displayResolutionStatus === "loading"}
-          onChange={handleSourceChange}
-          onSourceSelected={handleSourceSelected}
-          unresolved={
-            displayResolutionStatus === "failed" &&
-            sourceNeedsDisplayResolution &&
-            displaySourceNeedsResolution
-          }
-          value={displayActionSource}
-        />
+        <Form.Item
+          className={styles.operatorFormItem}
+          help={sourceError ?? undefined}
+          label={t("knowledgeNetwork.actionTypeOperatorLabel")}
+          required
+          validateStatus={sourceError ? "error" : undefined}
+        >
+          <ActionTypeSourcePicker
+            invalid={Boolean(sourceError)}
+            loading={displayResolutionStatus === "loading"}
+            onChange={handleSourceChange}
+            onSourceSelected={handleSourceSelected}
+            unresolved={
+              displayResolutionStatus === "failed" &&
+              sourceNeedsDisplayResolution &&
+              displaySourceNeedsResolution
+            }
+            value={displayActionSource}
+          />
+        </Form.Item>
       </div>
 
       <ActionTypeToolParamsTable

--- a/src/modules/knowledge-network/components/action-type/ActionTypeSourcePicker.module.css
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeSourcePicker.module.css
@@ -29,6 +29,16 @@
   outline: none;
 }
 
+.selectTriggerError {
+  border-color: #ff4d4f;
+}
+
+.selectTriggerError:hover,
+.selectTriggerError:focus-visible {
+  border-color: #ff7875;
+  box-shadow: 0 0 0 2px rgba(255, 38, 5, 0.06);
+}
+
 .placeholder {
   color: rgba(0, 0, 0, 0.25);
   flex: 1;

--- a/src/modules/knowledge-network/components/action-type/ActionTypeSourcePicker.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeSourcePicker.tsx
@@ -18,6 +18,7 @@ import { getActionSourceDisplayName } from "@/modules/knowledge-network/utils/ac
 import styles from "./ActionTypeSourcePicker.module.css";
 
 type ActionTypeSourcePickerProps = {
+  invalid?: boolean;
   loading?: boolean;
   onSourceSelected?: (source: ActionTypeActionSource) => void;
   unresolved?: boolean;
@@ -26,6 +27,7 @@ type ActionTypeSourcePickerProps = {
 };
 
 export function ActionTypeSourcePicker({
+  invalid = false,
   loading = false,
   onSourceSelected,
   unresolved = false,
@@ -49,7 +51,12 @@ export function ActionTypeSourcePicker({
   return (
     <>
       <div
-        className={styles.selectTrigger}
+        className={[
+          styles.selectTrigger,
+          invalid ? styles.selectTriggerError : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
         onClick={() => setModalOpen(true)}
         onKeyDown={(event) => {
           if (event.key === "Enter" || event.key === " ") {

--- a/src/modules/knowledge-network/locales/en-US/action-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/action-type.ts
@@ -64,6 +64,7 @@ export const actiontypePart = {
     actionTypeExecutionSourceName: "Execution source name",
     actionTypeExecutionSourceNamePlaceholder: "Enter a tool or execution source name",
     actionTypeExecutionSourceNameRequired: "Please enter an execution source name.",
+    actionTypeExecutionToolRequired: "Please select an execution tool.",
     actionTypeExecutionSourceTool: "Tool",
     actionTypeExecutionSourceType: "Execution source type",
     actionTypeExecutionStep: "Execution mapping",

--- a/src/modules/knowledge-network/locales/zh-CN/action-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/action-type.ts
@@ -59,6 +59,7 @@ export const actiontypePart = {
     actionTypeExecutionSourceName: "执行来源名称",
     actionTypeExecutionSourceNamePlaceholder: "输入工具或执行来源名称",
     actionTypeExecutionSourceNameRequired: "请输入执行来源名称。",
+    actionTypeExecutionToolRequired: "请选择执行工具。",
     actionTypeExecutionSourceTool: "工具",
     actionTypeExecutionSourceType: "执行来源类型",
     actionTypeExecutionStep: "执行映射",

--- a/src/modules/knowledge-network/scenes/ActionTypeExecutionScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeExecutionScene.tsx
@@ -15,12 +15,16 @@ import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import {
   ActionTypeExecutionEditor,
+  ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY,
   createDefaultActionTypeExecutionConfig,
   normalizeActionTypeExecutionConfig,
   validateActionTypeExecutionConfig,
 } from "@/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor";
 import type { ActionTypeExecutionParameterSchemaState } from "@/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
+import {
+  getActionSourceDisplayName,
+} from "@/modules/knowledge-network/utils/action-type-execution";
 import {
   getKnowledgeNetworkActionTypeDetail,
   updateKnowledgeNetworkActionType,
@@ -49,6 +53,7 @@ export function ActionTypeExecutionScene() {
       loaded: false,
       parameterCount: 0,
     });
+  const [executionSourceError, setExecutionSourceError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -92,14 +97,21 @@ export function ActionTypeExecutionScene() {
       return;
     }
 
-    const validationError = validateActionTypeExecutionConfig(t, executionValue, {
+    const validationErrorKey = validateActionTypeExecutionConfig(executionValue, {
       allowEmptyParameters:
         executionSchemaState.loaded && executionSchemaState.parameterCount === 0,
     });
-    if (validationError) {
+    if (validationErrorKey) {
+      const validationError = t(validationErrorKey);
+      setExecutionSourceError(
+        validationErrorKey === ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY
+          ? validationError
+          : null,
+      );
       void message.error(validationError);
       return;
     }
+    setExecutionSourceError(null);
 
     const normalizedExecution = normalizeActionTypeExecutionConfig(executionValue);
 
@@ -150,7 +162,16 @@ export function ActionTypeExecutionScene() {
             networkId={networkId}
             objectTypeId={detail?.objectTypeId ?? ""}
             onParameterSchemaStateChange={setExecutionSchemaState}
-            onChange={setExecutionValue}
+            onChange={(nextValue) => {
+              setExecutionValue(nextValue);
+              if (
+                getActionSourceDisplayName(nextValue.actionSource) ||
+                nextValue.sourceName.trim()
+              ) {
+                setExecutionSourceError(null);
+              }
+            }}
+            sourceError={executionSourceError}
             value={executionValue}
           />
         </div>

--- a/src/modules/knowledge-network/scenes/ActionTypeFormScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeFormScene.tsx
@@ -15,13 +15,17 @@ import { useAppServices } from "@/framework/context/use-app-services";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import {
   ActionTypeExecutionEditor,
+  ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY,
   createDefaultActionTypeExecutionConfig,
   normalizeActionTypeExecutionConfig,
   validateActionTypeExecutionConfig,
 } from "@/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor";
 import type { ActionTypeExecutionParameterSchemaState } from "@/modules/knowledge-network/components/action-type/ActionTypeExecutionEditor";
 import { ActionTypeConditionEditor } from "@/modules/knowledge-network/components/action-type/ActionTypeConditionEditor";
-import { normalizeActionTypeCondition } from "@/modules/knowledge-network/utils/action-type-execution";
+import {
+  getActionSourceDisplayName,
+  normalizeActionTypeCondition,
+} from "@/modules/knowledge-network/utils/action-type-execution";
 import { RelationTypeObjectTypeSelect } from "@/modules/knowledge-network/components/relation-type/RelationTypeObjectTypeSelect";
 import type { RelationTypePropertyOption } from "@/modules/knowledge-network/components/relation-type/RelationTypePropertySelect";
 import {
@@ -94,6 +98,7 @@ export function ActionTypeFormScene({ mode }: ActionTypeFormSceneProps) {
       loaded: false,
       parameterCount: 0,
     });
+  const [executionSourceError, setExecutionSourceError] = useState<string | null>(null);
   const [pageTitle, setPageTitle] = useState(
     mode === "edit"
       ? t("knowledgeNetwork.actionTypeEditTitle")
@@ -230,14 +235,21 @@ export function ActionTypeFormScene({ mode }: ActionTypeFormSceneProps) {
       return;
     }
 
-    const validationError = validateActionTypeExecutionConfig(t, executionValue, {
+    const validationErrorKey = validateActionTypeExecutionConfig(executionValue, {
       allowEmptyParameters:
         executionSchemaState.loaded && executionSchemaState.parameterCount === 0,
     });
-    if (validationError) {
+    if (validationErrorKey) {
+      const validationError = t(validationErrorKey);
+      setExecutionSourceError(
+        validationErrorKey === ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY
+          ? validationError
+          : null,
+      );
       void message.error(validationError);
       return;
     }
+    setExecutionSourceError(null);
 
     const normalizedExecution = normalizeActionTypeExecutionConfig(executionValue);
     const affect =
@@ -454,7 +466,16 @@ export function ActionTypeFormScene({ mode }: ActionTypeFormSceneProps) {
                           ""
                         }
                         onParameterSchemaStateChange={setExecutionSchemaState}
-                        onChange={setExecutionValue}
+                        onChange={(nextValue) => {
+                          setExecutionValue(nextValue);
+                          if (
+                            getActionSourceDisplayName(nextValue.actionSource) ||
+                            nextValue.sourceName.trim()
+                          ) {
+                            setExecutionSourceError(null);
+                          }
+                        }}
+                        sourceError={executionSourceError}
                         value={executionValue}
                       />
                     </div>

--- a/src/modules/knowledge-network/utils/action-type-execution.test.ts
+++ b/src/modules/knowledge-network/utils/action-type-execution.test.ts
@@ -9,9 +9,11 @@ import { describe, expect, it } from "vitest";
 
 import type { ActionTypeExecutionConfig } from "@/modules/knowledge-network/types/knowledge-network";
 
-import { validateActionTypeExecutionConfig } from "./action-type-execution";
-
-const t = (key: string) => key;
+import {
+  ACTION_TYPE_EXECUTION_PARAMETER_REQUIRED_KEY,
+  ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY,
+  validateActionTypeExecutionConfig,
+} from "./action-type-execution";
 
 function createExecutionConfig(
   patch: Partial<ActionTypeExecutionConfig> = {},
@@ -32,33 +34,32 @@ function createExecutionConfig(
 }
 
 describe("validateActionTypeExecutionConfig", () => {
-  it("keeps requiring an execution source", () => {
+  it("keeps requiring an execution tool", () => {
     expect(
-      validateActionTypeExecutionConfig(t, createExecutionConfig({
+      validateActionTypeExecutionConfig(createExecutionConfig({
         actionSource: undefined,
         sourceName: "",
       })),
-    ).toBe("knowledgeNetwork.actionTypeExecutionSourceNameRequired");
+    ).toBe(ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY);
   });
 
   it("allows empty parameters when the selected tool has no input schema", () => {
     expect(
-      validateActionTypeExecutionConfig(t, createExecutionConfig(), {
+      validateActionTypeExecutionConfig(createExecutionConfig(), {
         allowEmptyParameters: true,
       }),
     ).toBeNull();
   });
 
   it("keeps rejecting empty parameters when the selected tool requires mappings", () => {
-    expect(validateActionTypeExecutionConfig(t, createExecutionConfig())).toBe(
-      "knowledgeNetwork.actionTypeExecutionParameterRequired",
+    expect(validateActionTypeExecutionConfig(createExecutionConfig())).toBe(
+      ACTION_TYPE_EXECUTION_PARAMETER_REQUIRED_KEY,
     );
   });
 
   it("accepts configured dynamic input parameters", () => {
     expect(
       validateActionTypeExecutionConfig(
-        t,
         createExecutionConfig({
           parameters: [{ name: "order_id", valueFrom: "input" }],
         }),
@@ -69,11 +70,10 @@ describe("validateActionTypeExecutionConfig", () => {
   it("keeps rejecting incomplete constant or property mappings", () => {
     expect(
       validateActionTypeExecutionConfig(
-        t,
         createExecutionConfig({
           parameters: [{ name: "status", valueFrom: "const", value: "" }],
         }),
       ),
-    ).toBe("knowledgeNetwork.actionTypeExecutionParameterRequired");
+    ).toBe(ACTION_TYPE_EXECUTION_PARAMETER_REQUIRED_KEY);
   });
 });

--- a/src/modules/knowledge-network/utils/action-type-execution.ts
+++ b/src/modules/knowledge-network/utils/action-type-execution.ts
@@ -90,8 +90,13 @@ export type ActionTypeExecutionValidationOptions = {
   allowEmptyParameters?: boolean;
 };
 
+export const ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY =
+  "knowledgeNetwork.actionTypeExecutionToolRequired";
+
+export const ACTION_TYPE_EXECUTION_PARAMETER_REQUIRED_KEY =
+  "knowledgeNetwork.actionTypeExecutionParameterRequired";
+
 export function validateActionTypeExecutionConfig(
-  t: (key: string) => string,
   value: ActionTypeExecutionConfig,
   options: ActionTypeExecutionValidationOptions = {},
 ): string | null {
@@ -99,7 +104,7 @@ export function validateActionTypeExecutionConfig(
     getActionSourceDisplayName(value.actionSource) || value.sourceName.trim();
 
   if (!sourceLabel) {
-    return t("knowledgeNetwork.actionTypeExecutionSourceNameRequired");
+    return ACTION_TYPE_EXECUTION_TOOL_REQUIRED_KEY;
   }
 
   const validParameters = value.parameters.filter((item) => {
@@ -116,7 +121,7 @@ export function validateActionTypeExecutionConfig(
   });
 
   if (validParameters.length === 0 && !options.allowEmptyParameters) {
-    return t("knowledgeNetwork.actionTypeExecutionParameterRequired");
+    return ACTION_TYPE_EXECUTION_PARAMETER_REQUIRED_KEY;
   }
 
   return null;


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Mark action type execution tool as required in the form UI (asterisk + inline validation)
- [x] Update validation message to prompt tool selection explicitly
- [x] Show inline error and red border on the tool picker when save is attempted without a selection

---

## Why

- Action types cannot execute without a bound tool; save already blocked missing tools but the UI looked optional
- Improves clarity in the action rules step (2) execution tool section

---

## How

- `validateActionTypeExecutionConfig` now returns i18n error keys; missing tool uses `actionTypeExecutionToolRequired`
- `ActionTypeExecutionEditor` wraps the tool picker in `Form.Item` with `required` and `sourceError` feedback
- `ActionTypeFormScene` and `ActionTypeExecutionScene` set/clear inline errors on save and tool selection

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
- `npx vitest --run src/modules/knowledge-network/utils/action-type-execution.test.ts` (5 passed)
- `npx eslint` on changed TS files (0 warnings)
- `npx tsc -b --pretty false`

---

## Risk & Rollback

- Potential risks: Low — UX/validation messaging only; existing save semantics unchanged
- Rollback plan: Revert this PR

---

## Additional Notes

- N/A
