### PR TITLE
feat(shell): add user menu version info and install status link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,6 @@ VITE_DEV_REFRESH_TOKEN=
 # Backend install / service health page opened from the user menu (new tab).
 # Production: defaults to <current-host>/install-status.
 # Local dev: proxied via VITE_DEV_AUTH_ORIGIN; set that to your gateway, e.g.
-# VITE_DEV_AUTH_ORIGIN=https://14.103.77.23
+# VITE_DEV_AUTH_ORIGIN=https://<your-openbkn-instance>
 # Or override the link target directly:
-# VITE_INSTALL_STATUS_URL=https://14.103.77.23/install-status
+# VITE_INSTALL_STATUS_URL=https://<your-openbkn-instance>/install-status

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ VITE_USE_MOCK=false
 # OAuth2 login flow (/oauth2, /.well-known, /userinfo) are proxied there; the
 # gateway's hydra must have the openbkn-studio client seeded with a redirect_uri
 # matching this dev origin (http://localhost:8000/studio/callback).
+# /install-status (user menu link) is also proxied here during local dev.
 VITE_DEV_AUTH_ORIGIN=http://127.0.0.1:9000
 # Local Vega backend while other API and OAuth requests stay on VITE_DEV_AUTH_ORIGIN.
 VITE_VEGA_PROXY_TARGET=http://127.0.0.1:9000
@@ -13,3 +14,9 @@ VITE_VEGA_PROXY_TARGET=http://127.0.0.1:9000
 VITE_DEV_ACCESS_TOKEN=
 VITE_DEV_REFRESH_TOKEN=
 # VITE_PROXY_TARGET=https://<your-openbkn-instance>
+# Backend install / service health page opened from the user menu (new tab).
+# Production: defaults to <current-host>/install-status.
+# Local dev: proxied via VITE_DEV_AUTH_ORIGIN; set that to your gateway, e.g.
+# VITE_DEV_AUTH_ORIGIN=https://14.103.77.23
+# Or override the link target directly:
+# VITE_INSTALL_STATUS_URL=https://14.103.77.23/install-status

--- a/src/app/locales/resources/shell/en-US.ts
+++ b/src/app/locales/resources/shell/en-US.ts
@@ -11,6 +11,9 @@ export const shellEnUS = {
     modeStandalone: "Standalone",
     modeHosted: "Hosted",
     productTagline: "Studio Console",
+    userMenuProductTitle: "{{product}} {{tagline}}",
+    userMenuTagline: "Console",
+    versionLine: "Version {{version}}",
     headerAside: "Application shell baseline",
     collapseSidenav: "Collapse navigation",
     expandSidenav: "Expand navigation",
@@ -53,6 +56,7 @@ export const shellEnUS = {
       logManagement: "Log Management",
       apiKeys: "API Key",
       account: "Account",
+      installStatus: "Backend Service Status",
     },
   },
 } as const;

--- a/src/app/locales/resources/shell/zh-CN.ts
+++ b/src/app/locales/resources/shell/zh-CN.ts
@@ -11,6 +11,9 @@ export const shellZhCN = {
     modeStandalone: "独立运行",
     modeHosted: "宿主接入",
     productTagline: "控制台",
+    userMenuProductTitle: "{{product}} {{tagline}}",
+    userMenuTagline: "控制台",
+    versionLine: "版本 {{version}}",
     headerAside: "统一应用壳层",
     collapseSidenav: "收起导航",
     expandSidenav: "展开导航",
@@ -54,6 +57,7 @@ export const shellZhCN = {
       logManagement: "日志管理",
       apiKeys: "API Key",
       account: "个人中心",
+      installStatus: "后端服务状态",
     },
   },
 } as const;

--- a/src/app/shell/TopBar.tsx
+++ b/src/app/shell/TopBar.tsx
@@ -6,11 +6,13 @@
  */
 
 import {
+  CloudServerOutlined,
   LogoutOutlined,
   UserOutlined,
 } from "@ant-design/icons";
 import { Dropdown } from "antd";
-import { useEffect, useState } from "react";
+import type { MenuProps } from "antd";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMatches, useNavigate, useParams } from "react-router-dom";
 
@@ -19,6 +21,8 @@ import openBknLogo from "@/assets/brand/openbkn-logo.png";
 import type { AppRouteHandle } from "@/app/shell/route-meta";
 import { logout } from "@/framework/auth/oauth";
 import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
+import { APP_VERSION } from "@/framework/runtime/app-version";
+import { getInstallStatusUrl } from "@/framework/runtime/install-status-url";
 import { BuildActivityChip } from "@/modules/data-catalog/components/BuildActivityChip";
 import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
 
@@ -77,6 +81,63 @@ export function TopBar() {
       : []),
   ];
 
