### PR TITLE
feat(knowledge-network): 接入 Context Loader 受管生命周期

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
@@ -32,6 +32,11 @@ import {
   type KnDetail,
   type McpToolDef,
 } from "@/modules/knowledge-network/services/context-loader.service";
+import {
+  createBknLifecycle,
+  memoryExternalKeyStore,
+  withManagedTurn,
+} from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import { recommendationFingerprint } from "@/modules/knowledge-network/utils/agent-chat-cache";
 
 import {
@@ -368,6 +373,12 @@ export function AgentChat({
   const onBaseBusy = useCallback((b: boolean) => setPaneBusy("base", b), [setPaneBusy]);
   const onKnBusy = useCallback((b: boolean) => setPaneBusy("kn", b), [setPaneBusy]);
 
+  /** 平台侧预取用的一次性受管会话（不是任何一侧对话）。 */
+  const summaryLifecycle = useMemo(
+    () => createBknLifecycle(env, tokenProvider, { externalKeyStore: memoryExternalKeyStore(), oneShot: true }),
+    [env, tokenProvider],
+  );
+
   const soloRef = useRef<ChatPaneHandle>(null);
   const baseRef = useRef<ChatPaneHandle>(null);
   const knRef = useRef<ChatPaneHandle>(null);
@@ -399,7 +410,11 @@ export function AgentChat({
     setKnResourceIds(null);
     setKnDetail(null);
     setSuggestions(FALLBACK_SUGGESTIONS);
-    fetchKnDetail(env, tokenProvider)
+    // 摘要预取也是受管业务调用（get_kn_detail 走 /kn/*）。它不属于任何一侧对话，
+    // 因此用一次性会话，不要占用面板的 conversation。
+    withManagedTurn(summaryLifecycle, "载入知识网络摘要", (turn) =>
+      fetchKnDetail(env, tokenProvider, undefined, turn ?? undefined),
+    )
       .then((detail) => {
         if (cancelled) return;
         setKnContext(buildKnContext(detail));
@@ -415,7 +430,7 @@ export function AgentChat({
     return () => {
       cancelled = true;
     };
-  }, [env, tokenProvider]);
+  }, [env, tokenProvider, summaryLifecycle]);
 
   // 有默认模型就用 BKN 的业务描述生成建议问题，替换模板结果；无模型/失败/输出不合预期时留在模板。
   useEffect(() => {

--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/modules/knowledge-network/services/context-loader.service";
 import {
   createBknLifecycle,
+  lifecycleEnv,
   memoryExternalKeyStore,
   withManagedTurn,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
@@ -375,8 +376,12 @@ export function AgentChat({
 
   /** 平台侧预取用的一次性受管会话（不是任何一侧对话）。 */
   const summaryLifecycle = useMemo(
-    () => createBknLifecycle(env, tokenProvider, { externalKeyStore: memoryExternalKeyStore(), oneShot: true }),
-    [env, tokenProvider],
+    () =>
+      createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
+        externalKeyStore: memoryExternalKeyStore(),
+        oneShot: true,
+      }),
+    [env.base, knId, tokenProvider],
   );
 
   const soloRef = useRef<ChatPaneHandle>(null);

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/**
+ * 面板与受管生命周期的接线。服务层各自有单测，但「一轮问答对应一轮交互」这件事
+ * 只存在于 ChatPane.send 的 try/catch/finally 里 —— 漏掉终结、outcome 判错、
+ * 清空对话忘了换会话，都不会被服务层的测试发现。
+ */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BknLifecycle, BknTurn } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
+import type { McpToolDef } from "@/modules/knowledge-network/services/context-loader.service";
+import type { LlmModel } from "@/modules/model-resources/types/llm";
+
+import { ChatPane, DEFAULT_PROMPT, type ChatPaneHandle, type PaneProfile } from "./ChatPane";
+
+type AgentChatModule = typeof import("@/modules/knowledge-network/services/agent-chat.service");
+type LifecycleModule = typeof import("@/modules/knowledge-network/services/bkn-lifecycle.service");
+
+const { buildAgentTools, runAgentChat, createBknLifecycle } = vi.hoisted(() => ({
+  buildAgentTools: vi.fn<AgentChatModule["buildAgentTools"]>(),
+  runAgentChat: vi.fn<AgentChatModule["runAgentChat"]>(),
+  createBknLifecycle: vi.fn<LifecycleModule["createBknLifecycle"]>(),
+}));
+
+vi.mock("@/modules/knowledge-network/services/agent-chat.service", async (importOriginal) => ({
+  ...(await importOriginal<AgentChatModule>()),
+  buildAgentTools,
+  runAgentChat,
+}));
+
+vi.mock("@/modules/knowledge-network/services/bkn-lifecycle.service", async (importOriginal) => ({
+  ...(await importOriginal<LifecycleModule>()),
+  createBknLifecycle,
+}));
+
+vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }));
+
+const profile: PaneProfile = {
+  paneKey: "solo",
+  defaultPrompt: DEFAULT_PROMPT,
+  injectKnContext: false,
+  defaultToolNames: null,
+};
+
+const toolDefs: McpToolDef[] = [{ name: "run_sql" }];
+const models = [{ modelName: "qwen-test", default: true }] as unknown as LlmModel[];
+
+function stubLifecycle() {
+  const finish = vi.fn<BknTurn["finish"]>().mockResolvedValue(undefined);
+  const turn: BknTurn = {
+    conversationId: "conv_1",
+    interactionId: "int_1",
+    nextContext: (toolName) => ({
+      conversation_id: "conv_1",
+      interaction_id: "int_1",
+      operation_key: `${toolName}#1`,
+    }),
+    recordReceipt: vi.fn(),
+    complete: vi.fn<BknTurn["complete"]>().mockResolvedValue(undefined),
+    fail: vi.fn<BknTurn["fail"]>().mockResolvedValue(undefined),
+    cancel: vi.fn<BknTurn["cancel"]>().mockResolvedValue(undefined),
+    finish,
+  };
+  const beginTurn = vi.fn<BknLifecycle["beginTurn"]>().mockResolvedValue(turn);
+  const reset = vi.fn<BknLifecycle["reset"]>();
+  const session = { callTool: vi.fn() };
+  const lifecycle: BknLifecycle = {
+    session,
+    conversationId: () => "conv_1",
+    unsupported: () => false,
+    beginTurn,
+    reset,
+  };
+  createBknLifecycle.mockReturnValue(lifecycle);
+  return { beginTurn, finish, reset, session };
+}
+
+/** 本轮传给工具循环的选项（buildAgentTools 的第 6 个入参）。 */
+function toolOptions() {
+  return buildAgentTools.mock.calls[0][5];
+}
+
+function renderPane() {
+  const ref = createRef<ChatPaneHandle>();
+  render(
+    <ChatPane
+      ref={ref}
+      env={{ base: "https://platform.example.com", token: "token-1", knId: "kn-demo" }}
+      tokenProvider={{ getToken: () => "token-1", refresh: () => Promise.resolve("token-1") }}
+      profile={profile}
+      models={models}
+      modelsLoaded
+      knContext=""
+      knSummary={null}
+      suggestions={[]}
+      getTools={() => Promise.resolve(toolDefs)}
+      toolDefs={toolDefs}
+      pageScrollRef={createRef<HTMLDivElement>()}
+    />,
+  );
+  return ref;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+  buildAgentTools.mockReturnValue({});
+});
+
+afterEach(cleanup);
+
+describe("ChatPane 受管生命周期接线", () => {
+  it("一轮问答开一轮交互，把它交给工具循环，并以答复正文终结", async () => {
+    const { beginTurn, finish, session } = stubLifecycle();
+    runAgentChat.mockImplementation(({ onChunk }) => {
+      onChunk({ type: "text", delta: "答复" });
+      onChunk({ type: "text", delta: "正文" });
+      onChunk({ type: "finish" });
+      return Promise.resolve();
+    });
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    expect(beginTurn).toHaveBeenCalledWith("问一句");
+    // 工具循环必须拿到本轮交互和生命周期的会话，否则每次工具调用都会被挡在
+    // conversation_required。
+    expect(toolOptions()).toMatchObject({
+      session,
+      turn: expect.objectContaining({ interactionId: "int_1" }) as unknown,
+    });
+    expect(finish).toHaveBeenCalledWith("completed", "答复正文");
+  });
+
+  it("执行失败时以 failed 终结", async () => {
+    const { finish } = stubLifecycle();
+    runAgentChat.mockRejectedValue(new Error("模型不可用"));
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    expect(finish).toHaveBeenCalledWith("failed", "");
+  });
+
+  it("用户中途停止时以 canceled 终结", async () => {
+    const { finish } = stubLifecycle();
+    // runAgentChat 在 abort 时是正常返回而非抛错，所以 outcome 只能靠 signal 判断。
+    runAgentChat.mockImplementation(({ signal, onChunk }) => {
+      onChunk({ type: "text", delta: "半句" });
+      return new Promise<void>((resolve) => signal?.addEventListener("abort", () => resolve()));
+    });
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+    await act(async () => {
+      ref.current?.stop();
+      await Promise.resolve();
+    });
+
+    expect(finish).toHaveBeenCalledWith("canceled", "半句");
+  });
+
+  it("后端未启用受管生命周期时照常问答，不终结不存在的交互", async () => {
+    const { beginTurn, finish } = stubLifecycle();
+    beginTurn.mockResolvedValue(null);
+    runAgentChat.mockImplementation(({ onChunk }) => {
+      onChunk({ type: "text", delta: "答复" });
+      return Promise.resolve();
+    });
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    expect(runAgentChat).toHaveBeenCalled();
+    expect(toolOptions()).toMatchObject({ turn: null });
+    expect(finish).not.toHaveBeenCalled();
+  });
+
+  it("清空对话换掉受管会话", async () => {
+    const { reset } = stubLifecycle();
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.clear();
+      await Promise.resolve();
+    });
+
+    // 这是 conversation id 唯一的更换点；漏了会让「清空」后的新对话仍挂在旧会话上。
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -50,6 +50,11 @@ import {
   type AgentTokenProvider,
 } from "@/modules/knowledge-network/services/agent-chat.service";
 import {
+  createBknLifecycle,
+  localExternalKeyStore,
+  type TurnOutcome,
+} from "@/modules/knowledge-network/services/bkn-lifecycle.service";
+import {
   CONTEXT_LOADER_OPS,
   type ContextLoaderEnv,
   type McpToolDef,
@@ -177,6 +182,14 @@ export function fmtDuration(ms: number): string {
 /** 消息历史键：solo 沿用旧键（老对话不丢），对比面板加 :cmp-* 后缀隔离。 */
 function msgsLsKey(knId: string, paneKey: PaneKey): string {
   return paneKey === "solo" ? `bkn-studio:agentchat:${knId}` : `bkn-studio:agentchat:${knId}:cmp-${paneKey}`;
+}
+
+/**
+ * 受管会话身份键。每个面板一条独立 conversation —— 对比模式两侧是两个不同的 Agent
+ * 在各自答题，Trace 里也应当分别溯源、分别统计，不该混进同一条会话。
+ */
+function conversationLsKey(knId: string, paneKey: PaneKey): string {
+  return `bkn-studio:agentchat:conv:${knId}:${paneKey}`;
 }
 
 function loadPersisted(key: string): Partial<Persisted> {
@@ -542,7 +555,8 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
               {
                 id: chunk.id,
                 name: chunk.name,
-                // 展示实际发出的请求体（含注入的 kn_id 与 schema_brief 等默认值），而非模型原始入参。
+                // 展示实际发出的业务请求体（含注入的 kn_id 与 schema_brief 等默认值），而非模型原始入参。
+                // 受管上下文（bkn_context）在 execute 里逐次注入，不在这条流式事件里，故不展示。
                 args: effectiveToolArgs(chunk.name, chunk.args, knId),
                 status: "running",
                 startedAt: performance.now(),
@@ -581,6 +595,18 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
       }
     },
     [updateAssistant, knId],
+  );
+
+  /**
+   * 本面板的受管生命周期客户端。会话身份跟着 kn + 面板走，只有「清空对话」才换新
+   * ——刷新页面按 external_conversation_key 幂等复用同一条 conversation。
+   */
+  const lifecycle = useMemo(
+    () =>
+      createBknLifecycle(env, tokenProvider, {
+        externalKeyStore: localExternalKeyStore(conversationLsKey(knId, profile.paneKey)),
+      }),
+    [env, tokenProvider, knId, profile.paneKey],
   );
 
   // 实际发送的完整系统提示词 = 可编辑提示词 + （按画像）自动附加的知识网络摘要。
@@ -623,11 +649,21 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
 
       const controller = new AbortController();
       abortRef.current = controller;
+      // 一轮交互 = 一轮问答。答复正文另行累计：终结交互要把它作为 artifact 交给 Core，
+      // 而消息 state 是异步的，finally 里读不到本轮最终值。
+      let turn: Awaited<ReturnType<typeof lifecycle.beginTurn>> = null;
+      let outcome: TurnOutcome = "completed";
+      let answer = "";
       try {
+        turn = await lifecycle.beginTurn(question);
         const allTools = await getTools();
         // 硬限定：只把勾选的工具传给模型（null = 全部）。
         const activeTools = toolSelection ? allTools.filter((t) => toolSelection.includes(t.name)) : allTools;
-        const tools = buildAgentTools(activeTools, env, knId, config, tokenProvider, resourceScope);
+        const tools = buildAgentTools(activeTools, env, knId, config, tokenProvider, {
+          resourceScope,
+          session: lifecycle.session,
+          turn,
+        });
 
         await runAgentChat({
           env,
@@ -639,6 +675,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
           tokenProvider: modelTokenProvider ?? tokenProvider,
           signal: controller.signal,
           onChunk: (chunk) => {
+            if (chunk.type === "text") answer += chunk.delta;
             if (requestSequence === requestSequenceRef.current) handleChunk(chunk);
           },
         });
@@ -646,8 +683,10 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
         if (requestSequence !== requestSequenceRef.current) return;
         if (controller.signal.aborted) {
           // 用户中途停止：标记本轮 stopped（对比报告计为负面），保留已生成的部分内容。
+          outcome = "canceled";
           updateAssistant((m) => ({ ...m, stopped: true }));
         } else {
+          outcome = "failed";
           updateAssistant((m) => ({
             ...m,
             errored: true,
@@ -655,6 +694,12 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
           }));
         }
       } finally {
+        // 终结必须挡在 setBusy(false) 之前：一条 conversation 同时只允许一个 active
+        // interaction（Core 的 uq_..._interaction_active 唯一约束），提前放开输入框会让
+        // 用户手快发出的下一轮直接开不出交互。
+        // 用户点停止时 runAgentChat 是正常返回而非抛错，所以结果要认 aborted 而不是 outcome。
+        // 收尾失败不改写本轮结果：那是可观测面的问题，不该把答出来的一轮显示成失败。
+        if (turn) await turn.finish(controller.signal.aborted ? "canceled" : outcome, answer).catch(() => undefined);
         if (requestSequence === requestSequenceRef.current) {
           abortRef.current = null;
           const elapsed = performance.now() - startedAt;
@@ -667,7 +712,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
         }
       }
     },
-    [busy, model, messages, env, knId, composedSystem, config, toolSelection, getTools, tokenProvider, modelTokenProvider, resourceScope, handleChunk, updateAssistant, message],
+    [busy, model, messages, env, knId, composedSystem, config, toolSelection, getTools, tokenProvider, modelTokenProvider, resourceScope, lifecycle, handleChunk, updateAssistant, message],
   );
 
   const stop = useCallback(() => {
@@ -699,12 +744,15 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
   const clearChat = useCallback(() => {
     setMessages([]);
     setStats({ tokens: 0, ms: 0 });
+    // 清空对话 = 换一条受管会话。这是 conversation id 唯一的更换点：不清空就一直是同一个，
+    // 刷新页面也会按同一把 external_conversation_key 幂等复用回来。
+    lifecycle.reset();
     try {
       localStorage.removeItem(msgsLsKey(knId, profile.paneKey));
     } catch {
       /* ignore */
     }
-  }, [knId, profile.paneKey]);
+  }, [knId, profile.paneKey, lifecycle]);
 
   useImperativeHandle(
     ref,

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/modules/knowledge-network/services/agent-chat.service";
 import {
   createBknLifecycle,
+  lifecycleEnv,
   localExternalKeyStore,
   type TurnOutcome,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
@@ -603,10 +604,10 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
    */
   const lifecycle = useMemo(
     () =>
-      createBknLifecycle(env, tokenProvider, {
+      createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
         externalKeyStore: localExternalKeyStore(conversationLsKey(knId, profile.paneKey)),
       }),
-    [env, tokenProvider, knId, profile.paneKey],
+    [env.base, knId, tokenProvider, profile.paneKey],
   );
 
   // 实际发送的完整系统提示词 = 可编辑提示词 + （按画像）自动附加的知识网络摘要。

--- a/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
+++ b/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
@@ -10,6 +10,12 @@ import { Empty, Input, Spin, Tooltip } from "antd";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  createBknLifecycle,
+  memoryExternalKeyStore,
+  withManagedTurn,
+  type BknLifecycle,
+} from "@/modules/knowledge-network/services/bkn-lifecycle.service";
+import {
   fetchKnDetail,
   fetchObjectInstances,
   type ContextLoaderEnv,
@@ -50,6 +56,7 @@ function ObjectTypeCard({
   copy,
   env,
   auth,
+  lifecycle,
 }: {
   ot: KnObjectType;
   onFillField: (key: string, value: string) => void;
@@ -62,6 +69,8 @@ function ObjectTypeCard({
   env: ContextLoaderEnv;
   /** 401 自动刷新 token 用（OAuth 续期）。 */
   auth?: McpAuth;
+  /** 面板级受管生命周期：样本行预览也是受管业务调用。 */
+  lifecycle: BknLifecycle;
 }) {
   const [open, setOpen] = useState(false);
   const [filling, setFilling] = useState(false);
@@ -80,7 +89,9 @@ function ObjectTypeCard({
     if (next && previewRows === null && !previewLoading) {
       setPreviewLoading(true);
       setPreviewError(null);
-      fetchObjectInstances(env, ot.id, 5, auth)
+      withManagedTurn(lifecycle, `预览 ${ot.id} 样本行`, (turn) =>
+        fetchObjectInstances(env, ot.id, 5, auth, undefined, turn ?? undefined),
+      )
         .then((rows) => setPreviewRows(rows))
         .catch((error) => setPreviewError(error instanceof Error ? error.message : "查询失败"))
         .finally(() => setPreviewLoading(false));
@@ -274,6 +285,15 @@ export function DataBrowserPanel({
   const [reloadKey, setReloadKey] = useState(0);
   const loadedRef = useRef(false);
 
+  /**
+   * 数据浏览器读的 get_kn_detail / query_object_instance 都是受管业务工具，
+   * 不带 bkn_context 会被 Context Loader 挡回。这里不是对话，会话按本次挂载算一条。
+   */
+  const lifecycle = useMemo(
+    () => createBknLifecycle(env, auth, { externalKeyStore: memoryExternalKeyStore() }),
+    [env, auth],
+  );
+
   // 懒加载：首次切到「数据浏览器」标签时拉一次 schema，之后常驻不再重拉，保留预览/筛选上下文。
   useEffect(() => {
     if (!active || loadedRef.current) return;
@@ -283,7 +303,9 @@ export function DataBrowserPanel({
     const timeoutId = window.setTimeout(() => controller.abort(), DETAIL_LOAD_TIMEOUT_MS);
     setLoading(true);
     setError(null);
-    fetchKnDetail(env, auth, controller.signal)
+    withManagedTurn(lifecycle, "加载知识网络结构", (turn) =>
+      fetchKnDetail(env, auth, controller.signal, turn ?? undefined),
+    )
       .then((data) => {
         if (!cancelled) setDetail(data);
       })
@@ -308,7 +330,7 @@ export function DataBrowserPanel({
       window.clearTimeout(timeoutId);
       controller.abort();
     };
-  }, [active, auth, env, reloadKey]);
+  }, [active, auth, env, reloadKey, lifecycle]);
 
   const reload = () => {
     loadedRef.current = false;
@@ -477,6 +499,7 @@ export function DataBrowserPanel({
                       copy={copy}
                       env={env}
                       auth={auth}
+                      lifecycle={lifecycle}
                     />
                   ))}
                 </div>

--- a/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
+++ b/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   createBknLifecycle,
+  lifecycleEnv,
   memoryExternalKeyStore,
   withManagedTurn,
   type BknLifecycle,
@@ -290,8 +291,8 @@ export function DataBrowserPanel({
    * 不带 bkn_context 会被 Context Loader 挡回。这里不是对话，会话按本次挂载算一条。
    */
   const lifecycle = useMemo(
-    () => createBknLifecycle(env, auth, { externalKeyStore: memoryExternalKeyStore() }),
-    [env, auth],
+    () => createBknLifecycle(lifecycleEnv(env.base, env.knId), auth, { externalKeyStore: memoryExternalKeyStore() }),
+    [env.base, env.knId, auth],
   );
 
   // 懒加载：首次切到「数据浏览器」标签时拉一次 schema，之后常驻不再重拉，保留预览/筛选上下文。

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/modules/knowledge-network/services/context-loader.service";
 import {
   createBknLifecycle,
+  lifecycleEnv,
   memoryExternalKeyStore,
   withManagedTurn,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
@@ -384,8 +385,8 @@ export function ExperienceScene({
    * 会话本身按本次进入调试台算一条，刷新即换新（memory 键），不写 localStorage。
    */
   const lifecycle = useMemo(
-    () => createBknLifecycle(env, tokenProvider, { externalKeyStore: memoryExternalKeyStore() }),
-    [env, tokenProvider],
+    () => createBknLifecycle(lifecycleEnv(base, knId), tokenProvider, { externalKeyStore: memoryExternalKeyStore() }),
+    [base, knId, tokenProvider],
   );
 
   // 大模型（mf-model-api）不认 bak_ AppKey（AppKey 仅对 Context Loader 有效）→ 恒用 OAuth 会话 token，
@@ -538,20 +539,27 @@ export function ExperienceScene({
       const freshEnv = { ...env, token: freshToken };
       // 传 tokenProvider：401（token 过期）时刷新一次再重跑，不用手动重试。
       // 一次点击 = 一轮受管交互：业务调用没有 bkn_context 会被 Context Loader 直接挡回。
-      const result = await withManagedTurn(lifecycle, `调试台调用 ${op.id}`, async (turn) => {
-        const sent = await sendRequest(
-          freshEnv,
-          op,
-          mode,
-          queryVals,
-          bodyText,
-          tokenProvider,
-          controller.signal,
-          turn?.nextContext(op.id),
-        );
-        turn?.recordReceipt(sent.receipt);
-        return sent;
-      });
+      const result = await withManagedTurn(
+        lifecycle,
+        `调试台调用 ${op.id}`,
+        async (turn) => {
+          const sent = await sendRequest(
+            freshEnv,
+            op,
+            mode,
+            queryVals,
+            bodyText,
+            tokenProvider,
+            controller.signal,
+            turn?.nextContext(op.id),
+          );
+          turn?.recordReceipt(sent.receipt);
+          return sent;
+        },
+        // 业务返回 500 时这一轮仍算 completed —— 调用失败记在 Operation 的 Receipt 上
+        // （Core 已判 failed），Interaction 状态表达的是调用方这一轮走完了没有。
+        (sent) => `HTTP ${sent.status} · ${sent.sizeBytes}B`,
+      );
       if (requestSequence !== requestSequenceRef.current) return;
       setResponse(result);
     } catch (error) {

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -48,6 +48,11 @@ import {
   type KnRelationType,
   type McpToolDef,
 } from "@/modules/knowledge-network/services/context-loader.service";
+import {
+  createBknLifecycle,
+  memoryExternalKeyStore,
+  withManagedTurn,
+} from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import { AgentChat } from "@/modules/knowledge-network/components/agent-chat/AgentChat";
 import type { AgentTokenProvider } from "@/modules/knowledge-network/services/agent-chat.service";
 import { ContextLoaderIntegrationPanel } from "./ContextLoaderIntegrationPanel";
@@ -374,6 +379,15 @@ export function ExperienceScene({
     }),
     [authMode, appKey, runtimeConfig],
   );
+  /**
+   * 调试台的受管生命周期。这里不是对话，一次「发送请求」/「填充测试数据」就是一轮交互；
+   * 会话本身按本次进入调试台算一条，刷新即换新（memory 键），不写 localStorage。
+   */
+  const lifecycle = useMemo(
+    () => createBknLifecycle(env, tokenProvider, { externalKeyStore: memoryExternalKeyStore() }),
+    [env, tokenProvider],
+  );
+
   // 大模型（mf-model-api）不认 bak_ AppKey（AppKey 仅对 Context Loader 有效）→ 恒用 OAuth 会话 token，
   // 否则认证方式切到 API Key 后模型第一步就 401。
   const modelTokenProvider = useMemo<AgentTokenProvider>(
@@ -471,9 +485,20 @@ export function ExperienceScene({
     setReqError(null);
   }, [op, mode, knId, invalidateFill, invalidateRequest]);
 
-  // cURL 展示真实网关地址（终端可直接跑，无浏览器跨域顾虑）；请求本体仍走 env.base 代理。
+  /**
+   * cURL 展示真实网关地址（终端可直接跑，无浏览器跨域顾虑）；请求本体仍走 env.base 代理。
+   * bkn_context 用占位串而不是本页真实 id：受管交互一轮一开、终结后即失效，把当下这轮的
+   * id 复制出去，粘到终端时多半已经是 interaction_terminal。占位符至少说清了必须先建会话。
+   */
   const curl = useMemo(
-    () => (op ? buildCurl({ ...env, base: serverAddress }, op, mode, queryVals, bodyText) : ""),
+    () =>
+      op
+        ? buildCurl({ ...env, base: serverAddress }, op, mode, queryVals, bodyText, {
+            conversation_id: "<bkn_create_conversation 返回的 conversation_id>",
+            interaction_id: "<bkn_start_interaction 返回的 interaction_id>",
+            operation_key: `${op.id}#1`,
+          })
+        : "",
     [env, serverAddress, op, mode, queryVals, bodyText],
   );
 
@@ -512,7 +537,21 @@ export function ExperienceScene({
         authMode === "apikey" ? appKey.trim() : runtimeConfig.auth.tokenManager.getAccessToken() ?? env.token;
       const freshEnv = { ...env, token: freshToken };
       // 传 tokenProvider：401（token 过期）时刷新一次再重跑，不用手动重试。
-      const result = await sendRequest(freshEnv, op, mode, queryVals, bodyText, tokenProvider, controller.signal);
+      // 一次点击 = 一轮受管交互：业务调用没有 bkn_context 会被 Context Loader 直接挡回。
+      const result = await withManagedTurn(lifecycle, `调试台调用 ${op.id}`, async (turn) => {
+        const sent = await sendRequest(
+          freshEnv,
+          op,
+          mode,
+          queryVals,
+          bodyText,
+          tokenProvider,
+          controller.signal,
+          turn?.nextContext(op.id),
+        );
+        turn?.recordReceipt(sent.receipt);
+        return sent;
+      });
       if (requestSequence !== requestSequenceRef.current) return;
       setResponse(result);
     } catch (error) {
@@ -524,7 +563,7 @@ export function ExperienceScene({
         setSending(false);
       }
     }
-  }, [env, op, mode, queryVals, bodyText, runtimeConfig, authMode, appKey, tokenProvider]);
+  }, [env, op, mode, queryVals, bodyText, runtimeConfig, authMode, appKey, tokenProvider, lifecycle]);
 
   // 一键填充测试数据：用当前网络真实 schema + 样本行生成可直接发送的请求体。
   const onFillTestData = useCallback(async () => {
@@ -535,30 +574,32 @@ export function ExperienceScene({
     fillControllerRef.current = controller;
     setFillingTest(true);
     try {
-      const detail =
-        knDetailRef.current?.knId === knId
-          ? knDetailRef.current.detail
-          : await fetchKnDetail(env, tokenProvider, controller.signal);
-      if (fillSequence !== fillSequenceRef.current) return;
-      knDetailRef.current = { knId, detail };
+      // 取真实 schema / 样本行同样走 /kn/*，一次填充算一轮交互，两次取数共用它。
+      const fill = await withManagedTurn(lifecycle, `填充 ${op.id} 测试数据`, async (turn) => {
+        const detail =
+          knDetailRef.current?.knId === knId
+            ? knDetailRef.current.detail
+            : await fetchKnDetail(env, tokenProvider, controller.signal, turn ?? undefined);
+        if (fillSequence !== fillSequenceRef.current) return null;
+        knDetailRef.current = { knId, detail };
 
-      let ot: KnObjectType | null = null;
-      let sampleRow: Record<string, unknown> | null = null;
-      if (op.id === "query_object_instance" || op.id === "run_sql") {
-        ot = pickQueryableObjectType(detail);
-        if (!ot) {
-          message.warning("当前知识网络没有绑定数据资源的对象类型，无法生成测试数据");
-          return;
+        let ot: KnObjectType | null = null;
+        let sampleRow: Record<string, unknown> | null = null;
+        if (op.id === "query_object_instance" || op.id === "run_sql") {
+          ot = pickQueryableObjectType(detail);
+          if (!ot) {
+            message.warning("当前知识网络没有绑定数据资源的对象类型，无法生成测试数据");
+            return null;
+          }
         }
-      }
-      if (op.id === "query_object_instance" && ot) {
-        const rows = await fetchObjectInstances(env, ot.id, 1, tokenProvider, controller.signal);
-        if (fillSequence !== fillSequenceRef.current) return;
-        sampleRow = rows[0] ?? null;
-      }
-
-      const fill = buildTestData(op, mode, knId, detail, ot, sampleRow);
-      if (fillSequence !== fillSequenceRef.current) return;
+        if (op.id === "query_object_instance" && ot) {
+          const rows = await fetchObjectInstances(env, ot.id, 1, tokenProvider, controller.signal, turn ?? undefined);
+          if (fillSequence !== fillSequenceRef.current) return null;
+          sampleRow = rows[0] ?? null;
+        }
+        return buildTestData(op, mode, knId, detail, ot, sampleRow);
+      });
+      if (!fill || fillSequence !== fillSequenceRef.current) return;
       setBodyText(fill.body);
       setBodyError(null);
       if (fill.query) setQueryVals((prev) => ({ ...prev, ...fill.query }));
@@ -572,7 +613,7 @@ export function ExperienceScene({
         setFillingTest(false);
       }
     }
-  }, [env, op, mode, knId, message, tokenProvider]);
+  }, [env, op, mode, knId, message, tokenProvider, lifecycle]);
 
   // 当前接口是否按对象类型取数（决定数据浏览器卡片是否露出「填入测试请求」）。
   const opFillsFromObjectType = op?.id === "query_object_instance" || op?.id === "run_sql";
@@ -588,7 +629,9 @@ export function ExperienceScene({
         }
         let sampleRow: Record<string, unknown> | null = null;
         if (op.id === "query_object_instance") {
-          const rows = await fetchObjectInstances(env, ot.id, 1, tokenProvider);
+          const rows = await withManagedTurn(lifecycle, `取 ${ot.id} 样本行`, (turn) =>
+            fetchObjectInstances(env, ot.id, 1, tokenProvider, undefined, turn ?? undefined),
+          );
           sampleRow = rows[0] ?? null;
         }
         const detail = knDetailRef.current?.detail ?? { id: knId, object_types: [], concept_groups: [], relation_types: [] };
@@ -601,7 +644,7 @@ export function ExperienceScene({
         message.error(error instanceof Error ? error.message : "生成测试数据失败");
       }
     },
-    [env, op, mode, knId, message, tokenProvider],
+    [env, op, mode, knId, message, tokenProvider, lifecycle],
   );
 
   // 数据浏览器关系卡「填入子图」：用指定关系类拼 query_instance_subgraph 的 relation_type_paths。

--- a/src/modules/knowledge-network/services/agent-chat-tools.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat-tools.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { buildAgentTools, DEFAULT_AGENT_CONFIG } from "@/modules/knowledge-network/services/agent-chat.service";
+import type {
+  McpSession,
+  McpToolCallResult,
+  McpToolDef,
+} from "@/modules/knowledge-network/services/context-loader.service";
+
+const env = { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" };
+const tokenProvider = { getToken: () => "token-1", refresh: () => Promise.resolve("token-1") };
+
+/** 后端下发的业务工具 schema：bkn_context 已被 Context Loader 塞进 properties + required。 */
+const runSql: McpToolDef = {
+  name: "run_sql",
+  description: "执行 SQL",
+  inputSchema: {
+    type: "object",
+    properties: {
+      kn_id: { type: "string" },
+      sql: { type: "string" },
+      bkn_context: { type: "object", properties: { conversation_id: { type: "string" } } },
+    },
+    required: ["kn_id", "sql", "bkn_context"],
+  },
+};
+
+function stubSession(result?: Partial<McpToolCallResult>) {
+  const callTool = vi.fn<McpSession["callTool"]>().mockResolvedValue({
+    ok: true,
+    text: "rows",
+    latencyMs: 1,
+    isError: false,
+    ...result,
+  });
+  return { callTool } satisfies McpSession;
+}
+
+function schemaOf(tool: unknown): Record<string, unknown> {
+  const inputSchema = (tool as { inputSchema: { jsonSchema: Record<string, unknown> } }).inputSchema;
+  return inputSchema.jsonSchema;
+}
+
+function runTool(tool: unknown, input: unknown): Promise<string> {
+  const execute = (tool as { execute: (input: unknown, options: unknown) => Promise<string> }).execute;
+  return execute(input, { toolCallId: "call-1", messages: [] });
+}
+
+describe("buildAgentTools", () => {
+  it("hides bkn_context from the model", () => {
+    const session = stubSession();
+    const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, { session });
+
+    const schema = schemaOf(tools.run_sql);
+    // 模型看得见这个字段就会自己编 conversation/interaction id，而那些 id 在 Core 里根本不存在。
+    expect(schema.properties).not.toHaveProperty("bkn_context");
+    expect(schema.required).toEqual(["kn_id", "sql"]);
+  });
+
+  it("injects the turn context and locked kn_id into the real call", async () => {
+    const session = stubSession();
+    const turn = {
+      nextContext: vi.fn((toolName: string) => ({
+        conversation_id: "conv_1",
+        interaction_id: "int_1",
+        operation_key: `${toolName}#1`,
+      })),
+      recordReceipt: vi.fn(),
+    };
+    const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
+      session,
+      turn: turn as never,
+    });
+
+    await runTool(tools.run_sql, { sql: "SELECT 1", kn_id: "模型编的网络" });
+
+    expect(session.callTool).toHaveBeenCalledWith(
+      "run_sql",
+      expect.objectContaining({
+        sql: "SELECT 1",
+        // kn_id 与 bkn_context 都是平台侧身份，模型传什么都以锁定值为准。
+        kn_id: "kn-demo",
+        bkn_context: { conversation_id: "conv_1", interaction_id: "int_1", operation_key: "run_sql#1" },
+      }),
+    );
+  });
+
+  it("records the managed receipt of every business call", async () => {
+    const session = stubSession({
+      structured: { bkn_receipt: { operation_id: "op_1", receipt_id: "rcp_1", required: true } },
+    });
+    const recordReceipt = vi.fn();
+    const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
+      session,
+      turn: {
+        nextContext: () => ({ conversation_id: "conv_1", interaction_id: "int_1", operation_key: "run_sql#1" }),
+        recordReceipt,
+      } as never,
+    });
+
+    await runTool(tools.run_sql, { sql: "SELECT 1" });
+
+    expect(recordReceipt).toHaveBeenCalledWith({ operationId: "op_1", receiptId: "rcp_1", required: true });
+  });
+
+  it("sends no managed context when the backend has no lifecycle", async () => {
+    const session = stubSession();
+    const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, { session });
+
+    await runTool(tools.run_sql, { sql: "SELECT 1" });
+
+    // 老版本 Context Loader 不认这个字段，也不强制它；多发一个空壳只会让请求体对不上 schema。
+    expect(session.callTool.mock.calls[0][1]).not.toHaveProperty("bkn_context");
+  });
+});

--- a/src/modules/knowledge-network/services/agent-chat-tools.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat-tools.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { buildAgentTools, DEFAULT_AGENT_CONFIG } from "@/modules/knowledge-network/services/agent-chat.service";
 import type {
+  BknCallScope,
   McpSession,
   McpToolCallResult,
   McpToolDef,
@@ -66,17 +67,17 @@ describe("buildAgentTools", () => {
 
   it("injects the turn context and locked kn_id into the real call", async () => {
     const session = stubSession();
-    const turn = {
-      nextContext: vi.fn((toolName: string) => ({
+    const turn: BknCallScope = {
+      nextContext: (toolName) => ({
         conversation_id: "conv_1",
         interaction_id: "int_1",
         operation_key: `${toolName}#1`,
-      })),
+      }),
       recordReceipt: vi.fn(),
     };
     const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
       session,
-      turn: turn as never,
+      turn,
     });
 
     await runTool(tools.run_sql, { sql: "SELECT 1", kn_id: "模型编的网络" });
@@ -97,12 +98,13 @@ describe("buildAgentTools", () => {
       structured: { bkn_receipt: { operation_id: "op_1", receipt_id: "rcp_1", required: true } },
     });
     const recordReceipt = vi.fn();
+    const turn: BknCallScope = {
+      nextContext: () => ({ conversation_id: "conv_1", interaction_id: "int_1", operation_key: "run_sql#1" }),
+      recordReceipt,
+    };
     const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
       session,
-      turn: {
-        nextContext: () => ({ conversation_id: "conv_1", interaction_id: "int_1", operation_key: "run_sql#1" }),
-        recordReceipt,
-      } as never,
+      turn,
     });
 
     await runTool(tools.run_sql, { sql: "SELECT 1" });

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -17,8 +17,11 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { jsonSchema, stepCountIs, streamText, tool, type ModelMessage, type ToolSet } from "ai";
 
+import type { BknTurn } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import {
   createMcpSession,
+  receiptFromStructured,
+  type BknContext,
   type ContextLoaderEnv,
   type McpSession,
   type McpToolDef,
@@ -101,14 +104,39 @@ const TOOL_ARG_DEFAULTS: Record<string, Record<string, unknown>> = {
   search_schema: { schema_brief: true },
 };
 
-/** 实际发给 MCP 的最终 arguments = 通用默认 ← 工具默认 ← 模型入参 ← 锁定 kn_id。UI 工具卡片也用它展示真实请求。 */
-export function effectiveToolArgs(name: string, input: unknown, knId: string): Record<string, unknown> {
-  return {
+/** 实际发给 MCP 的最终 arguments = 通用默认 ← 工具默认 ← 模型入参 ← 锁定 kn_id ← 受管上下文。UI 工具卡片也用它展示真实请求。 */
+export function effectiveToolArgs(
+  name: string,
+  input: unknown,
+  knId: string,
+  bknContext?: BknContext,
+): Record<string, unknown> {
+  const args: Record<string, unknown> = {
     ...GLOBAL_ARG_DEFAULTS,
     ...TOOL_ARG_DEFAULTS[name],
     ...(input && typeof input === "object" ? (input as Record<string, unknown>) : {}),
     kn_id: knId,
   };
+  // 上下文是平台侧身份，和 kn_id 一样不接受模型覆盖：模型编出来的 id 一定不存在于 Core。
+  if (bknContext) args.bkn_context = bknContext;
+  return args;
+}
+
+/**
+ * 剥掉工具入参 schema 里的 `bkn_context`。后端把它塞进了每个业务工具的
+ * properties + required，原样喂给模型会让模型自己编 conversation/interaction id；
+ * 真值由 execute 注入，模型不该看见这个字段。
+ */
+function stripBknContextSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const properties = schema.properties;
+  if (!properties || typeof properties !== "object" || !("bkn_context" in properties)) return schema;
+  const nextProperties = { ...(properties as Record<string, unknown>) };
+  delete nextProperties.bkn_context;
+  const next: Record<string, unknown> = { ...schema, properties: nextProperties };
+  if (Array.isArray(schema.required)) {
+    next.required = schema.required.filter((name) => name !== "bkn_context");
+  }
+  return next;
 }
 
 /**
@@ -161,23 +189,41 @@ export type AgentChunk =
  * - execute 走会话级 MCP 客户端，并强制注入锁定 kn_id（模型不可改）。
  * 返回工具集 + 共享的 MCP 会话（复用同一 session）。
  */
+export type AgentToolsOptions = {
+  /** 当前知识网络绑定的 resource_id 集（KnDetail 的 data_source）。传入则默认把 list_resources 限定到本网络的数据表。 */
+  resourceScope?: readonly string[] | null;
+  /** 复用生命周期客户端的 MCP 会话，省一次 initialize 握手。 */
+  session?: McpSession;
+  /**
+   * 本轮受管交互。缺省/null 时不注入 bkn_context —— 只有后端未启用受管生命周期时才该这样，
+   * 启用了却不传会让每个工具调用都被挡在 `conversation_required`。
+   */
+  turn?: BknTurn | null;
+};
+
 export function buildAgentTools(
   mcpTools: McpToolDef[],
   env: ContextLoaderEnv,
   knId: string,
   cfg: AgentConfig,
   tokenProvider: AgentTokenProvider,
-  /** 当前知识网络绑定的 resource_id 集（KnDetail 的 data_source）。传入则默认把 list_resources 限定到本网络的数据表。 */
-  resourceScope?: readonly string[] | null,
+  options: AgentToolsOptions = {},
 ): ToolSet {
-  const session = createMcpSession(env, tokenProvider);
+  const { resourceScope, turn = null } = options;
+  const session = options.session ?? createMcpSession(env, tokenProvider);
   const scopeSet = resourceScope && resourceScope.length ? new Set(resourceScope) : null;
   const tools: ToolSet = {};
+  const call = async (name: string, args: Record<string, unknown>): Promise<string> => {
+    const res = await session.callTool(name, args);
+    // 每次业务调用的回执都要记账：终结本轮交互时清单必须列全，漏一条 Core 就判非法。
+    turn?.recordReceipt(receiptFromStructured(res.structured));
+    return res.text;
+  };
   for (const def of mcpTools) {
     if (!def.name) continue;
     const schema =
       def.inputSchema && typeof def.inputSchema === "object"
-        ? (def.inputSchema as Record<string, unknown>)
+        ? stripBknContextSchema(def.inputSchema as Record<string, unknown>)
         : { type: "object", properties: {} };
     const scopedList = scopeSet !== null && def.name === "list_resources";
     tools[def.name] = tool({
@@ -187,10 +233,10 @@ export function buildAgentTools(
         (scopedList ? " 返回结果已默认限定为当前知识网络绑定的数据表（其他 catalog 的表不会出现）。" : ""),
       inputSchema: jsonSchema(schema),
       execute: async (input: unknown): Promise<string> => {
-        if (scopedList && scopeSet) return listResourcesScoped(session, input, knId, scopeSet, cfg);
-        const args = effectiveToolArgs(def.name, input, knId);
-        const res = await session.callTool(def.name, args);
-        return capToolResult(res.text, def.name, cfg);
+        const bknContext = turn?.nextContext(def.name);
+        if (scopedList && scopeSet) return listResourcesScoped(call, input, knId, scopeSet, cfg, bknContext);
+        const args = effectiveToolArgs(def.name, input, knId, bknContext);
+        return capToolResult(await call(def.name, args), def.name, cfg);
       },
     });
   }
@@ -202,28 +248,29 @@ export function buildAgentTools(
  * 分页无意义），再按 KnDetail 的 resource_id 集过滤，只留本网络绑定的数据表。
  */
 async function listResourcesScoped(
-  session: McpSession,
+  call: (name: string, args: Record<string, unknown>) => Promise<string>,
   input: unknown,
   knId: string,
   scopeSet: Set<string>,
   cfg: AgentConfig,
+  bknContext: BknContext | undefined,
 ): Promise<string> {
   const args = {
-    ...effectiveToolArgs("list_resources", input, knId),
+    ...effectiveToolArgs("list_resources", input, knId, bknContext),
     response_format: "json",
     offset: 0,
     limit: Math.max(scopeSet.size + 5, 200),
   };
-  const res = await session.callTool("list_resources", args);
+  const text = await call("list_resources", args);
   try {
-    const parsed = JSON.parse(res.text) as { entries?: Array<{ resource_id?: string }> };
+    const parsed = JSON.parse(text) as { entries?: Array<{ resource_id?: string }> };
     const entries = Array.isArray(parsed.entries)
       ? parsed.entries.filter((e) => typeof e.resource_id === "string" && scopeSet.has(e.resource_id))
       : [];
     return capToolResult(JSON.stringify({ entries, total_count: entries.length }), "list_resources", cfg);
   } catch {
     // 非预期格式（如仍是 TOON）时不阻断，原样返回。
-    return capToolResult(res.text, "list_resources", cfg);
+    return capToolResult(text, "list_resources", cfg);
   }
 }
 

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -17,10 +17,10 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { jsonSchema, stepCountIs, streamText, tool, type ModelMessage, type ToolSet } from "ai";
 
-import type { BknTurn } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import {
   createMcpSession,
   receiptFromStructured,
+  type BknCallScope,
   type BknContext,
   type ContextLoaderEnv,
   type McpSession,
@@ -195,10 +195,12 @@ export type AgentToolsOptions = {
   /** 复用生命周期客户端的 MCP 会话，省一次 initialize 握手。 */
   session?: McpSession;
   /**
-   * 本轮受管交互。缺省/null 时不注入 bkn_context —— 只有后端未启用受管生命周期时才该这样，
+   * 本轮受管交互。工具循环只需要「取上下文 + 回执记账」这两件事，故取最小接口
+   * BknCallScope 而非整个 BknTurn —— 终结交互不归工具循环管。
+   * 缺省/null 时不注入 bkn_context：只有后端未启用受管生命周期时才该这样，
    * 启用了却不传会让每个工具调用都被挡在 `conversation_required`。
    */
-  turn?: BknTurn | null;
+  turn?: BknCallScope | null;
 };
 
 export function buildAgentTools(

--- a/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
@@ -187,13 +187,27 @@ export class BknLifecycleError extends Error {
 
 type LifecycleErrorPayload = { code?: unknown; message?: unknown; required_action?: unknown };
 
+/**
+ * 会话里还挂着一轮没终结的交互。正常路径不会走到这儿（本地闸门会排队），只有上一轮的
+ * 终结真的没送达 Core 时才出现——例如业务调用的响应丢在网络上，前端拿不到回执，
+ * 清单缺一条，终结被判 closure_manifest_invalid。
+ *
+ * 这时前端救不回来：补齐清单需要按 interaction 列出已登记的 operation，而受管接口
+ * 只允许按 id 查（TRACE.md 第三节：第三方 Agent 只能查询 Operation/Receipt）。
+ * 但用户有出路——清空对话会换一条全新 conversation，卡住的那轮留给 Core 的租约回收。
+ * 所以这里把出路写进报错，别让人对着「已有进行中的交互」干等 30 分钟租约。
+ */
+const STUCK_INTERACTION_HINT = "当前会话还有一轮未结束的交互没能正常收尾。点「清空」开一条新对话即可继续；卡住的那轮会由服务端租约自动回收。";
+
 function lifecycleErrorOf(tool: string, structured: unknown, fallbackText: string): BknLifecycleError {
   const envelope = structured && typeof structured === "object" ? (structured as Record<string, unknown>) : {};
   const error = (envelope.error ?? {}) as LifecycleErrorPayload;
+  const code = typeof error.code === "string" ? error.code : "";
+  const message = typeof error.message === "string" ? error.message : fallbackText;
   return new BknLifecycleError(
     tool,
-    typeof error.code === "string" ? error.code : "",
-    typeof error.message === "string" ? error.message : fallbackText,
+    code,
+    code === "interaction_in_progress" ? STUCK_INTERACTION_HINT : message,
     typeof error.required_action === "string" ? error.required_action : "",
   );
 }

--- a/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
@@ -1,0 +1,390 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/**
+ * BKN Trace 3.0 受管生命周期客户端 —— Context Loader 调用的前置协议边界。
+ *
+ * 契约见 bkn-foundry `adp/context-loader/agent-retrieval/TRACE.md`：REST `/kn/*` POST 与
+ * 除 `bkn_*` 外的全部 MCP `tools/call` 都必须携带 `bkn_context`（conversation_id +
+ * interaction_id + operation_key），缺任一字段返回稳定错误码且下游调用次数为 0。
+ * 三个 id 都不能前端自造，必须问 Core 要：
+ *
+ *   会话（conversation）—— 一条对话的身份，清空对话才换；页面刷新按 external_conversation_key 幂等复用。
+ *   交互（interaction）—— 一轮问答，发送时开、出答案/停止/出错时终结。
+ *   操作（operation）—— 一轮里的每次工具调用，由 operation_key 在交互内去重。
+ *
+ * 生命周期只由 MCP 工具暴露（agent-retrieval 没有对应 REST 路由），所以 REST 调试台也要
+ * 先走一遍 MCP 才能拿到上下文。
+ */
+
+import {
+  createMcpSession,
+  type BknContext,
+  type BknReceiptRef,
+  type ContextLoaderEnv,
+  type McpAuth,
+  type McpSession,
+} from "@/modules/knowledge-network/services/context-loader.service";
+
+/** 终结清单版本，与 Core `completion_manifest_version` 对应。 */
+const MANIFEST_VERSION = "1";
+
+/**
+ * 交互租约时长。终结时租约必须还没过期，否则 Core 判 `terminal_conflict`；
+ * 一轮 Agent 对话可以跑满 40 步工具，按分钟级留足。
+ */
+const DEFAULT_LEASE_SECONDS = 1800;
+
+/** 一轮交互的收尾原因（Core 只存字符串，不校验枚举）。 */
+export type TurnOutcome = "completed" | "failed" | "canceled";
+
+export type BknTurn = {
+  conversationId: string;
+  interactionId: string;
+  /** 取下一次业务调用的受管上下文；operation_key 在本轮内唯一。 */
+  nextContext(toolName: string): BknContext;
+  /** 记下一次业务调用的回执；终结时要把本轮全部 operation/receipt 列进清单。 */
+  recordReceipt(receipt: BknReceiptRef | undefined): void;
+  /** 正常收尾（answer 为本轮最终答复，Core 会存为 interaction artifact）。 */
+  complete(answer: string): Promise<void>;
+  /** 执行失败收尾。 */
+  fail(reason: string): Promise<void>;
+  /** 用户中途停止收尾。 */
+  cancel(reason: string): Promise<void>;
+  /** 按结果分派到 complete / fail / cancel。 */
+  finish(outcome: TurnOutcome, answer: string): Promise<void>;
+};
+
+export type BknLifecycle = {
+  /** 与业务调用共用的 MCP 会话（复用同一个 Mcp-Session-Id，少一次握手）。 */
+  session: McpSession;
+  /** 当前会话 id；还没建立时为 null。 */
+  conversationId(): string | null;
+  /** 后端不支持受管生命周期（老版本 Context Loader）时为 true，此时不注入 bkn_context。 */
+  unsupported(): boolean;
+  /**
+   * 开一轮交互。后端不支持时返回 null，调用方按旧行为继续。
+   * 同一条会话同时只允许一个 active interaction（Core 的
+   * `uq_bkn_trace_interaction_active` 唯一约束），因此并发调用会自动排队，
+   * 等上一轮终结后才真正开新的一轮。
+   */
+  beginTurn(question: string): Promise<BknTurn | null>;
+  /** 丢弃当前会话（清空对话）：下一轮会建一条全新 conversation。 */
+  reset(): void;
+};
+
+export type BknLifecycleOptions = {
+  /**
+   * 会话身份键。同一个键 `bkn_create_conversation` 幂等复用同一条 conversation，
+   * 所以它决定了「什么时候还算同一条对话」：刷新页面复用，清空对话换新。
+   */
+  externalKeyStore: ExternalKeyStore;
+  /** 单轮即弃的场景（如调试台一次点击）传 true，交给 Core 按 one-shot 语义收敛。 */
+  oneShot?: boolean;
+  leaseSeconds?: number;
+};
+
+/** 会话身份键的读写。localStorage 实现见 localExternalKeyStore。 */
+export type ExternalKeyStore = {
+  read(): string;
+  /** 换一把新键（清空对话）。 */
+  rotate(): void;
+};
+
+/** 随机 id：优先 crypto.randomUUID，测试环境/老浏览器兜底。 */
+export function randomLifecycleId(): string {
+  const cryptoRef: Crypto | undefined = typeof crypto === "undefined" ? undefined : crypto;
+  if (cryptoRef?.randomUUID) return cryptoRef.randomUUID();
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+/**
+ * localStorage 版会话身份键。键值只在 rotate（清空对话）时更换，
+ * 因此刷新页面仍会命中同一条 conversation —— 这正是「不清空就一直同一个 id」。
+ */
+export function localExternalKeyStore(storageKey: string): ExternalKeyStore {
+  let cached: string | null = null;
+  return {
+    read() {
+      if (cached) return cached;
+      try {
+        const stored = localStorage.getItem(storageKey);
+        if (stored) {
+          cached = stored;
+          return stored;
+        }
+      } catch {
+        /* localStorage 不可用时退化为内存键 */
+      }
+      const fresh = randomLifecycleId();
+      cached = fresh;
+      try {
+        localStorage.setItem(storageKey, fresh);
+      } catch {
+        /* 忽略：内存键仍能保证本次会话内稳定 */
+      }
+      return fresh;
+    },
+    rotate() {
+      cached = null;
+      try {
+        localStorage.removeItem(storageKey);
+      } catch {
+        /* 忽略 */
+      }
+    },
+  };
+}
+
+/** 进程内会话身份键：刷新即换新会话，适合一次性面板。 */
+export function memoryExternalKeyStore(): ExternalKeyStore {
+  let value = randomLifecycleId();
+  return {
+    read: () => value,
+    rotate() {
+      value = randomLifecycleId();
+    },
+  };
+}
+
+/** 生命周期调用失败：带 Core 的稳定错误码与 required_action，便于界面给出下一步。 */
+export class BknLifecycleError extends Error {
+  readonly code: string;
+  readonly requiredAction: string;
+
+  constructor(tool: string, code: string, message: string, requiredAction: string) {
+    super(message || `${tool} 失败（${code || "unknown"}）`);
+    this.name = "BknLifecycleError";
+    this.code = code;
+    this.requiredAction = requiredAction;
+  }
+}
+
+type LifecycleErrorPayload = { code?: unknown; message?: unknown; required_action?: unknown };
+
+function lifecycleErrorOf(tool: string, structured: unknown, fallbackText: string): BknLifecycleError {
+  const envelope = structured && typeof structured === "object" ? (structured as Record<string, unknown>) : {};
+  const error = (envelope.error ?? {}) as LifecycleErrorPayload;
+  return new BknLifecycleError(
+    tool,
+    typeof error.code === "string" ? error.code : "",
+    typeof error.message === "string" ? error.message : fallbackText,
+    typeof error.required_action === "string" ? error.required_action : "",
+  );
+}
+
+/**
+ * 后端没注册生命周期工具（升级前的 Context Loader）时的识别。
+ * 这类部署同时也不会强制 bkn_context，降级回旧行为是安全的；
+ * 但只认协议级 "工具不存在"，业务错误不能走这条路，否则会把真实的生命周期故障吞掉。
+ */
+function isToolMissing(rpcError: { code?: number; message?: string } | undefined): boolean {
+  if (!rpcError) return false;
+  const message = (rpcError.message ?? "").toLowerCase();
+  return message.includes("tool not found") || message.includes("unknown tool");
+}
+
+async function callLifecycleTool(
+  session: McpSession,
+  tool: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const result = await session.callTool(tool, args);
+  if (isToolMissing(result.rpcError)) {
+    throw new BknLifecycleError(tool, "lifecycle_not_supported", `${tool} 未注册`, "");
+  }
+  if (result.isError || !result.ok) {
+    throw lifecycleErrorOf(tool, result.structured, result.text);
+  }
+  if (!result.structured || typeof result.structured !== "object") {
+    throw new BknLifecycleError(tool, "lifecycle_malformed", `${tool} 未返回结构化状态`, "");
+  }
+  return result.structured as Record<string, unknown>;
+}
+
+function stringField(source: Record<string, unknown>, key: string): string {
+  const value = source[key];
+  return typeof value === "string" ? value : "";
+}
+
+function numberField(source: Record<string, unknown>, key: string): number {
+  const value = source[key];
+  return typeof value === "number" ? value : 0;
+}
+
+export function createBknLifecycle(
+  env: ContextLoaderEnv,
+  auth: McpAuth | undefined,
+  options: BknLifecycleOptions,
+): BknLifecycle {
+  return createBknLifecycleOn(createMcpSession(env, auth), options);
+}
+
+/** 同上但复用调用方给的 MCP 会话（也是测试注入点）。 */
+export function createBknLifecycleOn(session: McpSession, options: BknLifecycleOptions): BknLifecycle {
+  const { externalKeyStore, oneShot = false, leaseSeconds = DEFAULT_LEASE_SECONDS } = options;
+  let conversationId: string | null = null;
+  let notSupported = false;
+  /**
+   * 上一轮交互的终结闸门。会话内只能有一个 active interaction，抢跑的第二轮会被 Core
+   * 的唯一约束顶掉 —— 用户手快连发、数据浏览器同时展开两张卡都会走到这条路上。
+   */
+  let previousTurnSettled: Promise<void> = Promise.resolve();
+
+  async function ensureConversation(): Promise<string | null> {
+    if (notSupported) return null;
+    if (conversationId) return conversationId;
+    try {
+      // ensure-current 按 external_conversation_key 幂等：刷新页面拿回同一条会话，
+      // 会话已关闭则由 Core 开新 generation，前端不需要自己判断该 create 还是 resume。
+      const state = await callLifecycleTool(session, "bkn_create_conversation", {
+        external_conversation_key: externalKeyStore.read(),
+        idempotency_key: randomLifecycleId(),
+        one_shot: oneShot,
+      });
+      conversationId = stringField(state, "conversation_id") || null;
+      return conversationId;
+    } catch (error) {
+      if (error instanceof BknLifecycleError && error.code === "lifecycle_not_supported") {
+        notSupported = true;
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  return {
+    session,
+    conversationId: () => conversationId,
+    unsupported: () => notSupported,
+    reset() {
+      conversationId = null;
+      externalKeyStore.rotate();
+    },
+    async beginTurn(question: string) {
+      const waitFor = previousTurnSettled;
+      let release = () => undefined as void;
+      previousTurnSettled = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      try {
+        // 闸门只会 resolve、不会 reject（终结失败也照样放行），所以这里不会串联失败。
+        await waitFor;
+        const currentConversation = await ensureConversation();
+        if (!currentConversation) {
+          release();
+          return null;
+        }
+        const state = await callLifecycleTool(session, "bkn_start_interaction", {
+          conversation_id: currentConversation,
+          idempotency_key: randomLifecycleId(),
+          question,
+          lease_seconds: leaseSeconds,
+        });
+        return createTurn(session, currentConversation, state, release);
+      } catch (error) {
+        release();
+        throw error;
+      }
+    },
+  };
+}
+
+function createTurn(
+  session: McpSession,
+  conversationId: string,
+  state: Record<string, unknown>,
+  /** 终结后放行下一轮（成败都放行，否则一次收尾失败会让整条会话再也开不出交互）。 */
+  release: () => void,
+): BknTurn {
+  const interactionId = stringField(state, "interaction_id");
+  const leaseToken = stringField(state, "lease_token");
+  const leaseEpoch = numberField(state, "lease_epoch");
+  const receipts: BknReceiptRef[] = [];
+  let operationSeq = 0;
+  let terminated = false;
+
+  async function terminate(tool: string, reason: string, answer?: string): Promise<void> {
+    // 终结只做一次：重复调用会撞 Core 的 terminal_conflict，而调用方在
+    // 「停止后又出错」这类路径上很容易两次都触发。
+    if (terminated) return;
+    terminated = true;
+    // 清单必须一条不漏地列出本轮登记过的 operation / receipt，且 required 与 Core 侧一致，
+    // 数量对不上直接 closure_manifest_invalid。
+    const args: Record<string, unknown> = {
+      interaction_id: interactionId,
+      terminal_idempotency_key: randomLifecycleId(),
+      lease_token: leaseToken,
+      lease_epoch: leaseEpoch,
+      completion_manifest_version: MANIFEST_VERSION,
+      completion_reason: reason,
+      expected_operations: receipts.map((r) => ({ operation_id: r.operationId, required: r.required })),
+      expected_receipts: receipts.map((r) => ({ receipt_id: r.receiptId, required: r.required })),
+    };
+    if (answer !== undefined) args.answer = answer;
+    try {
+      await callLifecycleTool(session, tool, args);
+    } finally {
+      release();
+    }
+  }
+
+  return {
+    conversationId,
+    interactionId,
+    nextContext(toolName: string) {
+      operationSeq += 1;
+      return {
+        conversation_id: conversationId,
+        interaction_id: interactionId,
+        operation_key: `${toolName}#${operationSeq}`,
+      };
+    },
+    recordReceipt(receipt) {
+      // 同一 operation 的重放会回同一个 receipt，去重后清单才不会多算。
+      if (!receipt || receipts.some((r) => r.operationId === receipt.operationId)) return;
+      receipts.push(receipt);
+    },
+    complete: (answer: string) => terminate("bkn_complete_interaction", "answer_returned", answer),
+    fail: (reason: string) => terminate("bkn_fail_interaction", reason || "agent_error"),
+    cancel: (reason: string) => terminate("bkn_cancel_interaction", reason || "stopped_by_user"),
+    finish(outcome, answer) {
+      if (outcome === "canceled") return terminate("bkn_cancel_interaction", "stopped_by_user");
+      if (outcome === "failed") return terminate("bkn_fail_interaction", "agent_error");
+      return terminate("bkn_complete_interaction", "answer_returned", answer);
+    },
+  };
+}
+
+/**
+ * 一次性受管调用：开一轮交互跑 run，无论成败都收尾。
+ * 给「数据浏览器加载」「调试台点一次发送」这类非对话的业务调用用 —— 它们同样受强制拦截，
+ * 只是没有多轮语义。后端不支持生命周期时 turn 为 null，run 按旧行为直接发。
+ */
+export async function withManagedTurn<T>(
+  lifecycle: BknLifecycle,
+  question: string,
+  run: (turn: BknTurn | null) => Promise<T>,
+  /** 写进 Trace 的本轮「答复」摘要；这类调用没有自然语言答案，给一句能读的即可。 */
+  describeAnswer: (value: T) => string = () => "ok",
+): Promise<T> {
+  const turn = await lifecycle.beginTurn(question);
+  if (!turn) return run(null);
+  let outcome: TurnOutcome = "completed";
+  let answer = "";
+  try {
+    const value = await run(turn);
+    answer = describeAnswer(value);
+    return value;
+  } catch (error) {
+    outcome = "failed";
+    throw error;
+  } finally {
+    // 收尾失败不能盖掉业务错误：交互会由 Core 的租约回收兜底。
+    await turn.finish(outcome, answer).catch(() => undefined);
+  }
+}

--- a/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
@@ -39,6 +39,14 @@ const MANIFEST_VERSION = "1";
  */
 const DEFAULT_LEASE_SECONDS = 1800;
 
+/**
+ * 成功终结时给证据组装留的收敛窗口。Context Loader 目前只能把 Receipt 完成为
+ * `evidence_durability=pending`（3.0 Evidence Producer 未落地），而带 pending 回执的
+ * 成功交互必须在清单里给出 assembler_deadline，否则永远停在 assembling ——
+ * 现在没有 assembler 在跑，看不出差别，但 #544 上线后有它才会自动收敛。
+ */
+const ASSEMBLER_DEADLINE_MS = 5 * 60 * 1000;
+
 /** 一轮交互的收尾原因（Core 只存字符串，不校验枚举）。 */
 export type TurnOutcome = "completed" | "failed" | "canceled";
 
@@ -94,6 +102,19 @@ export type ExternalKeyStore = {
   /** 换一把新键（清空对话）。 */
   rotate(): void;
 };
+
+/**
+ * 生命周期客户端的稳定身份：只认 base + kn。
+ *
+ * `env.token` 仅是 auth provider 缺席时的兜底——MCP 会话每次请求都用
+ * `auth.getToken()` 现取，所以 OAuth 续期换掉 env 的对象身份时**不该**重建客户端：
+ * 重建会丢掉串行闸门，让并发的两轮同时开交互，撞上「一条会话只能有一个 active
+ * interaction」；顺带还会多打一次 initialize 握手。调用方用它把 useMemo 的依赖
+ * 收敛到真正稳定的标识上。
+ */
+export function lifecycleEnv(base: string, knId: string): ContextLoaderEnv {
+  return { base, token: "", knId };
+}
 
 /** 随机 id：优先 crypto.randomUUID，测试环境/老浏览器兜底。 */
 export function randomLifecycleId(): string {
@@ -325,7 +346,12 @@ function createTurn(
       expected_operations: receipts.map((r) => ({ operation_id: r.operationId, required: r.required })),
       expected_receipts: receipts.map((r) => ({ receipt_id: r.receiptId, required: r.required })),
     };
-    if (answer !== undefined) args.answer = answer;
+    // answer 只在 complete 的 schema 里声明；cancel / fail 传了会撞
+    // additionalProperties: false。
+    if (answer !== undefined) {
+      args.answer = answer;
+      args.assembler_deadline = new Date(Date.now() + ASSEMBLER_DEADLINE_MS).toISOString();
+    }
     try {
       await callLifecycleTool(session, tool, args);
     } finally {

--- a/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
@@ -206,6 +206,32 @@ describe("createBknLifecycle", () => {
     });
   });
 
+  it("tells the user how to escape a conversation stuck on an unterminated turn", async () => {
+    const { session } = fakeSession({
+      bkn_start_interaction: () => ({
+        ok: true,
+        text: "interaction_in_progress: the conversation already has an active interaction",
+        latencyMs: 1,
+        isError: true,
+        structured: {
+          error: {
+            code: "interaction_in_progress",
+            message: "the conversation already has an active interaction",
+            required_action: "complete_or_cancel_interaction",
+          },
+        },
+      }),
+    });
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    // 补清单需要按 interaction 列 operation，受管接口不给——前端救不回来，
+    // 但清空对话能换一条新会话，别让用户对着原文干等租约回收。
+    await expect(lifecycle.beginTurn("问")).rejects.toMatchObject({
+      code: "interaction_in_progress",
+      message: expect.stringContaining("清空") as unknown as string,
+    });
+  });
+
   it("queues a second turn until the first one is terminated", async () => {
     const { session, calls } = fakeSession();
     const lifecycle = createBknLifecycleOn(session, options());

--- a/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createBknLifecycleOn,
+  memoryExternalKeyStore,
+  withManagedTurn,
+} from "@/modules/knowledge-network/services/bkn-lifecycle.service";
+import type { McpSession, McpToolCallResult } from "@/modules/knowledge-network/services/context-loader.service";
+
+type Call = { name: string; args: Record<string, unknown> };
+
+/** 假的 Core：conversation 按 external_conversation_key 幂等，interaction 递增。 */
+function fakeSession(overrides: Record<string, () => McpToolCallResult> = {}) {
+  const calls: Call[] = [];
+  const conversations = new Map<string, string>();
+  let interactionSeq = 0;
+  const ok = (structured: unknown): McpToolCallResult => ({
+    ok: true,
+    text: "managed lifecycle state updated",
+    latencyMs: 1,
+    structured,
+    isError: false,
+  });
+  const session: McpSession = {
+    callTool(name, args) {
+      calls.push({ name, args });
+      const override = overrides[name];
+      if (override) return Promise.resolve(override());
+      if (name === "bkn_create_conversation") {
+        const key = String(args.external_conversation_key);
+        if (!conversations.has(key)) conversations.set(key, `conv_${conversations.size + 1}`);
+        return Promise.resolve(ok({ conversation_id: conversations.get(key), status: "active" }));
+      }
+      if (name === "bkn_start_interaction") {
+        interactionSeq += 1;
+        return Promise.resolve(
+          ok({
+            interaction_id: `int_${interactionSeq}`,
+            conversation_id: args.conversation_id,
+            lease_token: `lease_${interactionSeq}`,
+            lease_epoch: 1,
+          }),
+        );
+      }
+      if (name.startsWith("bkn_")) return Promise.resolve(ok({ interaction_id: args.interaction_id }));
+      // 业务工具：回一张受管回执。
+      return Promise.resolve({
+        ok: true,
+        text: "rows",
+        latencyMs: 1,
+        isError: false,
+        structured: {
+          bkn_receipt: {
+            operation_id: `op_${calls.length}`,
+            receipt_id: `rcp_${calls.length}`,
+            required: true,
+          },
+        },
+      });
+    },
+  };
+  return { session, calls };
+}
+
+const options = () => ({ externalKeyStore: memoryExternalKeyStore() });
+
+describe("createBknLifecycle", () => {
+  it("keeps one conversation across turns and only rotates it on reset", async () => {
+    const { session } = fakeSession();
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    const first = await lifecycle.beginTurn("第一问");
+    await first?.complete("答一");
+    const second = await lifecycle.beginTurn("第二问");
+    await second?.complete("答二");
+
+    // 不清空对话就一直是同一条会话；每轮问答各自一条交互。
+    expect(first?.conversationId).toBe(second?.conversationId);
+    expect(first?.interactionId).not.toBe(second?.interactionId);
+
+    lifecycle.reset();
+    const third = await lifecycle.beginTurn("清空后再问");
+    expect(third?.conversationId).not.toBe(first?.conversationId);
+  });
+
+  it("gives every tool call a distinct operation_key under the same interaction", async () => {
+    const { session } = fakeSession();
+    const lifecycle = createBknLifecycleOn(session, options());
+    const turn = await lifecycle.beginTurn("问");
+
+    const first = turn!.nextContext("run_sql");
+    const second = turn!.nextContext("run_sql");
+
+    expect(first.conversation_id).toBe(second.conversation_id);
+    expect(first.interaction_id).toBe(second.interaction_id);
+    // operation_key 在交互内唯一，否则第二次调用会被 Core 当成第一次的重放。
+    expect(first.operation_key).not.toBe(second.operation_key);
+  });
+
+  it("lists every recorded operation and receipt in the closure manifest", async () => {
+    const { session, calls } = fakeSession();
+    const lifecycle = createBknLifecycleOn(session, options());
+    const turn = await lifecycle.beginTurn("问");
+
+    turn!.recordReceipt({ operationId: "op_a", receiptId: "rcp_a", required: true });
+    turn!.recordReceipt({ operationId: "op_b", receiptId: "rcp_b", required: true });
+    // 同一 operation 的重放回同一张回执，清单里不能重复计数。
+    turn!.recordReceipt({ operationId: "op_a", receiptId: "rcp_a", required: true });
+    await turn!.complete("答");
+
+    const terminal = calls.find((call) => call.name === "bkn_complete_interaction")!;
+    expect(terminal.args.expected_operations).toEqual([
+      { operation_id: "op_a", required: true },
+      { operation_id: "op_b", required: true },
+    ]);
+    expect(terminal.args.expected_receipts).toEqual([
+      { receipt_id: "rcp_a", required: true },
+      { receipt_id: "rcp_b", required: true },
+    ]);
+    expect(terminal.args).toMatchObject({
+      lease_token: "lease_1",
+      lease_epoch: 1,
+      completion_manifest_version: "1",
+      answer: "答",
+    });
+  });
+
+  it("terminates a turn only once", async () => {
+    const { session, calls } = fakeSession();
+    const lifecycle = createBknLifecycleOn(session, options());
+    const turn = await lifecycle.beginTurn("问");
+
+    await turn!.cancel("stopped_by_user");
+    // 「停止后又抛错」的路径会两次触发收尾；第二次撞 Core 的 terminal_conflict。
+    await turn!.fail("agent_error");
+
+    expect(calls.filter((call) => call.name.endsWith("_interaction")).map((call) => call.name)).toEqual([
+      "bkn_start_interaction",
+      "bkn_cancel_interaction",
+    ]);
+  });
+
+  it("degrades to no managed context when the backend has no lifecycle tools", async () => {
+    const { session, calls } = fakeSession({
+      bkn_create_conversation: () => ({
+        ok: true,
+        text: "",
+        latencyMs: 1,
+        isError: false,
+        rpcError: { code: -32602, message: "tool not found: bkn_create_conversation" },
+      }),
+    });
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    await expect(lifecycle.beginTurn("问")).resolves.toBeNull();
+    expect(lifecycle.unsupported()).toBe(true);
+
+    // 判定为不支持后不再重试握手，业务调用按旧行为直接发。
+    await expect(lifecycle.beginTurn("再问")).resolves.toBeNull();
+    expect(calls.filter((call) => call.name === "bkn_create_conversation")).toHaveLength(1);
+  });
+
+  it("surfaces the stable lifecycle error code instead of a generic failure", async () => {
+    const { session } = fakeSession({
+      bkn_start_interaction: () => ({
+        ok: true,
+        text: "conversation_not_found: conversation is unknown",
+        latencyMs: 1,
+        isError: true,
+        structured: {
+          error: {
+            code: "conversation_not_found",
+            message: "conversation is unknown",
+            required_action: "create_conversation",
+          },
+        },
+      }),
+    });
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    await expect(lifecycle.beginTurn("问")).rejects.toMatchObject({
+      code: "conversation_not_found",
+      requiredAction: "create_conversation",
+    });
+  });
+
+  it("queues a second turn until the first one is terminated", async () => {
+    const { session, calls } = fakeSession();
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    const first = await lifecycle.beginTurn("第一问");
+    const secondPending = lifecycle.beginTurn("第二问");
+    await Promise.resolve();
+
+    // 会话内只能有一个 active interaction；抢跑的第二轮会被 Core 的唯一约束顶掉。
+    expect(calls.filter((call) => call.name === "bkn_start_interaction")).toHaveLength(1);
+
+    await first!.complete("答一");
+    const second = await secondPending;
+    expect(second!.interactionId).not.toBe(first!.interactionId);
+    expect(calls.filter((call) => call.name === "bkn_start_interaction")).toHaveLength(2);
+  });
+
+  it("still lets the next turn start after a terminal call fails", async () => {
+    const { session } = fakeSession({
+      bkn_complete_interaction: () => ({
+        ok: false,
+        text: "closure manifest invalid",
+        latencyMs: 1,
+        isError: true,
+        structured: { error: { code: "closure_manifest_invalid", message: "closure manifest invalid" } },
+      }),
+    });
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    const first = await lifecycle.beginTurn("第一问");
+    await expect(first!.complete("答")).rejects.toMatchObject({ code: "closure_manifest_invalid" });
+
+    // 收尾失败若不放行闸门，整条会话此后再也开不出交互。
+    await expect(lifecycle.beginTurn("第二问")).resolves.not.toBeNull();
+  });
+});
+
+describe("withManagedTurn", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("terminates the interaction even when the business call throws", async () => {
+    const { session, calls } = fakeSession();
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    await expect(
+      withManagedTurn(lifecycle, "加载", () => Promise.reject(new Error("boom"))),
+    ).rejects.toThrow("boom");
+
+    // 不终结的交互会一直挂在 active，直到 Core 租约回收，期间开不出下一轮。
+    expect(calls.map((call) => call.name)).toContain("bkn_fail_interaction");
+  });
+
+  it("does not let a failing terminal call mask the business result", async () => {
+    const { session } = fakeSession({
+      bkn_complete_interaction: () => ({
+        ok: false,
+        text: "closure manifest invalid",
+        latencyMs: 1,
+        isError: true,
+        structured: { error: { code: "closure_manifest_invalid", message: "closure manifest invalid" } },
+      }),
+    });
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    await expect(withManagedTurn(lifecycle, "加载", () => Promise.resolve("data"))).resolves.toBe("data");
+  });
+});

--- a/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
@@ -130,6 +130,21 @@ describe("createBknLifecycle", () => {
       completion_manifest_version: "1",
       answer: "答",
     });
+    // 带 pending 回执的成功交互要给收敛窗口，否则永远停在 assembling。
+    expect(terminal.args.assembler_deadline).toEqual(expect.any(String));
+  });
+
+  it("omits answer and assembler_deadline on the non-success terminals", async () => {
+    const { session, calls } = fakeSession();
+    const lifecycle = createBknLifecycleOn(session, options());
+    const turn = await lifecycle.beginTurn("问");
+
+    await turn!.cancel("stopped_by_user");
+
+    // cancel / fail 的 schema 没有这两个字段，additionalProperties: false 会直接拒。
+    const terminal = calls.find((call) => call.name === "bkn_cancel_interaction")!;
+    expect(terminal.args).not.toHaveProperty("answer");
+    expect(terminal.args).not.toHaveProperty("assembler_deadline");
   });
 
   it("terminates a turn only once", async () => {

--- a/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   createBknLifecycleOn,
@@ -244,10 +244,6 @@ describe("createBknLifecycle", () => {
 });
 
 describe("withManagedTurn", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("terminates the interaction even when the business call throws", async () => {
     const { session, calls } = fakeSession();
     const lifecycle = createBknLifecycleOn(session, options());

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -9,12 +9,27 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   CONTEXT_LOADER_OPS,
+  buildCurl,
   createMcpSession,
+  fetchKnDetail,
   listMcpTools,
   sendRequest,
 } from "@/modules/knowledge-network/services/context-loader.service";
 
 const searchSchema = CONTEXT_LOADER_OPS.find((operation) => operation.id === "search_schema")!;
+
+const bknContext = {
+  conversation_id: "conv_1",
+  interaction_id: "int_1",
+  operation_key: "search_schema#1",
+};
+
+function restBody(init: RequestInit | undefined): Record<string, unknown> {
+  if (typeof init?.body !== "string") {
+    throw new Error("Expected a JSON string request body");
+  }
+  return JSON.parse(init.body) as Record<string, unknown>;
+}
 
 function jsonRpcBody(init: RequestInit | undefined): Record<string, unknown> {
   if (typeof init?.body !== "string") {
@@ -68,6 +83,141 @@ describe("sendRequest", () => {
     expect(jsonRpcBody(fetchSpy.mock.calls[1][1])).toMatchObject({ method: "notifications/initialized" });
     expect(jsonRpcBody(fetchSpy.mock.calls[2][1])).toMatchObject({ method: "tools/call" });
     expect(fetchSpy.mock.calls[2][1]?.headers).toMatchObject({ "Mcp-Session-Id": "session-1" });
+  });
+
+  it("carries the managed context into the REST body", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await sendRequest(
+      { base: "https://platform.example.com", token: "", knId: "kn-demo" },
+      searchSchema,
+      "rest",
+      {},
+      '{"query":"订单"}',
+      undefined,
+      undefined,
+      bknContext,
+    );
+
+    // 少了 bkn_context 会被 Context Loader 判 conversation_required，下游调用次数为 0。
+    expect(restBody(fetchSpy.mock.calls[0][1])).toEqual({ query: "订单", bkn_context: bknContext });
+  });
+
+  it("carries the managed context into the MCP arguments", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200, headers: { "Mcp-Session-Id": "session-1" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(new Response('{"jsonrpc":"2.0","result":{"content":[]}}', { status: 200 }));
+
+    await sendRequest(
+      { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" },
+      searchSchema,
+      "mcp",
+      {},
+      '{"query":"订单"}',
+      undefined,
+      undefined,
+      bknContext,
+    );
+
+    expect(jsonRpcBody(fetchSpy.mock.calls[2][1])).toMatchObject({
+      params: { arguments: { query: "订单", bkn_context: bknContext } },
+    });
+  });
+
+  it("reports the managed receipt from REST headers and from the MCP structured result", async () => {
+    const restSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", {
+        status: 200,
+        headers: { "bkn-receipt-id": "rcp_1", "bkn-operation-id": "op_1" },
+      }),
+    );
+    const rest = await sendRequest(
+      { base: "https://platform.example.com", token: "", knId: "kn-demo" },
+      searchSchema,
+      "rest",
+      {},
+      "{}",
+      undefined,
+      undefined,
+      bknContext,
+    );
+    expect(rest.receipt).toEqual({ operationId: "op_1", receiptId: "rcp_1", required: true });
+    restSpy.mockRestore();
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200, headers: { "Mcp-Session-Id": "session-1" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response(
+          '{"jsonrpc":"2.0","result":{"content":[],"structuredContent":{"bkn_receipt":{"operation_id":"op_2","receipt_id":"rcp_2","required":true}}}}',
+          { status: 200 },
+        ),
+      );
+    const mcp = await sendRequest(
+      { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" },
+      searchSchema,
+      "mcp",
+      {},
+      "{}",
+      undefined,
+      undefined,
+      bknContext,
+    );
+    expect(mcp.receipt).toEqual({ operationId: "op_2", receiptId: "rcp_2", required: true });
+  });
+});
+
+describe("fetchKnDetail", () => {
+  it("takes its context from the turn and reports the receipt back to it", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"id":"kn-demo","object_types":[],"concept_groups":[],"relation_types":[]}', {
+        status: 200,
+        headers: { "bkn-receipt-id": "rcp_3", "bkn-operation-id": "op_3" },
+      }),
+    );
+    const recordReceipt = vi.fn();
+
+    await fetchKnDetail({ base: "https://platform.example.com", token: "", knId: "kn-demo" }, undefined, undefined, {
+      nextContext: (toolName) => ({ ...bknContext, operation_key: `${toolName}#1` }),
+      recordReceipt,
+    });
+
+    expect(restBody(fetchSpy.mock.calls[0][1])).toMatchObject({
+      kn_id: "kn-demo",
+      bkn_context: { ...bknContext, operation_key: "get_kn_detail#1" },
+    });
+    // 回执要记回本轮，否则终结交互时清单缺一条，Core 判 closure_manifest_invalid。
+    expect(recordReceipt).toHaveBeenCalledWith({ operationId: "op_3", receiptId: "rcp_3", required: true });
+  });
+});
+
+describe("buildCurl", () => {
+  it("includes the managed context so the copied command is the one that was sent", () => {
+    const curl = buildCurl(
+      { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" },
+      searchSchema,
+      "rest",
+      {},
+      '{"query":"订单"}',
+      bknContext,
+    );
+
+    expect(curl).toContain('"bkn_context":{"conversation_id":"conv_1"');
+  });
+
+  it("keeps a half-written request body readable instead of showing it as empty", () => {
+    const curl = buildCurl(
+      { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" },
+      searchSchema,
+      "rest",
+      {},
+      '{"query":',
+      bknContext,
+    );
+
+    expect(curl).toContain('{"query":');
   });
 });
 

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -431,24 +431,94 @@ function mcpBase(env: ContextLoaderEnv): string {
 }
 
 /**
+ * BKN Trace 3.0 受管调用上下文。Context Loader 对每次业务调用（REST `/kn/*` POST 与
+ * 除 `bkn_*` 生命周期工具外的全部 MCP tools/call）都强制要求，缺任一字段直接 400，
+ * 且下游调用次数为 0。三个 id 的来源见 bkn-lifecycle.service。
+ */
+export type BknContext = {
+  conversation_id: string;
+  interaction_id: string;
+  operation_key: string;
+};
+
+/**
+ * 一次受管业务调用的回执引用。终结 Interaction 时必须把本轮**全部** operation 与 receipt
+ * 一条不漏地列进 closure manifest（Core 按数量与归属校验，多一条少一条都报
+ * `closure_manifest_invalid`），所以每次业务调用都要把它记下来。
+ */
+export type BknReceiptRef = { operationId: string; receiptId: string; required: boolean };
+
+/** 从业务调用回执对象里取 operation/receipt 引用；形状不对返回 undefined。 */
+export function parseBknReceipt(value: unknown): BknReceiptRef | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const receipt = value as Record<string, unknown>;
+  const operationId = receipt.operation_id;
+  const receiptId = receipt.receipt_id;
+  if (typeof operationId !== "string" || !operationId) return undefined;
+  if (typeof receiptId !== "string" || !receiptId) return undefined;
+  // Context Loader 的受信适配器恒以 required=true 注册 Operation；缺字段时按它兜底，
+  // 因为 manifest 里的 required 必须与 Core 侧登记值一致，猜 false 会被直接判非法。
+  return { operationId, receiptId, required: receipt.required !== false };
+}
+
+/** 从 MCP 业务工具的 structuredContent 里取受管回执（正常执行是 bkn_receipt，重放/pending 是 receipt）。 */
+export function receiptFromStructured(structured: unknown): BknReceiptRef | undefined {
+  if (!structured || typeof structured !== "object") return undefined;
+  const envelope = structured as Record<string, unknown>;
+  return parseBknReceipt(envelope.bkn_receipt) ?? parseBknReceipt(envelope.receipt);
+}
+
+/**
+ * 一次受管交互对业务调用暴露的最小接口：取上下文 + 回执记账。
+ * bkn-lifecycle 的 BknTurn 结构上满足它 —— 这里不反向 import，避免两个服务互相依赖。
+ */
+export type BknCallScope = {
+  nextContext(toolName: string): BknContext;
+  recordReceipt(receipt: BknReceiptRef | undefined): void;
+};
+
+/** 把受管上下文并进业务请求体/arguments（已有 bkn_context 不覆盖）。 */
+function withBknContext(
+  payload: Record<string, unknown>,
+  bknContext: BknContext | undefined,
+): Record<string, unknown> {
+  if (!bknContext || "bkn_context" in payload) return payload;
+  return { ...payload, bkn_context: bknContext };
+}
+
+/** 解析请求体 JSON；非对象/非法 JSON 一律当空对象。 */
+function parseBodyObject(bodyText: string): Record<string, unknown> {
+  try {
+    return strictBodyObject(bodyText);
+  } catch {
+    return {};
+  }
+}
+
+/** 同上但不吞错：请求体写错时要让调用方看到 JSON 解析报错，而不是静悄悄发个空对象。 */
+function strictBodyObject(bodyText: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(bodyText || "{}");
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  return {};
+}
+
+/**
  * MCP tools/call 的 arguments：解析请求体 JSON，并把 response_format 选择器的值
  * 注入进 arguments（MCP 没有 query，response_format 必须走 arg；不传则后端默认 toon）。
  */
-function mcpCallArgs(bodyText: string, queryValues: Record<string, string>): Record<string, unknown> {
-  let args: Record<string, unknown> = {};
-  try {
-    const parsed: unknown = JSON.parse(bodyText || "{}");
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      args = parsed as Record<string, unknown>;
-    }
-  } catch {
-    args = {};
-  }
+function mcpCallArgs(
+  bodyText: string,
+  queryValues: Record<string, string>,
+  bknContext?: BknContext,
+): Record<string, unknown> {
+  const args = parseBodyObject(bodyText);
   const responseFormat = queryValues.response_format;
   if (responseFormat && !("response_format" in args)) {
     args.response_format = responseFormat;
   }
-  return args;
+  return withBknContext(args, bknContext);
 }
 
 export function buildCurl(
@@ -457,11 +527,12 @@ export function buildCurl(
   mode: ContextLoaderMode,
   queryValues: Record<string, string>,
   bodyText: string,
+  bknContext?: BknContext,
 ): string {
   if (mode === "mcp") {
     const url = mcpBase(env);
     const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream", ...authHeaders(env) };
-    const args = mcpCallArgs(bodyText, queryValues);
+    const args = mcpCallArgs(bodyText, queryValues, bknContext);
     const payload = { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: op.id, arguments: args } };
     let curl = `curl -X POST '${url}'`;
     Object.entries(headers).forEach(([key, value]) => {
@@ -477,7 +548,16 @@ export function buildCurl(
     curl += ` \\\n  -H '${key}: ${value}'`;
   });
   if (op.body !== null) {
-    curl += ` \\\n  -d '${(bodyText || "{}").replace(/\n\s*/g, "")}'`;
+    // 复制出去的 curl 必须和「发送请求」发的是同一份 —— 少了 bkn_context 直接 400，
+    // 拿去排查会把生命周期问题误读成业务参数问题。
+    // 请求体正在编辑中（JSON 还不合法）时保留原文，别把用户写了一半的内容显示成 {}。
+    let body: string;
+    try {
+      body = JSON.stringify(withBknContext(strictBodyObject(bodyText), bknContext));
+    } catch {
+      body = (bodyText || "{}").replace(/\n\s*/g, "");
+    }
+    curl += ` \\\n  -d '${body}'`;
   }
   return curl;
 }
@@ -489,7 +569,25 @@ export type ContextLoaderResponse = {
   latencyMs: number;
   sizeBytes: number;
   text: string;
+  /** 受管回执（REST 走响应头，MCP 走 structuredContent.bkn_receipt）；终结交互时要列全。 */
+  receipt?: BknReceiptRef;
 };
+
+/**
+ * REST 业务响应里的受管回执：首次正常执行走响应头 `bkn-receipt-id` / `bkn-operation-id`
+ * （业务响应体保持原形），终态重放或 pending 时改由响应体 `receipt` 字段带回。
+ */
+function restReceiptRef(response: Response, text: string): BknReceiptRef | undefined {
+  const receiptId = response.headers.get("bkn-receipt-id");
+  const operationId = response.headers.get("bkn-operation-id");
+  if (receiptId && operationId) return { operationId, receiptId, required: true };
+  try {
+    const parsed = JSON.parse(text) as { receipt?: unknown };
+    return parseBknReceipt(parsed.receipt);
+  } catch {
+    return undefined;
+  }
+}
 
 /** 真实发送请求（REST 或 MCP），返回原始响应文本 + 元信息。 */
 export async function sendRequest(
@@ -500,6 +598,7 @@ export async function sendRequest(
   bodyText: string,
   auth?: McpAuth,
   signal?: AbortSignal,
+  bknContext?: BknContext,
 ): Promise<ContextLoaderResponse> {
   const attempt = async (token: string): Promise<ContextLoaderResponse> => {
     const start = performance.now();
@@ -553,7 +652,7 @@ export async function sendRequest(
           jsonrpc: "2.0",
           id: 2,
           method: "tools/call",
-          params: { name: op.id, arguments: mcpCallArgs(bodyText, queryValues) },
+          params: { name: op.id, arguments: mcpCallArgs(bodyText, queryValues, bknContext) },
         }),
       });
       const text = await response.text();
@@ -564,13 +663,14 @@ export async function sendRequest(
         latencyMs: Math.round(performance.now() - start),
         sizeBytes: new Blob([text]).size,
         text,
+        receipt: receiptFromStructured(mcpStructuredContent(parseMcpEnvelope(text))),
       };
     }
     const url = buildRestUrl(env, op, queryValues);
     const headers = { "Content-Type": "application/json", ...bearer };
     const init: RequestInit = { method: "POST", headers, signal };
     if (op.body !== null) {
-      init.body = JSON.stringify(JSON.parse(bodyText || "{}"));
+      init.body = JSON.stringify(withBknContext(strictBodyObject(bodyText), bknContext));
     }
     const response = await fetch(url, init);
     const text = await response.text();
@@ -581,6 +681,7 @@ export async function sendRequest(
       latencyMs: Math.round(performance.now() - start),
       sizeBytes: new Blob([text]).size,
       text,
+      receipt: restReceiptRef(response, text),
     };
   };
 
@@ -721,7 +822,49 @@ export function mcpResultText(parsed: unknown): string {
   return JSON.stringify(result);
 }
 
-export type McpToolCallResult = { ok: boolean; text: string; latencyMs: number };
+/**
+ * 从 MCP tools/call 信封取 `result.structuredContent`。
+ * 业务工具的受管回执（`bkn_receipt`）与生命周期工具的返回体都只在这里，
+ * 不在 content[].text —— mcpResultText 对生命周期工具只会拿到那句人读的提示语。
+ */
+export function mcpStructuredContent(parsed: unknown): unknown {
+  if (!parsed || typeof parsed !== "object") return undefined;
+  const result = (parsed as Record<string, unknown>).result;
+  if (!result || typeof result !== "object") return undefined;
+  return (result as Record<string, unknown>).structuredContent;
+}
+
+/** tools/call 是否为工具级失败（JSON-RPC 200 + result.isError，区别于 HTTP 层失败）。 */
+function mcpIsError(parsed: unknown): boolean {
+  if (!parsed || typeof parsed !== "object") return false;
+  const result = (parsed as Record<string, unknown>).result;
+  if (!result || typeof result !== "object") return false;
+  return (result as Record<string, unknown>).isError === true;
+}
+
+/** JSON-RPC 协议级错误（如工具不存在），与 result.isError 的工具级失败是两回事。 */
+function mcpRpcError(parsed: unknown): { code?: number; message?: string } | undefined {
+  if (!parsed || typeof parsed !== "object") return undefined;
+  const error = (parsed as Record<string, unknown>).error;
+  if (!error || typeof error !== "object") return undefined;
+  const value = error as Record<string, unknown>;
+  return {
+    code: typeof value.code === "number" ? value.code : undefined,
+    message: typeof value.message === "string" ? value.message : undefined,
+  };
+}
+
+export type McpToolCallResult = {
+  ok: boolean;
+  text: string;
+  latencyMs: number;
+  /** `result.structuredContent`：受管回执与生命周期状态都在这里。 */
+  structured?: unknown;
+  /** 工具级失败（HTTP 200 但 result.isError）。 */
+  isError: boolean;
+  /** JSON-RPC 协议级错误（工具不存在等）。 */
+  rpcError?: { code?: number; message?: string };
+};
 
 export type McpSession = {
   callTool(name: string, args: Record<string, unknown>): Promise<McpToolCallResult>;
@@ -802,7 +945,14 @@ export function createMcpSession(env: ContextLoaderEnv, auth?: McpAuth): McpSess
       const text = await response.text();
       const parsed = parseMcpEnvelope(text);
       const payload = parsed ? mcpResultText(parsed) : text;
-      return { ok: response.ok, text: payload || text, latencyMs: Math.round(performance.now() - start) };
+      return {
+        ok: response.ok,
+        text: payload || text,
+        latencyMs: Math.round(performance.now() - start),
+        structured: mcpStructuredContent(parsed),
+        isError: mcpIsError(parsed),
+        rpcError: mcpRpcError(parsed),
+      };
     },
   };
 }
@@ -885,17 +1035,23 @@ async function restPost(
   return resp;
 }
 
-export async function fetchKnDetail(env: ContextLoaderEnv, auth?: McpAuth, signal?: AbortSignal): Promise<KnDetail> {
+export async function fetchKnDetail(
+  env: ContextLoaderEnv,
+  auth?: McpAuth,
+  signal?: AbortSignal,
+  scope?: BknCallScope,
+): Promise<KnDetail> {
   const base = env.base.replace(/\/+$/, "");
   const params = new URLSearchParams({ response_format: "json" });
   const response = await restPost(
     env,
     auth,
     `${base}${REST_PREFIX}/kn/get_kn_detail?${params.toString()}`,
-    { kn_id: env.knId },
+    withBknContext({ kn_id: env.knId }, scope?.nextContext("get_kn_detail")),
     signal,
   );
   const text = await response.text();
+  scope?.recordReceipt(restReceiptRef(response, text));
   if (!response.ok) {
     throw new Error(text || `获取知识网络详情失败（${response.status}）`);
   }
@@ -920,6 +1076,7 @@ export async function fetchObjectInstances(
   limit = 5,
   auth?: McpAuth,
   signal?: AbortSignal,
+  scope?: BknCallScope,
 ): Promise<Record<string, unknown>[]> {
   const base = env.base.replace(/\/+$/, "");
   const params = new URLSearchParams({ kn_id: env.knId, ot_id: otId, response_format: "json" });
@@ -927,10 +1084,11 @@ export async function fetchObjectInstances(
     env,
     auth,
     `${base}${REST_PREFIX}/kn/query_object_instance?${params.toString()}`,
-    { limit, need_total: false, properties: [] },
+    withBknContext({ limit, need_total: false, properties: [] }, scope?.nextContext("query_object_instance")),
     signal,
   );
   const text = await response.text();
+  scope?.recordReceipt(restReceiptRef(response, text));
   if (!response.ok) {
     throw new Error(text || `查询实例失败（${response.status}）`);
   }


### PR DESCRIPTION
## 背景

BKN Trace 3.0 把受管生命周期变成了 Context Loader 的**强制**协议边界（foundry #568 / #609，无开关）：REST `/kn/*` POST 与除 `bkn_*` 外的全部 MCP `tools/call` 都必须携带 `bkn_context{conversation_id, interaction_id, operation_key}`，缺任一字段返回稳定错误码且下游调用次数为 0。权威文档 `bkn-foundry/adp/context-loader/agent-retrieval/TRACE.md`。

「立即体验」的 Agent 对话、对比模式、数据浏览器与 REST/MCP 调试台走的都是这些端点，此前一个都没带，全线会被挡回。

## 改动

新增 `bkn-lifecycle.service.ts`。三个 id 不能前端自造，只能经 MCP 生命周期工具向 Core 要（agent-retrieval 没有对应 REST 路由）。

**会话（conversation）** 按 `external_conversation_key` 幂等复用。**每个对话面板一条独立 conversation** —— 对比模式两侧是两个 Agent 各自答题，Trace 里应分别溯源、分别统计。清空对话是唯一的更换点，刷新页面仍复用同一条。

**交互（interaction）** 一轮问答一条：发送时开，出答案 `complete`、用户停止 `cancel`、执行失败 `fail`。终结挡在 `setBusy(false)` 之前 —— 一条 conversation 同时只允许一个 active interaction（Core 的 `uq_bkn_trace_interaction_active`），提前放开输入框会让手快发出的下一轮直接开不出交互；并发开轮同理走闸门排队。

**操作（operation）** 一轮内每次工具调用一个 `operation_key`。终结清单必须列全本轮登记过的 operation 与 receipt，数量或 `required` 对不上即 `closure_manifest_invalid`，因此每次业务调用都记账（MCP 取 `structuredContent.bkn_receipt`，REST 取 `bkn-receipt-id` / `bkn-operation-id` 响应头）。

工具循环侧把 `bkn_context` 与 `kn_id` 同等对待：`execute` 里逐次注入、模型不可覆盖，并**从喂给模型的 inputSchema 里剥掉** —— 后端把它塞进了每个业务工具的 `required`，不剥模型会自己编 id，而编出来的在 Core 里根本不存在。

后端未注册生命周期工具时降级回旧行为，只认协议级「工具不存在」，业务错误不吞。

## 集群实测（14.103.77.23，agent-retrieval `shaf1ef179`，`BKN_TRACE_CORE_URL` 已配）

不带 `bkn_context`：
```
{"error":{"code":"conversation_required","required_action":"create_conversation"}}  HTTP 400
```

完整时序 —— 建会话 → 开交互 → 带上下文调业务 → 按清单终结：
```
conv_729b…  active
int_319c…   lease_epoch 1
业务调用 HTTP 200 + Bkn-Operation-Id / Bkn-Receipt-Id
complete → execution_status "completed"
```

故意漏一条 operation：
```
{"error":{"code":"closure_manifest_invalid",
 "message":"closure manifest must list every registered operation and receipt"}}  HTTP 422
```

补 `assembler_deadline` 前后：`evidence_status` 由 `assembling`（永久挂着）变为 `partial`（正常收敛）。

## 检查

`tsc -b` + `eslint.config.typechecked.js --max-warnings 0` 干净，617 个测试通过（新增 18 个：会话稳定性与 reset、operation_key 唯一、清单记账去重、只终结一次、并发排队、收尾失败仍放行、非成功终结不带 answer/deadline、降级路径、稳定错误码、`bkn_context` 注入 REST/MCP、schema 剥离、回执解析）。

## 遗留

- Context Loader 只能把 Receipt 完成为 `evidence_durability=pending`（3.0 Evidence Producer 见 foundry #533/#544），所以成功交互的证据完整度停在 `partial`，符合 TRACE.md 第八节的已知限制。
- `BKN_TRACE_CORE_URL` 未配置的部署，业务调用直接 501 `feature_not_installed`，中间件无条件挂载、无降级 —— 属 foundry 侧问题，前端无从规避。

🤖 Generated with [Claude Code](https://claude.com/claude-code)