### PR TITLE
ci(release-studio): 每个架构在原生 runner 上构建，不再跑 QEMU

### DIFF
--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -20,6 +20,14 @@ name: release-studio
 # default. Prerelease versions accumulate with no retention policy yet: GHCR
 # cleanup needs a PAT/App token (GITHUB_TOKEN can't wildcard-match tags), and
 # SWR needs its own console-side rule — both deferred.
+#
+# Each architecture builds on a runner of its own architecture, then the two are
+# stitched into one multi-arch tag. The previous single-job build asked one
+# amd64 runner for `platforms: linux/amd64,linux/arm64`, which ran the arm64 leg
+# under QEMU — and because the Dockerfile builds the SPA in-image, that meant a
+# full `pnpm install` + `vite build` interpreted instruction by instruction.
+# Observed on a634842: every other step finished in 44s while that one build ran
+# past 45 minutes, still inside `[linux/arm64 build 5/7] RUN pnpm install`.
 
 on:
   push:
@@ -51,13 +59,20 @@ env:
   SWR_NAMESPACE: openbkn-ai
 
 jobs:
-  build:
-    name: release-studio build verify
+  # Resolved once and handed to every downstream job: the per-arch legs and the
+  # manifest that unions them must all agree on one version string, and the
+  # chart's version has to match the image tag it points at.
+  setup:
+    name: resolve version
     runs-on: ubuntu-latest
     env:
       # Surfaced so step `if:` can test credential presence — secrets can't be
       # referenced in `if:` directly. Empty when the SWR secrets aren't set.
       SWR_USERNAME: ${{ secrets.HUAWEI_SWR_USERNAME }}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      publish: ${{ steps.gate.outputs.publish }}