+  const installStatusUrl = getInstallStatusUrl();
+  const userMenuItems = useMemo<MenuProps["items"]>(() => {
+    const items: MenuProps["items"] = [
+      {
+        disabled: true,
+        key: "version",
+        label: (
+          <span className="console-user-menu-version">
+            <strong>
+              {t("shell.userMenuProductTitle", {
+                product: t("app.title"),
+                tagline: t("shell.userMenuTagline"),
+              })}
+            </strong>
+            <span>{t("shell.versionLine", { version: APP_VERSION })}</span>
+          </span>
+        ),
+      },
+      { type: "divider" as const },
+    ];
+
+    items.push({
+      icon: <UserOutlined />,
+      key: "account",
+      label: t("shell.items.account"),
+      onClick: () => {
+        void navigate("/account");
+      },
+    });
+
+    if (installStatusUrl) {
+      items.push({
+        icon: <CloudServerOutlined />,
+        key: "install-status",
+        label: t("shell.items.installStatus"),
+        onClick: () => {
+          window.open(installStatusUrl, "_blank", "noopener,noreferrer");
+        },
+      });
+    }
+
+    items.push(
+      { type: "divider" as const },
+      {
+        danger: true,
+        icon: <LogoutOutlined />,
+        key: "logout",
+        label: t("auth.logout"),
+        onClick: () => {
+          logout(runtimeConfig.mode);
+        },
+      },
+    );
+
+    return items;
+  }, [installStatusUrl, navigate, runtimeConfig.mode, t]);
+
   return (
     <header className="console-topbar">
       <div className="console-brand">
@@ -118,28 +179,7 @@ export function TopBar() {
       <div className="console-topbar-actions">
         <BuildActivityChip />
         <Dropdown
-          menu={{
-            items: [
-              {
-                icon: <UserOutlined />,
-                key: "account",
-                label: t("shell.items.account"),
-                onClick: () => {
-                  void navigate("/account");
-                },
-              },
-              { type: "divider" },
-              {
-                danger: true,
-                icon: <LogoutOutlined />,
-                key: "logout",
-                label: t("auth.logout"),
-                onClick: () => {
-                  logout(runtimeConfig.mode);
-                },
-              },
-            ],
-          }}
+          menu={{ items: userMenuItems }}
           placement="bottomRight"
           trigger={["click"]}
         >

--- a/src/app/shell/TopBar.tsx
+++ b/src/app/shell/TopBar.tsx
@@ -82,6 +82,8 @@ export function TopBar() {
   ];
 
   const installStatusUrl = getInstallStatusUrl();
+  const canViewInstallStatus =
+    runtimeConfig.currentUser.isAdmin && installStatusUrl !== null;
   const userMenuItems = useMemo<MenuProps["items"]>(() => {
     const items: MenuProps["items"] = [
       {
@@ -111,7 +113,7 @@ export function TopBar() {
       },
     });
 
-    if (installStatusUrl) {
+    if (canViewInstallStatus) {
       items.push({
         icon: <CloudServerOutlined />,
         key: "install-status",
@@ -136,7 +138,7 @@ export function TopBar() {
     );
 
     return items;
-  }, [installStatusUrl, navigate, runtimeConfig.mode, t]);
+  }, [canViewInstallStatus, installStatusUrl, navigate, runtimeConfig.mode, t]);
 
   return (
     <header className="console-topbar">

--- a/src/framework/runtime/app-version.ts
+++ b/src/framework/runtime/app-version.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import packageJson from "../../../package.json";
+
+export const APP_VERSION = packageJson.version;
+
+export const APP_VERSION_LABEL = `v${APP_VERSION}`;

--- a/src/framework/runtime/install-status-url.test.ts
+++ b/src/framework/runtime/install-status-url.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getInstallStatusUrl,
+  resolveConfiguredInstallStatusUrl,
+} from "@/framework/runtime/install-status-url";
+
+describe("resolveConfiguredInstallStatusUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null for blank input", () => {
+    expect(resolveConfiguredInstallStatusUrl("")).toBeNull();
+    expect(resolveConfiguredInstallStatusUrl("   ")).toBeNull();
+  });
+
+  it("joins relative paths with window origin", () => {
+    vi.stubGlobal("window", { location: { origin: "https://gateway.example.com" } });
+    expect(resolveConfiguredInstallStatusUrl("/install-status")).toBe(
+      "https://gateway.example.com/install-status",
+    );
+  });
+
+  it("returns relative paths without window", () => {
+    vi.stubGlobal("window", undefined);
+    expect(resolveConfiguredInstallStatusUrl("/install-status")).toBe("/install-status");
+  });
+
+  it("rejects non-http(s) protocols", () => {
+    expect(resolveConfiguredInstallStatusUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("returns null for invalid URLs", () => {
+    expect(resolveConfiguredInstallStatusUrl("not a url")).toBeNull();
+  });
+
+  it("accepts absolute https URLs", () => {
+    expect(resolveConfiguredInstallStatusUrl("https://example.com/install-status")).toBe(
+      "https://example.com/install-status",
+    );
+  });
+});
+
+describe("getInstallStatusUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("prefers configured env override", () => {
+    vi.stubEnv("VITE_INSTALL_STATUS_URL", "https://remote.example/install-status");
+    expect(getInstallStatusUrl()).toBe("https://remote.example/install-status");
+  });
+
+  it("falls back to same-origin default", () => {
+    vi.stubEnv("VITE_INSTALL_STATUS_URL", "");
+    vi.stubGlobal("window", { location: { origin: "https://gateway.example.com" } });
+    expect(getInstallStatusUrl()).toBe("https://gateway.example.com/install-status");
+  });
+});

--- a/src/framework/runtime/install-status-url.ts
+++ b/src/framework/runtime/install-status-url.ts
@@ -7,7 +7,7 @@
 
 const INSTALL_STATUS_PATH = "/install-status";
 
-function resolveConfiguredInstallStatusUrl(raw: string): string | null {
+export function resolveConfiguredInstallStatusUrl(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;

--- a/src/framework/runtime/install-status-url.ts
+++ b/src/framework/runtime/install-status-url.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+const INSTALL_STATUS_PATH = "/install-status";
+
+function resolveConfiguredInstallStatusUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith("/")) {
+    if (typeof window !== "undefined") {
+      return `${window.location.origin}${trimmed}`;
+    }
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Install-status page URL for the user menu.
+ *
+ * Default: same gateway host as the studio SPA (`<origin>/install-status`), so
+ * deployed builds follow whatever host the operator opened without rebaking env.
+ * Override with VITE_INSTALL_STATUS_URL for local dev or split-host setups.
+ */
+export function getInstallStatusUrl(): string | null {
+  const raw: unknown = import.meta.env.VITE_INSTALL_STATUS_URL;
+  if (typeof raw === "string") {
+    const configured = resolveConfiguredInstallStatusUrl(raw);
+    if (configured) {
+      return configured;
+    }
+  }
+
+  if (typeof window !== "undefined") {
+    return `${window.location.origin}${INSTALL_STATUS_PATH}`;
+  }
+
+  return null;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -225,6 +225,22 @@ select {
   color: var(--color-primary-700);
 }
 
+.console-user-menu-version {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 160px;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.console-user-menu-version strong {
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .console-user-pill {
   display: inline-flex;
   align-items: center;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -16,6 +16,7 @@ interface ImportMetaEnv {
   readonly VITE_DEV_AUTH_ORIGIN?: string;
   readonly VITE_DEV_REFRESH_TOKEN?: string;
   readonly VITE_SAFE_PROXY_TARGET?: string;
+  readonly VITE_INSTALL_STATUS_URL?: string;
   readonly VITE_USE_MOCK?: "true" | "false";
   readonly VITE_CAPABILITY_UX_V2?: "true" | "false";
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,6 +97,13 @@ export default defineConfig(({ mode }) => {
           }
         : {}),
       proxy: {
+        // Gateway install-status page (same path as production). Dev-only: forwards
+        // to VITE_DEV_AUTH_ORIGIN so local联调 can open the remote status page.
+        "/install-status": {
+          changeOrigin: true,
+          secure: false,
+          target: devProxyOrigin,
+        },
         // Specific API prefixes must be listed before the generic /api proxy.
         "/api/agent-operator-integration": {
           changeOrigin: true,


### PR DESCRIPTION
## What Changed

- User dropdown header shows product title and version (OpenBKN 控制台 / Version 0.1.2).
- Added **Backend Service Status** menu item that opens the gateway /install-status page in a new tab.
- Production builds default to <current-host>/install-status; local dev proxies the path via VITE_DEV_AUTH_ORIGIN.
- Optional override via VITE_INSTALL_STATUS_URL.

---

## Why

- Related Issue: N/A (product UX request)
- Background: Operators need quick access to backend install/service health from the studio shell, and version info should be visible without cluttering the top bar.

---

## How

- TopBar: build user menu items with version header, account, install status, and logout (logout last).
- pp-version.ts: read version from package.json.
- install-status-url.ts: resolve install-status URL (env override → same-origin default).
- ite.config.ts: dev proxy for /install-status.
- i18n + .env.example documentation.

---

## Testing

- [x] Unit tests passed locally (pnpm exec vitest --run)
- [ ] Integration tests passed locally (N/A)
- [ ] Verified in test environment

Test notes:
- 
ode scripts/check-license-headers.mjs
- pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
- pnpm exec vitest --run
- pnpm exec tsc -b --pretty false
- pnpm exec vite build
- pnpm audit --prod

---

## Risk & Rollback

- Potential risks: Low — UI-only shell change plus external link; install-status URL falls back to same host.
- Rollback plan: Revert PR; no schema or API changes.

---

## Additional Notes

- Menu order: Account → Backend Service Status → Logout.
- Local dev requires VITE_DEV_AUTH_ORIGIN pointing at the gateway (or VITE_INSTALL_STATUS_URL override).

Made with [Cursor](https://cursor.com)