### PR TITLE
ci(review): 让 Claude 评审按需触发、不等 CI，并把深度换到影响面

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -5,18 +5,22 @@
 
 name: Claude Code Review
 
-# 由 Claude 对 PR 做代码评审：开启、重开、从 draft 转 ready、每次推送新提交，
-# 以及 PR 发起者留下评论/行内回复时，各跑一次。
+# 由 Claude 对 PR 做代码评审：开启、重开、从 draft 转 ready、每次推送新提交时各跑
+# 一次；此外可在评论里写 `/review` 或 `@claude` 手动要一轮。
 #
 # 覆盖每次推送而非只审首版，是因为评审之后追加的提交往往是「按意见快速改一下」，
 # 恰恰最容易引入新问题；只审首版会让这部分完全不过审。
 # 连续推送的浪费由下面的 concurrency 收敛：新一次运行会取消尚未完成的上一次。
 #
-# 也在评论事件上复评：评审提出的「待确认」项在澄清前不予批准（见下方 prompt），
-# 作者可以不改代码、只回帖来回应，因此必须让回帖也能触发一次复评，否则 approve
-# 永远补不上。为避免自我循环，评论事件由下方 job 的 if 过滤掉 bot 自己的评论，
-# 并限定发起者为 OWNER/MEMBER/COLLABORATOR——评论事件在 base 仓上下文携带
-# secret 运行，限定关联方可挡掉 fork 陌生人触发的 pwn-request。
+# 评论也能触发复评，但必须在正文里显式写 `/review` 或 `@claude`。早先是每条评论都跑
+# 一轮，作者每回一帖就复评一次，轮次膨胀且额度白烧——待确认项现在不阻断放行（见下方
+# prompt），自动复评失去了存在理由，改成按需触发。两个口令都收是因为 `@claude` 已是
+# 团队既有习惯，本仓没有别的 workflow 接管它；只认 `/review` 会让这个写法静默失效，
+# 连提示都没有。注意 contains 是子串匹配，评论里粘到含 `/review` 字样的链接或命令会
+# 误触发一轮——代价是一次评审，未做更严的匹配。
+# 为避免自我循环，评论事件由下方 job 的 if 过滤掉 bot 自己的评论，并限定发起者为
+# OWNER/MEMBER/COLLABORATOR——评论事件在 base 仓上下文携带 secret 运行，限定关联方
+# 可挡掉 fork 陌生人触发的 pwn-request。
 #
 # 需要对任意 PR 重新评审时，手动触发 workflow_dispatch 并填 PR 编号。
 #
@@ -59,7 +63,7 @@ concurrency:
   # 否则 claude-code-action（track_progress）在评论触发的复评跑到一半时以 bot 身份贴
   # tracking comment，那条 comment 又触发 issue_comment、排进同一 -comment 组，
   # cancel-in-progress 在 job if 过滤掉 bot 评论之前就把正在跑的复评取消了——评论触发的
-  # 复评每次贴进度评论那刻自杀（#243 的「作者回帖复评后放行」因此永远补不上 approve）。
+  # 复评每次贴进度评论那刻自杀，`/review` 一次都跑不完。
   # 按 comment.id 分组后每条评论各自独立、互不取消，bot 的进度评论也顶不掉正在跑的复评。
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}-${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && format('comment-{0}', github.event.comment.id) || 'push' }}
   cancel-in-progress: true
@@ -69,10 +73,12 @@ jobs:
     # 逐事件放行：
     #   - workflow_dispatch：手动，总放行。
     #   - pull_request：只同仓 PR（fork 拿不到 secret，跳过避免红叉）。
-    #   - 评论/行内回复：必须挂在 PR 上、PR 仍 open、非 bot 自己发的、且发起者为
-    #     OWNER/MEMBER/COLLABORATOR，挡掉自我循环与 fork 陌生人的 pwn-request。
+    #   - 评论/行内回复：必须挂在 PR 上、PR 仍 open、评论正文含 `/review` 或
+    #     `@claude`、非 bot 自己发的、且发起者为 OWNER/MEMBER/COLLABORATOR，
+    #     挡掉自我循环与 fork 陌生人的 pwn-request。
     #     state == 'open' 让合并/关闭后的评论不再触发复评——merge 已不可逆，
     #     再跑只是白费额度、在死 PR 上贴噪声。
