### PR TITLE
fix(studio): lighten selected model table rows

### DIFF
--- a/src/app/theme/theme.test.ts
+++ b/src/app/theme/theme.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { createThemeConfig } from "@/app/theme/theme";
+import type { RuntimeConfig } from "@/framework/runtime/types";
+
+const runtimeConfig: RuntimeConfig = {
+  apiBaseUrl: "/api",
+  auth: {
+    tokenManager: {
+      getAccessToken: () => null,
+      refreshAccessToken: () => Promise.resolve(null),
+    },
+  },
+  currentUser: {
+    businessDomainId: null,
+    id: null,
+    isAdmin: false,
+    name: null,
+    permissions: [],
+    roles: [],
+  },
+  locale: "zh-CN",
+  mode: "standalone",
+  router: { basename: "/studio" },
+  theme: {
+    borderRadius: 0,
+    primaryColor: "#1e3a8a",
+  },
+};
+
+describe("createThemeConfig", () => {
+  it("uses light, distinct states for selectable table rows", () => {
+    expect(createThemeConfig(runtimeConfig).components?.Table).toMatchObject({
+      rowHoverBg: "#f8fafc",
+      rowSelectedBg: "#eff6ff",
+      rowSelectedHoverBg: "#dbeafe",
+    });
+  });
+});

--- a/src/app/theme/theme.test.ts
+++ b/src/app/theme/theme.test.ts
@@ -43,10 +43,24 @@ describe("createThemeConfig", () => {
       throw new Error("Table theme tokens are not configured");
     }
 
-    const rowColors = [
-      tableTokens.rowHoverBg,
-      tableTokens.rowSelectedBg,
+    const requiredColor = (value: string | undefined, name: string) => {
+      if (typeof value !== "string") {
+        throw new Error(`${name} table theme token is not configured`);
+      }
+
+      return value;
+    };
+
+    const rowHoverBg = requiredColor(tableTokens.rowHoverBg, "rowHoverBg");
+    const rowSelectedBg = requiredColor(tableTokens.rowSelectedBg, "rowSelectedBg");
+    const rowSelectedHoverBg = requiredColor(
       tableTokens.rowSelectedHoverBg,
+      "rowSelectedHoverBg",
+    );
+    const rowColors = [
+      rowHoverBg,
+      rowSelectedBg,
+      rowSelectedHoverBg,
     ];
 
     expect(new Set(rowColors).size).toBe(3);
@@ -71,11 +85,11 @@ describe("createThemeConfig", () => {
       }, 0);
     };
 
-    expect(luminance(tableTokens.rowHoverBg)).toBeGreaterThan(
-      luminance(tableTokens.rowSelectedBg),
+    expect(luminance(rowHoverBg)).toBeGreaterThan(
+      luminance(rowSelectedBg),
     );
-    expect(luminance(tableTokens.rowSelectedBg)).toBeGreaterThan(
-      luminance(tableTokens.rowSelectedHoverBg),
+    expect(luminance(rowSelectedBg)).toBeGreaterThan(
+      luminance(rowSelectedHoverBg),
     );
   });
 });

--- a/src/app/theme/theme.test.ts
+++ b/src/app/theme/theme.test.ts
@@ -36,11 +36,46 @@ const runtimeConfig: RuntimeConfig = {
 };
 
 describe("createThemeConfig", () => {
-  it("uses light, distinct states for selectable table rows", () => {
-    expect(createThemeConfig(runtimeConfig).components?.Table).toMatchObject({
-      rowHoverBg: "#f8fafc",
-      rowSelectedBg: "#eff6ff",
-      rowSelectedHoverBg: "#dbeafe",
-    });
+  it("keeps selectable table row states light and visually distinct", () => {
+    const tableTokens = createThemeConfig(runtimeConfig).components?.Table;
+
+    if (!tableTokens) {
+      throw new Error("Table theme tokens are not configured");
+    }
+
+    const rowColors = [
+      tableTokens.rowHoverBg,
+      tableTokens.rowSelectedBg,
+      tableTokens.rowSelectedHoverBg,
+    ];
+
+    expect(new Set(rowColors).size).toBe(3);
+    expect(rowColors.every((color) => /^#[\da-f]{6}$/i.test(color))).toBe(true);
+
+    const luminance = (color: string) => {
+      const channels = color
+        .slice(1)
+        .match(/[\da-f]{2}/gi)
+        ?.map((channel) => Number.parseInt(channel, 16) / 255);
+
+      if (!channels || channels.length !== 3) {
+        throw new Error(`Expected a six-digit hex color, received ${color}`);
+      }
+
+      return channels.reduce((sum, channel, index) => {
+        const linear = channel <= 0.03928
+          ? channel / 12.92
+          : ((channel + 0.055) / 1.055) ** 2.4;
+        const weights = [0.2126, 0.7152, 0.0722];
+        return sum + linear * weights[index];
+      }, 0);
+    };
+
+    expect(luminance(tableTokens.rowHoverBg)).toBeGreaterThan(
+      luminance(tableTokens.rowSelectedBg),
+    );
+    expect(luminance(tableTokens.rowSelectedBg)).toBeGreaterThan(
+      luminance(tableTokens.rowSelectedHoverBg),
+    );
   });
 });

--- a/src/app/theme/theme.ts
+++ b/src/app/theme/theme.ts
@@ -51,7 +51,13 @@ export function createThemeConfig(runtimeConfig: RuntimeConfig): ThemeConfig {
         itemHoverColor: "#2563eb",
         itemSelectedColor: "#1e3a8a",
       },
+      Table: {
+        // Keep selectable rows easy to scan: hover gives a quiet cue, selection
+        // remains legible, and selected-hover adds only a small amount of emphasis.
+        rowHoverBg: "#f8fafc",
+        rowSelectedBg: "#eff6ff",
+        rowSelectedHoverBg: "#dbeafe",
+      },
     },
   };
 }
-


### PR DESCRIPTION
# fix(studio): lighten selected model table rows

## What Changed

- [x] Model resources table styling
- [ ] Other modules: N/A
- [ ] Documentation: N/A

## Why

Closes #86

The selected-row background in the model configuration table was too dark and visually heavy. It reduced readability and looked more like a disabled or blocked state.

## How

- Added explicit Ant Design `Table` theme tokens for hover, selected, and selected-hover states.
- Changed the selected-row background to a light blue color.
- Preserved the readability of text, links, icons, and tags.
- Applied the styling through the shared theme for consistent behavior across selectable tables.
- Added a regression test for the table row state colors.

Breaking changes: None.

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally: Not applicable
- [ ] Verified in test environment: Pending visual QA

Commands run:

    corepack pnpm exec vitest run src/app/theme/theme.test.ts
    corepack pnpm exec eslint src/app/theme/theme.ts src/app/theme/theme.test.ts --config eslint.config.typechecked.js --max-warnings 0
    corepack pnpm exec tsc -b --pretty false

All completed successfully.

## Risk & Rollback

- Potential risks:
  - The shared table theme affects other selectable tables using the common Ant Design theme.
  - No functional or data-flow impact is expected.

- Rollback plan:
  - Revert the table theme token changes and the associated regression test.

## Additional Notes

- Visual QA should verify single-row selection, multi-row selection, hover, selected-hover, and deselection on the model configuration page.
- No API, selection logic, sorting, filtering, or operation-menu behavior was changed.