### PR TITLE
fix(observability): 明确业务溯源三层视图与局部降级

### DIFF
--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -8,7 +8,7 @@
 export const bknTraceEnUS = {
   bknTrace: {
     businessProvenance: {
-      description: "Explain business outcomes and their data, logic, and action evidence by conversation, interaction, and request.",
+      description: "Explain business outcomes and their data, logic, and action evidence by business conversation, interaction turn, and OpenBKN call.",
       title: "Business Provenance",
     },
     traceAnalysis: {
@@ -99,6 +99,7 @@ export const bknTraceEnUS = {
       observed: "Observed",
       operationId: "Operation ID",
       operation: "Business operation",
+	  operationResult: "Call result",
       question: "User question",
       requestId: "Request ID",
       requestCount: "Calls in interaction",
@@ -152,7 +153,7 @@ export const bknTraceEnUS = {
       evidenceChain: "Evidence Chain",
       nodeDetails: "Node details",
       relations: "Business relationships",
-      requestDetail: "Business run details",
+	  requestDetail: "OpenBKN call details",
       interactionRequests: "OpenBKN calls in this interaction",
       snapshot: "Snapshot Preview",
       traceGraph: "Trace Graph",
@@ -174,6 +175,16 @@ export const bknTraceEnUS = {
     },
     runsDescription:
       "Start from the user question and business result, then inspect analysis, data, logic, action, and technical evidence.",
+	operationResults: {
+	  completed: "Completed with {{count}} business references",
+	  error: "Call failed",
+	  running: "In progress",
+	  unknown: "Status unknown",
+	},
+	operations: {
+	  runSql: "Query business data",
+	  searchSchema: "Inspect knowledge network structure",
+	},
     status: {
       completed: "Completed",
       error: "Error",
@@ -189,9 +200,9 @@ export const bknTraceEnUS = {
       unresolved: "Unresolved",
     },
     views: {
-      conversations: "Conversations",
-      interactions: "Interactions",
-      requests: "OpenBKN requests",
+      conversations: "Business conversations",
+      interactions: "Interaction turns",
+      requests: "OpenBKN calls",
     },
   },
 } as const;

--- a/src/modules/bkn-trace/locales/zh-CN.test.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { bknTraceZhCN } from "@/modules/bkn-trace/locales/zh-CN";
+
+describe("BKN Trace Chinese business hierarchy", () => {
+  it("uses business-readable labels for all three provenance levels", () => {
+    expect(bknTraceZhCN.bknTrace.views).toEqual({
+      conversations: "业务会话",
+      interactions: "交互轮次",
+      requests: "OpenBKN 调用",
+    });
+    expect(bknTraceZhCN.bknTrace.businessProvenance.description).toContain(
+      "业务会话、交互轮次和 OpenBKN 调用",
+    );
+  });
+});

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -8,7 +8,7 @@
 export const bknTraceZhCN = {
   bknTrace: {
     businessProvenance: {
-      description: "从会话、交互轮次和请求出发，解释业务结论及其数据、逻辑与行动依据。",
+      description: "从业务会话、交互轮次和 OpenBKN 调用出发，解释业务结论及其数据、逻辑与行动依据。",
       title: "业务溯源分析",
     },
     traceAnalysis: {
@@ -98,6 +98,7 @@ export const bknTraceZhCN = {
       observed: "已观测",
       operationId: "操作 ID",
       operation: "业务操作",
+	  operationResult: "调用结果",
       question: "用户问题",
       requestId: "Request ID",
       requestCount: "本轮调用数",
@@ -151,7 +152,7 @@ export const bknTraceZhCN = {
       evidenceChain: "证据链",
       nodeDetails: "节点明细",
       relations: "业务关系",
-      requestDetail: "业务运行详情",
+	  requestDetail: "OpenBKN 调用详情",
       interactionRequests: "本轮 OpenBKN 调用",
       snapshot: "快照预览",
       traceGraph: "调用链",
@@ -172,6 +173,16 @@ export const bknTraceZhCN = {
       runs: "业务运行",
     },
     runsDescription: "从用户问题和业务结果出发，查看分析、数据、逻辑、行动与技术调用依据。",
+	operationResults: {
+	  completed: "调用完成，关联 {{count}} 项业务依据",
+	  error: "调用失败",
+	  running: "调用中",
+	  unknown: "状态未知",
+	},
+	operations: {
+	  runSql: "查询业务数据",
+	  searchSchema: "检索知识网络结构",
+	},
     status: {
       completed: "已完成",
       error: "失败",
@@ -187,9 +198,9 @@ export const bknTraceZhCN = {
       unresolved: "未解析",
     },
     views: {
-      conversations: "会话",
+      conversations: "业务会话",
       interactions: "交互轮次",
-      requests: "OpenBKN 请求",
+      requests: "OpenBKN 调用",
     },
   },
 } as const;

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
@@ -294,6 +294,22 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
     expect(traceInput instanceof HTMLInputElement && traceInput.value).toBe("trace_001");
   });
 
+  it("业务制品按 Trace 不可用时仍展示技术调用链", async () => {
+    window.history.replaceState({}, "", "/observability/traces?trace_id=trace_001");
+    vi.mocked(getEvidenceChain).mockRejectedValueOnce(new Error("evidence chain not found"));
+    vi.mocked(getBusinessGraph).mockRejectedValueOnce(new Error("business graph not found"));
+    vi.mocked(getSnapshotPreview).mockRejectedValueOnce(new Error("snapshot preview not found"));
+
+    render(<BknTraceAdvancedExplorerScene />);
+    fireEvent.click(screen.getByRole("button", { name: /bknTrace\.actions\.query/ }));
+
+    expect(await screen.findByText("trace_001")).not.toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "bknTrace.tabs.diagnostics" }));
+    expect(await screen.findByText("bkn-agent.chat")).not.toBeNull();
+    expect(screen.queryByText("evidence chain not found")).toBeNull();
+    expect(screen.getByText("bknTrace.partial")).not.toBeNull();
+  });
+
   it("默认展示可筛选的会话列表，而不是要求用户输入内部 ID", async () => {
     render(<BknTraceExplorerScene />);
 
@@ -464,8 +480,8 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
     expect(getBusinessGraph).toHaveBeenCalledWith({ requestId: "req_business_001", limit: 100 });
     await waitFor(() => expect(getEvidenceArtifact).toHaveBeenCalledTimes(2));
 
-    expect(await screen.findByText("客户 A 的风险为什么上升？（完整问题）")).not.toBeNull();
-    expect(screen.getByText("近 7 天投诉增加 42%，因此风险等级从中升至高。（完整结论）")).not.toBeNull();
+    expect((await screen.findAllByText("客户 A 的风险为什么上升？（完整问题）")).length).toBeGreaterThan(1);
+    expect(screen.getAllByText("近 7 天投诉增加 42%，因此风险等级从中升至高。（完整结论）").length).toBeGreaterThan(1);
     expect(screen.getByText("客户风险")).not.toBeNull();
 
     fireEvent.click(screen.getByText("bknTrace.tabs.diagnostics"));
@@ -475,6 +491,52 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
     expect(await screen.findByText("bkn-agent.chat")).not.toBeNull();
     expect(screen.getByText("bkn-agent")).not.toBeNull();
   }, 30_000);
+
+  it("OpenBKN 调用以业务操作区分，而不是重复本轮问题和答案", async () => {
+	vi.mocked(getRequestSummaries).mockResolvedValue({
+	  entries: [{
+		...requestSummary,
+		operationId: "op_schema",
+		operationKey: "supply-chain-schema",
+		toolName: "search_schema",
+	  }, {
+		...requestSummary,
+		businessRefs: ["resource:forecast"],
+		operationId: "op_sql",
+		operationKey: "supply-chain-data",
+		requestId: "req_sql",
+		toolName: "run_sql",
+	  }],
+	  partial: false,
+	  partialReasons: [],
+	  total: 2,
+	  truncated: false,
+	});
+
+	window.history.replaceState({}, "", "/observability/business-provenance?view=requests");
+	render(<BknTraceExplorerScene />);
+
+	await waitFor(() => expect(getRequestSummaries).toHaveBeenCalledWith({ limit: 30 }));
+	expect(await screen.findByRole("button", { name: "bknTrace.operations.searchSchema" }, { timeout: 5_000 })).not.toBeNull();
+	expect(screen.getByRole("button", { name: "bknTrace.operations.runSql" })).not.toBeNull();
+	expect(screen.getAllByText("bknTrace.fields.operationResult")).not.toHaveLength(0);
+  });
+
+  it("可选证据视图缺失时仍展示 OpenBKN 调用基础详情", async () => {
+	vi.mocked(getRequestTraces).mockRejectedValue(new Error("trace graph not found"));
+	vi.mocked(getEvidenceChain).mockRejectedValue(new Error("evidence chain not found"));
+	vi.mocked(getBusinessGraph).mockRejectedValue(new Error("business graph not found"));
+	vi.mocked(getSnapshotPreview).mockRejectedValue(new Error("snapshot preview not found"));
+
+	window.history.replaceState({}, "", "/observability/business-provenance?view=requests");
+	render(<BknTraceExplorerScene />);
+	await waitFor(() => expect(getRequestSummaries).toHaveBeenCalledWith({ limit: 30 }));
+	fireEvent.click(await screen.findByRole("button", { name: /客户 A 的风险为什么上升/ }, { timeout: 5_000 }));
+
+	expect(await screen.findByText("bknTrace.sections.requestDetail")).not.toBeNull();
+	expect(screen.getAllByText("客户 A 的风险为什么上升？").length).toBeGreaterThan(0);
+	expect(screen.queryByText("trace graph not found")).toBeNull();
+  });
 
   it("按 interaction_id 聚合同一轮的多次 OpenBKN 调用", async () => {
     const interactionRequest = {

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.tsx
@@ -52,6 +52,7 @@ type TraceExplorerState = {
   evidenceChain?: EvidenceChain;
   snapshotPreview?: SnapshotPreview;
   traceGraph?: TraceGraph;
+  unavailableReasons?: string[];
 };
 
 const propertyKeys = [
@@ -186,19 +187,29 @@ export function BknTraceAdvancedExplorerScene() {
     setError(null);
     persistTraceScope(scopeMode, traceId.trim(), requestId.trim());
     try {
-      const traceGraphResult = effectiveScope.traceId
-        ? await getTraceGraph(effectiveScope.traceId)
-            .then((value) => ({ status: "fulfilled" as const, value }))
-            .catch((reason: unknown) => ({ reason, status: "rejected" as const }))
-        : { status: "fulfilled" as const, value: undefined };
-      const [evidenceChain, businessGraph, snapshotPreview] = await Promise.all([
+      const [traceGraphResult, evidenceChainResult, businessGraphResult, snapshotPreviewResult] = await Promise.allSettled([
+        effectiveScope.traceId ? getTraceGraph(effectiveScope.traceId) : Promise.resolve(undefined),
         getEvidenceChain(effectiveScope),
         getBusinessGraph(effectiveScope),
         getSnapshotPreview(effectiveScope),
       ]);
       const traceGraph = traceGraphResult.status === "fulfilled" ? traceGraphResult.value : undefined;
-      setState({ businessGraph, evidenceChain, snapshotPreview, traceGraph });
-      setSelectedNodeId(businessGraph.data.nodes[0]?.id ?? null);
+      const evidenceChain = evidenceChainResult.status === "fulfilled" ? evidenceChainResult.value : undefined;
+      const businessGraph = businessGraphResult.status === "fulfilled" ? businessGraphResult.value : undefined;
+      const snapshotPreview = snapshotPreviewResult.status === "fulfilled" ? snapshotPreviewResult.value : undefined;
+      const unavailableReasons = [
+        traceGraphResult.status === "rejected" ? "trace_graph_unavailable" : "",
+        evidenceChainResult.status === "rejected" ? "evidence_chain_unavailable" : "",
+        businessGraphResult.status === "rejected" ? "business_graph_unavailable" : "",
+        snapshotPreviewResult.status === "rejected" ? "snapshot_preview_unavailable" : "",
+      ].filter(Boolean);
+      if (!traceGraph && !evidenceChain && !businessGraph && !snapshotPreview) {
+        const firstFailure = [traceGraphResult, evidenceChainResult, businessGraphResult, snapshotPreviewResult]
+          .find((result) => result.status === "rejected");
+        throw firstFailure?.status === "rejected" ? firstFailure.reason : new Error(t("bknTrace.errors.queryFailed"));
+      }
+      setState({ businessGraph, evidenceChain, snapshotPreview, traceGraph, unavailableReasons });
+      setSelectedNodeId(businessGraph?.data.nodes[0]?.id ?? null);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : t("bknTrace.errors.queryFailed"));
     } finally {
@@ -213,11 +224,13 @@ export function BknTraceAdvancedExplorerScene() {
   const selectedNode = selectedNodeId ? nodeById.get(selectedNodeId) : undefined;
   const visibility = state.businessGraph?.visibilitySummary ?? state.evidenceChain?.visibilitySummary;
   const businessPartialReasons = explainabilityPartialReasons([
+    state.unavailableReasons ?? [],
     state.evidenceChain?.partialReason ?? [],
     state.businessGraph?.partialReason ?? [],
     state.snapshotPreview?.partialReason ?? [],
   ], state.businessGraph);
   const partialReasons = explainabilityPartialReasons([
+    state.unavailableReasons ?? [],
     state.traceGraph?.partialReason ?? [],
     state.evidenceChain?.partialReason ?? [],
     state.businessGraph?.partialReason ?? [],
@@ -391,19 +404,22 @@ export function BknTraceAdvancedExplorerScene() {
 
       {error ? <Alert className={styles.alert} type="error" message={error} showIcon /> : null}
       <Spin spinning={loading}>
-        {!state.businessGraph && !state.traceGraph ? <Empty className={styles.empty} description={t("bknTrace.empty")} /> : (
+        {!state.businessGraph && !state.traceGraph && !state.evidenceChain && !state.snapshotPreview ? <Empty className={styles.empty} description={t("bknTrace.empty")} /> : (
           <div className={styles.content}>
             <section className={styles.resultHeader}>
               <div>
                 <Typography.Text type="secondary">{t("bknTrace.fields.traceId")}</Typography.Text>
-                <Typography.Text className={styles.resultId}>{state.businessGraph?.traceId || state.traceGraph?.traceId || "-"}</Typography.Text>
+                <Typography.Text className={styles.resultId}>{state.businessGraph?.traceId || state.traceGraph?.traceId || state.evidenceChain?.traceId || state.snapshotPreview?.traceId || "-"}</Typography.Text>
               </div>
               <div>
                 <Typography.Text type="secondary">{t("bknTrace.fields.requestId")}</Typography.Text>
-                <Typography.Text className={styles.resultId}>{state.businessGraph?.requestId || "-"}</Typography.Text>
+                <Typography.Text className={styles.resultId}>{state.businessGraph?.requestId || state.evidenceChain?.requestId || state.snapshotPreview?.requestId || "-"}</Typography.Text>
               </div>
               <Button
-                href={buildLogDrilldownURL(state.businessGraph?.traceId || state.traceGraph?.traceId, state.businessGraph?.requestId)}
+                href={buildLogDrilldownURL(
+                  state.businessGraph?.traceId || state.traceGraph?.traceId || state.evidenceChain?.traceId || state.snapshotPreview?.traceId,
+                  state.businessGraph?.requestId || state.evidenceChain?.requestId || state.snapshotPreview?.requestId,
+                )}
                 icon={<SearchOutlined />}
               >
                 {t("bknTrace.actions.viewLogs")}

--- a/src/modules/bkn-trace/scenes/BknTraceRunsScene.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceRunsScene.tsx
@@ -63,10 +63,10 @@ import {
 
 type RequestDetail = {
   artifacts: EvidenceArtifact[];
-  businessGraph: BusinessGraph;
-  evidenceChain: EvidenceChain;
+  businessGraph?: BusinessGraph;
+  evidenceChain?: EvidenceChain;
   interaction?: InteractionSummary;
-  snapshotPreview: SnapshotPreview;
+  snapshotPreview?: SnapshotPreview;
   summary: RequestSummary;
   traces: SummaryPage<TraceExecutionSummary>;
 };
@@ -81,6 +81,8 @@ type ProvenanceListRow = {
   id: string;
   interactionCount?: number;
   interactionId?: string;
+	operationId?: string;
+	operationLabel?: string;
   questionPreview?: string;
   requestCount?: number;
   requestId?: string;
@@ -128,7 +130,7 @@ export function BknTraceRunsScene() {
         ? mapProvenancePage(await getConversationSummaries(request), mapConversationRow)
         : targetView === "interactions"
           ? mapProvenancePage(await getInteractionSummaries(request), mapInteractionRow)
-          : mapProvenancePage(await getRequestSummaries(request), mapRequestRow);
+          : mapProvenancePage(await getRequestSummaries(request), (entry) => mapRequestRow(entry, t));
       if (requestSequence !== provenanceRequestSequence.current) return;
       setPage((current) =>
         append && current
@@ -228,8 +230,8 @@ export function BknTraceRunsScene() {
     try {
       const scope = { limit: 100, requestId } as const;
       const summary = await getRequestSummary(requestId);
-      const [traces, evidenceChain, businessGraph, snapshotPreview, interaction] =
-        await Promise.all([
+      const [tracesResult, evidenceChainResult, businessGraphResult, snapshotResult, interactionResult] =
+        await Promise.allSettled([
           getRequestTraces(requestId, { limit: 100 }),
           getEvidenceChain(scope),
           getBusinessGraph(scope),
@@ -238,8 +240,13 @@ export function BknTraceRunsScene() {
             ? getInteractionSummary(summary.interactionId)
             : Promise.resolve(undefined),
         ]);
+      const traces = settledValue(tracesResult) ?? emptySummaryPage<TraceExecutionSummary>();
+      const evidenceChain = settledValue(evidenceChainResult);
+      const businessGraph = settledValue(businessGraphResult);
+      const snapshotPreview = settledValue(snapshotResult);
+      const interaction = settledValue(interactionResult);
       const artifactIds = [...new Set(
-        evidenceChain.data.artifactLinks
+        (evidenceChain?.data.artifactLinks ?? [])
           .map((link) => artifactId(link.artifactRef))
           .filter((value): value is string => Boolean(value)),
       )];
@@ -278,8 +285,8 @@ export function BknTraceRunsScene() {
       width: 170,
     },
     {
-      dataIndex: "questionPreview",
-      key: "questionPreview",
+      dataIndex: view === "requests" ? "operationLabel" : "questionPreview",
+      key: view === "requests" ? "operationLabel" : "questionPreview",
       render: (value: string | undefined, row) => (
         <Button
           className={styles.questionButton}
@@ -289,7 +296,7 @@ export function BknTraceRunsScene() {
           {value || row.id}
         </Button>
       ),
-      title: t("bknTrace.fields.question"),
+      title: t(view === "requests" ? "bknTrace.fields.operation" : "bknTrace.fields.question"),
     },
 	...(view !== "requests" ? [{
 	  dataIndex: view === "conversations" ? "interactionCount" : "requestCount",
@@ -303,7 +310,7 @@ export function BknTraceRunsScene() {
       dataIndex: "resultPreview",
       key: "resultPreview",
       render: (value?: string) => value || "-",
-      title: t("bknTrace.fields.result"),
+      title: t(view === "requests" ? "bknTrace.fields.operationResult" : "bknTrace.fields.result"),
     },
     {
       dataIndex: "agentOrApp",
@@ -376,6 +383,12 @@ export function BknTraceRunsScene() {
             <Descriptions.Item label={t("bknTrace.fields.requestId")}>
               {detail.summary.requestId}
             </Descriptions.Item>
+            <Descriptions.Item label={t("bknTrace.fields.operation")}>
+              {operationLabel(detail.summary, t)}
+            </Descriptions.Item>
+            <Descriptions.Item label={t("bknTrace.fields.operationId")}>
+              {detail.summary.operationId || "-"}
+            </Descriptions.Item>
             <Descriptions.Item label={t("bknTrace.fields.requestCount")}>
               {detail.interaction?.requests.length ?? 1}
             </Descriptions.Item>
@@ -390,7 +403,16 @@ export function BknTraceRunsScene() {
           <Tabs
             items={[
               {
-                children: <BusinessExplanation graph={detail.businessGraph} artifacts={detail.artifacts} />,
+                children: detail.businessGraph
+                  ? (
+					  <BusinessExplanation
+						artifacts={detail.artifacts}
+						fallbackQuestion={detail.summary.questionPreview}
+						fallbackResult={detail.summary.resultPreview}
+						graph={detail.businessGraph}
+					  />
+					)
+                  : <Empty description={t("bknTrace.emptyStates.businessNodes")} />,
                 key: "business",
                 label: t("bknTrace.tabs.business"),
               },
@@ -648,13 +670,19 @@ function BusinessContent({
 
 function BusinessExplanation({
   artifacts,
+	fallbackQuestion,
+	fallbackResult,
   graph,
 }: {
   artifacts: EvidenceArtifact[];
+	fallbackQuestion?: string;
+	fallbackResult?: string;
   graph: BusinessGraph;
 }) {
   const { t } = useTranslation();
   const stages = businessStoryStages(graph.data.nodes);
+	const question = artifacts.find((artifact) => artifact.artifactType === "question")?.content ?? fallbackQuestion;
+	const result = artifacts.find((artifact) => artifact.artifactType === "result")?.content ?? fallbackResult;
   const supportingArtifacts = artifacts.filter(
     (artifact) => !["question", "result"].includes(artifact.artifactType),
   );
@@ -676,7 +704,11 @@ function BusinessExplanation({
                     <Typography.Text type="secondary">{node.nodeType}</Typography.Text>
                   </details>
                 </div>
-              )) : <Typography.Text type="secondary">-</Typography.Text>}
+			  )) : stage.stage === "intent" && question ? (
+				<ArtifactContent content={question} />
+			  ) : stage.stage === "claim" && result ? (
+				<ArtifactContent content={result} />
+			  ) : <Typography.Text type="secondary">-</Typography.Text>}
             </div>
           ))}
         </div>
@@ -795,8 +827,8 @@ function Governance({
   snapshot,
   summary,
 }: {
-  chain: EvidenceChain;
-  snapshot: SnapshotPreview;
+  chain?: EvidenceChain;
+  snapshot?: SnapshotPreview;
   summary: RequestSummary;
 }) {
   const { t } = useTranslation();
@@ -809,16 +841,16 @@ function Governance({
         {summary.businessDomain || "-"}
       </Descriptions.Item>
       <Descriptions.Item label={t("bknTrace.visibility.authorized")}>
-        {chain.visibilitySummary.authorizedRefCount}
+        {chain?.visibilitySummary.authorizedRefCount ?? "-"}
       </Descriptions.Item>
       <Descriptions.Item label={t("bknTrace.visibility.unresolved")}>
-        {chain.visibilitySummary.unresolvedRefCount}
+        {chain?.visibilitySummary.unresolvedRefCount ?? "-"}
       </Descriptions.Item>
       <Descriptions.Item label={t("bknTrace.fields.snapshotId")}>
-        {snapshot.snapshotRef.snapshotId || "-"}
+        {snapshot?.snapshotRef.snapshotId || "-"}
       </Descriptions.Item>
       <Descriptions.Item label={t("bknTrace.fields.mode")}>
-        {snapshot.snapshotRef.mode}
+        {snapshot?.snapshotRef.mode || "-"}
       </Descriptions.Item>
     </Descriptions>
   );
@@ -940,19 +972,57 @@ function mapInteractionRow(summary: InteractionListSummary): ProvenanceListRow {
   };
 }
 
-function mapRequestRow(summary: RequestSummary): ProvenanceListRow {
+function mapRequestRow(
+  summary: RequestSummary,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): ProvenanceListRow {
   return {
     agentOrApp: summary.agentOrApp,
     conversationId: summary.conversationId,
     durationMs: summary.durationMs,
     evidenceCompleteness: summary.evidenceCompleteness,
-    id: summary.requestId,
+    id: summary.operationId || summary.requestId,
     interactionId: summary.interactionId,
+    operationId: summary.operationId,
+    operationLabel: operationLabel(summary, t),
     questionPreview: summary.questionPreview,
     requestId: summary.requestId,
-    resultPreview: summary.resultPreview,
+    resultPreview: operationResult(summary, t),
     startedAt: summary.startedAt,
     status: summary.status,
+  };
+}
+
+function operationLabel(
+  summary: RequestSummary,
+  t: (key: string, options?: Record<string, unknown>) => string,
+) {
+  const standardLabels: Record<string, string> = {
+    run_sql: "bknTrace.operations.runSql",
+    search_schema: "bknTrace.operations.searchSchema",
+  };
+  const key = summary.toolName ? standardLabels[summary.toolName] : undefined;
+  return key ? t(key) : summary.toolName || summary.operationKey || summary.questionPreview || summary.requestId;
+}
+
+function operationResult(
+  summary: RequestSummary,
+  t: (key: string, options?: Record<string, unknown>) => string,
+) {
+  return t(`bknTrace.operationResults.${summary.status}`, { count: summary.businessRefs.length });
+}
+
+function settledValue<T>(result: PromiseSettledResult<T>) {
+  return result.status === "fulfilled" ? result.value : undefined;
+}
+
+function emptySummaryPage<T>(): SummaryPage<T> {
+  return {
+    entries: [],
+    partial: true,
+    partialReasons: ["content_unavailable"],
+    total: 0,
+    truncated: false,
   };
 }
 

--- a/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
@@ -89,7 +89,7 @@ export function ObservabilityLogsScene() {
     { dataIndex: "eventTimestamp", key: "eventTimestamp", title: t("bknTrace.logs.columns.time"), width: 180, render: formatTime },
     {
       dataIndex: "summary", key: "summary", title: t("bknTrace.logs.columns.event"),
-      render: (value: string, record) => <div className={styles.summaryCell}><span>{value || record.eventName}</span><span className={styles.technicalId}>{record.eventName} · {record.logId}</span></div>,
+      render: (value: string, record) => <div className={styles.summaryCell}><span>{operationLabel(record.toolName, value, record.eventName, t)}</span><span className={styles.technicalId}>{record.eventName} · {record.logId}</span></div>,
     },
     { dataIndex: "category", key: "category", title: t("bknTrace.logs.columns.category"), width: 150, render: (value: string) => <Tag>{value}</Tag> },
     { dataIndex: "serviceName", key: "serviceName", title: t("bknTrace.logs.columns.service"), width: 160 },
@@ -154,4 +154,10 @@ function formatTime(value?: string) {
   if (!value) return "-";
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function operationLabel(toolName: string | undefined, summary: string, eventName: string, t: (key: string) => string) {
+  if (toolName === "run_sql") return t("bknTrace.operations.runSql");
+  if (toolName === "search_schema") return t("bknTrace.operations.searchSchema");
+  return toolName || summary || eventName;
 }

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -60,10 +60,10 @@ describe("observability workspace scenes", () => {
       count: { accuracy: "partial", value: 1 },
       data: [{
         attributes: {}, category: "runtime.business", environment: "production",
-        eventName: "knowledge.read.completed", eventTimestamp: "2026-08-01T10:00:00Z",
+        eventName: "operation.completed", eventTimestamp: "2026-08-01T10:00:00Z",
         logId: "log-a", observedTimestamp: "2026-08-01T10:00:01Z", outcome: "success",
         serviceName: "context-loader", severityNumber: 9, severityText: "INFO",
-        sourceId: "otel-ss4o", summary: "读取需求预测对象", traceId: "trace-a",
+        sourceId: "otel-ss4o", summary: "OpenBKN operation completed", toolName: "run_sql", traceId: "trace-a",
       }],
       partial: true,
       sourceStatus: [{ coveredModules: ["openbkn"], reason: "source_query_failed", reliability: "best_effort", sourceId: "safe-audit", status: "unavailable" }],
@@ -87,7 +87,8 @@ describe("observability workspace scenes", () => {
   it("日志检索展示授权类别、局部结果和来源状态", async () => {
     render(<ObservabilityLogsScene />);
     await waitFor(() => expect(listLogs).toHaveBeenCalledWith({ limit: 50 }));
-    expect(await screen.findByText("读取需求预测对象")).not.toBeNull();
+    expect(await screen.findByText("bknTrace.operations.runSql")).not.toBeNull();
+    expect(screen.queryByText("OpenBKN operation completed")).toBeNull();
     expect(screen.getByText("bknTrace.logs.partialWarning")).not.toBeNull();
     expect(screen.getByText("runtime.business")).not.toBeNull();
   });
@@ -124,7 +125,7 @@ describe("observability workspace scenes", () => {
 
 	 it("点击日志打开受控详情并可下钻 Trace", async () => {
 		 render(<ObservabilityLogsScene />);
-		 const summary = await screen.findByText("读取需求预测对象");
+		 const summary = await screen.findByText("bknTrace.operations.runSql");
 		 fireEvent.click(summary);
 		 await waitFor(() => expect(getLogDetail).toHaveBeenCalledWith("log-a"));
 		 expect(await screen.findByText("bknTrace.logs.detail.title")).not.toBeNull();

--- a/src/modules/bkn-trace/services/observability.service.test.ts
+++ b/src/modules/bkn-trace/services/observability.service.test.ts
@@ -43,6 +43,7 @@ describe("observability service", () => {
           outcome: "success",
           safe_summary: "读取需求预测对象",
           service_name: "context-loader",
+          tool_name: "run_sql",
           deployment_environment: "local",
           tenant_id: "tenant-a",
           ingress_principal: "otel-collector",
@@ -73,6 +74,7 @@ describe("observability service", () => {
       category: "runtime.business",
       logId: "log-a",
       summary: "读取需求预测对象",
+      toolName: "run_sql",
     });
     expect(getMock.mock.calls.flat().join(" ")).not.toContain("_search");
   });

--- a/src/modules/bkn-trace/services/observability.service.ts
+++ b/src/modules/bkn-trace/services/observability.service.ts
@@ -39,6 +39,7 @@ type BackendLogRecord = {
   severity_text: string;
   source_id: string;
   span_id?: string;
+  tool_name?: string;
   trace_id?: string;
 };
 
@@ -63,6 +64,7 @@ export type LogRecord = {
   sourceId: string;
   spanId?: string;
   summary: string;
+  toolName?: string;
   traceId?: string;
 };
 
@@ -247,6 +249,7 @@ function mapLogRecord(record: BackendLogRecord): LogRecord {
     sourceId: record.source_id,
     ...(record.span_id ? { spanId: record.span_id } : {}),
     summary: record.safe_summary,
+    ...(record.tool_name ? { toolName: record.tool_name } : {}),
     ...(record.trace_id ? { traceId: record.trace_id } : {}),
   };
 }

--- a/src/modules/bkn-trace/services/trace.service.test.ts
+++ b/src/modules/bkn-trace/services/trace.service.test.ts
@@ -309,6 +309,25 @@ describe("bkn-trace service", () => {
     expect(page.nextCursor).toBe("cursor-2");
   });
 
+  it("normalizes unsupported provenance statuses at the API boundary", async () => {
+    getMock.mockResolvedValue({
+      data: {
+        entries: [{
+          request_id: "req_future_status",
+          status: "future_status",
+        }],
+        total: 1,
+      },
+    });
+    const { getRequestSummaries } = await import(
+      "@/modules/bkn-trace/services/trace.service"
+    );
+
+    const page = await getRequestSummaries();
+
+    expect(page.entries[0].status).toBe("unknown");
+  });
+
   it("lists true conversation and interaction business provenance projections", async () => {
 	getMock
 	  .mockResolvedValueOnce({

--- a/src/modules/bkn-trace/services/trace.service.test.ts
+++ b/src/modules/bkn-trace/services/trace.service.test.ts
@@ -151,6 +151,7 @@ describe("bkn-trace service", () => {
       {
         headers: { "x-business-domain": "bd_demo" },
         params: { request_id: "req_001", limit: 50 },
+		skipErrorToast: true,
       },
     );
     expect(getMock).toHaveBeenNthCalledWith(
@@ -159,6 +160,7 @@ describe("bkn-trace service", () => {
       {
         headers: { "x-business-domain": "bd_demo" },
         params: { request_id: "req_001", limit: 50 },
+		skipErrorToast: true,
       },
     );
     expect(getMock.mock.calls.flat().join(" ")).not.toContain("_search");
@@ -238,6 +240,9 @@ describe("bkn-trace service", () => {
       data: {
         entries: [{
           request_id: "req_business_001",
+		  operation_id: "op_query_customer_risk",
+		  operation_key: "customer-risk-query",
+		  tool_name: "run_sql",
           started_at: "2026-07-27T09:00:00Z",
           completed_at: "2026-07-27T09:00:03Z",
           initiator: "业务分析员",
@@ -276,7 +281,7 @@ describe("bkn-trace service", () => {
       to: "2026-07-28T00:00:00Z",
     });
 
-    expect(getMock).toHaveBeenCalledWith("/agent-observability/v1/requests", {
+    expect(getMock).toHaveBeenCalledWith("/agent-observability/v1/business-provenance/requests", {
       headers: { "x-business-domain": "bd_demo" },
       params: {
         agent_or_app: "risk-agent",
@@ -293,6 +298,9 @@ describe("bkn-trace service", () => {
     });
     expect(page.entries[0]).toMatchObject({
       requestId: "req_business_001",
+	  operationId: "op_query_customer_risk",
+	  operationKey: "customer-risk-query",
+	  toolName: "run_sql",
       questionPreview: "客户 A 的风险为什么上升？",
       resultPreview: "近 7 天投诉增加，风险等级上升。",
       evidenceCompleteness: "complete",
@@ -419,12 +427,12 @@ describe("bkn-trace service", () => {
 
     expect(getMock).toHaveBeenNthCalledWith(
       1,
-      "/agent-observability/v1/requests/req_business_001",
+      "/agent-observability/v1/business-provenance/requests/req_business_001",
       { headers: { "x-business-domain": "bd_demo" } },
     );
     expect(getMock).toHaveBeenNthCalledWith(
       2,
-      "/agent-observability/v1/requests/req_business_001/traces",
+      "/agent-observability/v1/business-provenance/requests/req_business_001/traces",
       { headers: { "x-business-domain": "bd_demo" }, params: { limit: 30 } },
     );
     expect(getMock).toHaveBeenNthCalledWith(
@@ -459,7 +467,7 @@ describe("bkn-trace service", () => {
     });
 
     expect(getMock).toHaveBeenCalledWith(
-      "/agent-observability/v1/requests",
+      "/agent-observability/v1/business-provenance/requests",
       {
         headers: { "x-business-domain": "bd_demo" },
         params: {
@@ -497,7 +505,7 @@ describe("bkn-trace service", () => {
     const interaction = await getInteractionSummary("interaction_june_forecast");
 
     expect(getMock).toHaveBeenCalledWith(
-      "/agent-observability/v1/interactions/interaction_june_forecast",
+      "/agent-observability/v1/business-provenance/interactions/interaction_june_forecast",
       { headers: { "x-business-domain": "bd_demo" } },
     );
     expect(interaction.requests.map((item) => item.requestId)).toEqual([

--- a/src/modules/bkn-trace/services/trace.service.ts
+++ b/src/modules/bkn-trace/services/trace.service.ts
@@ -732,7 +732,7 @@ export async function getInteractionSummary(
     interactionId: response.data.interaction_id ?? "",
     requests: (response.data.requests ?? []).map(mapRequestSummary),
     startedAt: response.data.started_at,
-    status: response.data.status ?? "unknown",
+    status: normalizeExecutionStatus(response.data.status),
     traces: (response.data.traces ?? []).map(mapTraceExecutionSummary),
   };
 }
@@ -832,6 +832,12 @@ function mapActionSummary(data?: BackendActionSummary): ActionSummary {
   };
 }
 
+const EXECUTION_STATUSES = new Set(["completed", "error", "running", "unknown"]);
+
+function normalizeExecutionStatus(status?: string) {
+  return status && EXECUTION_STATUSES.has(status) ? status : "unknown";
+}
+
 function mapRequestSummary(data: BackendRequestSummary): RequestSummary {
   return {
     actionSummary: mapActionSummary(data.action_summary),
@@ -853,7 +859,7 @@ function mapRequestSummary(data: BackendRequestSummary): RequestSummary {
     requestId: data.request_id ?? "",
     resultPreview: data.result_preview,
     startedAt: data.started_at,
-    status: data.status ?? "unknown",
+    status: normalizeExecutionStatus(data.status),
     traceCount: data.trace_count ?? 0,
 	toolName: data.tool_name,
   };
@@ -876,7 +882,7 @@ function mapConversationSummary(data: BackendConversationSummary): ConversationS
     requestCount: data.request_count ?? 0,
     resultPreview: data.result_preview,
     startedAt: data.started_at,
-    status: data.status ?? "unknown",
+    status: normalizeExecutionStatus(data.status),
     traceCount: data.trace_count ?? 0,
   };
 }
@@ -898,7 +904,7 @@ function mapInteractionListSummary(data: BackendInteractionListSummary): Interac
     requestCount: data.request_count ?? 0,
     resultPreview: data.result_preview,
     startedAt: data.started_at,
-    status: data.status ?? "unknown",
+    status: normalizeExecutionStatus(data.status),
     traceCount: data.trace_count ?? 0,
   };
 }
@@ -916,7 +922,7 @@ function mapTraceExecutionSummary(data: BackendTraceExecutionSummary): TraceExec
     rootOperation: data.root_operation,
     spanCount: data.span_count ?? 0,
     startedAt: data.started_at,
-    status: data.status ?? "unknown",
+    status: normalizeExecutionStatus(data.status),
     traceId: data.trace_id ?? "",
   };
 }

--- a/src/modules/bkn-trace/services/trace.service.ts
+++ b/src/modules/bkn-trace/services/trace.service.ts
@@ -10,6 +10,7 @@ import { getRuntimeConfig } from "@/framework/runtime/config";
 
 const TRACE_API_PREFIX = "/agent-observability/v1/traces";
 const OBSERVABILITY_API_PREFIX = "/agent-observability/v1";
+const BUSINESS_PROVENANCE_PREFIX = `${OBSERVABILITY_API_PREFIX}/business-provenance`;
 
 export type VisibilitySummary = {
   authorizedRefCount: number;
@@ -214,6 +215,8 @@ export type RequestSummary = {
   initiator?: string;
   interactionId?: string;
   knowledgeNetworks: string[];
+	operationId?: string;
+	operationKey?: string;
   partialReasons: string[];
   questionPreview?: string;
   requestId: string;
@@ -221,6 +224,7 @@ export type RequestSummary = {
   startedAt?: string;
   status: string;
   traceCount: number;
+	toolName?: string;
 };
 
 export type ConversationSummary = {
@@ -510,6 +514,8 @@ type BackendRequestSummary = {
   initiator?: string;
   interaction_id?: string;
   knowledge_networks?: string[];
+	operation_id?: string;
+	operation_key?: string;
   partial_reasons?: string[];
   question_preview?: string;
   request_id?: string;
@@ -517,6 +523,7 @@ type BackendRequestSummary = {
   started_at?: string;
   status?: string;
   trace_count?: number;
+	tool_name?: string;
 };
 
 type BackendConversationSummary = {
@@ -650,6 +657,7 @@ export async function getEvidenceChain(scope: TraceQueryScope): Promise<Evidence
   const response = await http.get<BackendEvidenceChain>(targetPath(scope, "evidence-chain"), {
     headers: traceHeaders(),
     params: targetParams(scope),
+	skipErrorToast: true,
   });
   return mapEvidenceChain(response.data);
 }
@@ -658,6 +666,7 @@ export async function getBusinessGraph(scope: TraceQueryScope): Promise<Business
   const response = await http.get<BackendBusinessGraph>(targetPath(scope, "business-graph"), {
     headers: traceHeaders(),
     params: targetParams(scope),
+	skipErrorToast: true,
   });
   return mapBusinessGraph(response.data);
 }
@@ -666,6 +675,7 @@ export async function getSnapshotPreview(scope: TraceQueryScope): Promise<Snapsh
   const response = await http.get<BackendSnapshotPreview>(targetPath(scope, "snapshot-preview"), {
     headers: traceHeaders(),
     params: targetParams(scope),
+	skipErrorToast: true,
   });
   return mapSnapshotPreview(response.data);
 }
@@ -674,7 +684,7 @@ export async function getRequestSummaries(
   query: RequestSummaryQuery = {},
 ): Promise<SummaryPage<RequestSummary>> {
   const response = await http.get<BackendSummaryPage<BackendRequestSummary>>(
-    `${OBSERVABILITY_API_PREFIX}/requests`,
+    `${BUSINESS_PROVENANCE_PREFIX}/requests`,
     { headers: traceHeaders(), params: summaryParams(query) },
   );
   return mapSummaryPage(response.data, mapRequestSummary);
@@ -684,7 +694,7 @@ export async function getConversationSummaries(
   query: RequestSummaryQuery = {},
 ): Promise<SummaryPage<ConversationSummary>> {
   const response = await http.get<BackendSummaryPage<BackendConversationSummary>>(
-    `${OBSERVABILITY_API_PREFIX}/business-provenance/conversations`,
+    `${BUSINESS_PROVENANCE_PREFIX}/conversations`,
     { headers: traceHeaders(), params: summaryParams(query) },
   );
   return mapSummaryPage(response.data, mapConversationSummary);
@@ -694,7 +704,7 @@ export async function getInteractionSummaries(
   query: RequestSummaryQuery = {},
 ): Promise<SummaryPage<InteractionListSummary>> {
   const response = await http.get<BackendSummaryPage<BackendInteractionListSummary>>(
-    `${OBSERVABILITY_API_PREFIX}/business-provenance/interactions`,
+    `${BUSINESS_PROVENANCE_PREFIX}/interactions`,
     { headers: traceHeaders(), params: summaryParams(query) },
   );
   return mapSummaryPage(response.data, mapInteractionListSummary);
@@ -702,7 +712,7 @@ export async function getInteractionSummaries(
 
 export async function getRequestSummary(requestId: string): Promise<RequestSummary> {
   const response = await http.get<BackendRequestSummary>(
-    `${OBSERVABILITY_API_PREFIX}/requests/${encodeURIComponent(requestId)}`,
+    `${BUSINESS_PROVENANCE_PREFIX}/requests/${encodeURIComponent(requestId)}`,
     traceRequestConfig(),
   );
   return mapRequestSummary(response.data);
@@ -712,7 +722,7 @@ export async function getInteractionSummary(
   interactionId: string,
 ): Promise<InteractionSummary> {
   const response = await http.get<BackendInteractionSummary>(
-    `${OBSERVABILITY_API_PREFIX}/interactions/${encodeURIComponent(interactionId)}`,
+    `${BUSINESS_PROVENANCE_PREFIX}/interactions/${encodeURIComponent(interactionId)}`,
     traceRequestConfig(),
   );
   return {
@@ -732,7 +742,7 @@ export async function getRequestTraces(
   query: Pick<RequestSummaryQuery, "cursor" | "limit"> = {},
 ): Promise<SummaryPage<TraceExecutionSummary>> {
   const response = await http.get<BackendSummaryPage<BackendTraceExecutionSummary>>(
-    `${OBSERVABILITY_API_PREFIX}/requests/${encodeURIComponent(requestId)}/traces`,
+    `${BUSINESS_PROVENANCE_PREFIX}/requests/${encodeURIComponent(requestId)}/traces`,
     { headers: traceHeaders(), params: summaryParams(query) },
   );
   return mapSummaryPage(response.data, mapTraceExecutionSummary);
@@ -836,6 +846,8 @@ function mapRequestSummary(data: BackendRequestSummary): RequestSummary {
     initiator: data.initiator,
     interactionId: data.interaction_id,
     knowledgeNetworks: data.knowledge_networks ?? [],
+	operationId: data.operation_id,
+	operationKey: data.operation_key,
     partialReasons: data.partial_reasons ?? [],
     questionPreview: data.question_preview,
     requestId: data.request_id ?? "",
@@ -843,6 +855,7 @@ function mapRequestSummary(data: BackendRequestSummary): RequestSummary {
     startedAt: data.started_at,
     status: data.status ?? "unknown",
     traceCount: data.trace_count ?? 0,
+	toolName: data.tool_name,
   };
 }
 


### PR DESCRIPTION
## 概要
- 业务溯源统一呈现为业务会话、交互轮次、OpenBKN 调用三个业务层级
- OpenBKN 调用使用可读业务名称，并保留技术标识供下钻
- Trace、Evidence、Snapshot 等可选资源 404 时局部降级，保留已加载业务内容
- 提升日志事件名称和关联入口的可理解性

## 验证
- pnpm vitest run src/modules/bkn-trace --maxWorkers=1（8 files / 45 tests）
- pnpm exec tsc -b --pretty false
- pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
- node scripts/check-license-headers.mjs
- pnpm build

关联：#173、openbkn-ai/bkn-foundry#545、openbkn-ai/bkn-foundry#547
设计文档：openbkn-ai/bkn-docs#29