+    #     口令过滤把「每回一帖跑一轮」压成按需触发，评审轮次由人决定。
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
@@ -80,11 +86,13 @@ jobs:
        github.event.pull_request.state == 'open' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.sender.login != 'github-actions[bot]' &&
+       (contains(github.event.comment.body, '/review') || contains(github.event.comment.body, '@claude')) &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        github.event.issue.state == 'open' &&
        github.event.sender.login != 'github-actions[bot]' &&
+       (contains(github.event.comment.body, '/review') || contains(github.event.comment.body, '@claude')) &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     permissions:
@@ -154,30 +162,70 @@ jobs:
             - 没问题就说没问题，不要为了凑数提格式化/命名类的琐碎意见。
               lint 由 CI 的 eslint.config.typechecked.js 把关，不用人工复查风格。
 
-            这次可能是复评（作者推了新提交或回复了评论）。先把现状摸清再下结论：
-            - `gh pr view "$PR_NUMBER" --json reviewDecision,reviewRequests,comments`
-              以及 `gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/comments"`
-              读回你之前留下的 inline 评论与其下的回复，弄清哪些「待确认」项
-              PR 发起者已经回应、哪些还悬着。
-            - `gh pr checks "$PR_NUMBER"` 看必需检查（ci-quality / ci-smoke /
-              security-scan）当前状态。
+            评审的对象是**改动带来的整体影响**，不是这份 diff 的文本。diff 只是入口，
+            每一处改动都要先回答：谁在依赖它、它原本承诺了什么、改完之后这些承诺是否
+            仍然成立。至少覆盖下面四个面，逐个用 `git grep` / 读源码确认，而不是推测：
 
-            按下面的优先级落成一次 PR review（不是普通评论），三选一：
+            - **调用方与被调方**：改动的组件 props、hook 签名与返回值、请求封装、store
+              切片、导出的工具函数，找出全部引用点逐个核对新语义是否仍然成立。改了
+              请求封装就要把调用它的每个页面一起读，别只看改动这一半。
+            - **跨模块契约**：同一件事往往在多处各有一份声明，只改一处就是运行时不一致
+              ——路由注册与懒加载入口、MICRO_APP_CONTRACT 规定的挂载/卸载与通信约定、
+              权限点 key、i18n 的 zh 与 en 两份资源、以及与后端接口对齐的 TypeScript
+              类型定义。
+            - **配置与部署面**：Helm values、configmap、`VITE_` 构建期变量、运行时注入的
+              config，要分别核存量环境升级（沿用旧值会不会失效、缺省值会不会被覆盖）与
+              全新安装两条路径。注意构建期变量改了必须重新构建镜像才生效。
+            - **持久化状态面**：localStorage / sessionStorage 的结构与 key、缓存 key 的
+              组成、URL query 与路由参数的格式。这些都是存量数据：用户浏览器里的旧值、
+              别人发出去的旧链接，改完之后新代码必须仍能正确读出或安全降级。
 