+      swr: ${{ steps.gate.outputs.swr }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,42 +116,77 @@ jobs:
           else
             echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
+          # SWR mirroring is credential-gated; downstream jobs need the same
+          # answer without re-reading the secret.
+          if [[ -n "${SWR_USERNAME}" ]]; then
+            echo "swr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "swr=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - uses: docker/setup-qemu-action@v3
+      # Surface a silent skip: on a real publish the image is supposed to mirror
+      # to SWR, so make a missing credential loud instead of a no-op.
+      - name: Warn if SWR mirror is skipped
+        if: ${{ steps.gate.outputs.publish == 'true' && steps.gate.outputs.swr == 'false' }}
+        run: echo "::warning title=SWR mirror skipped::HUAWEI_SWR_USERNAME/PASSWORD not available to this repo — image pushed to GHCR only, NOT mirrored to ${SWR_REGISTRY}/${SWR_NAMESPACE}."
+
+  # One leg per architecture, each on a runner that natively speaks it. Every
+  # leg publishes an arch-suffixed tag; the manifest job below unions them into
+  # the plain `:<version>` tag that charts and deploys reference.
+  image:
+    name: build ${{ matrix.arch }}
+    needs: setup
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            # Free for public repositories. This label is the whole point of the
+            # split: no QEMU means the in-image `pnpm install` runs at native
+            # speed instead of being interpreted.
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      # No setup-qemu-action: each runner builds only its own architecture.
       - uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        if: ${{ steps.gate.outputs.publish == 'true' }}
+        if: ${{ needs.setup.outputs.publish == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      # Surface a silent skip: on a real publish the image is supposed to mirror
-      # to SWR, so make a missing credential loud instead of a no-op.
-      - name: Warn if SWR mirror is skipped
-        if: ${{ steps.gate.outputs.publish == 'true' && env.SWR_USERNAME == '' }}
-        run: echo "::warning title=SWR mirror skipped::HUAWEI_SWR_USERNAME/PASSWORD not available to this repo — image pushed to GHCR only, NOT mirrored to ${SWR_REGISTRY}/${SWR_NAMESPACE}."
-
       - name: Login to Huawei SWR
-        if: ${{ steps.gate.outputs.publish == 'true' && env.SWR_USERNAME != '' }}
+        if: ${{ needs.setup.outputs.publish == 'true' && needs.setup.outputs.swr == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.SWR_REGISTRY }}
           username: ${{ secrets.HUAWEI_SWR_USERNAME }}
           password: ${{ secrets.HUAWEI_SWR_PASSWORD }}
 
-      - name: Compute image tags
+      - name: Compute arch image tags
         id: tags
         shell: bash
         run: |
-          # GHCR always; SWR mirror only when publishing AND credentials present.
+          # Arch-suffixed tags are an intermediate: the manifest job unions them
+          # under the plain version tag. They are left in the registry on
+          # purpose — deleting them would break the manifest that references
+          # their digests, and this repo has no tag retention policy yet either
+          # way (see the header note).
+          VERSION="${{ needs.setup.outputs.version }}"
           {
             echo "tags<<EOF"
-            echo "ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}:${{ steps.version.outputs.version }}"
-            if [[ "${{ steps.gate.outputs.publish }}" == "true" && -n "${SWR_USERNAME}" ]]; then
-              echo "${SWR_REGISTRY}/${SWR_NAMESPACE}/${IMAGE_NAME}:${{ steps.version.outputs.version }}"
+            echo "ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}:${VERSION}-${{ matrix.arch }}"
+            if [[ "${{ needs.setup.outputs.publish }}" == "true" && "${{ needs.setup.outputs.swr }}" == "true" ]]; then
+              echo "${SWR_REGISTRY}/${SWR_NAMESPACE}/${IMAGE_NAME}:${VERSION}-${{ matrix.arch }}"
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
@@ -146,19 +196,76 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           # Huawei SWR rejects an OCI image index ("Invalid image, fail to parse
-          # 'manifest.json'"), so the multi-arch manifest must stay in the legacy
-          # Docker format. BuildKit v0.31 made OCI media types the default for all
-          # image exports, and setup-buildx-action pulls the floating
-          # moby/buildkit:buildx-stable-1 tag, which moved to v0.31.2 on
-          # 2026-07-16 — pinning the exporter is what keeps SWR pushes working.
-          # `outputs` replaces `push:` here: the two would each add an image
-          # exporter.
-          outputs: type=image,oci-mediatypes=false,push=${{ steps.gate.outputs.publish == 'true' }}
+          # 'manifest.json'"), so both the per-arch manifests and the list that
+          # unions them must stay in the legacy Docker format. BuildKit v0.31
+          # made OCI media types the default for all image exports, and
+          # setup-buildx-action pulls the floating moby/buildkit:buildx-stable-1
+          # tag, which moved to v0.31.2 on 2026-07-16 — pinning the exporter is
+          # what keeps SWR pushes working. `outputs` replaces `push:` here: the
+          # two would each add an image exporter.
+          outputs: type=image,oci-mediatypes=false,push=${{ needs.setup.outputs.publish == 'true' }}
+          # Attestations would turn the result into an index even with
+          # oci-mediatypes off, which is the shape SWR refuses.
           provenance: false
           sbom: false
           tags: ${{ steps.tags.outputs.tags }}
+          # The dependency layer keys on package.json + the lockfile, so it
+          # survives ordinary source pushes — which is most of the build. Scoped
+          # per architecture so the two legs do not evict each other.
+          cache-from: type=gha,scope=studio-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=studio-${{ matrix.arch }}
+
+  # Keeps the original job name so branch protection's required check still
+  # resolves. Unions the per-arch images and ships the chart.
+  build:
+    name: release-studio build verify
+    needs: [setup, image]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        if: ${{ needs.setup.outputs.publish == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to Huawei SWR
+        if: ${{ needs.setup.outputs.publish == 'true' && needs.setup.outputs.swr == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.SWR_REGISTRY }}
+          username: ${{ secrets.HUAWEI_SWR_USERNAME }}
+          password: ${{ secrets.HUAWEI_SWR_PASSWORD }}
+
+      - name: Union arch images into the version tag
+        if: ${{ needs.setup.outputs.publish == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.setup.outputs.version }}"
+          # `docker manifest` emits application/vnd.docker.distribution.manifest.list.v2+json,
+          # the legacy list format SWR accepts. `buildx imagetools create` would
+          # infer its media types from the sources instead, so the format SWR
+          # depends on would rest on inference rather than on the tool's
+          # contract.
+          union() {
+            local repo="$1"
+            docker manifest create "${repo}:${VERSION}" \
+              "${repo}:${VERSION}-amd64" \
+              "${repo}:${VERSION}-arm64"
+            docker manifest push "${repo}:${VERSION}"
+            echo "Pushed multi-arch ${repo}:${VERSION}"
+            docker manifest inspect "${repo}:${VERSION}" | head -20
+          }
+          union "ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}"
+          if [[ "${{ needs.setup.outputs.swr }}" == "true" ]]; then
+            union "${SWR_REGISTRY}/${SWR_NAMESPACE}/${IMAGE_NAME}"
+          fi
 
       # ---- Helm chart: same resolved version as the image, so the chart's
       #      image.tag and its own version always match. ----
@@ -168,7 +275,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.setup.outputs.version }}"
           sed -i "s/^version: .*/version: ${VERSION}/" "${CHART_PATH}/Chart.yaml"
           sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" "${CHART_PATH}/Chart.yaml"
           # Charts reference the image tag via the __VERSION__ placeholder.
@@ -181,9 +288,9 @@ jobs:
         run: helm package "${CHART_PATH}" --destination /tmp/charts
 
       - name: Push chart to GHCR
-        if: ${{ steps.gate.outputs.publish == 'true' }}
+        if: ${{ needs.setup.outputs.publish == 'true' }}
         run: |
           set -euo pipefail
           echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
-          helm push "/tmp/charts/${CHART_NAME}-${{ steps.version.outputs.version }}.tgz" \
+          helm push "/tmp/charts/${CHART_NAME}-${{ needs.setup.outputs.version }}.tgz" \
             "oci://ghcr.io/${{ github.repository_owner }}/charts"


### PR DESCRIPTION
## 问题

单 job 里向一台 amd64 runner 要 `platforms: linux/amd64,linux/arm64`，arm64 那条腿全程 QEMU 模拟。而 Dockerfile 有意把 SPA 编在镜像内（「a single `docker build` yields a self-contained artifact」），于是一整套 `pnpm install` + `vite build` 都在模拟层里跑。

代价有两层，**后者才是真正要命的**：

**1. 常态偏慢。** 同一分支同一天的三次构建：

| run | Build and push image | 结果 |
|---|---|---|
| 30794920954 | 6m39s | success |
| 30804413116 | 7m09s | success |
| 30831563727 | **5h59m26s** | **被 6 小时 job 上限掐掉** |

模拟的常态成本是 ~7 分钟（原生并行后是 ~2 分钟），不算灾难。

**2. 会不确定地挂死。** `30831563727` 用完全相同的配置卡在

```
#24 [linux/arm64 build 5/7] RUN pnpm install --frozen-lockfile
```

跑满 6 小时被 GitHub 掐掉，`release-studio build verify` 因此 fail。qemu-user 下 Node 的线程/futex 行为本就有这类挂起风险，重跑可能过也可能不过 —— 一个会随机耗掉 6 小时再失败的必需检查，比慢严重得多。

## 改动

- **按架构拆 job**，各自跑在同架构 runner 上（arm64 用 `ubuntu-24.04-arm`，公开仓库免费），彻底不进模拟层，两条腿并行。
- **版本号在 `setup` 里解析一次**下发给下游，避免各 job 各算一份对不上。
- **补 GHA 层缓存**，按架构分 scope 互不驱逐。依赖层只随 `package.json` / lockfile 失效，日常改源码的 push 直接命中。
- **合并用 `docker manifest` 而非 `buildx imagetools create`**：SWR 拒收 OCI image index，要的是 `application/vnd.docker.distribution.manifest.list.v2+json`；前者按契约就产出这个格式，后者要从来源推断 —— 同一个坑 BuildKit v0.31 把 OCI 转默认时炸过一次，不该再把它压在推断上。各架构镜像仍保留 `oci-mediatypes=false` 与关闭的 provenance/sbom。
- 保留 job 名 `release-studio build verify`，分支保护的必需检查不受影响。

## 效果

| job | 耗时 |
|---|---|
| resolve version | 7s |
| build amd64 | 1m55s |
| build arm64 | 1m36s（并行） |
| release-studio build verify（合 manifest + chart） | 47s |
| **总计** | **2m56s** |

常态从 ~7 分钟降到 ~3 分钟；更重要的是不再有模拟层挂死这条路。

## 验证

本分支 push 已真实发布过一次，`run 30835594789` 全绿。

合并后的 manifest 格式正确：

```
"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json"
   → "mediaType": "application/vnd.docker.distribution.manifest.v2+json"  "architecture": "amd64"
   → "mediaType": "application/vnd.docker.distribution.manifest.v2+json"  "architecture": "arm64"
```

GHCR 与 SWR 两个 registry 都 `Created manifest list` + `Pushed multi-arch` 成功 —— SWR 收下了合并后的 manifest，这是本次改动唯一没法静态验证、只能真推一次的点。

再从 amd64 真机（14.103.77.23）拉合并后的 tag 做端到端确认：

```
$ nerdctl --namespace k8s.io pull swr…/bkn-studio:0.1.2-ci-studio-native-arch-build.…sha11795e4
elapsed: 2.6 s   total: 3.3 Mi
$ nerdctl image inspect … --format '{{.Architecture}} {{.Os}}'
amd64 linux
```

多架构 tag 正确解析到本机架构。

## 两点说明

- **架构后缀 tag（`:<version>-amd64` / `-arm64`）留在仓库里**：多架构 manifest 引用它们的 digest，删了会把 manifest 打断。本仓库本来也还没有 tag 保留策略（见 workflow 头部注释）。
- **缓存效果尚未实测**：这次是冷缓存首跑，只负责把缓存写进去。下一次改源码的 push 才能看到依赖层命中。即便完全不算缓存，光靠原生构建就已经比模拟快一倍以上，且不再有挂死风险。

## 与 #336 的关系

#336 的唯一阻塞项就是被这个 6 小时挂死掐掉的 `release-studio build verify`（review 已 APPROVED）。建议先合本 PR，#336 同步 main 后重跑即可通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)