### PR TITLE
fix(knowledge-network): align managed lifecycle tools

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
@@ -35,7 +35,7 @@ import {
 import {
   createBknLifecycle,
   lifecycleEnv,
-  memoryExternalKeyStore,
+  memoryConversationStore,
   withManagedTurn,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import { recommendationFingerprint } from "@/modules/knowledge-network/utils/agent-chat-cache";
@@ -378,8 +378,7 @@ export function AgentChat({
   const summaryLifecycle = useMemo(
     () =>
       createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
-        externalKeyStore: memoryExternalKeyStore(),
-        oneShot: true,
+        conversationStore: memoryConversationStore(),
       }),
     [env.base, knId, tokenProvider],
   );

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
@@ -58,12 +58,10 @@ function stubLifecycle() {
   const turn: BknTurn = {
     conversationId: "conv_1",
     interactionId: "int_1",
-    nextContext: (toolName) => ({
+    nextContext: () => ({
       conversation_id: "conv_1",
       interaction_id: "int_1",
-      operation_key: `${toolName}#1`,
     }),
-    recordReceipt: vi.fn(),
     complete: vi.fn<BknTurn["complete"]>().mockResolvedValue(undefined),
     fail: vi.fn<BknTurn["fail"]>().mockResolvedValue(undefined),
     cancel: vi.fn<BknTurn["cancel"]>().mockResolvedValue(undefined),

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -52,7 +52,7 @@ import {
 import {
   createBknLifecycle,
   lifecycleEnv,
-  localExternalKeyStore,
+  localConversationStore,
   type TurnOutcome,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import {
@@ -190,7 +190,7 @@ function msgsLsKey(knId: string, paneKey: PaneKey): string {
  * 在各自答题，Trace 里也应当分别溯源、分别统计，不该混进同一条会话。
  */
 function conversationLsKey(knId: string, paneKey: PaneKey): string {
-  return `bkn-studio:agentchat:conv:${knId}:${paneKey}`;
+  return `bkn-studio:agentchat:conv:v2:${knId}:${paneKey}`;
 }
 
 function loadPersisted(key: string): Partial<Persisted> {
@@ -605,7 +605,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
   const lifecycle = useMemo(
     () =>
       createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
-        externalKeyStore: localExternalKeyStore(conversationLsKey(knId, profile.paneKey)),
+        conversationStore: localConversationStore(conversationLsKey(knId, profile.paneKey)),
       }),
     [env.base, knId, tokenProvider, profile.paneKey],
   );

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -193,6 +193,10 @@ function conversationLsKey(knId: string, paneKey: PaneKey): string {
   return `bkn-studio:agentchat:conv:v2:${knId}:${paneKey}`;
 }
 
+function legacyConversationLsKey(knId: string, paneKey: PaneKey): string {
+  return `bkn-studio:agentchat:conv:${knId}:${paneKey}`;
+}
+
 function loadPersisted(key: string): Partial<Persisted> {
   try {
     const raw = localStorage.getItem(key);
@@ -600,12 +604,15 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
 
   /**
    * 本面板的受管生命周期客户端。会话身份跟着 kn + 面板走，只有「清空对话」才换新
-   * ——刷新页面按 external_conversation_key 幂等复用同一条 conversation。
+   * ——刷新页面复用服务端下发的 conversation ID。
    */
   const lifecycle = useMemo(
     () =>
       createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
-        conversationStore: localConversationStore(conversationLsKey(knId, profile.paneKey)),
+        conversationStore: localConversationStore(
+          conversationLsKey(knId, profile.paneKey),
+          legacyConversationLsKey(knId, profile.paneKey),
+        ),
       }),
     [env.base, knId, tokenProvider, profile.paneKey],
   );
@@ -746,7 +753,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
     setMessages([]);
     setStats({ tokens: 0, ms: 0 });
     // 清空对话 = 换一条受管会话。这是 conversation id 唯一的更换点：不清空就一直是同一个，
-    // 刷新页面也会按同一把 external_conversation_key 幂等复用回来。
+    // 刷新页面会继续使用已保存的服务端 conversation ID。
     lifecycle.reset();
     try {
       localStorage.removeItem(msgsLsKey(knId, profile.paneKey));

--- a/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.test.ts
+++ b/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  businessInfoOf,
+  compareToolsInBusinessGroup,
+} from "@/modules/knowledge-network/scenes/context-loader-tool-business-info";
+import type { ContextLoaderOp } from "@/modules/knowledge-network/services/context-loader.service";
+
+function op(id: string, summary = id): ContextLoaderOp {
+  return { id, group: "test", summary, path: "/test", query: [], body: {} };
+}
+
+describe("businessInfoOf", () => {
+  it("assigns lifecycle tools distinct Chinese business names", () => {
+    expect(businessInfoOf(op("bkn_start_interaction"))).toEqual({ groupKey: "lifecycle", name: "开始交互" });
+    expect(businessInfoOf(op("bkn_finish_interaction"))).toEqual({ groupKey: "lifecycle", name: "结束交互" });
+    expect(businessInfoOf(op("bkn_get_operation"))).toEqual({ groupKey: "lifecycle", name: "查看操作状态" });
+    expect(businessInfoOf(op("list_action_execution"))).toEqual({ groupKey: "logic", name: "行动执行记录" });
+    expect(businessInfoOf(op("query_metric"))).toEqual({ groupKey: "logic", name: "指标数据查询" });
+  });
+
+  it("keeps an unknown lifecycle tool in the lifecycle group", () => {
+    expect(businessInfoOf(op("bkn_archive_interaction", "Archive an interaction"))).toEqual({
+      groupKey: "lifecycle",
+      name: "Archive an interaction",
+    });
+  });
+
+  it("does not classify bkn names as knowledge-network tools", () => {
+    expect(businessInfoOf(op("bkn_unknown"))).not.toMatchObject({ groupKey: "network" });
+    expect(businessInfoOf(op("search_schema"))).toEqual({ groupKey: "model", name: "语义检索" });
+  });
+
+  it("orders lifecycle tools from start to finish", () => {
+    const tools = [op("bkn_finish_interaction"), op("bkn_start_interaction")];
+    expect(tools.sort((left, right) => compareToolsInBusinessGroup("lifecycle", left, right)).map((tool) => tool.id)).toEqual([
+      "bkn_start_interaction",
+      "bkn_finish_interaction",
+    ]);
+  });
+});

--- a/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.test.ts
+++ b/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.test.ts
@@ -26,10 +26,10 @@ describe("businessInfoOf", () => {
     expect(businessInfoOf(op("query_metric"))).toEqual({ groupKey: "logic", name: "指标数据查询" });
   });
 
-  it("keeps an unknown lifecycle tool in the lifecycle group", () => {
+  it("keeps an unknown lifecycle tool in the lifecycle group with a compact fallback name", () => {
     expect(businessInfoOf(op("bkn_archive_interaction", "Archive an interaction"))).toEqual({
       groupKey: "lifecycle",
-      name: "Archive an interaction",
+      name: "交互生命周期工具",
     });
   });
 

--- a/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.tsx
+++ b/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.tsx
@@ -20,22 +20,23 @@ import {
   type McpToolDef,
 } from "@/modules/knowledge-network/services/context-loader.service";
 import { createClaudeCodeMcpCommand, createMcpRemoteJsonConfig, withMcpTrailingSlash } from "@/modules/knowledge-network/services/mcp-client-config";
+import {
+  businessInfoOf,
+  compareToolsInBusinessGroup,
+  type ToolBusinessGroupKey,
+} from "@/modules/knowledge-network/scenes/context-loader-tool-business-info";
 
 import styles from "./ExperienceScene.module.css";
 
 export type ResponseView = { kind: "json" | "toon"; text: string };
 
-type ToolBusinessInfo = {
-  groupKey: "model" | "query" | "data" | "logic" | "skill" | "network" | "other";
-  name: string;
-};
-
 const TOOL_GROUPS: Array<{
-  key: ToolBusinessInfo["groupKey"];
+  key: ToolBusinessGroupKey;
   label: string;
   description: string;
 }> = [
   { key: "network", label: "知识网络信息", description: "知识网络列表、当前网络详情" },
+  { key: "lifecycle", label: "交互生命周期", description: "受管会话、交互和操作状态" },
   { key: "model", label: "知识网络模型检索", description: "语义检索、对象类、关系类、行动类、指标定义查询" },
   { key: "query", label: "对象实例与关系子图查询", description: "对象实例查询、关系子图查询" },
   { key: "data", label: "数据资源与 SQL 查询", description: "数据资源列表、字段结构、SQL 数据查询" },
@@ -43,64 +44,6 @@ const TOOL_GROUPS: Array<{
   { key: "skill", label: "技能与动态工具", description: "Skill 检索和线上动态工具" },
   { key: "other", label: "其他能力", description: "暂未归类的 MCP 能力" },
 ];
-
-const TOOL_BUSINESS_NAMES: Record<string, ToolBusinessInfo> = {
-  search_schema: { groupKey: "model", name: "语义检索" },
-  get_object_types: { groupKey: "model", name: "对象类定义查询" },
-  get_relation_types: { groupKey: "model", name: "关系类定义查询" },
-  get_action_types: { groupKey: "model", name: "行动类定义查询" },
-  get_metric_types: { groupKey: "model", name: "指标定义查询" },
-  query_object_instance: { groupKey: "query", name: "对象实例查询" },
-  query_instance_subgraph: { groupKey: "query", name: "关系子图查询" },
-  list_resources: { groupKey: "data", name: "数据资源列表" },
-  describe_resource: { groupKey: "data", name: "资源字段结构" },
-  run_sql: { groupKey: "data", name: "SQL 数据查询" },
-  get_logic_properties_values: { groupKey: "logic", name: "逻辑属性计算" },
-  get_action_info: { groupKey: "logic", name: "行动工具召回" },
-  execute_action: { groupKey: "logic", name: "执行行动" },
-  get_action_execution: { groupKey: "logic", name: "行动执行结果" },
-  find_skills: { groupKey: "skill", name: "Skill 能力检索" },
-  list_knowledge_networks: { groupKey: "network", name: "知识网络列表" },
-  get_kn_detail: { groupKey: "network", name: "知识网络详情" },
-};
-
-const MODEL_TOOL_ORDER = ["search_schema", "get_object_types", "get_relation_types"];
-const QUERY_TOOL_ORDER = ["query_object_instance", "query_instance_subgraph"];
-
-function compareToolsInGroup(groupKey: ToolBusinessInfo["groupKey"], left: ContextLoaderOp, right: ContextLoaderOp): number {
-  const toolOrder = groupKey === "model" ? MODEL_TOOL_ORDER : groupKey === "query" ? QUERY_TOOL_ORDER : null;
-  if (!toolOrder) {
-    return 0;
-  }
-  const leftIndex = toolOrder.indexOf(left.id);
-  const rightIndex = toolOrder.indexOf(right.id);
-  return (leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex) - (rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex);
-}
-
-function businessInfoOf(op: ContextLoaderOp): ToolBusinessInfo {
-  const exact = TOOL_BUSINESS_NAMES[op.id];
-  if (exact) return exact;
-  const id = op.id.toLowerCase();
-  if (id.includes("object") || id.includes("relation") || id.includes("schema") || id.includes("metric_type")) {
-    return { groupKey: "model", name: "知识模型工具" };
-  }
-  if (id.includes("resource") || id.includes("sql") || id.includes("catalog")) {
-    return { groupKey: "data", name: "数据资源工具" };
-  }
-  if (id.includes("skill")) {
-    return { groupKey: "skill", name: "技能与动态工具" };
-  }
-  if (id.includes("action") || id.includes("logic") || id.includes("metric")) {
-    return { groupKey: "logic", name: "逻辑与行动工具" };
-  }
-  if (id.includes("instance") || id.includes("subgraph") || id.includes("query")) {
-    return { groupKey: "query", name: "对象查询工具" };
-  }
-  if (id.includes("kn") || id.includes("network")) {
-    return { groupKey: "network", name: "知识网络工具" };
-  }
-  return { groupKey: "other", name: "MCP 能力" };
-}
 
 type ContextLoaderIntegrationPanelProps = {
   mode: Exclude<ContextLoaderMode, "agent">;
@@ -330,7 +273,7 @@ export function ContextLoaderIntegrationPanel({
         const searchable = `${info.name} ${item.id} ${item.path} ${item.summary} ${group.label}`.toLowerCase();
         return info.groupKey === group.key && (!filterText || searchable.includes(filterText));
       })
-      .sort((left, right) => compareToolsInGroup(group.key, left, right)),
+      .sort((left, right) => compareToolsInBusinessGroup(group.key, left, right)),
   })).filter(({ items }) => items.length > 0);
 
   const isMcpVerifyView = mode === "mcp" && !showMcpConnect;

--- a/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
+++ b/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
@@ -12,7 +12,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   createBknLifecycle,
   lifecycleEnv,
-  memoryExternalKeyStore,
+  memoryConversationStore,
   withManagedTurn,
   type BknLifecycle,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
@@ -291,7 +291,7 @@ export function DataBrowserPanel({
    * 不带 bkn_context 会被 Context Loader 挡回。这里不是对话，会话按本次挂载算一条。
    */
   const lifecycle = useMemo(
-    () => createBknLifecycle(lifecycleEnv(env.base, env.knId), auth, { externalKeyStore: memoryExternalKeyStore() }),
+    () => createBknLifecycle(lifecycleEnv(env.base, env.knId), auth, { conversationStore: memoryConversationStore() }),
     [env.base, env.knId, auth],
   );
 

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -51,7 +51,7 @@ import {
 import {
   createBknLifecycle,
   lifecycleEnv,
-  memoryExternalKeyStore,
+  memoryConversationStore,
   withManagedTurn,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import { AgentChat } from "@/modules/knowledge-network/components/agent-chat/AgentChat";
@@ -385,7 +385,7 @@ export function ExperienceScene({
    * 会话本身按本次进入调试台算一条，刷新即换新（memory 键），不写 localStorage。
    */
   const lifecycle = useMemo(
-    () => createBknLifecycle(lifecycleEnv(base, knId), tokenProvider, { externalKeyStore: memoryExternalKeyStore() }),
+    () => createBknLifecycle(lifecycleEnv(base, knId), tokenProvider, { conversationStore: memoryConversationStore() }),
     [base, knId, tokenProvider],
   );
 
@@ -495,9 +495,8 @@ export function ExperienceScene({
     () =>
       op
         ? buildCurl({ ...env, base: serverAddress }, op, mode, queryVals, bodyText, {
-            conversation_id: "<bkn_create_conversation 返回的 conversation_id>",
+            conversation_id: "<bkn_start_interaction 返回的 conversation_id>",
             interaction_id: "<bkn_start_interaction 返回的 interaction_id>",
-            operation_key: `${op.id}#1`,
           })
         : "",
     [env, serverAddress, op, mode, queryVals, bodyText],
@@ -551,9 +550,8 @@ export function ExperienceScene({
             bodyText,
             tokenProvider,
             controller.signal,
-            turn?.nextContext(op.id),
+            turn?.nextContext(),
           );
-          turn?.recordReceipt(sent.receipt);
           return sent;
         },
         // 业务返回 500 时这一轮仍算 completed —— 调用失败记在 Operation 的 Receipt 上

--- a/src/modules/knowledge-network/scenes/context-loader-tool-business-info.ts
+++ b/src/modules/knowledge-network/scenes/context-loader-tool-business-info.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ContextLoaderOp } from "@/modules/knowledge-network/services/context-loader.service";
+
+export type ToolBusinessGroupKey = "model" | "query" | "data" | "logic" | "skill" | "network" | "lifecycle" | "other";
+
+export type ToolBusinessInfo = {
+  groupKey: ToolBusinessGroupKey;
+  name: string;
+};
+
+const TOOL_BUSINESS_NAMES: Record<string, ToolBusinessInfo> = {
+  search_schema: { groupKey: "model", name: "语义检索" },
+  get_object_types: { groupKey: "model", name: "对象类定义查询" },
+  get_relation_types: { groupKey: "model", name: "关系类定义查询" },
+  get_action_types: { groupKey: "model", name: "行动类定义查询" },
+  get_metric_types: { groupKey: "model", name: "指标定义查询" },
+  query_object_instance: { groupKey: "query", name: "对象实例查询" },
+  query_instance_subgraph: { groupKey: "query", name: "关系子图查询" },
+  list_resources: { groupKey: "data", name: "数据资源列表" },
+  describe_resource: { groupKey: "data", name: "资源字段结构" },
+  run_sql: { groupKey: "data", name: "SQL 数据查询" },
+  get_logic_properties_values: { groupKey: "logic", name: "逻辑属性计算" },
+  get_action_info: { groupKey: "logic", name: "行动工具召回" },
+  execute_action: { groupKey: "logic", name: "执行行动" },
+  get_action_execution: { groupKey: "logic", name: "行动执行结果" },
+  list_action_execution: { groupKey: "logic", name: "行动执行记录" },
+  list_action_executions: { groupKey: "logic", name: "行动执行记录" },
+  query_metric: { groupKey: "logic", name: "指标数据查询" },
+  find_skills: { groupKey: "skill", name: "Skill 能力检索" },
+  list_knowledge_networks: { groupKey: "network", name: "知识网络列表" },
+  get_kn_detail: { groupKey: "network", name: "知识网络详情" },
+  bkn_create_conversation: { groupKey: "lifecycle", name: "创建会话" },
+  bkn_resume_conversation: { groupKey: "lifecycle", name: "恢复会话" },
+  bkn_close_conversation: { groupKey: "lifecycle", name: "关闭会话" },
+  bkn_start_interaction: { groupKey: "lifecycle", name: "开始交互" },
+  bkn_finish_interaction: { groupKey: "lifecycle", name: "结束交互" },
+  bkn_complete_interaction: { groupKey: "lifecycle", name: "完成交互" },
+  bkn_fail_interaction: { groupKey: "lifecycle", name: "标记交互失败" },
+  bkn_cancel_interaction: { groupKey: "lifecycle", name: "取消交互" },
+  bkn_handoff_interaction: { groupKey: "lifecycle", name: "移交交互" },
+  bkn_get_operation: { groupKey: "lifecycle", name: "查看操作状态" },
+  bkn_retry_operation: { groupKey: "lifecycle", name: "重试操作" },
+  bkn_get_receipt: { groupKey: "lifecycle", name: "查看调用回执" },
+};
+
+const MODEL_TOOL_ORDER = ["search_schema", "get_object_types", "get_relation_types"];
+const QUERY_TOOL_ORDER = ["query_object_instance", "query_instance_subgraph"];
+const LIFECYCLE_TOOL_ORDER = ["bkn_start_interaction", "bkn_finish_interaction"];
+
+export function compareToolsInBusinessGroup(groupKey: ToolBusinessGroupKey, left: ContextLoaderOp, right: ContextLoaderOp): number {
+  const toolOrder =
+    groupKey === "model"
+      ? MODEL_TOOL_ORDER
+      : groupKey === "query"
+        ? QUERY_TOOL_ORDER
+        : groupKey === "lifecycle"
+          ? LIFECYCLE_TOOL_ORDER
+          : null;
+  if (!toolOrder) return 0;
+  const leftIndex = toolOrder.indexOf(left.id);
+  const rightIndex = toolOrder.indexOf(right.id);
+  return (leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex) - (rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex);
+}
+
+export function businessInfoOf(op: ContextLoaderOp): ToolBusinessInfo {
+  const exact = TOOL_BUSINESS_NAMES[op.id];
+  if (exact) return exact;
+  const id = op.id.toLowerCase();
+  if (id.startsWith("bkn_")) {
+    return { groupKey: "lifecycle", name: op.summary === op.id ? op.id.replace(/^bkn_/, "") : op.summary };
+  }
+  if (id.includes("object") || id.includes("relation") || id.includes("schema") || id.includes("metric_type")) {
+    return { groupKey: "model", name: "知识模型工具" };
+  }
+  if (id.includes("resource") || id.includes("sql") || id.includes("catalog")) {
+    return { groupKey: "data", name: "数据资源工具" };
+  }
+  if (id.includes("skill")) return { groupKey: "skill", name: "技能与动态工具" };
+  if (id.includes("action") || id.includes("logic") || id.includes("metric")) {
+    return { groupKey: "logic", name: "逻辑与行动工具" };
+  }
+  if (id.includes("instance") || id.includes("subgraph") || id.includes("query")) {
+    return { groupKey: "query", name: "对象查询工具" };
+  }
+  if (id.includes("kn_") || id.includes("network")) return { groupKey: "network", name: "知识网络工具" };
+  return { groupKey: "other", name: "MCP 能力" };
+}

--- a/src/modules/knowledge-network/scenes/context-loader-tool-business-info.ts
+++ b/src/modules/knowledge-network/scenes/context-loader-tool-business-info.ts
@@ -73,7 +73,7 @@ export function businessInfoOf(op: ContextLoaderOp): ToolBusinessInfo {
   if (exact) return exact;
   const id = op.id.toLowerCase();
   if (id.startsWith("bkn_")) {
-    return { groupKey: "lifecycle", name: op.summary === op.id ? op.id.replace(/^bkn_/, "") : op.summary };
+    return { groupKey: "lifecycle", name: "交互生命周期工具" };
   }
   if (id.includes("object") || id.includes("relation") || id.includes("schema") || id.includes("metric_type")) {
     return { groupKey: "model", name: "知识模型工具" };
@@ -88,6 +88,6 @@ export function businessInfoOf(op: ContextLoaderOp): ToolBusinessInfo {
   if (id.includes("instance") || id.includes("subgraph") || id.includes("query")) {
     return { groupKey: "query", name: "对象查询工具" };
   }
-  if (id.includes("kn_") || id.includes("network")) return { groupKey: "network", name: "知识网络工具" };
+  if (id.includes("kn") || id.includes("network")) return { groupKey: "network", name: "知识网络工具" };
   return { groupKey: "other", name: "MCP 能力" };
 }

--- a/src/modules/knowledge-network/services/agent-chat-tools.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat-tools.test.ts
@@ -68,12 +68,10 @@ describe("buildAgentTools", () => {
   it("injects the turn context and locked kn_id into the real call", async () => {
     const session = stubSession();
     const turn: BknCallScope = {
-      nextContext: (toolName) => ({
+      nextContext: () => ({
         conversation_id: "conv_1",
         interaction_id: "int_1",
-        operation_key: `${toolName}#1`,
       }),
-      recordReceipt: vi.fn(),
     };
     const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
       session,
@@ -88,28 +86,9 @@ describe("buildAgentTools", () => {
         sql: "SELECT 1",
         // kn_id 与 bkn_context 都是平台侧身份，模型传什么都以锁定值为准。
         kn_id: "kn-demo",
-        bkn_context: { conversation_id: "conv_1", interaction_id: "int_1", operation_key: "run_sql#1" },
+        bkn_context: { conversation_id: "conv_1", interaction_id: "int_1" },
       }),
     );
-  });
-
-  it("records the managed receipt of every business call", async () => {
-    const session = stubSession({
-      structured: { bkn_receipt: { operation_id: "op_1", receipt_id: "rcp_1", required: true } },
-    });
-    const recordReceipt = vi.fn();
-    const turn: BknCallScope = {
-      nextContext: () => ({ conversation_id: "conv_1", interaction_id: "int_1", operation_key: "run_sql#1" }),
-      recordReceipt,
-    };
-    const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
-      session,
-      turn,
-    });
-
-    await runTool(tools.run_sql, { sql: "SELECT 1" });
-
-    expect(recordReceipt).toHaveBeenCalledWith({ operationId: "op_1", receiptId: "rcp_1", required: true });
   });
 
   it("sends no managed context when the backend has no lifecycle", async () => {

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -19,7 +19,6 @@ import { jsonSchema, stepCountIs, streamText, tool, type ModelMessage, type Tool
 
 import {
   createMcpSession,
-  receiptFromStructured,
   type BknCallScope,
   type BknContext,
   type ContextLoaderEnv,
@@ -218,7 +217,6 @@ export function buildAgentTools(
   const call = async (name: string, args: Record<string, unknown>): Promise<string> => {
     const res = await session.callTool(name, args);
     // 每次业务调用的回执都要记账：终结本轮交互时清单必须列全，漏一条 Core 就判非法。
-    turn?.recordReceipt(receiptFromStructured(res.structured));
     return res.text;
   };
   for (const def of mcpTools) {
@@ -235,7 +233,7 @@ export function buildAgentTools(
         (scopedList ? " 返回结果已默认限定为当前知识网络绑定的数据表（其他 catalog 的表不会出现）。" : ""),
       inputSchema: jsonSchema(schema),
       execute: async (input: unknown): Promise<string> => {
-        const bknContext = turn?.nextContext(def.name);
+        const bknContext = turn?.nextContext();
         if (scopedList && scopeSet) return listResourcesScoped(call, input, knId, scopeSet, cfg, bknContext);
         const args = effectiveToolArgs(def.name, input, knId, bknContext);
         return capToolResult(await call(def.name, args), def.name, cfg);

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -194,7 +194,7 @@ export type AgentToolsOptions = {
   /** 复用生命周期客户端的 MCP 会话，省一次 initialize 握手。 */
   session?: McpSession;
   /**
-   * 本轮受管交互。工具循环只需要「取上下文 + 回执记账」这两件事，故取最小接口
+   * 本轮受管交互。工具循环只需要取得上下文，故取最小接口
    * BknCallScope 而非整个 BknTurn —— 终结交互不归工具循环管。
    * 缺省/null 时不注入 bkn_context：只有后端未启用受管生命周期时才该这样，
    * 启用了却不传会让每个工具调用都被挡在 `conversation_required`。
@@ -216,7 +216,6 @@ export function buildAgentTools(
   const tools: ToolSet = {};
   const call = async (name: string, args: Record<string, unknown>): Promise<string> => {
     const res = await session.callTool(name, args);
-    // 每次业务调用的回执都要记账：终结本轮交互时清单必须列全，漏一条 Core 就判非法。
     return res.text;
   };
   for (const def of mcpTools) {

--- a/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
@@ -5,180 +5,92 @@
  * Conditions. See LICENSE for the full text.
  */
 
-/**
- * BKN Trace 3.0 受管生命周期客户端 —— Context Loader 调用的前置协议边界。
- *
- * 契约见 bkn-foundry `adp/context-loader/agent-retrieval/TRACE.md`：REST `/kn/*` POST 与
- * 除 `bkn_*` 外的全部 MCP `tools/call` 都必须携带 `bkn_context`（conversation_id +
- * interaction_id + operation_key），缺任一字段返回稳定错误码且下游调用次数为 0。
- * 三个 id 都不能前端自造，必须问 Core 要：
- *
- *   会话（conversation）—— 一条对话的身份，清空对话才换；页面刷新按 external_conversation_key 幂等复用。
- *   交互（interaction）—— 一轮问答，发送时开、出答案/停止/出错时终结。
- *   操作（operation）—— 一轮里的每次工具调用，由 operation_key 在交互内去重。
- *
- * 生命周期只由 MCP 工具暴露（agent-retrieval 没有对应 REST 路由），所以 REST 调试台也要
- * 先走一遍 MCP 才能拿到上下文。
- */
-
 import {
   createMcpSession,
   type BknContext,
-  type BknReceiptRef,
   type ContextLoaderEnv,
   type McpAuth,
   type McpSession,
 } from "@/modules/knowledge-network/services/context-loader.service";
 
-/** 终结清单版本，与 Core `completion_manifest_version` 对应。 */
-const MANIFEST_VERSION = "1";
-
-/**
- * 交互租约时长。终结时租约必须还没过期，否则 Core 判 `terminal_conflict`；
- * 一轮 Agent 对话可以跑满 40 步工具，按分钟级留足。
- */
-const DEFAULT_LEASE_SECONDS = 1800;
-
-/**
- * 成功终结时给证据组装留的收敛窗口。Context Loader 目前只能把 Receipt 完成为
- * `evidence_durability=pending`（3.0 Evidence Producer 未落地），而带 pending 回执的
- * 成功交互必须在清单里给出 assembler_deadline，否则永远停在 assembling ——
- * 现在没有 assembler 在跑，看不出差别，但 #544 上线后有它才会自动收敛。
- */
-const ASSEMBLER_DEADLINE_MS = 5 * 60 * 1000;
-
-/** 一轮交互的收尾原因（Core 只存字符串，不校验枚举）。 */
 export type TurnOutcome = "completed" | "failed" | "canceled";
 
 export type BknTurn = {
   conversationId: string;
   interactionId: string;
-  /** 取下一次业务调用的受管上下文；operation_key 在本轮内唯一。 */
-  nextContext(toolName: string): BknContext;
-  /** 记下一次业务调用的回执；终结时要把本轮全部 operation/receipt 列进清单。 */
-  recordReceipt(receipt: BknReceiptRef | undefined): void;
-  /** 正常收尾（answer 为本轮最终答复，Core 会存为 interaction artifact）。 */
+  nextContext(): BknContext;
   complete(answer: string): Promise<void>;
-  /** 执行失败收尾。 */
   fail(reason: string): Promise<void>;
-  /** 用户中途停止收尾。 */
   cancel(reason: string): Promise<void>;
-  /** 按结果分派到 complete / fail / cancel。 */
   finish(outcome: TurnOutcome, answer: string): Promise<void>;
 };
 
 export type BknLifecycle = {
-  /** 与业务调用共用的 MCP 会话（复用同一个 Mcp-Session-Id，少一次握手）。 */
   session: McpSession;
-  /** 当前会话 id；还没建立时为 null。 */
   conversationId(): string | null;
-  /** 后端不支持受管生命周期（老版本 Context Loader）时为 true，此时不注入 bkn_context。 */
   unsupported(): boolean;
-  /**
-   * 开一轮交互。后端不支持时返回 null，调用方按旧行为继续。
-   * 同一条会话同时只允许一个 active interaction（Core 的
-   * `uq_bkn_trace_interaction_active` 唯一约束），因此并发调用会自动排队，
-   * 等上一轮终结后才真正开新的一轮。
-   */
   beginTurn(question: string): Promise<BknTurn | null>;
-  /** 丢弃当前会话（清空对话）：下一轮会建一条全新 conversation。 */
   reset(): void;
 };
 
-export type BknLifecycleOptions = {
-  /**
-   * 会话身份键。同一个键 `bkn_create_conversation` 幂等复用同一条 conversation，
-   * 所以它决定了「什么时候还算同一条对话」：刷新页面复用，清空对话换新。
-   */
-  externalKeyStore: ExternalKeyStore;
-  /** 单轮即弃的场景（如调试台一次点击）传 true，交给 Core 按 one-shot 语义收敛。 */
-  oneShot?: boolean;
-  leaseSeconds?: number;
+/** Persist only the server-issued conversation ID, never a client-created identity. */
+export type ConversationStore = {
+  read(): string | null;
+  write(conversationId: string): void;
+  clear(): void;
 };
 
-/** 会话身份键的读写。localStorage 实现见 localExternalKeyStore。 */
-export type ExternalKeyStore = {
-  read(): string;
-  /** 换一把新键（清空对话）。 */
-  rotate(): void;
-};
+export type BknLifecycleOptions = { conversationStore: ConversationStore };
 
-/**
- * 生命周期客户端的稳定身份：只认 base + kn。
- *
- * `env.token` 仅是 auth provider 缺席时的兜底——MCP 会话每次请求都用
- * `auth.getToken()` 现取，所以 OAuth 续期换掉 env 的对象身份时**不该**重建客户端：
- * 重建会丢掉串行闸门，让并发的两轮同时开交互，撞上「一条会话只能有一个 active
- * interaction」；顺带还会多打一次 initialize 握手。调用方用它把 useMemo 的依赖
- * 收敛到真正稳定的标识上。
- */
 export function lifecycleEnv(base: string, knId: string): ContextLoaderEnv {
   return { base, token: "", knId };
 }
 
-/** 随机 id：优先 crypto.randomUUID，测试环境/老浏览器兜底。 */
-export function randomLifecycleId(): string {
-  const cryptoRef: Crypto | undefined = typeof crypto === "undefined" ? undefined : crypto;
-  if (cryptoRef?.randomUUID) return cryptoRef.randomUUID();
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
-}
-
-/**
- * localStorage 版会话身份键。键值只在 rotate（清空对话）时更换，
- * 因此刷新页面仍会命中同一条 conversation —— 这正是「不清空就一直同一个 id」。
- */
-export function localExternalKeyStore(storageKey: string): ExternalKeyStore {
-  let cached: string | null = null;
+export function localConversationStore(storageKey: string): ConversationStore {
   return {
     read() {
-      if (cached) return cached;
       try {
-        const stored = localStorage.getItem(storageKey);
-        if (stored) {
-          cached = stored;
-          return stored;
-        }
+        return localStorage.getItem(storageKey);
       } catch {
-        /* localStorage 不可用时退化为内存键 */
+        return null;
       }
-      const fresh = randomLifecycleId();
-      cached = fresh;
-      try {
-        localStorage.setItem(storageKey, fresh);
-      } catch {
-        /* 忽略：内存键仍能保证本次会话内稳定 */
-      }
-      return fresh;
     },
-    rotate() {
-      cached = null;
+    write(conversationId) {
+      try {
+        localStorage.setItem(storageKey, conversationId);
+      } catch {
+        // Storage is an optimization; the in-memory ID remains valid.
+      }
+    },
+    clear() {
       try {
         localStorage.removeItem(storageKey);
       } catch {
-        /* 忽略 */
+        // Ignore unavailable storage.
       }
     },
   };
 }
 
-/** 进程内会话身份键：刷新即换新会话，适合一次性面板。 */
-export function memoryExternalKeyStore(): ExternalKeyStore {
-  let value = randomLifecycleId();
+export function memoryConversationStore(): ConversationStore {
+  let value: string | null = null;
   return {
     read: () => value,
-    rotate() {
-      value = randomLifecycleId();
+    write: (conversationId) => {
+      value = conversationId;
+    },
+    clear: () => {
+      value = null;
     },
   };
 }
 
-/** 生命周期调用失败：带 Core 的稳定错误码与 required_action，便于界面给出下一步。 */
 export class BknLifecycleError extends Error {
   readonly code: string;
   readonly requiredAction: string;
 
   constructor(tool: string, code: string, message: string, requiredAction: string) {
-    super(message || `${tool} 失败（${code || "unknown"}）`);
+    super(message || `${tool} failed (${code || "unknown"})`);
     this.name = "BknLifecycleError";
     this.code = code;
     this.requiredAction = requiredAction;
@@ -187,40 +99,18 @@ export class BknLifecycleError extends Error {
 
 type LifecycleErrorPayload = { code?: unknown; message?: unknown; required_action?: unknown };
 
-/**
- * 会话里还挂着一轮没终结的交互。正常路径不会走到这儿（本地闸门会排队），只有上一轮的
- * 终结真的没送达 Core 时才出现——例如业务调用的响应丢在网络上，前端拿不到回执，
- * 清单缺一条，终结被判 closure_manifest_invalid。
- *
- * 这时前端救不回来：补齐清单需要按 interaction 列出已登记的 operation，而受管接口
- * 只允许按 id 查（TRACE.md 第三节：第三方 Agent 只能查询 Operation/Receipt）。
- * 但用户有出路——清空对话会换一条全新 conversation，卡住的那轮留给 Core 的租约回收。
- * 所以这里把出路写进报错，别让人对着「已有进行中的交互」干等 30 分钟租约。
- */
-const STUCK_INTERACTION_HINT = "当前会话还有一轮未结束的交互没能正常收尾。点「清空」开一条新对话即可继续；卡住的那轮会由服务端租约自动回收。";
+function isToolMissing(rpcError: { code?: number; message?: string } | undefined): boolean {
+  if (!rpcError) return false;
+  const message = (rpcError.message ?? "").toLowerCase();
+  return message.includes("tool not found") || message.includes("unknown tool");
+}
 
 function lifecycleErrorOf(tool: string, structured: unknown, fallbackText: string): BknLifecycleError {
   const envelope = structured && typeof structured === "object" ? (structured as Record<string, unknown>) : {};
   const error = (envelope.error ?? {}) as LifecycleErrorPayload;
   const code = typeof error.code === "string" ? error.code : "";
   const message = typeof error.message === "string" ? error.message : fallbackText;
-  return new BknLifecycleError(
-    tool,
-    code,
-    code === "interaction_in_progress" ? STUCK_INTERACTION_HINT : message,
-    typeof error.required_action === "string" ? error.required_action : "",
-  );
-}
-
-/**
- * 后端没注册生命周期工具（升级前的 Context Loader）时的识别。
- * 这类部署同时也不会强制 bkn_context，降级回旧行为是安全的；
- * 但只认协议级 "工具不存在"，业务错误不能走这条路，否则会把真实的生命周期故障吞掉。
- */
-function isToolMissing(rpcError: { code?: number; message?: string } | undefined): boolean {
-  if (!rpcError) return false;
-  const message = (rpcError.message ?? "").toLowerCase();
-  return message.includes("tool not found") || message.includes("unknown tool");
+  return new BknLifecycleError(tool, code, message, typeof error.required_action === "string" ? error.required_action : "");
 }
 
 async function callLifecycleTool(
@@ -230,13 +120,11 @@ async function callLifecycleTool(
 ): Promise<Record<string, unknown>> {
   const result = await session.callTool(tool, args);
   if (isToolMissing(result.rpcError)) {
-    throw new BknLifecycleError(tool, "lifecycle_not_supported", `${tool} 未注册`, "");
+    throw new BknLifecycleError(tool, "lifecycle_not_supported", `${tool} is not registered`, "");
   }
-  if (result.isError || !result.ok) {
-    throw lifecycleErrorOf(tool, result.structured, result.text);
-  }
+  if (result.isError || !result.ok) throw lifecycleErrorOf(tool, result.structured, result.text);
   if (!result.structured || typeof result.structured !== "object") {
-    throw new BknLifecycleError(tool, "lifecycle_malformed", `${tool} 未返回结构化状态`, "");
+    throw new BknLifecycleError(tool, "lifecycle_malformed", `${tool} did not return structured content`, "");
   }
   return result.structured as Record<string, unknown>;
 }
@@ -244,11 +132,6 @@ async function callLifecycleTool(
 function stringField(source: Record<string, unknown>, key: string): string {
   const value = source[key];
   return typeof value === "string" ? value : "";
-}
-
-function numberField(source: Record<string, unknown>, key: string): number {
-  const value = source[key];
-  return typeof value === "number" ? value : 0;
 }
 
 export function createBknLifecycle(
@@ -259,38 +142,11 @@ export function createBknLifecycle(
   return createBknLifecycleOn(createMcpSession(env, auth), options);
 }
 
-/** 同上但复用调用方给的 MCP 会话（也是测试注入点）。 */
 export function createBknLifecycleOn(session: McpSession, options: BknLifecycleOptions): BknLifecycle {
-  const { externalKeyStore, oneShot = false, leaseSeconds = DEFAULT_LEASE_SECONDS } = options;
-  let conversationId: string | null = null;
+  const { conversationStore } = options;
+  let conversationId = conversationStore.read();
   let notSupported = false;
-  /**
-   * 上一轮交互的终结闸门。会话内只能有一个 active interaction，抢跑的第二轮会被 Core
-   * 的唯一约束顶掉 —— 用户手快连发、数据浏览器同时展开两张卡都会走到这条路上。
-   */
   let previousTurnSettled: Promise<void> = Promise.resolve();
-
-  async function ensureConversation(): Promise<string | null> {
-    if (notSupported) return null;
-    if (conversationId) return conversationId;
-    try {
-      // ensure-current 按 external_conversation_key 幂等：刷新页面拿回同一条会话，
-      // 会话已关闭则由 Core 开新 generation，前端不需要自己判断该 create 还是 resume。
-      const state = await callLifecycleTool(session, "bkn_create_conversation", {
-        external_conversation_key: externalKeyStore.read(),
-        idempotency_key: randomLifecycleId(),
-        one_shot: oneShot,
-      });
-      conversationId = stringField(state, "conversation_id") || null;
-      return conversationId;
-    } catch (error) {
-      if (error instanceof BknLifecycleError && error.code === "lifecycle_not_supported") {
-        notSupported = true;
-        return null;
-      }
-      throw error;
-    }
-  }
 
   return {
     session,
@@ -298,7 +154,7 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
     unsupported: () => notSupported,
     reset() {
       conversationId = null;
-      externalKeyStore.rotate();
+      conversationStore.clear();
     },
     async beginTurn(question: string) {
       const waitFor = previousTurnSettled;
@@ -307,21 +163,24 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
         release = resolve;
       });
       try {
-        // 闸门只会 resolve、不会 reject（终结失败也照样放行），所以这里不会串联失败。
         await waitFor;
-        const currentConversation = await ensureConversation();
-        if (!currentConversation) {
+        const args: Record<string, unknown> = { question };
+        if (conversationId) args.conversation_id = conversationId;
+        const state = await callLifecycleTool(session, "bkn_start_interaction", args);
+        const startedConversationId = stringField(state, "conversation_id");
+        const interactionId = stringField(state, "interaction_id");
+        if (!startedConversationId || !interactionId) {
+          throw new BknLifecycleError("bkn_start_interaction", "lifecycle_malformed", "bkn_start_interaction did not return authority IDs", "");
+        }
+        conversationId = startedConversationId;
+        conversationStore.write(startedConversationId);
+        return createTurn(session, startedConversationId, interactionId, release);
+      } catch (error) {
+        if (error instanceof BknLifecycleError && error.code === "lifecycle_not_supported") {
+          notSupported = true;
           release();
           return null;
         }
-        const state = await callLifecycleTool(session, "bkn_start_interaction", {
-          conversation_id: currentConversation,
-          idempotency_key: randomLifecycleId(),
-          question,
-          lease_seconds: leaseSeconds,
-        });
-        return createTurn(session, currentConversation, state, release);
-      } catch (error) {
         release();
         throw error;
       }
@@ -332,42 +191,19 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
 function createTurn(
   session: McpSession,
   conversationId: string,
-  state: Record<string, unknown>,
-  /** 终结后放行下一轮（成败都放行，否则一次收尾失败会让整条会话再也开不出交互）。 */
+  interactionId: string,
   release: () => void,
 ): BknTurn {
-  const interactionId = stringField(state, "interaction_id");
-  const leaseToken = stringField(state, "lease_token");
-  const leaseEpoch = numberField(state, "lease_epoch");
-  const receipts: BknReceiptRef[] = [];
-  let operationSeq = 0;
   let terminated = false;
 
-  async function terminate(tool: string, reason: string, answer?: string): Promise<void> {
-    // 终结只做一次：重复调用会撞 Core 的 terminal_conflict，而调用方在
-    // 「停止后又出错」这类路径上很容易两次都触发。
+  async function terminate(outcome: "completed" | "failed" | "cancelled", value?: string): Promise<void> {
     if (terminated) return;
     terminated = true;
-    // 清单必须一条不漏地列出本轮登记过的 operation / receipt，且 required 与 Core 侧一致，
-    // 数量对不上直接 closure_manifest_invalid。
-    const args: Record<string, unknown> = {
-      interaction_id: interactionId,
-      terminal_idempotency_key: randomLifecycleId(),
-      lease_token: leaseToken,
-      lease_epoch: leaseEpoch,
-      completion_manifest_version: MANIFEST_VERSION,
-      completion_reason: reason,
-      expected_operations: receipts.map((r) => ({ operation_id: r.operationId, required: r.required })),
-      expected_receipts: receipts.map((r) => ({ receipt_id: r.receiptId, required: r.required })),
-    };
-    // answer 只在 complete 的 schema 里声明；cancel / fail 传了会撞
-    // additionalProperties: false。
-    if (answer !== undefined) {
-      args.answer = answer;
-      args.assembler_deadline = new Date(Date.now() + ASSEMBLER_DEADLINE_MS).toISOString();
-    }
+    const args: Record<string, unknown> = { interaction_id: interactionId, outcome };
+    if (outcome === "completed") args.answer = value ?? "";
+    else args.reason = value || (outcome === "cancelled" ? "stopped_by_user" : "agent_error");
     try {
-      await callLifecycleTool(session, tool, args);
+      await callLifecycleTool(session, "bkn_finish_interaction", args);
     } finally {
       release();
     }
@@ -376,40 +212,22 @@ function createTurn(
   return {
     conversationId,
     interactionId,
-    nextContext(toolName: string) {
-      operationSeq += 1;
-      return {
-        conversation_id: conversationId,
-        interaction_id: interactionId,
-        operation_key: `${toolName}#${operationSeq}`,
-      };
-    },
-    recordReceipt(receipt) {
-      // 同一 operation 的重放会回同一个 receipt，去重后清单才不会多算。
-      if (!receipt || receipts.some((r) => r.operationId === receipt.operationId)) return;
-      receipts.push(receipt);
-    },
-    complete: (answer: string) => terminate("bkn_complete_interaction", "answer_returned", answer),
-    fail: (reason: string) => terminate("bkn_fail_interaction", reason || "agent_error"),
-    cancel: (reason: string) => terminate("bkn_cancel_interaction", reason || "stopped_by_user"),
+    nextContext: () => ({ conversation_id: conversationId, interaction_id: interactionId }),
+    complete: (answer) => terminate("completed", answer),
+    fail: (reason) => terminate("failed", reason),
+    cancel: (reason) => terminate("cancelled", reason),
     finish(outcome, answer) {
-      if (outcome === "canceled") return terminate("bkn_cancel_interaction", "stopped_by_user");
-      if (outcome === "failed") return terminate("bkn_fail_interaction", "agent_error");
-      return terminate("bkn_complete_interaction", "answer_returned", answer);
+      if (outcome === "canceled") return terminate("cancelled");
+      if (outcome === "failed") return terminate("failed");
+      return terminate("completed", answer);
     },
   };
 }
 
-/**
- * 一次性受管调用：开一轮交互跑 run，无论成败都收尾。
- * 给「数据浏览器加载」「调试台点一次发送」这类非对话的业务调用用 —— 它们同样受强制拦截，
- * 只是没有多轮语义。后端不支持生命周期时 turn 为 null，run 按旧行为直接发。
- */
 export async function withManagedTurn<T>(
   lifecycle: BknLifecycle,
   question: string,
   run: (turn: BknTurn | null) => Promise<T>,
-  /** 写进 Trace 的本轮「答复」摘要；这类调用没有自然语言答案，给一句能读的即可。 */
   describeAnswer: (value: T) => string = () => "ok",
 ): Promise<T> {
   const turn = await lifecycle.beginTurn(question);
@@ -424,7 +242,6 @@ export async function withManagedTurn<T>(
     outcome = "failed";
     throw error;
   } finally {
-    // 收尾失败不能盖掉业务错误：交互会由 Core 的租约回收兜底。
     await turn.finish(outcome, answer).catch(() => undefined);
   }
 }

--- a/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
@@ -33,7 +33,7 @@ export type BknLifecycle = {
   reset(): void;
 };
 
-/** Persist only the server-issued conversation ID, never a client-created identity. */
+/** 只持久化服务端下发的 conversation ID，不生成客户端身份。 */
 export type ConversationStore = {
   read(): string | null;
   write(conversationId: string): void;
@@ -46,10 +46,21 @@ export function lifecycleEnv(base: string, knId: string): ContextLoaderEnv {
   return { base, token: "", knId };
 }
 
-export function localConversationStore(storageKey: string): ConversationStore {
+export function localConversationStore(storageKey: string, legacyStorageKey?: string): ConversationStore {
+  let legacyCleared = false;
+  const clearLegacy = () => {
+    if (legacyCleared || !legacyStorageKey) return;
+    legacyCleared = true;
+    try {
+      localStorage.removeItem(legacyStorageKey);
+    } catch {
+      // 忽略不可用的 localStorage。
+    }
+  };
   return {
     read() {
       try {
+        clearLegacy();
         return localStorage.getItem(storageKey);
       } catch {
         return null;
@@ -59,14 +70,14 @@ export function localConversationStore(storageKey: string): ConversationStore {
       try {
         localStorage.setItem(storageKey, conversationId);
       } catch {
-        // Storage is an optimization; the in-memory ID remains valid.
+        // localStorage 不可用时，内存中的 ID 仍然有效。
       }
     },
     clear() {
       try {
         localStorage.removeItem(storageKey);
       } catch {
-        // Ignore unavailable storage.
+        // 忽略不可用的 localStorage。
       }
     },
   };
@@ -90,7 +101,7 @@ export class BknLifecycleError extends Error {
   readonly requiredAction: string;
 
   constructor(tool: string, code: string, message: string, requiredAction: string) {
-    super(message || `${tool} failed (${code || "unknown"})`);
+    super(message || `${tool} 失败（${code || "未知错误"}）`);
     this.name = "BknLifecycleError";
     this.code = code;
     this.requiredAction = requiredAction;
@@ -109,8 +120,16 @@ function lifecycleErrorOf(tool: string, structured: unknown, fallbackText: strin
   const envelope = structured && typeof structured === "object" ? (structured as Record<string, unknown>) : {};
   const error = (envelope.error ?? {}) as LifecycleErrorPayload;
   const code = typeof error.code === "string" ? error.code : "";
-  const message = typeof error.message === "string" ? error.message : fallbackText;
-  return new BknLifecycleError(tool, code, message, typeof error.required_action === "string" ? error.required_action : "");
+  const fallback = fallbackText || `${tool} 调用失败`;
+  const message = typeof error.message === "string" ? error.message : fallback;
+  const visibleMessage = code === "interaction_in_progress" ? STUCK_INTERACTION_HINT : message;
+  return new BknLifecycleError(tool, code, visibleMessage, typeof error.required_action === "string" ? error.required_action : "");
+}
+
+const STUCK_INTERACTION_HINT = "当前会话仍有未结束的交互。请清空对话后重试。";
+
+function shouldStartNewConversation(error: unknown): boolean {
+  return error instanceof BknLifecycleError && (error.code === "conversation_not_found" || error.code === "interaction_in_progress");
 }
 
 async function callLifecycleTool(
@@ -120,11 +139,11 @@ async function callLifecycleTool(
 ): Promise<Record<string, unknown>> {
   const result = await session.callTool(tool, args);
   if (isToolMissing(result.rpcError)) {
-    throw new BknLifecycleError(tool, "lifecycle_not_supported", `${tool} is not registered`, "");
+    throw new BknLifecycleError(tool, "lifecycle_not_supported", `${tool} 未注册`, "");
   }
   if (result.isError || !result.ok) throw lifecycleErrorOf(tool, result.structured, result.text);
   if (!result.structured || typeof result.structured !== "object") {
-    throw new BknLifecycleError(tool, "lifecycle_malformed", `${tool} did not return structured content`, "");
+    throw new BknLifecycleError(tool, "lifecycle_malformed", `${tool} 未返回结构化内容`, "");
   }
   return result.structured as Record<string, unknown>;
 }
@@ -164,13 +183,28 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
       });
       try {
         await waitFor;
-        const args: Record<string, unknown> = { question };
-        if (conversationId) args.conversation_id = conversationId;
-        const state = await callLifecycleTool(session, "bkn_start_interaction", args);
+        if (notSupported) {
+          release();
+          return null;
+        }
+        const startInteraction = (currentConversationId: string | null) => {
+          const args: Record<string, unknown> = { question };
+          if (currentConversationId) args.conversation_id = currentConversationId;
+          return callLifecycleTool(session, "bkn_start_interaction", args);
+        };
+        let state: Record<string, unknown>;
+        try {
+          state = await startInteraction(conversationId);
+        } catch (error) {
+          if (!conversationId || !shouldStartNewConversation(error)) throw error;
+          conversationId = null;
+          conversationStore.clear();
+          state = await startInteraction(null);
+        }
         const startedConversationId = stringField(state, "conversation_id");
         const interactionId = stringField(state, "interaction_id");
         if (!startedConversationId || !interactionId) {
-          throw new BknLifecycleError("bkn_start_interaction", "lifecycle_malformed", "bkn_start_interaction did not return authority IDs", "");
+          throw new BknLifecycleError("bkn_start_interaction", "lifecycle_malformed", "bkn_start_interaction 未返回会话或交互 ID", "");
         }
         conversationId = startedConversationId;
         conversationStore.write(startedConversationId);
@@ -188,6 +222,8 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
   };
 }
 
+type FinishOutcome = "completed" | "failed" | "cancelled";
+
 function createTurn(
   session: McpSession,
   conversationId: string,
@@ -196,7 +232,7 @@ function createTurn(
 ): BknTurn {
   let terminated = false;
 
-  async function terminate(outcome: "completed" | "failed" | "cancelled", value?: string): Promise<void> {
+  async function terminate(outcome: FinishOutcome, value?: string): Promise<void> {
     if (terminated) return;
     terminated = true;
     const args: Record<string, unknown> = { interaction_id: interactionId, outcome };

--- a/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
@@ -9,291 +9,143 @@ import { describe, expect, it } from "vitest";
 
 import {
   createBknLifecycleOn,
-  memoryExternalKeyStore,
+  memoryConversationStore,
   withManagedTurn,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import type { McpSession, McpToolCallResult } from "@/modules/knowledge-network/services/context-loader.service";
 
 type Call = { name: string; args: Record<string, unknown> };
 
-/** 假的 Core：conversation 按 external_conversation_key 幂等，interaction 递增。 */
 function fakeSession(overrides: Record<string, () => McpToolCallResult> = {}) {
   const calls: Call[] = [];
-  const conversations = new Map<string, string>();
   let interactionSeq = 0;
-  const ok = (structured: unknown): McpToolCallResult => ({
-    ok: true,
-    text: "managed lifecycle state updated",
-    latencyMs: 1,
-    structured,
-    isError: false,
-  });
   const session: McpSession = {
     callTool(name, args) {
       calls.push({ name, args });
       const override = overrides[name];
       if (override) return Promise.resolve(override());
-      if (name === "bkn_create_conversation") {
-        const key = String(args.external_conversation_key);
-        if (!conversations.has(key)) conversations.set(key, `conv_${conversations.size + 1}`);
-        return Promise.resolve(ok({ conversation_id: conversations.get(key), status: "active" }));
-      }
       if (name === "bkn_start_interaction") {
         interactionSeq += 1;
-        return Promise.resolve(
-          ok({
+        const conversationId = typeof args.conversation_id === "string" ? args.conversation_id : "conv_1";
+        return Promise.resolve({
+          ok: true,
+          text: "started",
+          latencyMs: 1,
+          isError: false,
+          structured: {
             interaction_id: `int_${interactionSeq}`,
-            conversation_id: args.conversation_id,
-            lease_token: `lease_${interactionSeq}`,
-            lease_epoch: 1,
-          }),
-        );
-      }
-      if (name.startsWith("bkn_")) return Promise.resolve(ok({ interaction_id: args.interaction_id }));
-      // 业务工具：回一张受管回执。
-      return Promise.resolve({
-        ok: true,
-        text: "rows",
-        latencyMs: 1,
-        isError: false,
-        structured: {
-          bkn_receipt: {
-            operation_id: `op_${calls.length}`,
-            receipt_id: `rcp_${calls.length}`,
-            required: true,
+            conversation_id: conversationId,
+            execution_status: "active",
           },
-        },
-      });
+        });
+      }
+      if (name === "bkn_finish_interaction") {
+        return Promise.resolve({
+          ok: true,
+          text: "finished",
+          latencyMs: 1,
+          isError: false,
+          structured: { interaction_id: args.interaction_id, conversation_id: "conv_1", execution_status: "completed" },
+        });
+      }
+      return Promise.resolve({ ok: true, text: "ok", latencyMs: 1, isError: false, structured: {} });
     },
   };
   return { session, calls };
 }
 
-const options = () => ({ externalKeyStore: memoryExternalKeyStore() });
+const options = () => ({ conversationStore: memoryConversationStore() });
 
 describe("createBknLifecycle", () => {
-  it("keeps one conversation across turns and only rotates it on reset", async () => {
-    const { session } = fakeSession();
-    const lifecycle = createBknLifecycleOn(session, options());
-
-    const first = await lifecycle.beginTurn("第一问");
-    await first?.complete("答一");
-    const second = await lifecycle.beginTurn("第二问");
-    await second?.complete("答二");
-
-    // 不清空对话就一直是同一条会话；每轮问答各自一条交互。
-    expect(first?.conversationId).toBe(second?.conversationId);
-    expect(first?.interactionId).not.toBe(second?.interactionId);
-
-    lifecycle.reset();
-    const third = await lifecycle.beginTurn("清空后再问");
-    expect(third?.conversationId).not.toBe(first?.conversationId);
-  });
-
-  it("gives every tool call a distinct operation_key under the same interaction", async () => {
-    const { session } = fakeSession();
-    const lifecycle = createBknLifecycleOn(session, options());
-    const turn = await lifecycle.beginTurn("问");
-
-    const first = turn!.nextContext("run_sql");
-    const second = turn!.nextContext("run_sql");
-
-    expect(first.conversation_id).toBe(second.conversation_id);
-    expect(first.interaction_id).toBe(second.interaction_id);
-    // operation_key 在交互内唯一，否则第二次调用会被 Core 当成第一次的重放。
-    expect(first.operation_key).not.toBe(second.operation_key);
-  });
-
-  it("lists every recorded operation and receipt in the closure manifest", async () => {
+  it("starts the first interaction without a conversation and reuses the authority ID", async () => {
     const { session, calls } = fakeSession();
     const lifecycle = createBknLifecycleOn(session, options());
-    const turn = await lifecycle.beginTurn("问");
 
-    turn!.recordReceipt({ operationId: "op_a", receiptId: "rcp_a", required: true });
-    turn!.recordReceipt({ operationId: "op_b", receiptId: "rcp_b", required: true });
-    // 同一 operation 的重放回同一张回执，清单里不能重复计数。
-    turn!.recordReceipt({ operationId: "op_a", receiptId: "rcp_a", required: true });
-    await turn!.complete("答");
+    const first = await lifecycle.beginTurn("first question");
+    await first?.complete("first answer");
+    const second = await lifecycle.beginTurn("second question");
 
-    const terminal = calls.find((call) => call.name === "bkn_complete_interaction")!;
-    expect(terminal.args.expected_operations).toEqual([
-      { operation_id: "op_a", required: true },
-      { operation_id: "op_b", required: true },
-    ]);
-    expect(terminal.args.expected_receipts).toEqual([
-      { receipt_id: "rcp_a", required: true },
-      { receipt_id: "rcp_b", required: true },
-    ]);
-    expect(terminal.args).toMatchObject({
-      lease_token: "lease_1",
-      lease_epoch: 1,
-      completion_manifest_version: "1",
-      answer: "答",
+    expect(calls[0]).toEqual({ name: "bkn_start_interaction", args: { question: "first question" } });
+    expect(calls[2]).toEqual({
+      name: "bkn_start_interaction",
+      args: { question: "second question", conversation_id: "conv_1" },
     });
-    // 带 pending 回执的成功交互要给收敛窗口，否则永远停在 assembling。
-    expect(terminal.args.assembler_deadline).toEqual(expect.any(String));
+    expect(second?.conversationId).toBe(first?.conversationId);
   });
 
-  it("omits answer and assembler_deadline on the non-success terminals", async () => {
+  it("uses only bkn_start_interaction and bkn_finish_interaction", async () => {
     const { session, calls } = fakeSession();
     const lifecycle = createBknLifecycleOn(session, options());
-    const turn = await lifecycle.beginTurn("问");
+    const turn = await lifecycle.beginTurn("question");
 
-    await turn!.cancel("stopped_by_user");
+    expect(turn?.nextContext()).toEqual({ conversation_id: "conv_1", interaction_id: "int_1" });
+    await turn?.complete("answer");
 
-    // cancel / fail 的 schema 没有这两个字段，additionalProperties: false 会直接拒。
-    const terminal = calls.find((call) => call.name === "bkn_cancel_interaction")!;
-    expect(terminal.args).not.toHaveProperty("answer");
-    expect(terminal.args).not.toHaveProperty("assembler_deadline");
-  });
-
-  it("terminates a turn only once", async () => {
-    const { session, calls } = fakeSession();
-    const lifecycle = createBknLifecycleOn(session, options());
-    const turn = await lifecycle.beginTurn("问");
-
-    await turn!.cancel("stopped_by_user");
-    // 「停止后又抛错」的路径会两次触发收尾；第二次撞 Core 的 terminal_conflict。
-    await turn!.fail("agent_error");
-
-    expect(calls.filter((call) => call.name.endsWith("_interaction")).map((call) => call.name)).toEqual([
-      "bkn_start_interaction",
-      "bkn_cancel_interaction",
+    expect(calls).toEqual([
+      { name: "bkn_start_interaction", args: { question: "question" } },
+      { name: "bkn_finish_interaction", args: { interaction_id: "int_1", outcome: "completed", answer: "answer" } },
     ]);
   });
 
-  it("degrades to no managed context when the backend has no lifecycle tools", async () => {
+  it("maps cancellation and failure to the unified finish outcome", async () => {
+    const { session, calls } = fakeSession();
+    const lifecycle = createBknLifecycleOn(session, options());
+
+    const canceled = await lifecycle.beginTurn("cancel");
+    await canceled?.cancel("user stopped");
+    const failed = await lifecycle.beginTurn("fail");
+    await failed?.fail("model error");
+
+    expect(calls.filter((call) => call.name === "bkn_finish_interaction").map((call) => call.args)).toEqual([
+      { interaction_id: "int_1", outcome: "cancelled", reason: "user stopped" },
+      { interaction_id: "int_2", outcome: "failed", reason: "model error" },
+    ]);
+  });
+
+  it("degrades only when bkn_start_interaction is unavailable", async () => {
     const { session, calls } = fakeSession({
-      bkn_create_conversation: () => ({
-        ok: true,
-        text: "",
-        latencyMs: 1,
-        isError: false,
-        rpcError: { code: -32602, message: "tool not found: bkn_create_conversation" },
-      }),
-    });
-    const lifecycle = createBknLifecycleOn(session, options());
-
-    await expect(lifecycle.beginTurn("问")).resolves.toBeNull();
-    expect(lifecycle.unsupported()).toBe(true);
-
-    // 判定为不支持后不再重试握手，业务调用按旧行为直接发。
-    await expect(lifecycle.beginTurn("再问")).resolves.toBeNull();
-    expect(calls.filter((call) => call.name === "bkn_create_conversation")).toHaveLength(1);
-  });
-
-  it("surfaces the stable lifecycle error code instead of a generic failure", async () => {
-    const { session } = fakeSession({
       bkn_start_interaction: () => ({
-        ok: true,
-        text: "conversation_not_found: conversation is unknown",
-        latencyMs: 1,
-        isError: true,
-        structured: {
-          error: {
-            code: "conversation_not_found",
-            message: "conversation is unknown",
-            required_action: "create_conversation",
-          },
-        },
-      }),
-    });
-    const lifecycle = createBknLifecycleOn(session, options());
-
-    await expect(lifecycle.beginTurn("问")).rejects.toMatchObject({
-      code: "conversation_not_found",
-      requiredAction: "create_conversation",
-    });
-  });
-
-  it("tells the user how to escape a conversation stuck on an unterminated turn", async () => {
-    const { session } = fakeSession({
-      bkn_start_interaction: () => ({
-        ok: true,
-        text: "interaction_in_progress: the conversation already has an active interaction",
-        latencyMs: 1,
-        isError: true,
-        structured: {
-          error: {
-            code: "interaction_in_progress",
-            message: "the conversation already has an active interaction",
-            required_action: "complete_or_cancel_interaction",
-          },
-        },
-      }),
-    });
-    const lifecycle = createBknLifecycleOn(session, options());
-
-    // 补清单需要按 interaction 列 operation，受管接口不给——前端救不回来，
-    // 但清空对话能换一条新会话，别让用户对着原文干等租约回收。
-    await expect(lifecycle.beginTurn("问")).rejects.toMatchObject({
-      code: "interaction_in_progress",
-      message: expect.stringContaining("清空") as unknown as string,
-    });
-  });
-
-  it("queues a second turn until the first one is terminated", async () => {
-    const { session, calls } = fakeSession();
-    const lifecycle = createBknLifecycleOn(session, options());
-
-    const first = await lifecycle.beginTurn("第一问");
-    const secondPending = lifecycle.beginTurn("第二问");
-    await Promise.resolve();
-
-    // 会话内只能有一个 active interaction；抢跑的第二轮会被 Core 的唯一约束顶掉。
-    expect(calls.filter((call) => call.name === "bkn_start_interaction")).toHaveLength(1);
-
-    await first!.complete("答一");
-    const second = await secondPending;
-    expect(second!.interactionId).not.toBe(first!.interactionId);
-    expect(calls.filter((call) => call.name === "bkn_start_interaction")).toHaveLength(2);
-  });
-
-  it("still lets the next turn start after a terminal call fails", async () => {
-    const { session } = fakeSession({
-      bkn_complete_interaction: () => ({
         ok: false,
-        text: "closure manifest invalid",
+        text: "tool not found",
         latencyMs: 1,
         isError: true,
-        structured: { error: { code: "closure_manifest_invalid", message: "closure manifest invalid" } },
+        rpcError: { code: -32602, message: "tool not found: bkn_start_interaction" },
       }),
     });
     const lifecycle = createBknLifecycleOn(session, options());
 
-    const first = await lifecycle.beginTurn("第一问");
-    await expect(first!.complete("答")).rejects.toMatchObject({ code: "closure_manifest_invalid" });
+    await expect(lifecycle.beginTurn("question")).resolves.toBeNull();
+    expect(lifecycle.unsupported()).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
 
-    // 收尾失败若不放行闸门，整条会话此后再也开不出交互。
-    await expect(lifecycle.beginTurn("第二问")).resolves.not.toBeNull();
+  it("releases the next turn when finish fails", async () => {
+    const { session } = fakeSession({
+      bkn_finish_interaction: () => ({
+        ok: false,
+        text: "finish failed",
+        latencyMs: 1,
+        isError: true,
+        structured: { error: { code: "terminal_conflict", message: "finish failed" } },
+      }),
+    });
+    const lifecycle = createBknLifecycleOn(session, options());
+    const first = await lifecycle.beginTurn("first");
+
+    await expect(first?.complete("answer")).rejects.toMatchObject({ code: "terminal_conflict" });
+    await expect(lifecycle.beginTurn("second")).resolves.not.toBeNull();
   });
 });
 
 describe("withManagedTurn", () => {
-  it("terminates the interaction even when the business call throws", async () => {
+  it("finishes failed business calls with the unified terminal", async () => {
     const { session, calls } = fakeSession();
     const lifecycle = createBknLifecycleOn(session, options());
 
-    await expect(
-      withManagedTurn(lifecycle, "加载", () => Promise.reject(new Error("boom"))),
-    ).rejects.toThrow("boom");
-
-    // 不终结的交互会一直挂在 active，直到 Core 租约回收，期间开不出下一轮。
-    expect(calls.map((call) => call.name)).toContain("bkn_fail_interaction");
-  });
-
-  it("does not let a failing terminal call mask the business result", async () => {
-    const { session } = fakeSession({
-      bkn_complete_interaction: () => ({
-        ok: false,
-        text: "closure manifest invalid",
-        latencyMs: 1,
-        isError: true,
-        structured: { error: { code: "closure_manifest_invalid", message: "closure manifest invalid" } },
-      }),
+    await expect(withManagedTurn(lifecycle, "load", () => Promise.reject(new Error("boom")))).rejects.toThrow("boom");
+    expect(calls.at(-1)).toEqual({
+      name: "bkn_finish_interaction",
+      args: { interaction_id: "int_1", outcome: "failed", reason: "agent_error" },
     });
-    const lifecycle = createBknLifecycleOn(session, options());
-
-    await expect(withManagedTurn(lifecycle, "加载", () => Promise.resolve("data"))).resolves.toBe("data");
   });
 });

--- a/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createBknLifecycleOn,
@@ -115,8 +115,44 @@ describe("createBknLifecycle", () => {
     const lifecycle = createBknLifecycleOn(session, options());
 
     await expect(lifecycle.beginTurn("question")).resolves.toBeNull();
+    await expect(lifecycle.beginTurn("another question")).resolves.toBeNull();
     expect(lifecycle.unsupported()).toBe(true);
     expect(calls).toHaveLength(1);
+  });
+
+  it("starts a new conversation when a persisted conversation is no longer usable", async () => {
+    let starts = 0;
+    const { session, calls } = fakeSession({
+      bkn_start_interaction: () => {
+        starts += 1;
+        if (starts === 1) {
+          return {
+            ok: false,
+            text: "conversation not found",
+            latencyMs: 1,
+            isError: true,
+            structured: { error: { code: "conversation_not_found", message: "conversation not found" } },
+          };
+        }
+        return {
+          ok: true,
+          text: "started",
+          latencyMs: 1,
+          isError: false,
+          structured: { interaction_id: "int_2", conversation_id: "conv_2", execution_status: "active" },
+        };
+      },
+    });
+    const store = { read: () => "stale_conv", write: vi.fn(), clear: vi.fn() };
+    const lifecycle = createBknLifecycleOn(session, { conversationStore: store });
+
+    await expect(lifecycle.beginTurn("question")).resolves.toMatchObject({ conversationId: "conv_2", interactionId: "int_2" });
+    expect(calls).toEqual([
+      { name: "bkn_start_interaction", args: { question: "question", conversation_id: "stale_conv" } },
+      { name: "bkn_start_interaction", args: { question: "question" } },
+    ]);
+    expect(store.clear).toHaveBeenCalledOnce();
+    expect(store.write).toHaveBeenCalledWith("conv_2");
   });
 
   it("releases the next turn when finish fails", async () => {

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -125,47 +125,6 @@ describe("sendRequest", () => {
     });
   });
 
-  it("reports the managed receipt from REST headers and from the MCP structured result", async () => {
-    const restSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("{}", {
-        status: 200,
-        headers: { "bkn-receipt-id": "rcp_1", "bkn-operation-id": "op_1" },
-      }),
-    );
-    const rest = await sendRequest(
-      { base: "https://platform.example.com", token: "", knId: "kn-demo" },
-      searchSchema,
-      "rest",
-      {},
-      "{}",
-      undefined,
-      undefined,
-      bknContext,
-    );
-    expect(rest.receipt).toEqual({ operationId: "op_1", receiptId: "rcp_1", required: true });
-    restSpy.mockRestore();
-
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response("{}", { status: 200, headers: { "Mcp-Session-Id": "session-1" } }))
-      .mockResolvedValueOnce(new Response(null, { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response(
-          '{"jsonrpc":"2.0","result":{"content":[],"structuredContent":{"bkn_receipt":{"operation_id":"op_2","receipt_id":"rcp_2","required":true}}}}',
-          { status: 200 },
-        ),
-      );
-    const mcp = await sendRequest(
-      { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" },
-      searchSchema,
-      "mcp",
-      {},
-      "{}",
-      undefined,
-      undefined,
-      bknContext,
-    );
-    expect(mcp.receipt).toEqual({ operationId: "op_2", receiptId: "rcp_2", required: true });
-  });
 });
 
 describe("fetchKnDetail", () => {
@@ -184,7 +143,6 @@ describe("fetchKnDetail", () => {
       kn_id: "kn-demo",
       bkn_context: bknContext,
     });
-    // 回执要记回本轮，否则终结交互时清单缺一条，Core 判 closure_manifest_invalid。
   });
 });
 

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -21,7 +21,6 @@ const searchSchema = CONTEXT_LOADER_OPS.find((operation) => operation.id === "se
 const bknContext = {
   conversation_id: "conv_1",
   interaction_id: "int_1",
-  operation_key: "search_schema#1",
 };
 
 function restBody(init: RequestInit | undefined): Record<string, unknown> {
@@ -177,19 +176,15 @@ describe("fetchKnDetail", () => {
         headers: { "bkn-receipt-id": "rcp_3", "bkn-operation-id": "op_3" },
       }),
     );
-    const recordReceipt = vi.fn();
-
     await fetchKnDetail({ base: "https://platform.example.com", token: "", knId: "kn-demo" }, undefined, undefined, {
-      nextContext: (toolName) => ({ ...bknContext, operation_key: `${toolName}#1` }),
-      recordReceipt,
+      nextContext: () => bknContext,
     });
 
     expect(restBody(fetchSpy.mock.calls[0][1])).toMatchObject({
       kn_id: "kn-demo",
-      bkn_context: { ...bknContext, operation_key: "get_kn_detail#1" },
+      bkn_context: bknContext,
     });
     // 回执要记回本轮，否则终结交互时清单缺一条，Core 判 closure_manifest_invalid。
-    expect(recordReceipt).toHaveBeenCalledWith({ operationId: "op_3", receiptId: "rcp_3", required: true });
   });
 });
 

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -440,7 +440,6 @@ function mcpBase(env: ContextLoaderEnv): string {
 export type BknContext = {
   conversation_id: string;
   interaction_id: string;
-  operation_key: string;
 };
 
 /**
@@ -475,8 +474,7 @@ export function receiptFromStructured(structured: unknown): BknReceiptRef | unde
  * bkn-lifecycle 的 BknTurn 结构上满足它 —— 这里不反向 import，避免两个服务互相依赖。
  */
 export type BknCallScope = {
-  nextContext(toolName: string): BknContext;
-  recordReceipt(receipt: BknReceiptRef | undefined): void;
+  nextContext(): BknContext;
 };
 
 /** 把受管上下文并进业务请求体/arguments（已有 bkn_context 不覆盖）。 */
@@ -1049,11 +1047,10 @@ export async function fetchKnDetail(
     env,
     auth,
     `${base}${REST_PREFIX}/kn/get_kn_detail?${params.toString()}`,
-    withBknContext({ kn_id: env.knId }, scope?.nextContext("get_kn_detail")),
+    withBknContext({ kn_id: env.knId }, scope?.nextContext()),
     signal,
   );
   const text = await response.text();
-  scope?.recordReceipt(restReceiptRef(response, text));
   if (!response.ok) {
     throw new Error(text || `获取知识网络详情失败（${response.status}）`);
   }
@@ -1086,11 +1083,10 @@ export async function fetchObjectInstances(
     env,
     auth,
     `${base}${REST_PREFIX}/kn/query_object_instance?${params.toString()}`,
-    withBknContext({ limit, need_total: false, properties: [] }, scope?.nextContext("query_object_instance")),
+    withBknContext({ limit, need_total: false, properties: [] }, scope?.nextContext()),
     signal,
   );
   const text = await response.text();
-  scope?.recordReceipt(restReceiptRef(response, text));
   if (!response.ok) {
     throw new Error(text || `查询实例失败（${response.status}）`);
   }

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -443,34 +443,7 @@ export type BknContext = {
 };
 
 /**
- * 一次受管业务调用的回执引用。终结 Interaction 时必须把本轮**全部** operation 与 receipt
- * 一条不漏地列进 closure manifest（Core 按数量与归属校验，多一条少一条都报
- * `closure_manifest_invalid`），所以每次业务调用都要把它记下来。
- */
-export type BknReceiptRef = { operationId: string; receiptId: string; required: boolean };
-
-/** 从业务调用回执对象里取 operation/receipt 引用；形状不对返回 undefined。 */
-export function parseBknReceipt(value: unknown): BknReceiptRef | undefined {
-  if (!value || typeof value !== "object") return undefined;
-  const receipt = value as Record<string, unknown>;
-  const operationId = receipt.operation_id;
-  const receiptId = receipt.receipt_id;
-  if (typeof operationId !== "string" || !operationId) return undefined;
-  if (typeof receiptId !== "string" || !receiptId) return undefined;
-  // Context Loader 的受信适配器恒以 required=true 注册 Operation；缺字段时按它兜底，
-  // 因为 manifest 里的 required 必须与 Core 侧登记值一致，猜 false 会被直接判非法。
-  return { operationId, receiptId, required: receipt.required !== false };
-}
-
-/** 从 MCP 业务工具的 structuredContent 里取受管回执（正常执行是 bkn_receipt，重放/pending 是 receipt）。 */
-export function receiptFromStructured(structured: unknown): BknReceiptRef | undefined {
-  if (!structured || typeof structured !== "object") return undefined;
-  const envelope = structured as Record<string, unknown>;
-  return parseBknReceipt(envelope.bkn_receipt) ?? parseBknReceipt(envelope.receipt);
-}
-
-/**
- * 一次受管交互对业务调用暴露的最小接口：取上下文 + 回执记账。
+ * 一次受管交互对业务调用暴露的最小接口：取上下文。
  * bkn-lifecycle 的 BknTurn 结构上满足它 —— 这里不反向 import，避免两个服务互相依赖。
  */
 export type BknCallScope = {
@@ -569,25 +542,7 @@ export type ContextLoaderResponse = {
   latencyMs: number;
   sizeBytes: number;
   text: string;
-  /** 受管回执（REST 走响应头，MCP 走 structuredContent.bkn_receipt）；终结交互时要列全。 */
-  receipt?: BknReceiptRef;
 };
-
-/**
- * REST 业务响应里的受管回执：首次正常执行走响应头 `bkn-receipt-id` / `bkn-operation-id`
- * （业务响应体保持原形），终态重放或 pending 时改由响应体 `receipt` 字段带回。
- */
-function restReceiptRef(response: Response, text: string): BknReceiptRef | undefined {
-  const receiptId = response.headers.get("bkn-receipt-id");
-  const operationId = response.headers.get("bkn-operation-id");
-  if (receiptId && operationId) return { operationId, receiptId, required: true };
-  try {
-    const parsed = JSON.parse(text) as { receipt?: unknown };
-    return parseBknReceipt(parsed.receipt);
-  } catch {
-    return undefined;
-  }
-}
 
 /** 真实发送请求（REST 或 MCP），返回原始响应文本 + 元信息。 */
 export async function sendRequest(
@@ -663,7 +618,6 @@ export async function sendRequest(
         latencyMs: Math.round(performance.now() - start),
         sizeBytes: new Blob([text]).size,
         text,
-        receipt: receiptFromStructured(mcpStructuredContent(parseMcpEnvelope(text))),
       };
     }
     const url = buildRestUrl(env, op, queryValues);
@@ -681,7 +635,6 @@ export async function sendRequest(
       latencyMs: Math.round(performance.now() - start),
       sizeBytes: new Blob([text]).size,
       text,
-      receipt: restReceiptRef(response, text),
     };
   };
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Align Knowledge Network managed lifecycle calls with `bkn_start_interaction` and `bkn_finish_interaction`.
- [x] Add lifecycle-specific MCP Debug labels, grouping, and ordering.
- [x] Add focused regression coverage for lifecycle and MCP Debug display behavior.

---

## Why

- Related Issue: Closes #349
- Related Issue: Closes #345
- Related Feature: N/A
- Background: Context Loader now exposes a two-tool managed lifecycle contract. The MCP Debug sidebar also needed distinct lifecycle names instead of repeated generic labels.

---

## How

- Key implementation points: Persist server-issued conversation IDs, inject only authority IDs into business calls, finish every turn through the unified terminal tool, and classify `bkn_*` tools in a dedicated lifecycle group.
- Breaking changes (API, config, database, etc.): The Studio client no longer sends retired lifecycle tools or client-managed lease, manifest, receipt, and operation-key fields.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run; no local Context Loader/Core integration environment used)
- [ ] Verified in test environment (not run)

Test notes:

- `pnpm exec vitest --run src/modules/knowledge-network/services/bkn-lifecycle.test.ts src/modules/knowledge-network/services/agent-chat-tools.test.ts src/modules/knowledge-network/services/context-loader.request.test.ts src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.test.ts` (29 tests passed)
- `pnpm exec tsc -b --pretty false`
- Focused ESLint with `--max-warnings 0` for all changed modules
- `pnpm exec vite build`
- Full Vitest suite, license-header check, and production audit were not run per request to limit validation to affected modules.

---

## Risk & Rollback

- Potential risks: Requires Context Loader versions that expose the new lifecycle contract. The display mapping has an English-description fallback for future unknown `bkn_*` tools.
- Rollback plan: Revert commit `773dd2b`.

---

## Additional Notes

- MCP Debug lifecycle tools are ordered with start before finish.