-            1. 有阻塞项（确定的缺陷）→ `gh pr review "$PR_NUMBER" --request-changes
-               --body "<阻塞清单>"`。
-            2. 无阻塞项，但仍有待确认项没有被澄清 → 不要 approve。用
-               `gh pr review "$PR_NUMBER" --comment --body "<未澄清项清单>"` 留言等回应。
-               逐条判断发起者的回应是否真正澄清了该疑点：
-               - 回应正面、切题、能打消疑虑 → 该条视为已澄清。
-               - 回应缺失、答非所问、回避，或仍留有实质疑点 → 该条仍未澄清，
-                 在留言里点名说明还差什么、请补充；别默认「回了就算清」。
-               - 回应本身暴露出新的确定缺陷 → 归到第 1 类。
-               判断要讲理、就事论事，不要为难：回应只要合理对上了疑点就放行，
-               不必追求完美措辞，也不要凭「可能」反复追问同一条。
-            3. 无阻塞项、所有待确认项都已被你判定为澄清、且必需检查没有失败也没有
-               还在跑 → `gh pr review "$PR_NUMBER" --approve --body "<一句放行理由>"`。
-               必需检查只要有失败或仍 pending，就退回第 2 类留言说明在等 CI，先不批。
+            顶层结论里要点明这次改动的影响范围（波及哪些模块、页面、接口、存量状态），
+            而不只是逐行问题清单。
+
+            以下三类改动，只读 diff 必然看不出问题，必须走出 diff 去核源码：
+
+            - **整份新增或整体重写的快照类文件**（lock 文件、生成的接口类型、i18n 全量
+              资源等）：不要只读新文件本身。必须 `git show <ref>:<上一版本的同名文件>`
+              取出前一版逐行比对，确认差异只有本次改动应有的那几处。「全量快照」最容易
+              夹带无关漂移——丢字段、改名、复活已废弃的项——而这些在 diff 里全是 `+`，
+              读不出来。
+            - **props / 字段 / 配置项的改名或删除**：定义其语义的地方通常不在 diff 里。
+              除了 `git grep` 旧名确认无残留（含 i18n key、权限点 key、测试与 mock
+              fixture），还要读**类型定义与默认值**，确认新逻辑没有把原本合法的可选值
+              （`undefined`、空数组、空字符串）判成非法、把可选配置当成必填。
+            - **被删掉的代码**：先问它在维护什么不变量、当初为什么要写。空态分支、
+              `useEffect` 的 cleanup、请求竞态守卫、异常兜底，删掉一个就是不再保证那个
+              不变量。必须确认对应的输入形态确实已经不存在，而不是「当前主路径不会产生」
+              ——用户浏览器里的存量状态和慢网络下的乱序响应仍会产生。
+
+            这次可能是复评（作者推了新提交）。复评的目标是收敛，不是每轮重开一次
+            全面评审：
+            - 先读回你之前留下的 inline 评论与其下的回复：
+              `gh pr view "$PR_NUMBER" --json reviewDecision,comments` 与
+              `gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/comments"`。
+            - 已经提过的问题，作者改了、或给出对得上疑点的解释，就算过。不必追求
+              措辞完美，更不要凭「可能」把同一条追问第二遍。
+            - 上面「必须走出 diff」那三条的全量兜底重扫只在首轮做一次；复评的深挖
+              范围限定在上一轮之后新增的提交与文件。
+            - 第二轮起，除非发现你能说清失效场景的确定阻断项，否则就 approve。
+              评审轮次本身有成本，把 PR 反复挂起比放过一个待确认项更贵。
+
+            按下面的规则落成一次 PR review（不是普通评论），二选一：
+
+            1. 有阻塞项 → `gh pr review "$PR_NUMBER" --request-changes
+               --body "<阻塞清单>"`。阻塞项的门槛是：你已经读过源码核实，能说清
+               具体的失效场景（什么输入、什么状态、坏成什么样）。说不清就不是阻塞项。
+               body 末尾固定带一句「改完请推新提交，或回复 `/review` 要一轮复评」——
+               CHANGES_REQUESTED 会一直挡着合并，而改动若落在本 workflow 的 paths
+               之外，推提交并不会自动复评，作者必须知道怎么把这个状态解掉。
+            2. 没有阻塞项 → `gh pr review "$PR_NUMBER" --approve --body "<放行理由>"`。
+               待确认项不阻断放行：写进 approve 的 body 里当提示，由作者自行判断，
+               不要为了等一个回应而改用 --comment 或 --request-changes。
+
+            不要把 CI 当放行条件。CI 全绿是 Branch Protection 的独立闸门，合并时自然
+            会拦住，评审只判代码本身。必需检查还在跑、甚至已经失败，都照常按上面二选一
+            表态；失败如果明显由这份改动引起，在 body 里点一句即可，不改变结论。
 
             批准以 github-actions[bot] 身份提交，只表态、不合并。人工仍需自行 merge。
 
