### PR TITLE
feat(knowledge-network): 接入 Context Loader 受管生命周期（BKN Trace）

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
@@ -35,7 +35,7 @@ import {
 import {
   createBknLifecycle,
   lifecycleEnv,
-  memoryExternalKeyStore,
+  memoryConversationStore,
   withManagedTurn,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import { recommendationFingerprint } from "@/modules/knowledge-network/utils/agent-chat-cache";
@@ -378,8 +378,8 @@ export function AgentChat({
   const summaryLifecycle = useMemo(
     () =>
       createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
-        externalKeyStore: memoryExternalKeyStore(),
-        oneShot: true,
+        conversationStore: memoryConversationStore(),
+        agentName: "bkn-studio · kn-summary",
       }),
     [env.base, knId, tokenProvider],
   );

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
@@ -58,12 +58,7 @@ function stubLifecycle() {
   const turn: BknTurn = {
     conversationId: "conv_1",
     interactionId: "int_1",
-    nextContext: (toolName) => ({
-      conversation_id: "conv_1",
-      interaction_id: "int_1",
-      operation_key: `${toolName}#1`,
-    }),
-    recordReceipt: vi.fn(),
+    context: () => ({ conversation_id: "conv_1", interaction_id: "int_1" }),
     complete: vi.fn<BknTurn["complete"]>().mockResolvedValue(undefined),
     fail: vi.fn<BknTurn["fail"]>().mockResolvedValue(undefined),
     cancel: vi.fn<BknTurn["cancel"]>().mockResolvedValue(undefined),

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -52,7 +52,7 @@ import {
 import {
   createBknLifecycle,
   lifecycleEnv,
-  localExternalKeyStore,
+  localConversationStore,
   type TurnOutcome,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import {
@@ -186,11 +186,14 @@ function msgsLsKey(knId: string, paneKey: PaneKey): string {
 }
 
 /**
- * 受管会话身份键。每个面板一条独立 conversation —— 对比模式两侧是两个不同的 Agent
+ * 受管会话存放键。每个面板一条独立 conversation —— 对比模式两侧是两个不同的 Agent
  * 在各自答题，Trace 里也应当分别溯源、分别统计，不该混进同一条会话。
+ *
+ * `conv2` 是第二版：老键存的是已下线的 external_conversation_key（前端自造的随机串），
+ * 现在存的是 Core 分配的 conversation_id。换个键免得老值被当会话 id 白打一次请求。
  */
 function conversationLsKey(knId: string, paneKey: PaneKey): string {
-  return `bkn-studio:agentchat:conv:${knId}:${paneKey}`;
+  return `bkn-studio:agentchat:conv2:${knId}:${paneKey}`;
 }
 
 function loadPersisted(key: string): Partial<Persisted> {
@@ -600,12 +603,13 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
 
   /**
    * 本面板的受管生命周期客户端。会话身份跟着 kn + 面板走，只有「清空对话」才换新
-   * ——刷新页面按 external_conversation_key 幂等复用同一条 conversation。
+   * ——conversation_id 落在 localStorage，刷新页面接回同一条 conversation。
    */
   const lifecycle = useMemo(
     () =>
       createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
-        externalKeyStore: localExternalKeyStore(conversationLsKey(knId, profile.paneKey)),
+        conversationStore: localConversationStore(conversationLsKey(knId, profile.paneKey)),
+        agentName: `bkn-studio · ${profile.paneKey}`,
       }),
     [env.base, knId, tokenProvider, profile.paneKey],
   );
@@ -746,7 +750,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
     setMessages([]);
     setStats({ tokens: 0, ms: 0 });
     // 清空对话 = 换一条受管会话。这是 conversation id 唯一的更换点：不清空就一直是同一个，
-    // 刷新页面也会按同一把 external_conversation_key 幂等复用回来。
+    // 刷新页面也会从 localStorage 把它读回来。
     lifecycle.reset();
     try {
       localStorage.removeItem(msgsLsKey(knId, profile.paneKey));
@@ -765,13 +769,16 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
     () => models.map((m) => ({ value: m.modelName, label: m.default ? `${m.modelName} · 默认` : m.modelName })),
     [models],
   );
+  // 可勾选的工具 = 业务工具。`bkn_*` 是受管生命周期/溯源工具，由本面板自己调，
+  // 既不喂模型（见 buildAgentTools）也不该出现在勾选框里。
+  const agentToolDefs = useMemo(() => toolDefs?.filter((t) => !t.name.startsWith("bkn_")) ?? null, [toolDefs]);
   // 与 MCP 侧栏同款分组：本地 op 定义带组名，线上新增的归 Knowledge Network。
   const toolOptions = useMemo(() => {
-    if (!toolDefs) return [];
+    if (!agentToolDefs) return [];
     const groupOf = (name: string) => CONTEXT_LOADER_OPS.find((op) => op.id === name)?.group ?? "Knowledge Network";
     const order = [...new Set(CONTEXT_LOADER_OPS.map((op) => op.group))];
     const buckets = new Map<string, { value: string; label: string }[]>();
-    for (const t of toolDefs) {
+    for (const t of agentToolDefs) {
       const group = groupOf(t.name);
       if (!buckets.has(group)) buckets.set(group, []);
       buckets.get(group)!.push({ value: t.name, label: t.name });
@@ -783,11 +790,11 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
         return (ia === -1 ? order.length : ia) - (ib === -1 ? order.length : ib);
       })
       .map((group) => ({ label: group, title: group, options: buckets.get(group)! }));
-  }, [toolDefs]);
+  }, [agentToolDefs]);
   // 选择器展示值：null（全部）时显示当前已知的全部工具名。
   const draftToolValue = useMemo(
-    () => draftToolSelection ?? (toolDefs ? toolDefs.map((t) => t.name) : []),
-    [draftToolSelection, toolDefs],
+    () => draftToolSelection ?? (agentToolDefs ? agentToolDefs.map((t) => t.name) : []),
+    [draftToolSelection, agentToolDefs],
   );
 
   const empty = messages.length === 0;

--- a/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
+++ b/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
@@ -12,7 +12,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   createBknLifecycle,
   lifecycleEnv,
-  memoryExternalKeyStore,
+  memoryConversationStore,
   withManagedTurn,
   type BknLifecycle,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
@@ -291,7 +291,11 @@ export function DataBrowserPanel({
    * 不带 bkn_context 会被 Context Loader 挡回。这里不是对话，会话按本次挂载算一条。
    */
   const lifecycle = useMemo(
-    () => createBknLifecycle(lifecycleEnv(env.base, env.knId), auth, { externalKeyStore: memoryExternalKeyStore() }),
+    () =>
+      createBknLifecycle(lifecycleEnv(env.base, env.knId), auth, {
+        conversationStore: memoryConversationStore(),
+        agentName: "bkn-studio · data-browser",
+      }),
     [env.base, env.knId, auth],
   );
 

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -51,7 +51,7 @@ import {
 import {
   createBknLifecycle,
   lifecycleEnv,
-  memoryExternalKeyStore,
+  memoryConversationStore,
   withManagedTurn,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import { AgentChat } from "@/modules/knowledge-network/components/agent-chat/AgentChat";
@@ -382,10 +382,14 @@ export function ExperienceScene({
   );
   /**
    * 调试台的受管生命周期。这里不是对话，一次「发送请求」/「填充测试数据」就是一轮交互；
-   * 会话本身按本次进入调试台算一条，刷新即换新（memory 键），不写 localStorage。
+   * 会话本身按本次进入调试台算一条，刷新即换新（内存态），不写 localStorage。
    */
   const lifecycle = useMemo(
-    () => createBknLifecycle(lifecycleEnv(base, knId), tokenProvider, { externalKeyStore: memoryExternalKeyStore() }),
+    () =>
+      createBknLifecycle(lifecycleEnv(base, knId), tokenProvider, {
+        conversationStore: memoryConversationStore(),
+        agentName: "bkn-studio · context-loader-console",
+      }),
     [base, knId, tokenProvider],
   );
 
@@ -495,9 +499,8 @@ export function ExperienceScene({
     () =>
       op
         ? buildCurl({ ...env, base: serverAddress }, op, mode, queryVals, bodyText, {
-            conversation_id: "<bkn_create_conversation 返回的 conversation_id>",
+            conversation_id: "<bkn_start_interaction 返回的 conversation_id>",
             interaction_id: "<bkn_start_interaction 返回的 interaction_id>",
-            operation_key: `${op.id}#1`,
           })
         : "",
     [env, serverAddress, op, mode, queryVals, bodyText],
@@ -542,8 +545,8 @@ export function ExperienceScene({
       const result = await withManagedTurn(
         lifecycle,
         `调试台调用 ${op.id}`,
-        async (turn) => {
-          const sent = await sendRequest(
+        (turn) =>
+          sendRequest(
             freshEnv,
             op,
             mode,
@@ -551,11 +554,8 @@ export function ExperienceScene({
             bodyText,
             tokenProvider,
             controller.signal,
-            turn?.nextContext(op.id),
-          );
-          turn?.recordReceipt(sent.receipt);
-          return sent;
-        },
+            turn?.context(),
+          ),
         // 业务返回 500 时这一轮仍算 completed —— 调用失败记在 Operation 的 Receipt 上
         // （Core 已判 failed），Interaction 状态表达的是调用方这一轮走完了没有。
         (sent) => `HTTP ${sent.status} · ${sent.sizeBytes}B`,

--- a/src/modules/knowledge-network/services/agent-chat-tools.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat-tools.test.ts
@@ -68,12 +68,7 @@ describe("buildAgentTools", () => {
   it("injects the turn context and locked kn_id into the real call", async () => {
     const session = stubSession();
     const turn: BknCallScope = {
-      nextContext: (toolName) => ({
-        conversation_id: "conv_1",
-        interaction_id: "int_1",
-        operation_key: `${toolName}#1`,
-      }),
-      recordReceipt: vi.fn(),
+      context: () => ({ conversation_id: "conv_1", interaction_id: "int_1" }),
     };
     const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
       session,
@@ -88,28 +83,24 @@ describe("buildAgentTools", () => {
         sql: "SELECT 1",
         // kn_id 与 bkn_context 都是平台侧身份，模型传什么都以锁定值为准。
         kn_id: "kn-demo",
-        bkn_context: { conversation_id: "conv_1", interaction_id: "int_1", operation_key: "run_sql#1" },
+        bkn_context: { conversation_id: "conv_1", interaction_id: "int_1" },
       }),
     );
   });
 
-  it("records the managed receipt of every business call", async () => {
-    const session = stubSession({
-      structured: { bkn_receipt: { operation_id: "op_1", receipt_id: "rcp_1", required: true } },
-    });
-    const recordReceipt = vi.fn();
-    const turn: BknCallScope = {
-      nextContext: () => ({ conversation_id: "conv_1", interaction_id: "int_1", operation_key: "run_sql#1" }),
-      recordReceipt,
-    };
-    const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
-      session,
-      turn,
-    });
+  it("never hands the lifecycle tools to the model", () => {
+    const session = stubSession();
+    const tools = buildAgentTools(
+      [runSql, { name: "bkn_finish_interaction", description: "终结本轮交互" }],
+      env,
+      "kn-demo",
+      DEFAULT_AGENT_CONFIG,
+      tokenProvider,
+      { session },
+    );
 
-    await runTool(tools.run_sql, { sql: "SELECT 1" });
-
-    expect(recordReceipt).toHaveBeenCalledWith({ operationId: "op_1", receiptId: "rcp_1", required: true });
+    // 模型自己调 bkn_finish_interaction 会把本轮当场关掉，后续调用全被判 interaction_terminal。
+    expect(Object.keys(tools)).toEqual(["run_sql"]);
   });
 
   it("sends no managed context when the backend has no lifecycle", async () => {

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -19,7 +19,6 @@ import { jsonSchema, stepCountIs, streamText, tool, type ModelMessage, type Tool
 
 import {
   createMcpSession,
-  receiptFromStructured,
   type BknCallScope,
   type BknContext,
   type ContextLoaderEnv,
@@ -195,7 +194,7 @@ export type AgentToolsOptions = {
   /** 复用生命周期客户端的 MCP 会话，省一次 initialize 握手。 */
   session?: McpSession;
   /**
-   * 本轮受管交互。工具循环只需要「取上下文 + 回执记账」这两件事，故取最小接口
+   * 本轮受管交互。工具循环只需要「取本轮上下文」这一件事，故取最小接口
    * BknCallScope 而非整个 BknTurn —— 终结交互不归工具循环管。
    * 缺省/null 时不注入 bkn_context：只有后端未启用受管生命周期时才该这样，
    * 启用了却不传会让每个工具调用都被挡在 `conversation_required`。
@@ -217,12 +216,14 @@ export function buildAgentTools(
   const tools: ToolSet = {};
   const call = async (name: string, args: Record<string, unknown>): Promise<string> => {
     const res = await session.callTool(name, args);
-    // 每次业务调用的回执都要记账：终结本轮交互时清单必须列全，漏一条 Core 就判非法。
-    turn?.recordReceipt(receiptFromStructured(res.structured));
     return res.text;
   };
   for (const def of mcpTools) {
     if (!def.name) continue;
+    // 生命周期与溯源工具一律不喂模型：这一轮的开与终结由 ChatPane 管，模型自己调
+    // bkn_finish_interaction 会把本轮当场关掉，后续工具调用全被判 interaction_terminal。
+    // 按前缀整体过滤而不是列名单 —— 业务工具一概不带 `bkn_` 前缀，后端加工具时不用跟改。
+    if (def.name.startsWith("bkn_")) continue;
     const schema =
       def.inputSchema && typeof def.inputSchema === "object"
         ? stripBknContextSchema(def.inputSchema as Record<string, unknown>)
@@ -235,7 +236,7 @@ export function buildAgentTools(
         (scopedList ? " 返回结果已默认限定为当前知识网络绑定的数据表（其他 catalog 的表不会出现）。" : ""),
       inputSchema: jsonSchema(schema),
       execute: async (input: unknown): Promise<string> => {
-        const bknContext = turn?.nextContext(def.name);
+        const bknContext = turn?.context();
         if (scopedList && scopeSet) return listResourcesScoped(call, input, knId, scopeSet, cfg, bknContext);
         const args = effectiveToolArgs(def.name, input, knId, bknContext);
         return capToolResult(await call(def.name, args), def.name, cfg);

--- a/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
@@ -6,57 +6,50 @@
  */
 
 /**
- * BKN Trace 3.0 受管生命周期客户端 —— Context Loader 调用的前置协议边界。
+ * BKN Trace 受管生命周期客户端 —— Context Loader 调用的前置协议边界。
  *
- * 契约见 bkn-foundry `adp/context-loader/agent-retrieval/TRACE.md`：REST `/kn/*` POST 与
- * 除 `bkn_*` 外的全部 MCP `tools/call` 都必须携带 `bkn_context`（conversation_id +
- * interaction_id + operation_key），缺任一字段返回稳定错误码且下游调用次数为 0。
- * 三个 id 都不能前端自造，必须问 Core 要：
+ * 除 `bkn_*` 外的全部 MCP `tools/call` 与 REST `/kn/*` POST 都必须携带
+ * `bkn_context{conversation_id, interaction_id}`，缺了直接返回 `conversation_required`
+ * 且下游调用次数为 0。两个 id 都不能前端自造，只能问 Core 要：
  *
- *   会话（conversation）—— 一条对话的身份，清空对话才换；页面刷新按 external_conversation_key 幂等复用。
+ *   会话（conversation）—— 一条对话的身份，清空对话才换；首轮由 Core 分配，之后回传复用。
  *   交互（interaction）—— 一轮问答，发送时开、出答案/停止/出错时终结。
- *   操作（operation）—— 一轮里的每次工具调用，由 operation_key 在交互内去重。
  *
  * 生命周期只由 MCP 工具暴露（agent-retrieval 没有对应 REST 路由），所以 REST 调试台也要
- * 先走一遍 MCP 才能拿到上下文。
+ * 先走一遍 MCP 才能拿到上下文。契约实测（2026-08-05，foundry #618 之后）只剩两个工具：
+ *
+ *   bkn_start_interaction  {question*, conversation_id?, agent_name?}
+ *     → {interaction_id, conversation_id, execution_status:"active"}
+ *   bkn_finish_interaction {interaction_id*, outcome*, answer?, reason?}
+ *     → {interaction_id, conversation_id, execution_status, evidence_status}
+ *
+ * 租约、终结清单（expected_operations / expected_receipts）、operation_key 全部收回 facade
+ * 内部，调用方不再参与 —— 老契约那套 `bkn_create_conversation` + 三个终结工具已下线。
  */
 
 import {
   createMcpSession,
   type BknContext,
-  type BknReceiptRef,
   type ContextLoaderEnv,
   type McpAuth,
   type McpSession,
 } from "@/modules/knowledge-network/services/context-loader.service";
 
-/** 终结清单版本，与 Core `completion_manifest_version` 对应。 */
-const MANIFEST_VERSION = "1";
-
-/**
- * 交互租约时长。终结时租约必须还没过期，否则 Core 判 `terminal_conflict`；
- * 一轮 Agent 对话可以跑满 40 步工具，按分钟级留足。
- */
-const DEFAULT_LEASE_SECONDS = 1800;
-
-/**
- * 成功终结时给证据组装留的收敛窗口。Context Loader 目前只能把 Receipt 完成为
- * `evidence_durability=pending`（3.0 Evidence Producer 未落地），而带 pending 回执的
- * 成功交互必须在清单里给出 assembler_deadline，否则永远停在 assembling ——
- * 现在没有 assembler 在跑，看不出差别，但 #544 上线后有它才会自动收敛。
- */
-const ASSEMBLER_DEADLINE_MS = 5 * 60 * 1000;
-
-/** 一轮交互的收尾原因（Core 只存字符串，不校验枚举）。 */
+/** 一轮交互的收尾结果。注意线上入参枚举是 `cancelled`（双 l），见 WIRE_OUTCOME。 */
 export type TurnOutcome = "completed" | "failed" | "canceled";
+
+/** 前端枚举 → `bkn_finish_interaction.outcome` 的线上拼写。 */
+const WIRE_OUTCOME: Record<TurnOutcome, string> = {
+  completed: "completed",
+  failed: "failed",
+  canceled: "cancelled",
+};
 
 export type BknTurn = {
   conversationId: string;
   interactionId: string;
-  /** 取下一次业务调用的受管上下文；operation_key 在本轮内唯一。 */
-  nextContext(toolName: string): BknContext;
-  /** 记下一次业务调用的回执；终结时要把本轮全部 operation/receipt 列进清单。 */
-  recordReceipt(receipt: BknReceiptRef | undefined): void;
+  /** 本轮的受管上下文，随每次业务调用一起发出。 */
+  context(): BknContext;
   /** 正常收尾（answer 为本轮最终答复，Core 会存为 interaction artifact）。 */
   complete(answer: string): Promise<void>;
   /** 执行失败收尾。 */
@@ -70,7 +63,7 @@ export type BknTurn = {
 export type BknLifecycle = {
   /** 与业务调用共用的 MCP 会话（复用同一个 Mcp-Session-Id，少一次握手）。 */
   session: McpSession;
-  /** 当前会话 id；还没建立时为 null。 */
+  /** 当前会话 id；还没开过交互时为 null。 */
   conversationId(): string | null;
   /** 后端不支持受管生命周期（老版本 Context Loader）时为 true，此时不注入 bkn_context。 */
   unsupported(): boolean;
@@ -81,26 +74,26 @@ export type BknLifecycle = {
    * 等上一轮终结后才真正开新的一轮。
    */
   beginTurn(question: string): Promise<BknTurn | null>;
-  /** 丢弃当前会话（清空对话）：下一轮会建一条全新 conversation。 */
+  /** 丢弃当前会话（清空对话）：下一轮会开一条全新 conversation。 */
   reset(): void;
 };
 
 export type BknLifecycleOptions = {
   /**
-   * 会话身份键。同一个键 `bkn_create_conversation` 幂等复用同一条 conversation，
-   * 所以它决定了「什么时候还算同一条对话」：刷新页面复用，清空对话换新。
+   * 会话 id 的存放处。新契约没有 `external_conversation_key` 之类的幂等键，
+   * 「刷新页面还是同一条对话」只能靠前端把 Core 分配的 conversation_id 存下来。
    */
-  externalKeyStore: ExternalKeyStore;
-  /** 单轮即弃的场景（如调试台一次点击）传 true，交给 Core 按 one-shot 语义收敛。 */
-  oneShot?: boolean;
-  leaseSeconds?: number;
+  conversationStore: ConversationStore;
+  /** 写进 Trace 的调用方显示名（Core 只在首轮登记，之后传同值即可）。 */
+  agentName?: string;
 };
 
-/** 会话身份键的读写。localStorage 实现见 localExternalKeyStore。 */
-export type ExternalKeyStore = {
-  read(): string;
-  /** 换一把新键（清空对话）。 */
-  rotate(): void;
+/** 会话 id 的读写。localStorage 实现见 localConversationStore。 */
+export type ConversationStore = {
+  /** 还没有会话时返回 null。 */
+  read(): string | null;
+  write(id: string): void;
+  clear(): void;
 };
 
 /**
@@ -124,33 +117,30 @@ export function randomLifecycleId(): string {
 }
 
 /**
- * localStorage 版会话身份键。键值只在 rotate（清空对话）时更换，
- * 因此刷新页面仍会命中同一条 conversation —— 这正是「不清空就一直同一个 id」。
+ * localStorage 版会话存放处。只在 clear（清空对话）时丢弃，
+ * 因此刷新页面仍会接回同一条 conversation —— 这正是「不清空就一直同一个 id」。
  */
-export function localExternalKeyStore(storageKey: string): ExternalKeyStore {
+export function localConversationStore(storageKey: string): ConversationStore {
   let cached: string | null = null;
   return {
     read() {
       if (cached) return cached;
       try {
-        const stored = localStorage.getItem(storageKey);
-        if (stored) {
-          cached = stored;
-          return stored;
-        }
+        cached = localStorage.getItem(storageKey);
       } catch {
-        /* localStorage 不可用时退化为内存键 */
+        /* localStorage 不可用时退化为内存态 */
       }
-      const fresh = randomLifecycleId();
-      cached = fresh;
-      try {
-        localStorage.setItem(storageKey, fresh);
-      } catch {
-        /* 忽略：内存键仍能保证本次会话内稳定 */
-      }
-      return fresh;
+      return cached;
     },
-    rotate() {
+    write(id: string) {
+      cached = id;
+      try {
+        localStorage.setItem(storageKey, id);
+      } catch {
+        /* 忽略：内存态仍能保证本次会话内稳定 */
+      }
+    },
+    clear() {
       cached = null;
       try {
         localStorage.removeItem(storageKey);
@@ -161,13 +151,16 @@ export function localExternalKeyStore(storageKey: string): ExternalKeyStore {
   };
 }
 
-/** 进程内会话身份键：刷新即换新会话，适合一次性面板。 */
-export function memoryExternalKeyStore(): ExternalKeyStore {
-  let value = randomLifecycleId();
+/** 进程内会话存放处：刷新即换新会话，适合一次性面板。 */
+export function memoryConversationStore(): ConversationStore {
+  let value: string | null = null;
   return {
     read: () => value,
-    rotate() {
-      value = randomLifecycleId();
+    write(id: string) {
+      value = id;
+    },
+    clear() {
+      value = null;
     },
   };
 }
@@ -176,26 +169,35 @@ export function memoryExternalKeyStore(): ExternalKeyStore {
 export class BknLifecycleError extends Error {
   readonly code: string;
   readonly requiredAction: string;
+  /** `interaction_in_progress` 时 Core 回带的在途交互 id，用于回收。 */
+  readonly currentInteractionId: string;
 
-  constructor(tool: string, code: string, message: string, requiredAction: string) {
+  constructor(
+    tool: string,
+    code: string,
+    message: string,
+    requiredAction: string,
+    currentInteractionId = "",
+  ) {
     super(message || `${tool} 失败（${code || "unknown"}）`);
     this.name = "BknLifecycleError";
     this.code = code;
     this.requiredAction = requiredAction;
+    this.currentInteractionId = currentInteractionId;
   }
 }
 
-type LifecycleErrorPayload = { code?: unknown; message?: unknown; required_action?: unknown };
+type LifecycleErrorPayload = {
+  code?: unknown;
+  message?: unknown;
+  required_action?: unknown;
+  current_interaction_id?: unknown;
+};
 
 /**
- * 会话里还挂着一轮没终结的交互。正常路径不会走到这儿（本地闸门会排队），只有上一轮的
- * 终结真的没送达 Core 时才出现——例如业务调用的响应丢在网络上，前端拿不到回执，
- * 清单缺一条，终结被判 closure_manifest_invalid。
- *
- * 这时前端救不回来：补齐清单需要按 interaction 列出已登记的 operation，而受管接口
- * 只允许按 id 查（TRACE.md 第三节：第三方 Agent 只能查询 Operation/Receipt）。
- * 但用户有出路——清空对话会换一条全新 conversation，卡住的那轮留给 Core 的租约回收。
- * 所以这里把出路写进报错，别让人对着「已有进行中的交互」干等 30 分钟租约。
+ * 会话里还挂着一轮没终结的交互，且自动回收也没能收掉。正常路径不会走到这儿——本地闸门会
+ * 排队，回收逻辑还会替上一轮收尾——只有回收本身也失败时才出现。用户的出路是清空对话换一条
+ * 全新 conversation，卡住的那轮留给 Core 的租约回收。
  */
 const STUCK_INTERACTION_HINT = "当前会话还有一轮未结束的交互没能正常收尾。点「清空」开一条新对话即可继续；卡住的那轮会由服务端租约自动回收。";
 
@@ -209,6 +211,7 @@ function lifecycleErrorOf(tool: string, structured: unknown, fallbackText: strin
     code,
     code === "interaction_in_progress" ? STUCK_INTERACTION_HINT : message,
     typeof error.required_action === "string" ? error.required_action : "",
+    typeof error.current_interaction_id === "string" ? error.current_interaction_id : "",
   );
 }
 
@@ -246,11 +249,6 @@ function stringField(source: Record<string, unknown>, key: string): string {
   return typeof value === "string" ? value : "";
 }
 
-function numberField(source: Record<string, unknown>, key: string): number {
-  const value = source[key];
-  return typeof value === "number" ? value : 0;
-}
-
 export function createBknLifecycle(
   env: ContextLoaderEnv,
   auth: McpAuth | undefined,
@@ -261,8 +259,7 @@ export function createBknLifecycle(
 
 /** 同上但复用调用方给的 MCP 会话（也是测试注入点）。 */
 export function createBknLifecycleOn(session: McpSession, options: BknLifecycleOptions): BknLifecycle {
-  const { externalKeyStore, oneShot = false, leaseSeconds = DEFAULT_LEASE_SECONDS } = options;
-  let conversationId: string | null = null;
+  const { conversationStore, agentName } = options;
   let notSupported = false;
   /**
    * 上一轮交互的终结闸门。会话内只能有一个 active interaction，抢跑的第二轮会被 Core
@@ -270,23 +267,40 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
    */
   let previousTurnSettled: Promise<void> = Promise.resolve();
 
-  async function ensureConversation(): Promise<string | null> {
-    if (notSupported) return null;
-    if (conversationId) return conversationId;
+  function startArgs(question: string): Record<string, unknown> {
+    const args: Record<string, unknown> = { question };
+    // 首轮不带 conversation_id，由 Core 分配；之后回传拿回同一条会话。
+    const known = conversationStore.read();
+    if (known) args.conversation_id = known;
+    if (agentName) args.agent_name = agentName;
+    return args;
+  }
+
+  /**
+   * 开交互，并处理两类可自愈的失败：
+   *
+   *   resource_not_disclosed —— 存下来的 conversation_id 在当前账户/部署下已不可见
+   *     （后端换库、换租户、会话被清理）。丢掉它重开一条，而不是让面板从此打不开。
+   *   interaction_in_progress —— 会话里挂着一轮没收尾的交互。走到这儿说明本地闸门是空的
+   *     （beginTurn 已经排过队），所以那一轮必定是泄漏的：刷新页面打断了 finish 的多半就是它。
+   *     用 Core 回带的 current_interaction_id 替它收尾再重开；收不掉才把出路提示抛给用户。
+   */
+  async function startInteraction(question: string): Promise<Record<string, unknown>> {
     try {
-      // ensure-current 按 external_conversation_key 幂等：刷新页面拿回同一条会话，
-      // 会话已关闭则由 Core 开新 generation，前端不需要自己判断该 create 还是 resume。
-      const state = await callLifecycleTool(session, "bkn_create_conversation", {
-        external_conversation_key: externalKeyStore.read(),
-        idempotency_key: randomLifecycleId(),
-        one_shot: oneShot,
-      });
-      conversationId = stringField(state, "conversation_id") || null;
-      return conversationId;
+      return await callLifecycleTool(session, "bkn_start_interaction", startArgs(question));
     } catch (error) {
-      if (error instanceof BknLifecycleError && error.code === "lifecycle_not_supported") {
-        notSupported = true;
-        return null;
+      if (!(error instanceof BknLifecycleError)) throw error;
+      if (error.code === "resource_not_disclosed") {
+        conversationStore.clear();
+        return callLifecycleTool(session, "bkn_start_interaction", startArgs(question));
+      }
+      if (error.code === "interaction_in_progress" && error.currentInteractionId) {
+        await callLifecycleTool(session, "bkn_finish_interaction", {
+          interaction_id: error.currentInteractionId,
+          outcome: WIRE_OUTCOME.canceled,
+          reason: "reclaimed_by_client",
+        });
+        return callLifecycleTool(session, "bkn_start_interaction", startArgs(question));
       }
       throw error;
     }
@@ -294,13 +308,13 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
 
   return {
     session,
-    conversationId: () => conversationId,
+    conversationId: () => conversationStore.read(),
     unsupported: () => notSupported,
     reset() {
-      conversationId = null;
-      externalKeyStore.rotate();
+      conversationStore.clear();
     },
     async beginTurn(question: string) {
+      if (notSupported) return null;
       const waitFor = previousTurnSettled;
       let release = () => undefined as void;
       previousTurnSettled = new Promise<void>((resolve) => {
@@ -309,20 +323,20 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
       try {
         // 闸门只会 resolve、不会 reject（终结失败也照样放行），所以这里不会串联失败。
         await waitFor;
-        const currentConversation = await ensureConversation();
-        if (!currentConversation) {
+        if (notSupported) {
           release();
           return null;
         }
-        const state = await callLifecycleTool(session, "bkn_start_interaction", {
-          conversation_id: currentConversation,
-          idempotency_key: randomLifecycleId(),
-          question,
-          lease_seconds: leaseSeconds,
-        });
-        return createTurn(session, currentConversation, state, release);
+        const state = await startInteraction(question);
+        const conversationId = stringField(state, "conversation_id");
+        if (conversationId) conversationStore.write(conversationId);
+        return createTurn(session, conversationId, stringField(state, "interaction_id"), release);
       } catch (error) {
         release();
+        if (error instanceof BknLifecycleError && error.code === "lifecycle_not_supported") {
+          notSupported = true;
+          return null;
+        }
         throw error;
       }
     },
@@ -332,42 +346,26 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
 function createTurn(
   session: McpSession,
   conversationId: string,
-  state: Record<string, unknown>,
+  interactionId: string,
   /** 终结后放行下一轮（成败都放行，否则一次收尾失败会让整条会话再也开不出交互）。 */
   release: () => void,
 ): BknTurn {
-  const interactionId = stringField(state, "interaction_id");
-  const leaseToken = stringField(state, "lease_token");
-  const leaseEpoch = numberField(state, "lease_epoch");
-  const receipts: BknReceiptRef[] = [];
-  let operationSeq = 0;
   let terminated = false;
 
-  async function terminate(tool: string, reason: string, answer?: string): Promise<void> {
+  async function terminate(outcome: TurnOutcome, answer?: string, reason?: string): Promise<void> {
     // 终结只做一次：重复调用会撞 Core 的 terminal_conflict，而调用方在
     // 「停止后又出错」这类路径上很容易两次都触发。
     if (terminated) return;
     terminated = true;
-    // 清单必须一条不漏地列出本轮登记过的 operation / receipt，且 required 与 Core 侧一致，
-    // 数量对不上直接 closure_manifest_invalid。
     const args: Record<string, unknown> = {
       interaction_id: interactionId,
-      terminal_idempotency_key: randomLifecycleId(),
-      lease_token: leaseToken,
-      lease_epoch: leaseEpoch,
-      completion_manifest_version: MANIFEST_VERSION,
-      completion_reason: reason,
-      expected_operations: receipts.map((r) => ({ operation_id: r.operationId, required: r.required })),
-      expected_receipts: receipts.map((r) => ({ receipt_id: r.receiptId, required: r.required })),
+      outcome: WIRE_OUTCOME[outcome],
     };
-    // answer 只在 complete 的 schema 里声明；cancel / fail 传了会撞
-    // additionalProperties: false。
-    if (answer !== undefined) {
-      args.answer = answer;
-      args.assembler_deadline = new Date(Date.now() + ASSEMBLER_DEADLINE_MS).toISOString();
-    }
+    // schema 是 additionalProperties:false，空串也别塞。
+    if (answer) args.answer = answer;
+    if (reason) args.reason = reason;
     try {
-      await callLifecycleTool(session, tool, args);
+      await callLifecycleTool(session, "bkn_finish_interaction", args);
     } finally {
       release();
     }
@@ -376,26 +374,14 @@ function createTurn(
   return {
     conversationId,
     interactionId,
-    nextContext(toolName: string) {
-      operationSeq += 1;
-      return {
-        conversation_id: conversationId,
-        interaction_id: interactionId,
-        operation_key: `${toolName}#${operationSeq}`,
-      };
-    },
-    recordReceipt(receipt) {
-      // 同一 operation 的重放会回同一个 receipt，去重后清单才不会多算。
-      if (!receipt || receipts.some((r) => r.operationId === receipt.operationId)) return;
-      receipts.push(receipt);
-    },
-    complete: (answer: string) => terminate("bkn_complete_interaction", "answer_returned", answer),
-    fail: (reason: string) => terminate("bkn_fail_interaction", reason || "agent_error"),
-    cancel: (reason: string) => terminate("bkn_cancel_interaction", reason || "stopped_by_user"),
+    context: () => ({ conversation_id: conversationId, interaction_id: interactionId }),
+    complete: (answer: string) => terminate("completed", answer),
+    fail: (reason: string) => terminate("failed", undefined, reason || "agent_error"),
+    cancel: (reason: string) => terminate("canceled", undefined, reason || "stopped_by_user"),
     finish(outcome, answer) {
-      if (outcome === "canceled") return terminate("bkn_cancel_interaction", "stopped_by_user");
-      if (outcome === "failed") return terminate("bkn_fail_interaction", "agent_error");
-      return terminate("bkn_complete_interaction", "answer_returned", answer);
+      if (outcome === "canceled") return terminate("canceled", undefined, "stopped_by_user");
+      if (outcome === "failed") return terminate("failed", undefined, "agent_error");
+      return terminate("completed", answer);
     },
   };
 }

--- a/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
@@ -9,17 +9,23 @@ import { describe, expect, it } from "vitest";
 
 import {
   createBknLifecycleOn,
-  memoryExternalKeyStore,
+  memoryConversationStore,
   withManagedTurn,
+  type ConversationStore,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import type { McpSession, McpToolCallResult } from "@/modules/knowledge-network/services/context-loader.service";
 
 type Call = { name: string; args: Record<string, unknown> };
 
-/** 假的 Core：conversation 按 external_conversation_key 幂等，interaction 递增。 */
-function fakeSession(overrides: Record<string, () => McpToolCallResult> = {}) {
+/**
+ * 假的 Core，照 foundry #618 之后的契约建模：
+ * 首轮不带 conversation_id 由后端分配，之后回传复用；一条会话同时只准一个 active interaction。
+ */
+function fakeSession(overrides: Record<string, () => McpToolCallResult | null> = {}) {
   const calls: Call[] = [];
-  const conversations = new Map<string, string>();
+  /** 已分配的会话 → 在途交互 id（null = 空闲）。 */
+  const active = new Map<string, string | null>();
+  let conversationSeq = 0;
   let interactionSeq = 0;
   const ok = (structured: unknown): McpToolCallResult => ({
     ok: true,
@@ -28,48 +34,71 @@ function fakeSession(overrides: Record<string, () => McpToolCallResult> = {}) {
     structured,
     isError: false,
   });
+  const failed = (structured: unknown, text: string): McpToolCallResult => ({
+    ok: true,
+    text,
+    latencyMs: 1,
+    structured,
+    isError: true,
+  });
   const session: McpSession = {
     callTool(name, args) {
       calls.push({ name, args });
-      const override = overrides[name];
-      if (override) return Promise.resolve(override());
-      if (name === "bkn_create_conversation") {
-        const key = String(args.external_conversation_key);
-        if (!conversations.has(key)) conversations.set(key, `conv_${conversations.size + 1}`);
-        return Promise.resolve(ok({ conversation_id: conversations.get(key), status: "active" }));
-      }
+      // override 返回 null = 这一次交还给默认实现（用于「只让第一次失败」这类场景）。
+      const overridden = overrides[name]?.();
+      if (overridden) return Promise.resolve(overridden);
       if (name === "bkn_start_interaction") {
+        let conversationId = typeof args.conversation_id === "string" ? args.conversation_id : "";
+        if (conversationId && !active.has(conversationId)) {
+          return Promise.resolve(
+            failed(
+              { error: { code: "resource_not_disclosed", message: "request was not found in the authorized scope" } },
+              "resource_not_disclosed",
+            ),
+          );
+        }
+        if (!conversationId) {
+          conversationSeq += 1;
+          conversationId = `conv_${conversationSeq}`;
+          active.set(conversationId, null);
+        }
+        const inFlight = active.get(conversationId);
+        if (inFlight) {
+          return Promise.resolve(
+            failed(
+              {
+                error: {
+                  code: "interaction_in_progress",
+                  message: "the conversation already has an active interaction",
+                  required_action: "bkn_finish_interaction",
+                  current_interaction_id: inFlight,
+                },
+              },
+              "interaction_in_progress",
+            ),
+          );
+        }
         interactionSeq += 1;
+        const interactionId = `int_${interactionSeq}`;
+        active.set(conversationId, interactionId);
         return Promise.resolve(
-          ok({
-            interaction_id: `int_${interactionSeq}`,
-            conversation_id: args.conversation_id,
-            lease_token: `lease_${interactionSeq}`,
-            lease_epoch: 1,
-          }),
+          ok({ interaction_id: interactionId, conversation_id: conversationId, execution_status: "active" }),
         );
       }
-      if (name.startsWith("bkn_")) return Promise.resolve(ok({ interaction_id: args.interaction_id }));
-      // 业务工具：回一张受管回执。
-      return Promise.resolve({
-        ok: true,
-        text: "rows",
-        latencyMs: 1,
-        isError: false,
-        structured: {
-          bkn_receipt: {
-            operation_id: `op_${calls.length}`,
-            receipt_id: `rcp_${calls.length}`,
-            required: true,
-          },
-        },
-      });
+      if (name === "bkn_finish_interaction") {
+        const interactionId = String(args.interaction_id);
+        for (const [conversationId, inFlight] of active) {
+          if (inFlight === interactionId) active.set(conversationId, null);
+        }
+        return Promise.resolve(ok({ interaction_id: interactionId, execution_status: "completed" }));
+      }
+      return Promise.resolve({ ok: true, text: "rows", latencyMs: 1, isError: false });
     },
   };
   return { session, calls };
 }
 
-const options = () => ({ externalKeyStore: memoryExternalKeyStore() });
+const options = () => ({ conversationStore: memoryConversationStore() });
 
 describe("createBknLifecycle", () => {
   it("keeps one conversation across turns and only rotates it on reset", async () => {
@@ -85,66 +114,59 @@ describe("createBknLifecycle", () => {
     expect(first?.conversationId).toBe(second?.conversationId);
     expect(first?.interactionId).not.toBe(second?.interactionId);
 
+    await second?.complete("答二");
     lifecycle.reset();
     const third = await lifecycle.beginTurn("清空后再问");
     expect(third?.conversationId).not.toBe(first?.conversationId);
   });
 
-  it("gives every tool call a distinct operation_key under the same interaction", async () => {
+  it("asks for a conversation only on the first turn and reuses the assigned id", async () => {
+    const { session, calls } = fakeSession();
+    const store = memoryConversationStore();
+    const lifecycle = createBknLifecycleOn(session, { conversationStore: store, agentName: "bkn-studio · test" });
+
+    const first = await lifecycle.beginTurn("第一问");
+    await first!.complete("答一");
+    await lifecycle.beginTurn("第二问");
+
+    const starts = calls.filter((call) => call.name === "bkn_start_interaction");
+    // 首轮不带 conversation_id（新契约由 Core 分配），第二轮回传它拿回同一条会话。
+    expect(starts[0].args).not.toHaveProperty("conversation_id");
+    expect(starts[0].args.agent_name).toBe("bkn-studio · test");
+    expect(starts[1].args.conversation_id).toBe(first!.conversationId);
+    expect(store.read()).toBe(first!.conversationId);
+  });
+
+  it("shares one context across every tool call in a turn", async () => {
     const { session } = fakeSession();
     const lifecycle = createBknLifecycleOn(session, options());
     const turn = await lifecycle.beginTurn("问");
 
-    const first = turn!.nextContext("run_sql");
-    const second = turn!.nextContext("run_sql");
-
-    expect(first.conversation_id).toBe(second.conversation_id);
-    expect(first.interaction_id).toBe(second.interaction_id);
-    // operation_key 在交互内唯一，否则第二次调用会被 Core 当成第一次的重放。
-    expect(first.operation_key).not.toBe(second.operation_key);
-  });
-
-  it("lists every recorded operation and receipt in the closure manifest", async () => {
-    const { session, calls } = fakeSession();
-    const lifecycle = createBknLifecycleOn(session, options());
-    const turn = await lifecycle.beginTurn("问");
-
-    turn!.recordReceipt({ operationId: "op_a", receiptId: "rcp_a", required: true });
-    turn!.recordReceipt({ operationId: "op_b", receiptId: "rcp_b", required: true });
-    // 同一 operation 的重放回同一张回执，清单里不能重复计数。
-    turn!.recordReceipt({ operationId: "op_a", receiptId: "rcp_a", required: true });
-    await turn!.complete("答");
-
-    const terminal = calls.find((call) => call.name === "bkn_complete_interaction")!;
-    expect(terminal.args.expected_operations).toEqual([
-      { operation_id: "op_a", required: true },
-      { operation_id: "op_b", required: true },
-    ]);
-    expect(terminal.args.expected_receipts).toEqual([
-      { receipt_id: "rcp_a", required: true },
-      { receipt_id: "rcp_b", required: true },
-    ]);
-    expect(terminal.args).toMatchObject({
-      lease_token: "lease_1",
-      lease_epoch: 1,
-      completion_manifest_version: "1",
-      answer: "答",
+    // operation_key 已收回 facade 内部（后端按入参哈希自己算），前端只带这两个 id。
+    expect(turn!.context()).toEqual({
+      conversation_id: turn!.conversationId,
+      interaction_id: turn!.interactionId,
     });
-    // 带 pending 回执的成功交互要给收敛窗口，否则永远停在 assembling。
-    expect(terminal.args.assembler_deadline).toEqual(expect.any(String));
+    expect(turn!.context()).toEqual(turn!.context());
   });
 
-  it("omits answer and assembler_deadline on the non-success terminals", async () => {
+  it("sends the wire outcome spelling and only the fields the schema declares", async () => {
     const { session, calls } = fakeSession();
     const lifecycle = createBknLifecycleOn(session, options());
-    const turn = await lifecycle.beginTurn("问");
 
-    await turn!.cancel("stopped_by_user");
+    const completed = await lifecycle.beginTurn("问一");
+    await completed!.complete("答");
+    const canceled = await lifecycle.beginTurn("问二");
+    await canceled!.cancel("stopped_by_user");
 
-    // cancel / fail 的 schema 没有这两个字段，additionalProperties: false 会直接拒。
-    const terminal = calls.find((call) => call.name === "bkn_cancel_interaction")!;
-    expect(terminal.args).not.toHaveProperty("answer");
-    expect(terminal.args).not.toHaveProperty("assembler_deadline");
+    const [done, stopped] = calls.filter((call) => call.name === "bkn_finish_interaction");
+    expect(done.args).toEqual({ interaction_id: completed!.interactionId, outcome: "completed", answer: "答" });
+    // 入参枚举是 cancelled（双 l），出参才是 canceled；additionalProperties:false，answer 不能带。
+    expect(stopped.args).toEqual({
+      interaction_id: canceled!.interactionId,
+      outcome: "cancelled",
+      reason: "stopped_by_user",
+    });
   });
 
   it("terminates a turn only once", async () => {
@@ -158,18 +180,18 @@ describe("createBknLifecycle", () => {
 
     expect(calls.filter((call) => call.name.endsWith("_interaction")).map((call) => call.name)).toEqual([
       "bkn_start_interaction",
-      "bkn_cancel_interaction",
+      "bkn_finish_interaction",
     ]);
   });
 
   it("degrades to no managed context when the backend has no lifecycle tools", async () => {
     const { session, calls } = fakeSession({
-      bkn_create_conversation: () => ({
+      bkn_start_interaction: () => ({
         ok: true,
         text: "",
         latencyMs: 1,
         isError: false,
-        rpcError: { code: -32602, message: "tool not found: bkn_create_conversation" },
+        rpcError: { code: -32602, message: "tool not found: bkn_start_interaction" },
       }),
     });
     const lifecycle = createBknLifecycleOn(session, options());
@@ -179,21 +201,21 @@ describe("createBknLifecycle", () => {
 
     // 判定为不支持后不再重试握手，业务调用按旧行为直接发。
     await expect(lifecycle.beginTurn("再问")).resolves.toBeNull();
-    expect(calls.filter((call) => call.name === "bkn_create_conversation")).toHaveLength(1);
+    expect(calls.filter((call) => call.name === "bkn_start_interaction")).toHaveLength(1);
   });
 
   it("surfaces the stable lifecycle error code instead of a generic failure", async () => {
     const { session } = fakeSession({
       bkn_start_interaction: () => ({
         ok: true,
-        text: "conversation_not_found: conversation is unknown",
+        text: "quota_exhausted: interaction quota exhausted",
         latencyMs: 1,
         isError: true,
         structured: {
           error: {
-            code: "conversation_not_found",
-            message: "conversation is unknown",
-            required_action: "create_conversation",
+            code: "quota_exhausted",
+            message: "interaction quota exhausted",
+            required_action: "wait_and_retry",
           },
         },
       }),
@@ -201,31 +223,64 @@ describe("createBknLifecycle", () => {
     const lifecycle = createBknLifecycleOn(session, options());
 
     await expect(lifecycle.beginTurn("问")).rejects.toMatchObject({
-      code: "conversation_not_found",
-      requiredAction: "create_conversation",
+      code: "quota_exhausted",
+      requiredAction: "wait_and_retry",
     });
   });
 
-  it("tells the user how to escape a conversation stuck on an unterminated turn", async () => {
+  it("drops a stored conversation the backend no longer discloses and opens a fresh one", async () => {
+    const { session, calls } = fakeSession();
+    const store: ConversationStore = memoryConversationStore();
+    // 后端换库/换租户后，存下来的会话 id 已不在授权范围内。
+    store.write("conv_from_another_deploy");
+    const lifecycle = createBknLifecycleOn(session, { conversationStore: store });
+
+    const turn = await lifecycle.beginTurn("问");
+
+    expect(turn!.conversationId).toBe("conv_1");
+    expect(store.read()).toBe("conv_1");
+    const starts = calls.filter((call) => call.name === "bkn_start_interaction");
+    expect(starts.map((call) => call.args.conversation_id)).toEqual(["conv_from_another_deploy", undefined]);
+  });
+
+  it("reclaims a leaked interaction instead of leaving the conversation stuck", async () => {
+    const { session, calls } = fakeSession();
+    const store = memoryConversationStore();
+    // 上一次页面在 finish 之前被刷掉：会话里的那轮永远留在 active，只有租约能回收。
+    const leaked = createBknLifecycleOn(session, { conversationStore: store });
+    const abandoned = await leaked.beginTurn("被打断的一问");
+
+    const lifecycle = createBknLifecycleOn(session, { conversationStore: store });
+    const turn = await lifecycle.beginTurn("刷新后再问");
+
+    // 本地闸门是空的，所以在途那轮必定是泄漏的：替它收尾再开新的一轮。
+    const reclaim = calls.find(
+      (call) => call.name === "bkn_finish_interaction" && call.args.reason === "reclaimed_by_client",
+    );
+    expect(reclaim?.args).toMatchObject({ interaction_id: abandoned!.interactionId, outcome: "cancelled" });
+    expect(turn!.conversationId).toBe(abandoned!.conversationId);
+    expect(turn!.interactionId).not.toBe(abandoned!.interactionId);
+  });
+
+  it("tells the user how to escape when the stuck turn cannot be reclaimed", async () => {
     const { session } = fakeSession({
       bkn_start_interaction: () => ({
         ok: true,
         text: "interaction_in_progress: the conversation already has an active interaction",
         latencyMs: 1,
         isError: true,
+        // 没回带 current_interaction_id 就无从回收，只能把出路交给用户。
         structured: {
           error: {
             code: "interaction_in_progress",
             message: "the conversation already has an active interaction",
-            required_action: "complete_or_cancel_interaction",
+            required_action: "bkn_finish_interaction",
           },
         },
       }),
     });
     const lifecycle = createBknLifecycleOn(session, options());
 
-    // 补清单需要按 interaction 列 operation，受管接口不给——前端救不回来，
-    // 但清空对话能换一条新会话，别让用户对着原文干等租约回收。
     await expect(lifecycle.beginTurn("问")).rejects.toMatchObject({
       code: "interaction_in_progress",
       message: expect.stringContaining("清空") as unknown as string,
@@ -250,19 +305,25 @@ describe("createBknLifecycle", () => {
   });
 
   it("still lets the next turn start after a terminal call fails", async () => {
+    let terminals = 0;
     const { session } = fakeSession({
-      bkn_complete_interaction: () => ({
-        ok: false,
-        text: "closure manifest invalid",
-        latencyMs: 1,
-        isError: true,
-        structured: { error: { code: "closure_manifest_invalid", message: "closure manifest invalid" } },
-      }),
+      bkn_finish_interaction: () => {
+        terminals += 1;
+        // 只让第一次收尾失败；之后交还默认实现，好让回收那一步真的把在途交互清掉。
+        if (terminals > 1) return null;
+        return {
+          ok: false,
+          text: "terminal conflict",
+          latencyMs: 1,
+          isError: true,
+          structured: { error: { code: "terminal_conflict", message: "terminal conflict" } },
+        };
+      },
     });
     const lifecycle = createBknLifecycleOn(session, options());
 
     const first = await lifecycle.beginTurn("第一问");
-    await expect(first!.complete("答")).rejects.toMatchObject({ code: "closure_manifest_invalid" });
+    await expect(first!.complete("答")).rejects.toMatchObject({ code: "terminal_conflict" });
 
     // 收尾失败若不放行闸门，整条会话此后再也开不出交互。
     await expect(lifecycle.beginTurn("第二问")).resolves.not.toBeNull();
@@ -279,17 +340,20 @@ describe("withManagedTurn", () => {
     ).rejects.toThrow("boom");
 
     // 不终结的交互会一直挂在 active，直到 Core 租约回收，期间开不出下一轮。
-    expect(calls.map((call) => call.name)).toContain("bkn_fail_interaction");
+    expect(calls.find((call) => call.name === "bkn_finish_interaction")?.args).toMatchObject({
+      outcome: "failed",
+      reason: "agent_error",
+    });
   });
 
   it("does not let a failing terminal call mask the business result", async () => {
     const { session } = fakeSession({
-      bkn_complete_interaction: () => ({
+      bkn_finish_interaction: () => ({
         ok: false,
-        text: "closure manifest invalid",
+        text: "terminal conflict",
         latencyMs: 1,
         isError: true,
-        structured: { error: { code: "closure_manifest_invalid", message: "closure manifest invalid" } },
+        structured: { error: { code: "terminal_conflict", message: "terminal conflict" } },
       }),
     });
     const lifecycle = createBknLifecycleOn(session, options());

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -18,11 +18,7 @@ import {
 
 const searchSchema = CONTEXT_LOADER_OPS.find((operation) => operation.id === "search_schema")!;
 
-const bknContext = {
-  conversation_id: "conv_1",
-  interaction_id: "int_1",
-  operation_key: "search_schema#1",
-};
+const bknContext = { conversation_id: "conv_1", interaction_id: "int_1" };
 
 function restBody(init: RequestInit | undefined): Record<string, unknown> {
   if (typeof init?.body !== "string") {
@@ -126,70 +122,19 @@ describe("sendRequest", () => {
     });
   });
 
-  it("reports the managed receipt from REST headers and from the MCP structured result", async () => {
-    const restSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("{}", {
-        status: 200,
-        headers: { "bkn-receipt-id": "rcp_1", "bkn-operation-id": "op_1" },
-      }),
-    );
-    const rest = await sendRequest(
-      { base: "https://platform.example.com", token: "", knId: "kn-demo" },
-      searchSchema,
-      "rest",
-      {},
-      "{}",
-      undefined,
-      undefined,
-      bknContext,
-    );
-    expect(rest.receipt).toEqual({ operationId: "op_1", receiptId: "rcp_1", required: true });
-    restSpy.mockRestore();
-
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response("{}", { status: 200, headers: { "Mcp-Session-Id": "session-1" } }))
-      .mockResolvedValueOnce(new Response(null, { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response(
-          '{"jsonrpc":"2.0","result":{"content":[],"structuredContent":{"bkn_receipt":{"operation_id":"op_2","receipt_id":"rcp_2","required":true}}}}',
-          { status: 200 },
-        ),
-      );
-    const mcp = await sendRequest(
-      { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" },
-      searchSchema,
-      "mcp",
-      {},
-      "{}",
-      undefined,
-      undefined,
-      bknContext,
-    );
-    expect(mcp.receipt).toEqual({ operationId: "op_2", receiptId: "rcp_2", required: true });
-  });
 });
 
 describe("fetchKnDetail", () => {
-  it("takes its context from the turn and reports the receipt back to it", async () => {
+  it("takes its context from the turn", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response('{"id":"kn-demo","object_types":[],"concept_groups":[],"relation_types":[]}', {
-        status: 200,
-        headers: { "bkn-receipt-id": "rcp_3", "bkn-operation-id": "op_3" },
-      }),
+      new Response('{"id":"kn-demo","object_types":[],"concept_groups":[],"relation_types":[]}', { status: 200 }),
     );
-    const recordReceipt = vi.fn();
 
     await fetchKnDetail({ base: "https://platform.example.com", token: "", knId: "kn-demo" }, undefined, undefined, {
-      nextContext: (toolName) => ({ ...bknContext, operation_key: `${toolName}#1` }),
-      recordReceipt,
+      context: () => bknContext,
     });
 
-    expect(restBody(fetchSpy.mock.calls[0][1])).toMatchObject({
-      kn_id: "kn-demo",
-      bkn_context: { ...bknContext, operation_key: "get_kn_detail#1" },
-    });
-    // 回执要记回本轮，否则终结交互时清单缺一条，Core 判 closure_manifest_invalid。
-    expect(recordReceipt).toHaveBeenCalledWith({ operationId: "op_3", receiptId: "rcp_3", required: true });
+    expect(restBody(fetchSpy.mock.calls[0][1])).toMatchObject({ kn_id: "kn-demo", bkn_context: bknContext });
   });
 });
 

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -431,50 +431,24 @@ function mcpBase(env: ContextLoaderEnv): string {
 }
 
 /**
- * BKN Trace 3.0 受管调用上下文。Context Loader 对每次业务调用（REST `/kn/*` POST 与
- * 除 `bkn_*` 生命周期工具外的全部 MCP tools/call）都强制要求，缺任一字段直接 400，
- * 且下游调用次数为 0。三个 id 的来源见 bkn-lifecycle.service。
+ * BKN Trace 受管调用上下文。Context Loader 对每次业务调用（REST `/kn/*` POST 与
+ * 除 `bkn_*` 生命周期工具外的全部 MCP tools/call）都强制要求，缺任一字段直接返回
+ * `conversation_required`，且下游调用次数为 0。两个 id 的来源见 bkn-lifecycle.service。
  */
 export type BknContext = {
   conversation_id: string;
   interaction_id: string;
-  operation_key: string;
 };
 
 /**
- * 一次受管业务调用的回执引用。终结 Interaction 时必须把本轮**全部** operation 与 receipt
- * 一条不漏地列进 closure manifest（Core 按数量与归属校验，多一条少一条都报
- * `closure_manifest_invalid`），所以每次业务调用都要把它记下来。
- */
-export type BknReceiptRef = { operationId: string; receiptId: string; required: boolean };
-
-/** 从业务调用回执对象里取 operation/receipt 引用；形状不对返回 undefined。 */
-export function parseBknReceipt(value: unknown): BknReceiptRef | undefined {
-  if (!value || typeof value !== "object") return undefined;
-  const receipt = value as Record<string, unknown>;
-  const operationId = receipt.operation_id;
-  const receiptId = receipt.receipt_id;
-  if (typeof operationId !== "string" || !operationId) return undefined;
-  if (typeof receiptId !== "string" || !receiptId) return undefined;
-  // Context Loader 的受信适配器恒以 required=true 注册 Operation；缺字段时按它兜底，
-  // 因为 manifest 里的 required 必须与 Core 侧登记值一致，猜 false 会被直接判非法。
-  return { operationId, receiptId, required: receipt.required !== false };
-}
-
-/** 从 MCP 业务工具的 structuredContent 里取受管回执（正常执行是 bkn_receipt，重放/pending 是 receipt）。 */
-export function receiptFromStructured(structured: unknown): BknReceiptRef | undefined {
-  if (!structured || typeof structured !== "object") return undefined;
-  const envelope = structured as Record<string, unknown>;
-  return parseBknReceipt(envelope.bkn_receipt) ?? parseBknReceipt(envelope.receipt);
-}
-
-/**
- * 一次受管交互对业务调用暴露的最小接口：取上下文 + 回执记账。
+ * 一次受管交互对业务调用暴露的最小接口：取本轮上下文。
  * bkn-lifecycle 的 BknTurn 结构上满足它 —— 这里不反向 import，避免两个服务互相依赖。
+ *
+ * 老契约还要求把每次调用的回执记账、终结时列成 closure manifest；facade 收回去以后
+ * operation 的登记与收敛全由后端自理，前端只管把 conversation/interaction 带上。
  */
 export type BknCallScope = {
-  nextContext(toolName: string): BknContext;
-  recordReceipt(receipt: BknReceiptRef | undefined): void;
+  context(): BknContext;
 };
 
 /** 把受管上下文并进业务请求体/arguments（已有 bkn_context 不覆盖）。 */
@@ -569,25 +543,7 @@ export type ContextLoaderResponse = {
   latencyMs: number;
   sizeBytes: number;
   text: string;
-  /** 受管回执（REST 走响应头，MCP 走 structuredContent.bkn_receipt）；终结交互时要列全。 */
-  receipt?: BknReceiptRef;
 };
-
-/**
- * REST 业务响应里的受管回执：首次正常执行走响应头 `bkn-receipt-id` / `bkn-operation-id`
- * （业务响应体保持原形），终态重放或 pending 时改由响应体 `receipt` 字段带回。
- */
-function restReceiptRef(response: Response, text: string): BknReceiptRef | undefined {
-  const receiptId = response.headers.get("bkn-receipt-id");
-  const operationId = response.headers.get("bkn-operation-id");
-  if (receiptId && operationId) return { operationId, receiptId, required: true };
-  try {
-    const parsed = JSON.parse(text) as { receipt?: unknown };
-    return parseBknReceipt(parsed.receipt);
-  } catch {
-    return undefined;
-  }
-}
 
 /** 真实发送请求（REST 或 MCP），返回原始响应文本 + 元信息。 */
 export async function sendRequest(
@@ -663,7 +619,6 @@ export async function sendRequest(
         latencyMs: Math.round(performance.now() - start),
         sizeBytes: new Blob([text]).size,
         text,
-        receipt: receiptFromStructured(mcpStructuredContent(parseMcpEnvelope(text))),
       };
     }
     const url = buildRestUrl(env, op, queryValues);
@@ -681,7 +636,6 @@ export async function sendRequest(
       latencyMs: Math.round(performance.now() - start),
       sizeBytes: new Blob([text]).size,
       text,
-      receipt: restReceiptRef(response, text),
     };
   };
 
@@ -824,7 +778,7 @@ export function mcpResultText(parsed: unknown): string {
 
 /**
  * 从 MCP tools/call 信封取 `result.structuredContent`。
- * 业务工具的受管回执（`bkn_receipt`）与生命周期工具的返回体都只在这里，
+ * 生命周期工具的返回体（以及业务工具的受管回执 `bkn_receipt`）都只在这里，
  * 不在 content[].text —— mcpResultText 对生命周期工具只会拿到那句人读的提示语。
  */
 export function mcpStructuredContent(parsed: unknown): unknown {
@@ -1047,11 +1001,10 @@ export async function fetchKnDetail(
     env,
     auth,
     `${base}${REST_PREFIX}/kn/get_kn_detail?${params.toString()}`,
-    withBknContext({ kn_id: env.knId }, scope?.nextContext("get_kn_detail")),
+    withBknContext({ kn_id: env.knId }, scope?.context()),
     signal,
   );
   const text = await response.text();
-  scope?.recordReceipt(restReceiptRef(response, text));
   if (!response.ok) {
     throw new Error(text || `获取知识网络详情失败（${response.status}）`);
   }
@@ -1084,11 +1037,10 @@ export async function fetchObjectInstances(
     env,
     auth,
     `${base}${REST_PREFIX}/kn/query_object_instance?${params.toString()}`,
-    withBknContext({ limit, need_total: false, properties: [] }, scope?.nextContext("query_object_instance")),
+    withBknContext({ limit, need_total: false, properties: [] }, scope?.context()),
     signal,
   );
   const text = await response.text();
-  scope?.recordReceipt(restReceiptRef(response, text));
   if (!response.ok) {
     throw new Error(text || `查询实例失败（${response.status}）`);
   }


### PR DESCRIPTION
## 背景

Context Loader 对每次业务调用（REST `/kn/*` POST 与除 `bkn_*` 外的全部 MCP `tools/call`）强制要求 `bkn_context{conversation_id, interaction_id}`，缺了直接返回 `conversation_required`，下游调用次数为 0。这两个 id 不能前端自造，只能问 Core 要 —— 所以「立即体验」「数据浏览器」「Agent 对话」这三处都得先走一遍受管生命周期才能发业务请求。

本 PR 把这条链路接起来，并跟上 foundry #618「MCP 零配置接入」之后的新契约。

## 改了什么

新增 `services/bkn-lifecycle.service.ts`，把受管生命周期收成一个客户端：

- 会话（conversation）= 一条对话的身份，清空对话才换；交互（interaction）= 一轮问答，发送时开、出答案/停止/出错时终结。
- 一条 conversation 同时只允许一个 active interaction（Core 的 `uq_bkn_trace_interaction_active`），客户端内建串行闸门，用户手快连发或两张卡同时展开都会排队而不是撞唯一约束。
- `withManagedTurn` 给「数据浏览器加载」「调试台点一次发送」这类非对话调用用：开一轮、跑、无论成败都收尾。
- 后端没注册生命周期工具（老版本 Context Loader）时降级为不注入 `bkn_context`，按旧行为继续。

四个调用点接线：`ExperienceScene`（调试台）、`DataBrowserPanel`、`ChatPane`（Agent 对话，会话 id 落 localStorage，刷新复用、清空才换）、`AgentChat`（网络摘要预取）。

## 契约迁移（最后一个 commit）

线上契约在 #618 之后变了，而前端还按老的写 —— 打 `bkn_create_conversation` 拿到 `tool not found`，恰好命中「后端不支持生命周期」的降级判定，于是静默关掉受管上下文，之后每次业务调用都裸发被判 `conversation_required`。三处功能在新后端上全打不开，且没有任何报错指向真正原因。

按实测契约（`tools/list` + 逐项探测）改：

- 只剩 `bkn_start_interaction` / `bkn_finish_interaction`；conversation_id 由首轮分配后回传复用，`external_conversation_key` 幂等键下线，「刷新页面还是同一条对话」改成前端存 conversation_id。
- 租约与终结清单（`lease_token` / `expected_operations` / `expected_receipts` / `completion_manifest_version` / `assembler_deadline`）全部由 facade 内部兜，调用方不再传，随之删掉整条回执记账链路。
- `bkn_context` 去掉 `operation_key`（已从 schema 移除，后端按入参哈希自算）；两个 id 仍是必填。
- `outcome` 入参拼 `cancelled`（双 l），出参才是 `canceled`，在线上边界处映射。

## 两个顺带修的洞

- `interaction_in_progress` 从死路变自愈：Core 现在回带 `current_interaction_id`，本地闸门空着就说明那一轮是泄漏的（多半是刷新打断了 finish），替它收尾再重开；收不掉才提示清空对话。
- `bkn_*` 工具不再喂给模型，也不进工具勾选框 —— 模型自己调 `bkn_finish_interaction` 会把本轮当场关掉，后续调用全被判 `interaction_terminal`。按前缀过滤而非列名单，后端加工具时不用跟改。

## 验证

- `tsc -b` 与 `eslint.config.typechecked.js --max-warnings 0` 干净；全量 624 个用例通过。
- 真机（VM 后端，走 dev proxy）跑通三条路径：受管一轮 + `get_kn_detail`、泄漏交互回收、陈旧 conversation 丢弃。

## 已知取舍

ChatPane 的 conversation_id 存在 localStorage（键为 `conv2`，老值不会被误读）。同一个 kn + 面板开两个标签页会共用它，后开的那个可能把前一个正在跑的交互当泄漏收掉。取舍是「刷新页面能自愈」优先于「多标签页并发」；要反过来的话，把回收条件收紧成「只回收本客户端开过的 interaction」即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)