@@ -185,10 +233,10 @@ jobs:
           # 否则会伸手 Read/Grep/git diff 等未授权工具而被拒，撞满轮次后评论冻在
           # 「进行中」。这里补齐只读检视工具并放宽轮次上限。
           claude_args: |
-            --model claude-opus-4-8
-            --effort high
+            --model claude-opus-5
+            --effort xhigh
             --max-turns 60
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,LS,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,LS,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git grep:*)"
 
       - name: Warn when credential missing
         if: env.CLAUDE_CODE_OAUTH_TOKEN == ''


### PR DESCRIPTION
## 背景

评审工作流有三处成本花在了不产生判断的地方：

1. 每条 PR 评论都触发一轮复评 —— 作者每回一帖就跑一次。
2. 待确认项在澄清前不予批准 —— 靠 `--comment` 留言等回应，再靠评论触发下一轮。
3. 必需检查还在跑或已失败时，退回留言说「在等 CI」，先不批。

三者叠在一起，一个 PR 往往要跑五六轮才拿得到 approve，多出来的轮次几乎都在重复上一轮的结论。

## 改动

对齐 bkn-foundry 的同名 workflow：

**放行不再等 CI。** CI 全绿是 Branch Protection 的独立闸门，合并时自然会拦住，评审只判代码本身。检查还在跑、甚至已经失败，都照常表态；失败如果明显由这份改动引起，在 body 里点一句即可，不改变结论。

**评论触发改按需。** job `if` 加口令过滤，评论正文含 `/review` 或 `@claude` 才跑。两个口令都收是因为 `@claude` 已是团队既有习惯，本仓没有别的 workflow 接管它。注意 `contains` 是子串匹配，粘到含 `/review` 字样的链接会误触发一轮 —— 代价是一次评审，未做更严的匹配。

**放行规则三选一收成二选一。** 待确认项不再阻断 approve，写进 body 里当提示交由作者判断。第二轮起除非发现能说清失效场景的确定阻断项，否则就 approve —— 评审轮次本身有成本，把 PR 反复挂起比放过一个待确认项更贵。

`--request-changes` 的 body 现在固定带一句怎么解掉该状态：改动若落在本 workflow 的 `paths` 之外，推提交不会自动复评，作者需要知道可以回复 `/review`。

**省下的额度换成单轮深度。** 评审对象改为「改动带来的整体影响」而非 diff 文本，明确四个必查面 —— 调用方与被调方、跨模块契约（路由注册 / MICRO_APP_CONTRACT / 权限点 key / i18n 双语资源 / 接口类型）、配置与部署面（Helm values、`VITE_` 构建期变量、运行时注入）、持久化状态面（localStorage、缓存 key、URL query —— 用户浏览器里的旧值和别人发出去的旧链接都是存量数据）。另加三类只读 diff 必然看不出问题的改动：快照类文件要 `git show` 上一版逐行比对、改名删除要 grep 旧名并读类型定义与默认值、被删掉的代码先问它守什么不变量。

模型 `claude-opus-4-8/high` 提到 `claude-opus-5/xhigh`，并补上 `Bash(git grep:*)` 授权 —— 否则上面「grep 旧名确认无残留」这类指令会撞权限拒绝、空耗轮次。

全量兜底重扫只在首轮做，复评的深挖范围限定在上一轮之后的新提交，避免加深度反而把复评也变贵。

## 验证

YAML 可解析，`claude_args` 渲染结果已核对。行为验证只能在合并后的真实 PR 上观察 —— 这个 workflow 的 `paths` 不含 `.github/**`，本 PR 自身不会触发评审。

🤖 Generated with [Claude Code](https://claude.com/claude-code)