### PR TITLE
fix(knowledge-network): enforce record-level permissions

### DIFF
--- a/src/modules/knowledge-network/components/action-type/ActionTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeListPanel.tsx
@@ -36,6 +36,7 @@ import type {
 import styles from "@/modules/knowledge-network/components/shared/ResourceListPanel.module.css";
 
 type ActionTypeListPanelProps = {
+  canModify: boolean;
   items: KnowledgeNetworkActionTypeRecord[];
   loading?: boolean;
   networkId: string;
@@ -62,6 +63,7 @@ function getActionKindLabel(
 }
 
 export function ActionTypeListPanel({
+  canModify,
   items,
   loading,
   networkId,
@@ -235,9 +237,13 @@ export function ActionTypeListPanel({
       render: (_value, record) => {
         const menuItems: MenuProps["items"] = [
           { key: "view", label: t("common.detail") },
-          { key: "edit", label: t("common.edit") },
-          { key: "execution", label: t("knowledgeNetwork.actionTypeExecutionEntry") },
-          { key: "delete", danger: true, label: t("common.delete") },
+          ...(canModify
+            ? [
+                { key: "edit", label: t("common.edit") },
+                { key: "execution", label: t("knowledgeNetwork.actionTypeExecutionEntry") },
+                { key: "delete", danger: true, label: t("common.delete") },
+              ]
+            : []),
         ];
 
         return (
@@ -314,6 +320,15 @@ export function ActionTypeListPanel({
       );
     }
 
+    if (!canModify) {
+      return (
+        <Empty
+          className={styles.emptyPanel}
+          description={t("knowledgeNetwork.emptyActionTypes")}
+        />
+      );
+    }
+
     return (
       <Empty
         className={styles.emptyPanel}
@@ -341,25 +356,29 @@ export function ActionTypeListPanel({
 
       <div className={styles.toolbar}>
         <div className={styles.toolbarLeft}>
-          <AppButton
-            className={styles.toolbarButton}
-            icon={<PlusOutlined />}
-            onClick={() => {
-              void navigate(`/knowledge-network/workspace/${networkId}/action-types/create`);
-            }}
-            type="primary"
-          >
-            {t("common.create")}
-          </AppButton>
-          <AppButton
-            className={styles.toolbarButton}
-            danger
-            disabled={selectedRows.length === 0}
-            icon={<DeleteOutlined />}
-            onClick={() => confirmDelete(selectedRows)}
-          >
-            {t("common.delete")}
-          </AppButton>
+          {canModify ? (
+            <>
+              <AppButton
+                className={styles.toolbarButton}
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  void navigate(`/knowledge-network/workspace/${networkId}/action-types/create`);
+                }}
+                type="primary"
+              >
+                {t("common.create")}
+              </AppButton>
+              <AppButton
+                className={styles.toolbarButton}
+                danger
+                disabled={selectedRows.length === 0}
+                icon={<DeleteOutlined />}
+                onClick={() => confirmDelete(selectedRows)}
+              >
+                {t("common.delete")}
+              </AppButton>
+            </>
+          ) : null}
         </div>
         <div className={styles.toolbarRight}>
           <Input
@@ -456,12 +475,16 @@ export function ActionTypeListPanel({
           locale={{ emptyText: renderEmptyContent() }}
           pagination={false}
           rowKey="id"
-          rowSelection={{
-            selectedRowKeys,
-            onChange: (nextSelectedRowKeys) => {
-              setSelectedRowKeys(nextSelectedRowKeys.map(String));
-            },
-          }}
+          rowSelection={
+            canModify
+              ? {
+                  selectedRowKeys,
+                  onChange: (nextSelectedRowKeys) => {
+                    setSelectedRowKeys(nextSelectedRowKeys.map(String));
+                  },
+                }
+              : undefined
+          }
           scroll={{ x: 1180 }}
           size="middle"
         />

--- a/src/modules/knowledge-network/components/concept-group/ConceptGroupListPanel.tsx
+++ b/src/modules/knowledge-network/components/concept-group/ConceptGroupListPanel.tsx
@@ -40,6 +40,7 @@ import type {
 import styles from "@/modules/knowledge-network/components/shared/ResourceListPanel.module.css";
 
 type ConceptGroupListPanelProps = {
+  canModify: boolean;
   items: ConceptGroupRecord[];
   loading?: boolean;
   networkId: string;
@@ -64,6 +65,7 @@ function downloadConceptGroupExport(detail: ConceptGroupDetail) {
 }
 
 export function ConceptGroupListPanel({
+  canModify,
   items,
   loading,
   networkId,
@@ -231,12 +233,7 @@ export function ConceptGroupListPanel({
           >
             <AppstoreOutlined />
           </span>
-          <div className={styles.objectNameColumn}>
-            <span className={styles.objectName}>{value}</span>
-            <span className={styles.objectSubName}>
-              {record.description || t("knowledgeNetwork.noDescription")}
-            </span>
-          </div>
+          <span className={styles.objectName}>{value}</span>
         </div>
       ),
     },
@@ -248,9 +245,13 @@ export function ConceptGroupListPanel({
       render: (_value, record) => {
         const menuItems: MenuProps["items"] = [
           { key: "view", label: t("common.detail") },
-          { key: "edit", label: t("common.edit") },
           { key: "export", label: t("knowledgeNetwork.conceptGroupExport") },
-          { key: "delete", danger: true, label: t("common.delete") },
+          ...(canModify
+            ? [
+                { key: "edit", label: t("common.edit") },
+                { key: "delete", danger: true, label: t("common.delete") },
+              ]
+            : []),
         ];
 
         return (
@@ -313,6 +314,15 @@ export function ConceptGroupListPanel({
       );
     }
 
+    if (!canModify) {
+      return (
+        <Empty
+          className={styles.emptyPanel}
+          description={t("knowledgeNetwork.emptyConceptGroups")}
+        />
+      );
+    }
+
     return (
       <Empty
         className={styles.emptyPanel}
@@ -340,30 +350,34 @@ export function ConceptGroupListPanel({
 
       <div className={styles.toolbar}>
         <div className={styles.toolbarLeft}>
-          <AppButton
-            className={styles.toolbarButton}
-            icon={<PlusOutlined />}
-            onClick={() => {
-              void navigate(`/knowledge-network/workspace/${networkId}/concept-groups/create`);
-            }}
-            type="primary"
-          >
-            {t("common.create")}
-          </AppButton>
-          <AppButton
-            className={styles.toolbarButton}
-            danger
-            disabled={selectedRows.length === 0}
-            icon={<DeleteOutlined />}
-            onClick={() => confirmDelete(selectedRows)}
-          >
-            {t("common.delete")}
-          </AppButton>
-          <JsonResourceImportButton
-            className={styles.toolbarButton}
-            onImported={onRefresh}
-            onImport={onImport}
-          />
+          {canModify ? (
+            <>
+              <AppButton
+                className={styles.toolbarButton}
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  void navigate(`/knowledge-network/workspace/${networkId}/concept-groups/create`);
+                }}
+                type="primary"
+              >
+                {t("common.create")}
+              </AppButton>
+              <AppButton
+                className={styles.toolbarButton}
+                danger
+                disabled={selectedRows.length === 0}
+                icon={<DeleteOutlined />}
+                onClick={() => confirmDelete(selectedRows)}
+              >
+                {t("common.delete")}
+              </AppButton>
+              <JsonResourceImportButton
+                className={styles.toolbarButton}
+                onImported={onRefresh}
+                onImport={onImport}
+              />
+            </>
+          ) : null}
         </div>
         <div className={styles.toolbarRight}>
           <Input
@@ -442,12 +456,16 @@ export function ConceptGroupListPanel({
           locale={{ emptyText: renderEmptyContent() }}
           pagination={false}
           rowKey="id"
-          rowSelection={{
-            selectedRowKeys,
-            onChange: (nextSelectedRowKeys) => {
-              setSelectedRowKeys(nextSelectedRowKeys.map(String));
-            },
-          }}
+          rowSelection={
+            canModify
+              ? {
+                  selectedRowKeys,
+                  onChange: (nextSelectedRowKeys) => {
+                    setSelectedRowKeys(nextSelectedRowKeys.map(String));
+                  },
+                }
+              : undefined
+          }
           scroll={{ x: 920 }}
           size="middle"
         />

--- a/src/modules/knowledge-network/components/metric/MetricListPanel.tsx
+++ b/src/modules/knowledge-network/components/metric/MetricListPanel.tsx
@@ -44,6 +44,7 @@ import { resolveMetricBoundObjectTypeName } from "@/modules/knowledge-network/ut
 import styles from "@/modules/knowledge-network/components/shared/ResourceListPanel.module.css";
 
 type MetricListPanelProps = {
+  canModify: boolean;
   loading?: boolean;
   metrics: KnowledgeNetworkMetricRecord[];
   networkId: string;
@@ -68,6 +69,7 @@ function getMetricTypeLabel(
 }
 
 export function MetricListPanel({
+  canModify,
   loading,
   metrics,
   networkId,
@@ -221,8 +223,12 @@ export function MetricListPanel({
       render: (_value, record) => {
         const menuItems: MenuProps["items"] = [
           { key: "view", label: t("common.detail") },
-          { key: "edit", label: t("common.edit") },
-          { key: "delete", danger: true, label: t("common.delete") },
+          ...(canModify
+            ? [
+                { key: "edit", label: t("common.edit") },
+                { key: "delete", danger: true, label: t("common.delete") },
+              ]
+            : []),
         ];
 
         return (
@@ -300,6 +306,15 @@ export function MetricListPanel({
       );
     }
 
+    if (!canModify) {
+      return (
+        <Empty
+          className={styles.emptyPanel}
+          description={t("knowledgeNetwork.emptyMetrics")}
+        />
+      );
+    }
+
     return (
       <Empty
         className={styles.emptyPanel}
@@ -331,10 +346,14 @@ export function MetricListPanel({
         loading={tableLoading}
         pagination={false}
         rowKey="id"
-        rowSelection={{
-          selectedRowKeys,
-          onChange: (keys) => setSelectedRowKeys(keys as string[]),
-        }}
+        rowSelection={
+          canModify
+            ? {
+                selectedRowKeys,
+                onChange: (keys) => setSelectedRowKeys(keys as string[]),
+              }
+            : undefined
+        }
         scroll={{ x: 980 }}
         size="middle"
       />
@@ -355,28 +374,32 @@ export function MetricListPanel({
 
       <div className={styles.toolbar}>
         <div className={styles.toolbarLeft}>
-          <AppButton
-            className={styles.toolbarButton}
-            icon={<PlusOutlined />}
-            onClick={() => {
-              void navigate(`/knowledge-network/workspace/${networkId}/metrics/create`);
-            }}
-            type="primary"
-          >
-            {t("common.create")}
-          </AppButton>
-          <AppButton
-            className={styles.toolbarButton}
-            danger
-            disabled={selectedRowKeys.length === 0}
-            icon={<DeleteOutlined />}
-            onClick={() => {
-              const pageSelectedRecords = tableMetrics.filter((item) => selectedRowKeys.includes(item.id));
-              confirmDelete(pageSelectedRecords);
-            }}
-          >
-            {t("common.delete")}
-          </AppButton>
+          {canModify ? (
+            <>
+              <AppButton
+                className={styles.toolbarButton}
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  void navigate(`/knowledge-network/workspace/${networkId}/metrics/create`);
+                }}
+                type="primary"
+              >
+                {t("common.create")}
+              </AppButton>
+              <AppButton
+                className={styles.toolbarButton}
+                danger
+                disabled={selectedRowKeys.length === 0}
+                icon={<DeleteOutlined />}
+                onClick={() => {
+                  const pageSelectedRecords = tableMetrics.filter((item) => selectedRowKeys.includes(item.id));
+                  confirmDelete(pageSelectedRecords);
+                }}
+              >
+                {t("common.delete")}
+              </AppButton>
+            </>
+          ) : null}
         </div>
         <div className={styles.toolbarRight}>
           <Input

--- a/src/modules/knowledge-network/components/network/KnowledgeNetworkCard.test.tsx
+++ b/src/modules/knowledge-network/components/network/KnowledgeNetworkCard.test.tsx
@@ -14,14 +14,14 @@ import {
   getKnowledgeNetworkCardMenuKeys,
 } from "./knowledge-network-card";
 
-function createRecord(operations: string[]): KnowledgeNetworkRecord {
+function createRecord(operations?: string[]): KnowledgeNetworkRecord {
   return {
     id: "network-1",
     identifier: "network_1",
     name: "Network 1",
     description: "",
     color: "#1677ff",
-    operations,
+    ...(operations === undefined ? {} : { operations }),
     tags: [],
     createTime: "",
     updateTime: "",
@@ -64,8 +64,9 @@ describe("getKnowledgeNetworkCardMenuKeys", () => {
     ).toEqual(["view", "edit", "export", "delete"]);
   });
 
-  it("treats missing records and missing operations as no write access", () => {
+  it("treats missing records as no access and missing operations as fallback allow", () => {
     expect(hasKnowledgeNetworkRecordOperation(null, "modify")).toBe(false);
+    expect(hasKnowledgeNetworkRecordOperation(createRecord(), "modify")).toBe(true);
     expect(hasKnowledgeNetworkRecordOperation(createRecord(["view_detail"]), "modify")).toBe(false);
   });
 });

--- a/src/modules/knowledge-network/components/network/KnowledgeNetworkCard.test.tsx
+++ b/src/modules/knowledge-network/components/network/KnowledgeNetworkCard.test.tsx
@@ -7,7 +7,35 @@
 
 import { describe, expect, it } from "vitest";
 
-import { formatKnowledgeNetworkUpdateTime } from "./knowledge-network-card";
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
+import {
+  formatKnowledgeNetworkUpdateTime,
+  getKnowledgeNetworkCardMenuKeys,
+} from "./knowledge-network-card";
+
+function createRecord(operations: string[]): KnowledgeNetworkRecord {
+  return {
+    id: "network-1",
+    identifier: "network_1",
+    name: "Network 1",
+    description: "",
+    color: "#1677ff",
+    operations,
+    tags: [],
+    createTime: "",
+    updateTime: "",
+    creatorName: "",
+    updaterName: "",
+    statistics: {
+      objectTypesTotal: 0,
+      relationTypesTotal: 0,
+      actionTypesTotal: 0,
+      conceptGroupsTotal: 0,
+      metricsTotal: 0,
+    },
+  };
+}
 
 describe("formatKnowledgeNetworkUpdateTime", () => {
   it("removes seconds only from a complete time value", () => {
@@ -19,5 +47,25 @@ describe("formatKnowledgeNetworkUpdateTime", () => {
     expect(formatKnowledgeNetworkUpdateTime("-")).toBe("-");
     expect(formatKnowledgeNetworkUpdateTime("")).toBe("--");
     expect(formatKnowledgeNetworkUpdateTime()).toBe("--");
+  });
+});
+
+describe("getKnowledgeNetworkCardMenuKeys", () => {
+  it("hides edit and delete when record operations do not allow them", () => {
+    expect(getKnowledgeNetworkCardMenuKeys(createRecord(["view_detail"]))).toEqual([
+      "view",
+      "export",
+    ]);
+  });
+
+  it("shows edit and delete only when record operations allow them", () => {
+    expect(
+      getKnowledgeNetworkCardMenuKeys(createRecord(["view_detail", "modify", "delete"])),
+    ).toEqual(["view", "edit", "export", "delete"]);
+  });
+
+  it("treats missing records and missing operations as no write access", () => {
+    expect(hasKnowledgeNetworkRecordOperation(null, "modify")).toBe(false);
+    expect(hasKnowledgeNetworkRecordOperation(createRecord(["view_detail"]), "modify")).toBe(false);
   });
 });

--- a/src/modules/knowledge-network/components/network/KnowledgeNetworkCard.tsx
+++ b/src/modules/knowledge-network/components/network/KnowledgeNetworkCard.tsx
@@ -13,7 +13,10 @@ import { useTranslation } from "react-i18next";
 import { MarkdownText } from "@/framework/ui/common/MarkdownText";
 import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
 
-import { formatKnowledgeNetworkUpdateTime } from "./knowledge-network-card";
+import {
+  formatKnowledgeNetworkUpdateTime,
+  getKnowledgeNetworkCardMenuKeys,
+} from "./knowledge-network-card";
 import styles from "./KnowledgeNetworkCard.module.css";
 
 type KnowledgeNetworkCardProps = {
@@ -34,25 +37,20 @@ export function KnowledgeNetworkCard({
   const { t } = useTranslation();
   const description = record.description || t("knowledgeNetwork.noDescription");
   const updateTime = formatKnowledgeNetworkUpdateTime(record.updateTime);
-  const dropdownItems: MenuProps["items"] = [
-    {
-      key: "view",
-      label: t("common.detail"),
-    },
-    {
-      key: "edit",
-      label: t("common.edit"),
-    },
-    {
-      key: "export",
-      label: t("knowledgeNetwork.export"),
-    },
-    {
-      key: "delete",
-      danger: true,
-      label: t("common.delete"),
-    },
-  ];
+  const dropdownItems: MenuProps["items"] = getKnowledgeNetworkCardMenuKeys(record).map(
+    (key) => ({
+      key,
+      danger: key === "delete",
+      label:
+        key === "view"
+          ? t("common.detail")
+          : key === "edit"
+            ? t("common.edit")
+            : key === "export"
+              ? t("knowledgeNetwork.export")
+              : t("common.delete"),
+    }),
+  );
 
   return (
     <article

--- a/src/modules/knowledge-network/components/network/knowledge-network-card.ts
+++ b/src/modules/knowledge-network/components/network/knowledge-network-card.ts
@@ -5,6 +5,18 @@
  * Conditions. See LICENSE for the full text.
  */
 
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
+
 export function formatKnowledgeNetworkUpdateTime(value?: string): string {
   return value?.replace(/(\d{2}:\d{2}):\d{2}$/, "$1") || "--";
+}
+
+export function getKnowledgeNetworkCardMenuKeys(record: KnowledgeNetworkRecord) {
+  return [
+    "view",
+    ...(hasKnowledgeNetworkRecordOperation(record, "modify") ? ["edit"] : []),
+    "export",
+    ...(hasKnowledgeNetworkRecordOperation(record, "delete") ? ["delete"] : []),
+  ];
 }

--- a/src/modules/knowledge-network/components/object-type/ObjectTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/object-type/ObjectTypeListPanel.tsx
@@ -39,6 +39,7 @@ import type {
 import styles from "@/modules/knowledge-network/components/shared/ResourceListPanel.module.css";
 
 type ObjectTypeListPanelProps = {
+  canModify: boolean;
   items: KnowledgeNetworkObjectTypeRecord[];
   loading?: boolean;
   networkId: string;
@@ -57,6 +58,7 @@ function readSortDirection(value: string | null): "asc" | "desc" {
 const PAGE_SIZE_STORAGE_SCOPE = "object-types";
 
 export function ObjectTypeListPanel({
+  canModify,
   items,
   loading,
   networkId,
@@ -86,7 +88,11 @@ export function ObjectTypeListPanel({
     () => items.map((item) => item.dataSource?.id),
     [items],
   );
-  const { buildTasksByResourceId, loading: resourceBuildTasksLoading } =
+  const {
+    buildTasksByResourceId,
+    canLoadResourceIndexStates,
+    loading: resourceBuildTasksLoading,
+  } =
     useResourceIndexStates(boundResourceIds);
 
   useEffect(() => {
@@ -309,8 +315,12 @@ export function ObjectTypeListPanel({
       render: (_value, record) => {
         const menuItems: MenuProps["items"] = [
           { key: "view", label: t("common.detail") },
-          { key: "edit", label: t("common.edit") },
-          { key: "delete", danger: true, label: t("common.delete") },
+          ...(canModify
+            ? [
+                { key: "edit", label: t("common.edit") },
+                { key: "delete", danger: true, label: t("common.delete") },
+              ]
+            : []),
         ];
 
         return (
@@ -368,9 +378,13 @@ export function ObjectTypeListPanel({
           return "--";
         }
 
-        const label = resourceBuildTasksLoading
-          ? t("knowledgeNetwork.objectTypeDataViewIndexLoading")
-          : formatResourceIndexStateLabel(buildTasksByResourceId.get(resourceId) ?? [], t);
+        const label = canLoadResourceIndexStates
+          ? resourceBuildTasksLoading
+            ? t("knowledgeNetwork.objectTypeDataViewIndexLoading")
+            : formatResourceIndexStateLabel(buildTasksByResourceId.get(resourceId) ?? [], t)
+          : record.hasIndex
+            ? t("knowledgeNetwork.previewIndexed")
+            : t("knowledgeNetwork.previewNotIndexed");
 
         return (
           <button
@@ -423,6 +437,15 @@ export function ObjectTypeListPanel({
       );
     }
 
+    if (!canModify) {
+      return (
+        <Empty
+          className={styles.emptyPanel}
+          description={t("knowledgeNetwork.emptyObjectTypes")}
+        />
+      );
+    }
+
     return (
       <Empty
         className={styles.emptyPanel}
@@ -456,25 +479,29 @@ export function ObjectTypeListPanel({
 
       <div className={styles.toolbar}>
         <div className={styles.toolbarLeft}>
-          <AppButton
-            className={styles.toolbarButton}
-            icon={<PlusOutlined />}
-            onClick={() => {
-              void navigate(`/knowledge-network/workspace/${networkId}/object-types/create`);
-            }}
-            type="primary"
-          >
-            {t("common.create")}
-          </AppButton>
-          <AppButton
-            className={styles.toolbarButton}
-            danger
-            disabled={selectedRows.length === 0}
-            icon={<DeleteOutlined />}
-            onClick={() => confirmDelete(selectedRows)}
-          >
-            {t("common.delete")}
-          </AppButton>
+          {canModify ? (
+            <>
+              <AppButton
+                className={styles.toolbarButton}
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  void navigate(`/knowledge-network/workspace/${networkId}/object-types/create`);
+                }}
+                type="primary"
+              >
+                {t("common.create")}
+              </AppButton>
+              <AppButton
+                className={styles.toolbarButton}
+                danger
+                disabled={selectedRows.length === 0}
+                icon={<DeleteOutlined />}
+                onClick={() => confirmDelete(selectedRows)}
+              >
+                {t("common.delete")}
+              </AppButton>
+            </>
+          ) : null}
         </div>
         <div className={styles.toolbarRight}>
           <Input
@@ -559,12 +586,16 @@ export function ObjectTypeListPanel({
           locale={{ emptyText: tableEmptyText }}
           pagination={false}
           rowKey="id"
-          rowSelection={{
-            selectedRowKeys,
-            onChange: (nextSelectedRowKeys) => {
-              setSelectedRowKeys(nextSelectedRowKeys.map(String));
-            },
-          }}
+          rowSelection={
+            canModify
+              ? {
+                  selectedRowKeys,
+                  onChange: (nextSelectedRowKeys) => {
+                    setSelectedRowKeys(nextSelectedRowKeys.map(String));
+                  },
+                }
+              : undefined
+          }
           scroll={{ x: 1180 }}
           size="middle"
         />

--- a/src/modules/knowledge-network/components/preview/OverviewOntologyBlock.tsx
+++ b/src/modules/knowledge-network/components/preview/OverviewOntologyBlock.tsx
@@ -170,7 +170,11 @@ export function OverviewOntologyBlock({
     () => objectTypes.map((item) => item.dataSource?.id),
     [objectTypes],
   );
-  const { buildTasksByResourceId, loading: resourceIndexLoading } =
+  const {
+    buildTasksByResourceId,
+    canLoadResourceIndexStates,
+    loading: resourceIndexLoading,
+  } =
     useResourceIndexStates(boundResourceIds);
 
   const renderResourceIndexState = useCallback(
@@ -180,13 +184,17 @@ export function OverviewOntologyBlock({
         return <span className={styles.muted}>—</span>;
       }
 
-      const label = resourceIndexLoading
-        ? t("knowledgeNetwork.objectTypeDataViewIndexLoading")
-        : formatResourceIndexStateLabel(buildTasksByResourceId.get(resourceId) ?? [], t);
+      const label = canLoadResourceIndexStates
+        ? resourceIndexLoading
+          ? t("knowledgeNetwork.objectTypeDataViewIndexLoading")
+          : formatResourceIndexStateLabel(buildTasksByResourceId.get(resourceId) ?? [], t)
+        : entity.hasIndex
+          ? t("knowledgeNetwork.previewIndexed")
+          : t("knowledgeNetwork.previewNotIndexed");
 
       return <span>{label}</span>;
     },
-    [buildTasksByResourceId, resourceIndexLoading, t],
+    [buildTasksByResourceId, canLoadResourceIndexStates, resourceIndexLoading, t],
   );
 
   const entityColumns: ColumnsType<KnowledgeNetworkObjectTypeRecord> = useMemo(
@@ -329,11 +337,13 @@ export function OverviewOntologyBlock({
     <div className={styles.block}>
       <Spin spinning={previewLoading}>
         <OntologyGraphCard
-          buildTasksByResourceId={buildTasksByResourceId}
+          buildTasksByResourceId={
+            canLoadResourceIndexStates ? buildTasksByResourceId : undefined
+          }
           networkId={networkId}
           objectTypes={objectTypes}
           relationTypes={relationTypes}
-          resourceIndexLoading={resourceIndexLoading}
+          resourceIndexLoading={canLoadResourceIndexStates && resourceIndexLoading}
         />
       </Spin>
 

--- a/src/modules/knowledge-network/components/relation-type/RelationTypeListPanel.tsx
+++ b/src/modules/knowledge-network/components/relation-type/RelationTypeListPanel.tsx
@@ -34,6 +34,7 @@ import type {
 import styles from "@/modules/knowledge-network/components/shared/ResourceListPanel.module.css";
 
 type RelationTypeListPanelProps = {
+  canModify: boolean;
   items: KnowledgeNetworkRelationTypeRecord[];
   loading?: boolean;
   networkId: string;
@@ -43,6 +44,7 @@ type RelationTypeListPanelProps = {
 };
 
 export function RelationTypeListPanel({
+  canModify,
   items,
   loading,
   networkId,
@@ -242,9 +244,13 @@ export function RelationTypeListPanel({
       render: (_value, record) => {
         const menuItems: MenuProps["items"] = [
           { key: "view", label: t("common.detail") },
-          { key: "edit", label: t("common.edit") },
-          { key: "mapping", label: t("knowledgeNetwork.relationTypeMappingEntry") },
-          { key: "delete", danger: true, label: t("common.delete") },
+          ...(canModify
+            ? [
+                { key: "edit", label: t("common.edit") },
+                { key: "mapping", label: t("knowledgeNetwork.relationTypeMappingEntry") },
+                { key: "delete", danger: true, label: t("common.delete") },
+              ]
+            : []),
         ];
 
         return (
@@ -333,6 +339,15 @@ export function RelationTypeListPanel({
       );
     }
 
+    if (!canModify) {
+      return (
+        <Empty
+          className={styles.emptyPanel}
+          description={t("knowledgeNetwork.emptyRelationTypes")}
+        />
+      );
+    }
+
     return (
       <Empty
         className={styles.emptyPanel}
@@ -366,25 +381,29 @@ export function RelationTypeListPanel({
 
       <div className={styles.toolbar}>
         <div className={styles.toolbarLeft}>
-          <AppButton
-            className={styles.toolbarButton}
-            icon={<PlusOutlined />}
-            onClick={() => {
-              void navigate(`/knowledge-network/workspace/${networkId}/relation-types/create`);
-            }}
-            type="primary"
-          >
-            {t("common.create")}
-          </AppButton>
-          <AppButton
-            className={styles.toolbarButton}
-            danger
-            disabled={selectedRows.length === 0}
-            icon={<DeleteOutlined />}
-            onClick={() => confirmDelete(selectedRows)}
-          >
-            {t("common.delete")}
-          </AppButton>
+          {canModify ? (
+            <>
+              <AppButton
+                className={styles.toolbarButton}
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  void navigate(`/knowledge-network/workspace/${networkId}/relation-types/create`);
+                }}
+                type="primary"
+              >
+                {t("common.create")}
+              </AppButton>
+              <AppButton
+                className={styles.toolbarButton}
+                danger
+                disabled={selectedRows.length === 0}
+                icon={<DeleteOutlined />}
+                onClick={() => confirmDelete(selectedRows)}
+              >
+                {t("common.delete")}
+              </AppButton>
+            </>
+          ) : null}
         </div>
         <div className={styles.toolbarRight}>
           <Input
@@ -486,12 +505,16 @@ export function RelationTypeListPanel({
           locale={{ emptyText: tableEmptyText }}
           pagination={false}
           rowKey="id"
-          rowSelection={{
-            selectedRowKeys,
-            onChange: (nextSelectedRowKeys) => {
-              setSelectedRowKeys(nextSelectedRowKeys.map(String));
-            },
-          }}
+          rowSelection={
+            canModify
+              ? {
+                  selectedRowKeys,
+                  onChange: (nextSelectedRowKeys) => {
+                    setSelectedRowKeys(nextSelectedRowKeys.map(String));
+                  },
+                }
+              : undefined
+          }
           scroll={{ x: 1280 }}
           size="middle"
         />

--- a/src/modules/knowledge-network/components/shared/ResourceListPanel.module.css
+++ b/src/modules/knowledge-network/components/shared/ResourceListPanel.module.css
@@ -190,22 +190,6 @@
   white-space: nowrap;
 }
 
-.objectNameColumn {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-.objectSubName {
-  color: rgba(0, 0, 0, 0.45);
-  font-size: 12px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .relatedStats {
   display: flex;
   align-items: center;
@@ -562,11 +546,6 @@
 
 .metricPage .noticeBanner :global(.ant-alert) {
   border-radius: 0;
-}
-
-.conceptGroupPage .objectSubName {
-  color: #6b7280;
-  line-height: 1.4;
 }
 
 .dropdownMenu :global(.ant-dropdown-menu) {

--- a/src/modules/knowledge-network/hooks/useAccountDirectory.ts
+++ b/src/modules/knowledge-network/hooks/useAccountDirectory.ts
@@ -11,15 +11,29 @@ import {
   buildAuditUserDirectory,
   formatAuditUserDisplay,
 } from "@/modules/execution-factory-lab/utils/audit-user-display";
+import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
+import { hasPermissions } from "@/framework/permission/has-permissions";
 import { getUser, listUsers } from "@/modules/system-admin/services/admin.service";
+import { systemAdminPermissions } from "@/modules/system-admin/permissions";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function useAccountDirectory() {
+  const runtimeConfig = useRuntimeConfig();
   const [directory, setDirectory] = useState<Map<string, string>>(new Map());
+  const canListUsers = hasPermissions({
+    currentPermissions: runtimeConfig.currentUser.permissions,
+    mode: "any",
+    requiredPermissions: systemAdminPermissions.users,
+  });
 
   useEffect(() => {
+    if (!canListUsers) {
+      setDirectory(new Map());
+      return;
+    }
+
     void listUsers({ skipErrorToast: true })
       .then((users) => {
         setDirectory(buildAuditUserDirectory(users));
@@ -27,7 +41,7 @@ export function useAccountDirectory() {
       .catch(() => {
         setDirectory(new Map());
       });
-  }, []);
+  }, [canListUsers]);
 
   return directory;
 }
@@ -47,7 +61,13 @@ export function resolveUpdaterDisplayName(
 
 export function useResolvedUpdaterName(updaterName?: string, emptyLabel = "--") {
   const directory = useAccountDirectory();
+  const runtimeConfig = useRuntimeConfig();
   const [resolved, setResolved] = useState(emptyLabel);
+  const canReadUserDetail = hasPermissions({
+    currentPermissions: runtimeConfig.currentUser.permissions,
+    mode: "any",
+    requiredPermissions: systemAdminPermissions.users,
+  });
 
   useEffect(() => {
     const trimmed = updaterName?.trim();
@@ -64,6 +84,11 @@ export function useResolvedUpdaterName(updaterName?: string, emptyLabel = "--") 
 
     if (!UUID_PATTERN.test(trimmed)) {
       setResolved(trimmed);
+      return;
+    }
+
+    if (!canReadUserDetail) {
+      setResolved(emptyLabel);
       return;
     }
 
@@ -85,7 +110,7 @@ export function useResolvedUpdaterName(updaterName?: string, emptyLabel = "--") 
     return () => {
       cancelled = true;
     };
-  }, [directory, emptyLabel, updaterName]);
+  }, [canReadUserDetail, directory, emptyLabel, updaterName]);
 
   return resolved;
 }

--- a/src/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify.ts
+++ b/src/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify.ts
@@ -10,13 +10,27 @@ import { useEffect, useState } from "react";
 import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
 import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 
-export function useKnowledgeNetworkCanModify(networkId: string) {
-  const [canModify, setCanModify] = useState(false);
+type OperationAccess = Record<string, boolean>;
+
+function createOperationAccess(operations: readonly string[], value: boolean) {
+  return Object.fromEntries(operations.map((operation) => [operation, value]));
+}
+
+export function useKnowledgeNetworkOperationAccess(
+  networkId: string,
+  operations: readonly string[],
+) {
+  const [access, setAccess] = useState<OperationAccess>(() =>
+    createOperationAccess(operations, false),
+  );
+  const operationsKey = operations.join("\u0000");
 
   useEffect(() => {
     let cancelled = false;
+    const requestedOperations =
+      operationsKey.length > 0 ? operationsKey.split("\u0000") : [];
 
-    setCanModify(false);
+    setAccess(createOperationAccess(requestedOperations, false));
 
     if (!networkId) {
       return () => {
@@ -27,19 +41,34 @@ export function useKnowledgeNetworkCanModify(networkId: string) {
     void getKnowledgeNetwork(networkId)
       .then((record) => {
         if (!cancelled) {
-          setCanModify(hasKnowledgeNetworkRecordOperation(record, "modify"));
+          setAccess(
+            Object.fromEntries(
+              requestedOperations.map((operation) => [
+                operation,
+                hasKnowledgeNetworkRecordOperation(record, operation),
+              ]),
+            ),
+          );
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setCanModify(false);
+          setAccess(createOperationAccess(requestedOperations, false));
         }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [networkId]);
+  }, [networkId, operationsKey]);
 
-  return canModify;
+  return access;
+}
+
+export function useKnowledgeNetworkCanOperate(networkId: string, operation: string) {
+  return useKnowledgeNetworkOperationAccess(networkId, [operation])[operation] ?? false;
+}
+
+export function useKnowledgeNetworkCanModify(networkId: string) {
+  return useKnowledgeNetworkCanOperate(networkId, "modify");
 }

--- a/src/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify.ts
+++ b/src/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { useEffect, useState } from "react";
+
+import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
+
+export function useKnowledgeNetworkCanModify(networkId: string) {
+  const [canModify, setCanModify] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setCanModify(false);
+
+    if (!networkId) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void getKnowledgeNetwork(networkId)
+      .then((record) => {
+        if (!cancelled) {
+          setCanModify(hasKnowledgeNetworkRecordOperation(record, "modify"));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCanModify(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [networkId]);
+
+  return canModify;
+}

--- a/src/modules/knowledge-network/hooks/useResourceIndexStates.ts
+++ b/src/modules/knowledge-network/hooks/useResourceIndexStates.ts
@@ -7,11 +7,19 @@
 
 import { useEffect, useMemo, useState } from "react";
 
+import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
+import { hasPermissions } from "@/framework/permission/has-permissions";
 import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
 import { loadResourceIndexBuildTasks } from "@/modules/knowledge-network/utils/load-resource-index-build-tasks";
 
 /** Load data-catalog index build tasks for a deduplicated set of resource ids. */
 export function useResourceIndexStates(resourceIds: Array<string | undefined>) {
+  const runtimeConfig = useRuntimeConfig();
+  const canLoadResourceIndexStates = hasPermissions({
+    currentPermissions: runtimeConfig.currentUser.permissions,
+    mode: "any",
+    requiredPermissions: ["resource:view_detail", "resource:task_manage"],
+  });
   const boundResourceIds = useMemo(
     () =>
       Array.from(new Set(resourceIds.filter((id): id is string => Boolean(id)))),
@@ -22,7 +30,7 @@ export function useResourceIndexStates(resourceIds: Array<string | undefined>) {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    if (boundResourceIds.length === 0) {
+    if (!canLoadResourceIndexStates || boundResourceIds.length === 0) {
       setResourceBuildTasks([]);
       setLoading(false);
       return undefined;
@@ -51,7 +59,7 @@ export function useResourceIndexStates(resourceIds: Array<string | undefined>) {
     return () => {
       cancelled = true;
     };
-  }, [boundResourceIds]);
+  }, [boundResourceIds, canLoadResourceIndexStates]);
 
   const buildTasksByResourceId = useMemo(() => {
     const next = new Map<string, BuildTask[]>();
@@ -61,5 +69,5 @@ export function useResourceIndexStates(resourceIds: Array<string | undefined>) {
     return next;
   }, [resourceBuildTasks]);
 
-  return { buildTasksByResourceId, loading };
+  return { buildTasksByResourceId, canLoadResourceIndexStates, loading };
 }

--- a/src/modules/knowledge-network/locales/en-US/network.ts
+++ b/src/modules/knowledge-network/locales/en-US/network.ts
@@ -34,6 +34,7 @@ export const networkPart = {
     emptyObjectTypes: "No object types yet.",
     emptyRecentObjects: "No recent object types yet.",
     emptyRelationTypes: "No relation types yet.",
+    emptyMetrics: "No metrics yet.",
     emptyTasks: "No tasks yet.",
     emptyTitle: "No knowledge networks yet",
     enterWorkspace: "Open workspace",

--- a/src/modules/knowledge-network/locales/zh-CN/network.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/network.ts
@@ -33,6 +33,7 @@ export const networkPart = {
     emptyObjectTypes: "当前没有对象类。",
     emptyRecentObjects: "当前没有最近修改的对象类。",
     emptyRelationTypes: "当前没有关系类。",
+    emptyMetrics: "当前没有指标。",
     emptyTasks: "当前没有任务。",
     emptyTitle: "暂无知识网络",
     enterWorkspace: "进入工作区",

--- a/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.test.tsx
+++ b/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+import { KnowledgeNetworkModifyRouteGate } from "./KnowledgeNetworkModifyRouteGate";
+
+vi.mock("@/modules/knowledge-network/services/knowledge-network.service", () => ({
+  getKnowledgeNetwork: vi.fn(),
+}));
+
+const mockedGetKnowledgeNetwork = vi.mocked(getKnowledgeNetwork);
+
+function createRecord(operations?: string[]): KnowledgeNetworkRecord {
+  return {
+    id: "network-1",
+    identifier: "network_1",
+    name: "Network 1",
+    description: "",
+    color: "#1677ff",
+    ...(operations === undefined ? {} : { operations }),
+    tags: [],
+    createTime: "",
+    updateTime: "",
+    creatorName: "",
+    updaterName: "",
+    statistics: {
+      objectTypesTotal: 0,
+      relationTypesTotal: 0,
+      actionTypesTotal: 0,
+      conceptGroupsTotal: 0,
+      metricsTotal: 0,
+    },
+  };
+}
+
+function renderGate() {
+  return render(
+    <MemoryRouter
+      initialEntries={["/knowledge-network/workspace/network-1/object-types/create"]}
+    >
+      <Routes>
+        <Route
+          element={
+            <KnowledgeNetworkModifyRouteGate>
+              <div>modify form</div>
+            </KnowledgeNetworkModifyRouteGate>
+          }
+          path="/knowledge-network/workspace/:networkId/object-types/create"
+        />
+        <Route
+          element={<div>overview page</div>}
+          path="/knowledge-network/workspace/:networkId/overview"
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("KnowledgeNetworkModifyRouteGate", () => {
+  beforeEach(() => {
+    mockedGetKnowledgeNetwork.mockReset();
+  });
+
+  it("renders children when modify is allowed", async () => {
+    mockedGetKnowledgeNetwork.mockResolvedValue(createRecord(["modify"]));
+
+    renderGate();
+
+    expect(await screen.findByText("modify form")).toBeTruthy();
+  });
+
+  it("redirects to overview when modify is forbidden", async () => {
+    mockedGetKnowledgeNetwork.mockResolvedValue(createRecord(["view_detail"]));
+
+    renderGate();
+
+    expect(await screen.findByText("overview page")).toBeTruthy();
+  });
+
+  it("shows the request failure instead of redirecting on non-permission errors", async () => {
+    mockedGetKnowledgeNetwork.mockRejectedValue(
+      Object.assign(new Error("backend unavailable"), {
+        response: { status: 500 },
+      }),
+    );
+
+    renderGate();
+
+    expect(await screen.findByText("backend unavailable")).toBeTruthy();
+    expect(screen.queryByText("overview page")).toBeNull();
+  });
+});

--- a/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.tsx
+++ b/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.tsx
@@ -5,11 +5,13 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Spin } from "antd";
+import { Alert, Spin } from "antd";
 import { type ReactNode, useEffect, useState } from "react";
 import { Navigate, useParams } from "react-router-dom";
 
+import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { getRequestErrorStatus } from "@/modules/knowledge-network/services/shared/runtime";
 import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 
 type KnowledgeNetworkModifyRouteGateProps = {
@@ -21,20 +23,27 @@ export function KnowledgeNetworkModifyRouteGate({
 }: KnowledgeNetworkModifyRouteGateProps) {
   const { networkId = "" } = useParams<{ networkId: string }>();
   const [allowed, setAllowed] = useState<boolean | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
     setAllowed(null);
+    setError(null);
     void getKnowledgeNetwork(networkId)
       .then((record) => {
         if (!cancelled) {
           setAllowed(hasKnowledgeNetworkRecordOperation(record, "modify"));
         }
       })
-      .catch(() => {
+      .catch((nextError: unknown) => {
         if (!cancelled) {
-          setAllowed(false);
+          if (getRequestErrorStatus(nextError) === 403) {
+            setAllowed(false);
+            return;
+          }
+
+          setError(extractRequestErrorMessage(nextError));
         }
       });
 
@@ -42,6 +51,10 @@ export function KnowledgeNetworkModifyRouteGate({
       cancelled = true;
     };
   }, [networkId]);
+
+  if (error) {
+    return <Alert message={error} showIcon type="error" />;
+  }
 
   if (allowed === null) {
     return <Spin fullscreen />;

--- a/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.tsx
+++ b/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { Spin } from "antd";
+import { type ReactNode, useEffect, useState } from "react";
+import { Navigate, useParams } from "react-router-dom";
+
+import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
+
+type KnowledgeNetworkModifyRouteGateProps = {
+  children: ReactNode;
+};
+
+export function KnowledgeNetworkModifyRouteGate({
+  children,
+}: KnowledgeNetworkModifyRouteGateProps) {
+  const { networkId = "" } = useParams<{ networkId: string }>();
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setAllowed(null);
+    void getKnowledgeNetwork(networkId)
+      .then((record) => {
+        if (!cancelled) {
+          setAllowed(hasKnowledgeNetworkRecordOperation(record, "modify"));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAllowed(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [networkId]);
+
+  if (allowed === null) {
+    return <Spin fullscreen />;
+  }
+
+  if (!allowed) {
+    return (
+      <Navigate
+        replace
+        to={`/knowledge-network/workspace/${networkId}/overview`}
+      />
+    );
+  }
+
+  return children;
+}

--- a/src/modules/knowledge-network/routes/standalone-routes.tsx
+++ b/src/modules/knowledge-network/routes/standalone-routes.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { RouteObject } from "react-router-dom";
+import type { ReactNode } from "react";
 
 import {
   ActionTypeCreatePage,
@@ -30,7 +31,12 @@ import {
   TaskDetailPage,
   workspaceSectionPage,
 } from "@/modules/knowledge-network/routes/lazy-pages";
+import { KnowledgeNetworkModifyRouteGate } from "@/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate";
 import { createKnowledgeNetworkRoute } from "@/modules/knowledge-network/routes/route-factory";
+
+function modifyRoute(element: ReactNode) {
+  return <KnowledgeNetworkModifyRouteGate>{element}</KnowledgeNetworkModifyRouteGate>;
+}
 
 export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
   createKnowledgeNetworkRoute(
@@ -79,7 +85,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.conceptGroupCreateDescription",
       titleKey: "knowledgeNetwork.conceptGroupCreateTitle",
     },
-    <ConceptGroupCreatePage />,
+    modifyRoute(<ConceptGroupCreatePage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/concept-groups/:conceptGroupId/edit",
@@ -87,7 +93,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.conceptGroupEditDescription",
       titleKey: "knowledgeNetwork.conceptGroupEditTitle",
     },
-    <ConceptGroupEditPage />,
+    modifyRoute(<ConceptGroupEditPage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/concept-groups/:conceptGroupId/detail",
@@ -135,7 +141,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.metricCreateDescription",
       titleKey: "knowledgeNetwork.metricCreateTitle",
     },
-    <MetricCreatePage />,
+    modifyRoute(<MetricCreatePage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/metrics/:metricId/edit",
@@ -143,7 +149,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.metricEditDescription",
       titleKey: "knowledgeNetwork.metricEditTitle",
     },
-    <MetricEditPage />,
+    modifyRoute(<MetricEditPage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/metrics/:metricId/detail",
@@ -167,7 +173,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.objectTypeCreateDescription",
       titleKey: "knowledgeNetwork.objectTypeCreateTitle",
     },
-    <ObjectTypeCreatePage />,
+    modifyRoute(<ObjectTypeCreatePage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/object-types/:objectTypeId/edit",
@@ -175,7 +181,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.objectTypeEditDescription",
       titleKey: "knowledgeNetwork.objectTypeEditTitle",
     },
-    <ObjectTypeEditPage />,
+    modifyRoute(<ObjectTypeEditPage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/object-types/:objectTypeId/detail",
@@ -191,7 +197,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.relationTypeCreateDescription",
       titleKey: "knowledgeNetwork.relationTypeCreateTitle",
     },
-    <RelationTypeCreatePage />,
+    modifyRoute(<RelationTypeCreatePage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/relation-types/:relationTypeId/edit",
@@ -199,7 +205,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.relationTypeEditDescription",
       titleKey: "knowledgeNetwork.relationTypeEditTitle",
     },
-    <RelationTypeEditPage />,
+    modifyRoute(<RelationTypeEditPage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/relation-types/:relationTypeId/detail",
@@ -215,7 +221,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.relationTypeMappingDescription",
       titleKey: "knowledgeNetwork.relationTypeMappingTitle",
     },
-    <RelationTypeMappingPage />,
+    modifyRoute(<RelationTypeMappingPage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/action-types/create",
@@ -223,7 +229,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.actionTypeCreateDescription",
       titleKey: "knowledgeNetwork.actionTypeCreateTitle",
     },
-    <ActionTypeCreatePage />,
+    modifyRoute(<ActionTypeCreatePage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/action-types/:actionTypeId/edit",
@@ -231,7 +237,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.actionTypeEditDescription",
       titleKey: "knowledgeNetwork.actionTypeEditTitle",
     },
-    <ActionTypeEditPage />,
+    modifyRoute(<ActionTypeEditPage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/action-types/:actionTypeId/detail",
@@ -247,7 +253,7 @@ export const knowledgeNetworkStandaloneRoutes: RouteObject[] = [
       descriptionKey: "knowledgeNetwork.actionTypeExecutionDescription",
       titleKey: "knowledgeNetwork.actionTypeExecutionTitle",
     },
-    <ActionTypeExecutionPage />,
+    modifyRoute(<ActionTypeExecutionPage />),
   ),
   createKnowledgeNetworkRoute(
     "/knowledge-network/workspace/:networkId/tasks",

--- a/src/modules/knowledge-network/scenes/ActionTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeDetailScene.tsx
@@ -25,7 +25,7 @@ import {
   getKnowledgeNetworkActionTypeDetail,
   listKnowledgeNetworkObjectTypes,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
-import { useKnowledgeNetworkCanModify } from "@/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify";
+import { useKnowledgeNetworkOperationAccess } from "@/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify";
 import type {
   ActionTypeDetail,
   KnowledgeNetworkObjectTypeRecord,
@@ -35,6 +35,8 @@ import { getActionTypeDynamicParameters } from "@/modules/knowledge-network/util
 import styles from "./ActionTypeDetailScene.module.css";
 
 type DetailTab = "overview" | "tasks";
+
+const ACTION_TYPE_DETAIL_OPERATIONS = ["modify", "task_manage"] as const;
 
 export function ActionTypeDetailScene() {
   const { t } = useTranslation();
@@ -52,7 +54,12 @@ export function ActionTypeDetailScene() {
   const [executeModalOpen, setExecuteModalOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [taskRefreshToken, setTaskRefreshToken] = useState(0);
-  const canModify = useKnowledgeNetworkCanModify(networkId);
+  const operationAccess = useKnowledgeNetworkOperationAccess(
+    networkId,
+    ACTION_TYPE_DETAIL_OPERATIONS,
+  );
+  const canModify = operationAccess.modify;
+  const canTaskManage = operationAccess.task_manage;
 
   const activeTab: DetailTab = searchParams.get("tab") === "tasks" ? "tasks" : "overview";
   const listPath = `/knowledge-network/workspace/${networkId}/action-types`;
@@ -165,39 +172,45 @@ export function ActionTypeDetailScene() {
   return (
     <KnowledgeNetworkResourceConfigShell
       actions={
-        canModify ? (
+        canModify || canTaskManage ? (
           <>
-            <AppButton
-              icon={<PlayCircleOutlined />}
-              loading={executing}
-              onClick={handleExecuteNow}
-              type="primary"
-            >
-              {t("knowledgeNetwork.actionTypeExecuteImmediately")}
-            </AppButton>
-            <AppButton
-              icon={<EditOutlined />}
-              onClick={() => {
-                void navigate(
-                  `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/edit`,
-                );
-              }}
-            >
-              {t("common.edit")}
-            </AppButton>
-            <AppButton
-              icon={<ThunderboltOutlined />}
-              onClick={() => {
-                void navigate(
-                  `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/execution`,
-                );
-              }}
-            >
-              {t("knowledgeNetwork.actionTypeExecutionEntry")}
-            </AppButton>
-            <AppButton danger onClick={confirmDelete}>
-              {t("common.delete")}
-            </AppButton>
+            {canTaskManage ? (
+              <AppButton
+                icon={<PlayCircleOutlined />}
+                loading={executing}
+                onClick={handleExecuteNow}
+                type="primary"
+              >
+                {t("knowledgeNetwork.actionTypeExecuteImmediately")}
+              </AppButton>
+            ) : null}
+            {canModify ? (
+              <>
+                <AppButton
+                  icon={<EditOutlined />}
+                  onClick={() => {
+                    void navigate(
+                      `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/edit`,
+                    );
+                  }}
+                >
+                  {t("common.edit")}
+                </AppButton>
+                <AppButton
+                  icon={<ThunderboltOutlined />}
+                  onClick={() => {
+                    void navigate(
+                      `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/execution`,
+                    );
+                  }}
+                >
+                  {t("knowledgeNetwork.actionTypeExecutionEntry")}
+                </AppButton>
+                <AppButton danger onClick={confirmDelete}>
+                  {t("common.delete")}
+                </AppButton>
+              </>
+            ) : null}
           </>
         ) : null
       }

--- a/src/modules/knowledge-network/scenes/ActionTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeDetailScene.tsx
@@ -25,6 +25,7 @@ import {
   getKnowledgeNetworkActionTypeDetail,
   listKnowledgeNetworkObjectTypes,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { useKnowledgeNetworkCanModify } from "@/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify";
 import type {
   ActionTypeDetail,
   KnowledgeNetworkObjectTypeRecord,
@@ -51,6 +52,7 @@ export function ActionTypeDetailScene() {
   const [executeModalOpen, setExecuteModalOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [taskRefreshToken, setTaskRefreshToken] = useState(0);
+  const canModify = useKnowledgeNetworkCanModify(networkId);
 
   const activeTab: DetailTab = searchParams.get("tab") === "tasks" ? "tasks" : "overview";
   const listPath = `/knowledge-network/workspace/${networkId}/action-types`;
@@ -163,39 +165,41 @@ export function ActionTypeDetailScene() {
   return (
     <KnowledgeNetworkResourceConfigShell
       actions={
-        <>
-          <AppButton
-            icon={<PlayCircleOutlined />}
-            loading={executing}
-            onClick={handleExecuteNow}
-            type="primary"
-          >
-            {t("knowledgeNetwork.actionTypeExecuteImmediately")}
-          </AppButton>
-          <AppButton
-            icon={<EditOutlined />}
-            onClick={() => {
-              void navigate(
-                `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/edit`,
-              );
-            }}
-          >
-            {t("common.edit")}
-          </AppButton>
-          <AppButton
-            icon={<ThunderboltOutlined />}
-            onClick={() => {
-              void navigate(
-                `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/execution`,
-              );
-            }}
-          >
-            {t("knowledgeNetwork.actionTypeExecutionEntry")}
-          </AppButton>
-          <AppButton danger onClick={confirmDelete}>
-            {t("common.delete")}
-          </AppButton>
-        </>
+        canModify ? (
+          <>
+            <AppButton
+              icon={<PlayCircleOutlined />}
+              loading={executing}
+              onClick={handleExecuteNow}
+              type="primary"
+            >
+              {t("knowledgeNetwork.actionTypeExecuteImmediately")}
+            </AppButton>
+            <AppButton
+              icon={<EditOutlined />}
+              onClick={() => {
+                void navigate(
+                  `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/edit`,
+                );
+              }}
+            >
+              {t("common.edit")}
+            </AppButton>
+            <AppButton
+              icon={<ThunderboltOutlined />}
+              onClick={() => {
+                void navigate(
+                  `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/execution`,
+                );
+              }}
+            >
+              {t("knowledgeNetwork.actionTypeExecutionEntry")}
+            </AppButton>
+            <AppButton danger onClick={confirmDelete}>
+              {t("common.delete")}
+            </AppButton>
+          </>
+        ) : null
       }
       onBack={() => {
         void navigate(listPath);

--- a/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.tsx
@@ -30,6 +30,7 @@ import {
   getKnowledgeNetworkConceptGroup,
   removeObjectTypesFromKnowledgeNetworkConceptGroup,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { useKnowledgeNetworkCanModify } from "@/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify";
 import type {
   ConceptGroupDetail,
   ConceptGroupRelatedItem,
@@ -140,6 +141,7 @@ export function ConceptGroupDetailScene() {
   const [addObjectTypesOpen, setAddObjectTypesOpen] = useState(false);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+  const canModify = useKnowledgeNetworkCanModify(networkId);
 
   const listPath = `/knowledge-network/workspace/${networkId}/concept-groups`;
 
@@ -435,16 +437,18 @@ export function ConceptGroupDetailScene() {
       <KnowledgeNetworkResourceConfigShell
         actions={
           <>
-            <AppButton
-              icon={<EditOutlined />}
-              onClick={() => {
-                void navigate(
-                  `/knowledge-network/workspace/${networkId}/concept-groups/${conceptGroupId}/edit`,
-                );
-              }}
-            >
-              {t("common.edit")}
-            </AppButton>
+            {canModify ? (
+              <AppButton
+                icon={<EditOutlined />}
+                onClick={() => {
+                  void navigate(
+                    `/knowledge-network/workspace/${networkId}/concept-groups/${conceptGroupId}/edit`,
+                  );
+                }}
+              >
+                {t("common.edit")}
+              </AppButton>
+            ) : null}
             <AppButton
               icon={<DownloadOutlined />}
               onClick={() => {
@@ -454,9 +458,11 @@ export function ConceptGroupDetailScene() {
             >
               {t("knowledgeNetwork.conceptGroupExport")}
             </AppButton>
-            <AppButton danger onClick={confirmDelete}>
-              {t("common.delete")}
-            </AppButton>
+            {canModify ? (
+              <AppButton danger onClick={confirmDelete}>
+                {t("common.delete")}
+              </AppButton>
+            ) : null}
           </>
         }
         onBack={() => {
@@ -516,7 +522,7 @@ export function ConceptGroupDetailScene() {
             />
             <div className={styles.sectionToolbar}>
               <div className={styles.toolbarLeft}>
-                {activeTab === "object" ? (
+                {activeTab === "object" && canModify ? (
                   <>
                     <AppButton
                       icon={<PlusOutlined />}
@@ -585,7 +591,7 @@ export function ConceptGroupDetailScene() {
               }}
               rowKey="id"
               rowSelection={
-                activeTab === "object"
+                activeTab === "object" && canModify
                   ? {
                       onChange: (keys) => setSelectedObjectTypeIds(keys.map(String)),
                       selectedRowKeys: selectedObjectTypeIds,

--- a/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
+++ b/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
@@ -41,6 +41,7 @@ import {
   integrateWorkspaceTasks,
 } from "@/modules/knowledge-network/services/shared/runtime";
 import type { KnowledgeNetworkMutationPayload } from "@/modules/knowledge-network/types/knowledge-network";
+import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 
 import styles from "./KnowledgeNetworkWorkspaceScene.module.css";
 
@@ -96,6 +97,7 @@ export function KnowledgeNetworkWorkspaceScene({
 
   const [networkFormOpen, setNetworkFormOpen] = useState(false);
   const [sideCollapsed, setSideCollapsed] = useState(false);
+  const canModify = hasKnowledgeNetworkRecordOperation(detail, "modify");
 
   const navigationItems: WorkspaceNavItem[] = useMemo(() => {
     const items: WorkspaceNavItem[] = [
@@ -217,6 +219,7 @@ export function KnowledgeNetworkWorkspaceScene({
           detailLoading={detailLoading}
           loadRecentObjects={loadRecentObjects}
           networkId={activeNetworkId}
+          canModify={canModify}
           onEdit={() => setNetworkFormOpen(true)}
           recentLoading={recentLoading}
           recentObjects={recentObjects}
@@ -236,6 +239,7 @@ export function KnowledgeNetworkWorkspaceScene({
     return (
       <WorkspaceResourceSection
         data={workspaceData}
+        canModify={canModify}
         networkId={activeNetworkId}
         section={section}
       />

--- a/src/modules/knowledge-network/scenes/MetricDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/MetricDetailScene.tsx
@@ -25,6 +25,7 @@ import {
   getKnowledgeNetworkObjectTypeDetail,
   listKnowledgeNetworkObjectTypes,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { useKnowledgeNetworkCanModify } from "@/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify";
 import type { RelationTypePropertyOption } from "@/modules/knowledge-network/components/relation-type/RelationTypePropertySelect";
 import type {
   KnowledgeNetworkMetricRecord,
@@ -68,6 +69,7 @@ export function MetricDetailScene({
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("info");
   const resolvedUpdaterName = useResolvedUpdaterName(detail?.updaterName);
+  const canModify = useKnowledgeNetworkCanModify(networkId);
 
   const listPath = `/knowledge-network/workspace/${networkId}/metrics`;
 
@@ -165,24 +167,26 @@ export function MetricDetailScene({
   return (
     <KnowledgeNetworkResourceConfigShell
       actions={
-        <>
-          <AppButton
-            icon={<EditOutlined />}
-            onClick={() => {
-              if (onEdit) {
-                onEdit();
-                return;
-              }
+        canModify ? (
+          <>
+            <AppButton
+              icon={<EditOutlined />}
+              onClick={() => {
+                if (onEdit) {
+                  onEdit();
+                  return;
+                }
 
-              void navigate(`/knowledge-network/workspace/${networkId}/metrics/${metricId}/edit`);
-            }}
-          >
-            {t("common.edit")}
-          </AppButton>
-          <AppButton danger onClick={confirmDelete}>
-            {t("common.delete")}
-          </AppButton>
-        </>
+                void navigate(`/knowledge-network/workspace/${networkId}/metrics/${metricId}/edit`);
+              }}
+            >
+              {t("common.edit")}
+            </AppButton>
+            <AppButton danger onClick={confirmDelete}>
+              {t("common.delete")}
+            </AppButton>
+          </>
+        ) : null
       }
       onBack={() => {
         if (onBack) {

--- a/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
@@ -17,6 +17,8 @@ import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { useAppServices } from "@/framework/context/use-app-services";
+import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
+import { hasPermissions } from "@/framework/permission/has-permissions";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
@@ -46,6 +48,7 @@ import {
   listKnowledgeNetworkMetrics,
   listKnowledgeNetworkRelationTypes,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { useKnowledgeNetworkCanModify } from "@/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify";
 import type {
   KnowledgeNetworkActionTypeRecord,
   KnowledgeNetworkMetricRecord,
@@ -164,6 +167,7 @@ export function ObjectTypeDetailScene() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const runtimeConfig = useRuntimeConfig();
   const { message, modal } = useAppServices();
   const { networkId = "", objectTypeId = "" } = useParams<{
     networkId: string;
@@ -229,6 +233,12 @@ export function ObjectTypeDetailScene() {
   const [relatedKeyword, setRelatedKeyword] = useState("");
   const propertyTableState = useObjectTypePropertyTableState();
   const loadedObjectTypeKeyRef = useRef<string | null>(null);
+  const canModify = useKnowledgeNetworkCanModify(networkId);
+  const canLoadResourceIndexStates = hasPermissions({
+    currentPermissions: runtimeConfig.currentUser.permissions,
+    mode: "any",
+    requiredPermissions: ["resource:view_detail", "resource:task_manage"],
+  });
 
   const listPath = `/knowledge-network/workspace/${networkId}/object-types`;
   const detailPath = `/knowledge-network/workspace/${networkId}/object-types/${objectTypeId}/detail`;
@@ -629,7 +639,7 @@ export function ObjectTypeDetailScene() {
   useEffect(() => {
     const resourceId = detail?.dataSource?.id;
 
-    if (!resourceId) {
+    if (!canLoadResourceIndexStates || !resourceId) {
       setResourceBuildTasks([]);
       setResourceBuildTasksLoading(false);
       return;
@@ -658,7 +668,7 @@ export function ObjectTypeDetailScene() {
     return () => {
       cancelled = true;
     };
-  }, [detail?.dataSource?.id]);
+  }, [canLoadResourceIndexStates, detail?.dataSource?.id]);
 
   const filteredDataProperties = useMemo(() => {
     const normalized = keyword.trim().toLowerCase();
@@ -1176,9 +1186,13 @@ export function ObjectTypeDetailScene() {
                   {t("knowledgeNetwork.objectTypeDataViewIndexState")}
                 </span>
                 <span className={styles.dataViewStatus}>
-                  {resourceBuildTasksLoading
-                    ? t("knowledgeNetwork.objectTypeDataViewIndexLoading")
-                    : formatIndexStateLabel(resourceIndexState, t)}
+                  {canLoadResourceIndexStates
+                    ? resourceBuildTasksLoading
+                      ? t("knowledgeNetwork.objectTypeDataViewIndexLoading")
+                      : formatIndexStateLabel(resourceIndexState, t)
+                    : detail.hasIndex
+                      ? t("knowledgeNetwork.previewIndexed")
+                      : t("knowledgeNetwork.previewNotIndexed")}
                 </span>
               </div>
             </div>
@@ -1981,25 +1995,27 @@ export function ObjectTypeDetailScene() {
   return (
     <KnowledgeNetworkResourceConfigShell
       actions={
-        <>
-          <AppButton
-            icon={<EditOutlined />}
-            onClick={() => {
-              void navigate(
-                `/knowledge-network/workspace/${networkId}/object-types/${objectTypeId}/edit`,
-              );
-            }}
-          >
-            {t("common.edit")}
-          </AppButton>
-          <AppButton
-            danger
-            icon={<DeleteOutlined />}
-            onClick={confirmDelete}
-          >
-            {t("common.delete")}
-          </AppButton>
-        </>
+        canModify ? (
+          <>
+            <AppButton
+              icon={<EditOutlined />}
+              onClick={() => {
+                void navigate(
+                  `/knowledge-network/workspace/${networkId}/object-types/${objectTypeId}/edit`,
+                );
+              }}
+            >
+              {t("common.edit")}
+            </AppButton>
+            <AppButton
+              danger
+              icon={<DeleteOutlined />}
+              onClick={confirmDelete}
+            >
+              {t("common.delete")}
+            </AppButton>
+          </>
+        ) : null
       }
       onBack={() => {
         void navigate(returnPath);

--- a/src/modules/knowledge-network/scenes/RelationTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/RelationTypeDetailScene.tsx
@@ -21,6 +21,7 @@ import {
   deleteKnowledgeNetworkRelationType,
   getKnowledgeNetworkRelationTypeDetail,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { useKnowledgeNetworkCanModify } from "@/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify";
 import type { RelationTypeDetail } from "@/modules/knowledge-network/types/knowledge-network";
 
 import styles from "./RelationTypeDetailScene.module.css";
@@ -41,6 +42,7 @@ export function RelationTypeDetailScene() {
   const [detail, setDetail] = useState<RelationTypeDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const canModify = useKnowledgeNetworkCanModify(networkId);
 
   const listPath = `/knowledge-network/workspace/${networkId}/relation-types`;
   const detailPath = `/knowledge-network/workspace/${networkId}/relation-types/${relationTypeId}/detail`;
@@ -111,31 +113,33 @@ export function RelationTypeDetailScene() {
   return (
     <KnowledgeNetworkResourceConfigShell
       actions={
-        <>
-          <AppButton
-            icon={<EditOutlined />}
-            onClick={() => {
-              void navigate(
-                `/knowledge-network/workspace/${networkId}/relation-types/${relationTypeId}/edit`,
-              );
-            }}
-          >
-            {t("common.edit")}
-          </AppButton>
-          <AppButton
-            icon={<ApartmentOutlined />}
-            onClick={() => {
-              void navigate(
-                `/knowledge-network/workspace/${networkId}/relation-types/${relationTypeId}/mapping`,
-              );
-            }}
-          >
-            {t("knowledgeNetwork.relationTypeMappingEntry")}
-          </AppButton>
-          <AppButton danger onClick={confirmDelete}>
-            {t("common.delete")}
-          </AppButton>
-        </>
+        canModify ? (
+          <>
+            <AppButton
+              icon={<EditOutlined />}
+              onClick={() => {
+                void navigate(
+                  `/knowledge-network/workspace/${networkId}/relation-types/${relationTypeId}/edit`,
+                );
+              }}
+            >
+              {t("common.edit")}
+            </AppButton>
+            <AppButton
+              icon={<ApartmentOutlined />}
+              onClick={() => {
+                void navigate(
+                  `/knowledge-network/workspace/${networkId}/relation-types/${relationTypeId}/mapping`,
+                );
+              }}
+            >
+              {t("knowledgeNetwork.relationTypeMappingEntry")}
+            </AppButton>
+            <AppButton danger onClick={confirmDelete}>
+              {t("common.delete")}
+            </AppButton>
+          </>
+        ) : null
       }
       onBack={() => {
         void navigate(returnPath);

--- a/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.tsx
@@ -40,6 +40,7 @@ import type {
 import styles from "../KnowledgeNetworkWorkspaceScene.module.css";
 
 type WorkspaceOverviewSectionProps = {
+  canModify: boolean;
   detail: KnowledgeNetworkRecord | null;
   detailLoading?: boolean;
   loadRecentObjects: () => Promise<void>;
@@ -54,6 +55,7 @@ function formatOverviewCount(value?: number) {
 }
 
 export function WorkspaceOverviewSection({
+  canModify,
   detail,
   detailLoading = false,
   loadRecentObjects,
@@ -179,9 +181,11 @@ export function WorkspaceOverviewSection({
                 {t("systemAdmin.objectGrants.authorize")}
               </AppButton>
             </PermissionGate>
-            <AppButton icon={<EditOutlined />} onClick={onEdit}>
-              {t("common.edit")}
-            </AppButton>
+            {canModify ? (
+              <AppButton icon={<EditOutlined />} onClick={onEdit}>
+                {t("common.edit")}
+              </AppButton>
+            ) : null}
           </div>
         </div>
         <div className={styles.overviewHeaderComment}>
@@ -236,17 +240,19 @@ export function WorkspaceOverviewSection({
               <p>{formatOverviewCount(detail?.statistics.objectTypesTotal)}</p>
             </dd>
           </dl>
-          <AppButton
-            className={styles.overviewStatAction}
-            onClick={() => {
-              void navigate(
-                `/knowledge-network/workspace/${networkId}/object-types/create`,
-              );
-            }}
-            type="link"
-          >
-            {t("knowledgeNetwork.createObjectTypeEntry")}
-          </AppButton>
+          {canModify ? (
+            <AppButton
+              className={styles.overviewStatAction}
+              onClick={() => {
+                void navigate(
+                  `/knowledge-network/workspace/${networkId}/object-types/create`,
+                );
+              }}
+              type="link"
+            >
+              {t("knowledgeNetwork.createObjectTypeEntry")}
+            </AppButton>
+          ) : null}
         </div>
 
         <div className={styles.overviewStatCard}>
@@ -262,17 +268,19 @@ export function WorkspaceOverviewSection({
               <p>{formatOverviewCount(detail?.statistics.relationTypesTotal)}</p>
             </dd>
           </dl>
-          <AppButton
-            className={styles.overviewStatAction}
-            onClick={() => {
-              void navigate(
-                `/knowledge-network/workspace/${networkId}/relation-types/create`,
-              );
-            }}
-            type="link"
-          >
-            {t("knowledgeNetwork.createRelationTypeEntry")}
-          </AppButton>
+          {canModify ? (
+            <AppButton
+              className={styles.overviewStatAction}
+              onClick={() => {
+                void navigate(
+                  `/knowledge-network/workspace/${networkId}/relation-types/create`,
+                );
+              }}
+              type="link"
+            >
+              {t("knowledgeNetwork.createRelationTypeEntry")}
+            </AppButton>
+          ) : null}
         </div>
 
         <div className={styles.overviewStatCard}>
@@ -288,17 +296,19 @@ export function WorkspaceOverviewSection({
               <p>{formatOverviewCount(detail?.statistics.actionTypesTotal)}</p>
             </dd>
           </dl>
-          <AppButton
-            className={styles.overviewStatAction}
-            onClick={() => {
-              void navigate(
-                `/knowledge-network/workspace/${networkId}/action-types/create`,
-              );
-            }}
-            type="link"
-          >
-            {t("knowledgeNetwork.createActionTypeEntry")}
-          </AppButton>
+          {canModify ? (
+            <AppButton
+              className={styles.overviewStatAction}
+              onClick={() => {
+                void navigate(
+                  `/knowledge-network/workspace/${networkId}/action-types/create`,
+                );
+              }}
+              type="link"
+            >
+              {t("knowledgeNetwork.createActionTypeEntry")}
+            </AppButton>
+          ) : null}
         </div>
       </div>
       </Spin>

--- a/src/modules/knowledge-network/scenes/workspace/WorkspaceResourceSection.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/WorkspaceResourceSection.tsx
@@ -29,12 +29,14 @@ import { useWorkspaceData } from "@/modules/knowledge-network/scenes/workspace/u
 type WorkspaceData = ReturnType<typeof useWorkspaceData>;
 
 type WorkspaceResourceSectionProps = {
+  canModify: boolean;
   data: WorkspaceData;
   networkId: string;
   section: KnowledgeNetworkWorkspaceSection;
 };
 
 export function WorkspaceResourceSection({
+  canModify,
   data,
   networkId,
   section,
@@ -47,6 +49,7 @@ export function WorkspaceResourceSection({
       return (
         <ConceptGroupListPanel
           items={data.conceptGroups}
+          canModify={canModify}
           loading={data.sectionLoading}
           networkId={networkId}
           onDelete={async (records) => {
@@ -68,6 +71,7 @@ export function WorkspaceResourceSection({
       return (
         <ObjectTypeListPanel
           items={data.objectTypes}
+          canModify={canModify}
           loading={data.sectionLoading}
           networkId={networkId}
           onDelete={async (records) => {
@@ -86,6 +90,7 @@ export function WorkspaceResourceSection({
       return (
         <RelationTypeListPanel
           items={data.relationTypes}
+          canModify={canModify}
           loading={data.sectionLoading}
           networkId={networkId}
           objectTypes={data.objectTypes}
@@ -105,6 +110,7 @@ export function WorkspaceResourceSection({
       return (
         <ActionTypeListPanel
           items={data.actionTypes}
+          canModify={canModify}
           loading={data.sectionLoading}
           networkId={networkId}
           objectTypes={data.objectTypes}
@@ -124,6 +130,7 @@ export function WorkspaceResourceSection({
       return (
         <MetricListPanel
           loading={data.sectionLoading}
+          canModify={canModify}
           metrics={data.metrics}
           networkId={networkId}
           onDelete={async (metricId) => {

--- a/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.test.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/useWorkspaceData.test.tsx
@@ -43,6 +43,7 @@ function createDetail(metricsTotal = 0): KnowledgeNetworkRecord {
     id: "kn-1",
     identifier: "kn-1",
     name: "Test KN",
+    operations: [],
     statistics: {
       actionTypesTotal: 0,
       conceptGroupsTotal: 0,

--- a/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.test.ts
+++ b/src/modules/knowledge-network/scenes/workspace/workspaceMetricsTotal.test.ts
@@ -24,6 +24,7 @@ function createDetail(metricsTotal = 0): KnowledgeNetworkRecord {
     id: "kn-1",
     identifier: "kn-1",
     name: "Test KN",
+    operations: [],
     statistics: {
       actionTypesTotal: 0,
       conceptGroupsTotal: 0,

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -79,6 +79,9 @@ describe("sendRequest", () => {
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(fetchSpy.mock.calls[0][0]).toBe("https://platform.example.com/api/agent-retrieval/v1/mcp/");
+    expect(fetchSpy.mock.calls[1][0]).toBe("https://platform.example.com/api/agent-retrieval/v1/mcp/");
+    expect(fetchSpy.mock.calls[2][0]).toBe("https://platform.example.com/api/agent-retrieval/v1/mcp/");
     expect(jsonRpcBody(fetchSpy.mock.calls[0][1])).toMatchObject({ method: "initialize" });
     expect(jsonRpcBody(fetchSpy.mock.calls[1][1])).toMatchObject({ method: "notifications/initialized" });
     expect(jsonRpcBody(fetchSpy.mock.calls[2][1])).toMatchObject({ method: "tools/call" });
@@ -129,20 +132,43 @@ describe("sendRequest", () => {
 });
 
 describe("fetchKnDetail", () => {
-  it("takes its context from the turn and reports the receipt back to it", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response('{"id":"kn-demo","object_types":[],"concept_groups":[],"relation_types":[]}', {
-        status: 200,
-        headers: { "bkn-receipt-id": "rcp_3", "bkn-operation-id": "op_3" },
-      }),
-    );
+  it("uses the MCP get_kn_detail tool with managed context", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200, headers: { "Mcp-Session-Id": "session-1" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            result: {
+              structuredContent: {
+                id: "kn-demo",
+                object_types: [],
+                concept_groups: [],
+                relation_types: [],
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+
     await fetchKnDetail({ base: "https://platform.example.com", token: "", knId: "kn-demo" }, undefined, undefined, {
       nextContext: () => bknContext,
     });
 
-    expect(restBody(fetchSpy.mock.calls[0][1])).toMatchObject({
-      kn_id: "kn-demo",
-      bkn_context: bknContext,
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(jsonRpcBody(fetchSpy.mock.calls[2][1])).toMatchObject({
+      method: "tools/call",
+      params: {
+        name: "get_kn_detail",
+        arguments: {
+          kn_id: "kn-demo",
+          response_format: "json",
+          bkn_context: bknContext,
+        },
+      },
     });
   });
 });
@@ -232,6 +258,9 @@ describe("listMcpTools", () => {
     expect(tools).toEqual([{ name: "search_schema", inputSchema: { type: "object" }, outputSchema: undefined }]);
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledTimes(4);
+    expect(fetchSpy.mock.calls[1][0]).toBe("https://platform.example.com/api/agent-retrieval/v1/mcp/");
+    expect(fetchSpy.mock.calls[2][0]).toBe("https://platform.example.com/api/agent-retrieval/v1/mcp/");
+    expect(fetchSpy.mock.calls[3][0]).toBe("https://platform.example.com/api/agent-retrieval/v1/mcp/");
     expect(fetchSpy.mock.calls[0][1]?.headers).toMatchObject({ Authorization: "Bearer expired-token" });
     expect(fetchSpy.mock.calls[1][1]?.headers).toMatchObject({ Authorization: "Bearer fresh-token" });
     expect(jsonRpcBody(fetchSpy.mock.calls[2][1])).toMatchObject({ method: "notifications/initialized" });

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -40,7 +40,7 @@ export type ContextLoaderOp = {
 export const REST_PREFIX = "/api/agent-retrieval/v1";
 
 /** MCP 端点（实测 /api/agent-retrieval/v1/mcp，非根 /mcp）。 */
-export const MCP_PATH = "/api/agent-retrieval/v1/mcp";
+export const MCP_PATH = "/api/agent-retrieval/v1/mcp/";
 
 export type RequestDataAssistantKind = "concept-group" | "object-type" | "resource" | "relation";
 
@@ -224,6 +224,7 @@ export const CONTEXT_LOADER_OPS: ContextLoaderOp[] = [
     id: "get_kn_detail",
     group: "Knowledge Network",
     summary: "查询指定知识网络的详细信息。",
+    mcpOnly: true,
     path: `${REST_PREFIX}/kn/get_kn_detail`,
     query: [{ name: "response_format", value: "json", options: ["json", "toon"] }],
     body: { kn_id: "your_kn_id" },
@@ -1009,6 +1010,44 @@ function parseRelationTypes(raw: unknown): KnRelationType[] {
     .filter((r) => r.id && r.sourceId && r.targetId);
 }
 
+function normalizeKnDetailPayload(
+  data: Partial<KnDetail> & Record<string, unknown>,
+  fallbackId: string,
+): KnDetail {
+  return {
+    id: data.id ?? fallbackId,
+    name: data.name,
+    comment: typeof data.comment === "string" ? data.comment : undefined,
+    object_types: Array.isArray(data.object_types) ? data.object_types : [],
+    concept_groups: Array.isArray(data.concept_groups) ? data.concept_groups : [],
+    relation_types: parseRelationTypes(data.relation_types ?? data.relations),
+  };
+}
+
+function knDetailFromMcpPayload(payload: unknown, fallbackId: string): KnDetail | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const record = payload as Partial<KnDetail> & Record<string, unknown>;
+  const data = record.data;
+  const candidate =
+    data && typeof data === "object"
+      ? (data as Partial<KnDetail> & Record<string, unknown>)
+      : record;
+
+  if (
+    !("object_types" in candidate) &&
+    !("concept_groups" in candidate) &&
+    !("relation_types" in candidate) &&
+    !("relations" in candidate)
+  ) {
+    return null;
+  }
+
+  return normalizeKnDetailPayload(candidate, fallbackId);
+}
+
 /**
  * 取知识网络详情（对象类型 + 资源绑定 + 概念分组），供数据浏览器展示与「填入请求体」。
  * 走与调试台一致的真实 REST 鉴权路径（get_kn_detail 已验证可用）。
@@ -1035,6 +1074,49 @@ async function restPost(
 }
 
 export async function fetchKnDetail(
+  env: ContextLoaderEnv,
+  auth?: McpAuth,
+  signal?: AbortSignal,
+  scope?: BknCallScope,
+): Promise<KnDetail> {
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  const result = await createMcpSession(env, auth).callTool(
+    "get_kn_detail",
+    withBknContext(
+      { kn_id: env.knId, response_format: "json" },
+      scope?.nextContext(),
+    ),
+  );
+
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  if (!result.ok || result.isError || result.rpcError) {
+    throw new Error(result.rpcError?.message || result.text || "get_kn_detail failed");
+  }
+
+  const fromStructured = knDetailFromMcpPayload(result.structured, env.knId);
+  if (fromStructured) {
+    return fromStructured;
+  }
+
+  try {
+    const fromText = knDetailFromMcpPayload(JSON.parse(result.text) as unknown, env.knId);
+    if (fromText) {
+      return fromText;
+    }
+  } catch {
+    // JSON response requested; fall through to the normalized error below.
+  }
+
+  throw new Error("get_kn_detail did not return knowledge network detail");
+}
+
+export async function fetchKnDetailRestLegacy(
   env: ContextLoaderEnv,
   auth?: McpAuth,
   signal?: AbortSignal,

--- a/src/modules/knowledge-network/services/context-loader.test-data.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.test-data.test.ts
@@ -57,6 +57,7 @@ describe("opSupportsTestData", () => {
 describe("REST_CONTEXT_LOADER_OPS", () => {
   it("excludes MCP-only metric queries from the REST debugger", () => {
     expect(REST_CONTEXT_LOADER_OPS.some((op) => op.id === "query_metric")).toBe(false);
+    expect(REST_CONTEXT_LOADER_OPS.some((op) => op.id === "get_kn_detail")).toBe(false);
   });
 });
 
@@ -75,7 +76,7 @@ describe("buildTestData", () => {
   const d = detail([ot("orders", ["status", "amount"], "res_orders")], [{ id: "grp_sales" }]);
 
   it("get_kn_detail fills only kn_id", () => {
-    const fill = buildTestData(opById("get_kn_detail"), "rest", "kn_demo", d, null, null);
+    const fill = buildTestData(opById("get_kn_detail"), "mcp", "kn_demo", d, null, null);
     expect(JSON.parse(fill.body)).toEqual({ kn_id: "kn_demo" });
   });
 

--- a/src/modules/knowledge-network/services/mappers/backend-types.ts
+++ b/src/modules/knowledge-network/services/mappers/backend-types.ts
@@ -37,6 +37,7 @@ export type BackendKnowledgeNetwork = {
   icon?: string;
   id: string;
   name: string;
+  operations?: string[];
   statistics?: {
     action_types_total?: number;
     concept_groups_total?: number;

--- a/src/modules/knowledge-network/services/mappers/index.ts
+++ b/src/modules/knowledge-network/services/mappers/index.ts
@@ -53,6 +53,7 @@ export function mapKnowledgeNetwork(item: BackendKnowledgeNetwork): KnowledgeNet
     description: item.comment ?? item.description ?? "",
     color: item.color?.trim() || "#1677ff",
     icon: item.icon,
+    operations: item.operations ?? [],
     tags: item.tags ?? [],
     createTime: formatTimestamp(item.create_time),
     updateTime: formatTimestamp(item.update_time),

--- a/src/modules/knowledge-network/services/mappers/index.ts
+++ b/src/modules/knowledge-network/services/mappers/index.ts
@@ -53,7 +53,7 @@ export function mapKnowledgeNetwork(item: BackendKnowledgeNetwork): KnowledgeNet
     description: item.comment ?? item.description ?? "",
     color: item.color?.trim() || "#1677ff",
     icon: item.icon,
-    operations: item.operations ?? [],
+    ...(item.operations === undefined ? {} : { operations: item.operations }),
     tags: item.tags ?? [],
     createTime: formatTimestamp(item.create_time),
     updateTime: formatTimestamp(item.update_time),

--- a/src/modules/knowledge-network/services/mock/state.ts
+++ b/src/modules/knowledge-network/services/mock/state.ts
@@ -38,10 +38,20 @@ import type {
 } from "@/modules/knowledge-network/types/knowledge-network";
 import { formatTimestamp } from "@/modules/knowledge-network/services/shared/runtime";
 
+const mockKnowledgeNetworkOperations = [
+  "view_detail",
+  "data_query",
+  "modify",
+  "delete",
+  "authorize",
+  "task_manage",
+];
+
 export let mockKnowledgeNetworks: KnowledgeNetworkRecord[] = [
   {
     id: "kn-domain-risk",
     identifier: "domain_risk_network",
+    operations: mockKnowledgeNetworkOperations,
     name: "领域风控知识网络",
     description:
       "围绕风控对象、风险关系与行动策略组织的领域业务知识网络。",
@@ -63,6 +73,7 @@ export let mockKnowledgeNetworks: KnowledgeNetworkRecord[] = [
   {
     id: "kn-domain-supply",
     identifier: "domain_supply_network",
+    operations: mockKnowledgeNetworkOperations,
     name: "领域供应链知识网络",
     description:
       "用于供应商、仓配、履约行动和经营指标建模的领域知识网络。",
@@ -84,6 +95,7 @@ export let mockKnowledgeNetworks: KnowledgeNetworkRecord[] = [
   {
     id: "kn-domain-customer",
     identifier: "domain_customer_network",
+    operations: mockKnowledgeNetworkOperations,
     name: "领域客户知识网络",
     description:
       "聚焦客户主体、标签体系和营销动作的业务知识网络。",

--- a/src/modules/knowledge-network/services/network.service.ts
+++ b/src/modules/knowledge-network/services/network.service.ts
@@ -53,6 +53,14 @@ import {
 } from "@/modules/knowledge-network/services/shared/runtime";
 
 const DEFAULT_BUSINESS_DOMAIN_ID = "bd_public";
+const MOCK_KNOWLEDGE_NETWORK_OPERATIONS = [
+  "view_detail",
+  "data_query",
+  "modify",
+  "delete",
+  "authorize",
+  "task_manage",
+];
 
 function getKnowledgeNetworkDomainHeaders() {
   const runtimeConfig = getRuntimeConfig();
@@ -167,6 +175,7 @@ export async function createKnowledgeNetwork(input: KnowledgeNetworkMutationPayl
       description: input.description,
       color: input.color,
       icon: "deployment-unit",
+      operations: MOCK_KNOWLEDGE_NETWORK_OPERATIONS,
       tags: input.tags,
       createTime: formatTimestamp(Date.now()),
       updateTime: formatTimestamp(Date.now()),
@@ -343,6 +352,7 @@ export async function importKnowledgeNetwork(
       ),
       color: stringFromUnknown(payload.color, "#1677ff"),
       icon: stringFromUnknown(payload.icon, "deployment-unit"),
+      operations: MOCK_KNOWLEDGE_NETWORK_OPERATIONS,
       tags: Array.isArray(payload.tags) ? (payload.tags as string[]) : [],
       createTime: formatTimestamp(Date.now()),
       updateTime: formatTimestamp(Date.now()),

--- a/src/modules/knowledge-network/types/network.ts
+++ b/src/modules/knowledge-network/types/network.ts
@@ -31,6 +31,7 @@ export type KnowledgeNetworkRecord = {
   id: string;
   identifier: string;
   name: string;
+  operations: string[];
   statistics: KnowledgeNetworkStatistics;
   tags: string[];
   updateTime: string;

--- a/src/modules/knowledge-network/types/network.ts
+++ b/src/modules/knowledge-network/types/network.ts
@@ -31,7 +31,7 @@ export type KnowledgeNetworkRecord = {
   id: string;
   identifier: string;
   name: string;
-  operations: string[];
+  operations?: string[];
   statistics: KnowledgeNetworkStatistics;
   tags: string[];
   updateTime: string;

--- a/src/modules/knowledge-network/utils/record-operations.ts
+++ b/src/modules/knowledge-network/utils/record-operations.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+
+export function hasKnowledgeNetworkRecordOperation(
+  record: KnowledgeNetworkRecord | null | undefined,
+  operation: string,
+) {
+  return Boolean(
+    record?.operations.includes("*") || record?.operations.includes(operation),
+  );
+}

--- a/src/modules/knowledge-network/utils/record-operations.ts
+++ b/src/modules/knowledge-network/utils/record-operations.ts
@@ -11,7 +11,13 @@ export function hasKnowledgeNetworkRecordOperation(
   record: KnowledgeNetworkRecord | null | undefined,
   operation: string,
 ) {
-  return Boolean(
-    record?.operations.includes("*") || record?.operations.includes(operation),
-  );
+  if (!record) {
+    return false;
+  }
+
+  if (record.operations === undefined) {
+    return true;
+  }
+
+  return record.operations.includes("*") || record.operations.includes(operation);
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Enforce knowledge-network record operations for card, workspace list, detail, and mutation routes.
- [x] Hide create/edit/delete/write controls for read-only knowledge-network users across concept groups, object types, relation types, action types, and metrics.
- [x] Prevent non-admin knowledge-network views from calling admin user APIs or data-catalog resource status APIs.
- [x] Align MCP debug calls with the `/mcp/` endpoint and move `get_kn_detail` usage to MCP-only flow.

---

## Why

- Related Issue: Closes #321
- Related Issue: Closes #322
- Related follow-up: #357
- Background: Read-only or object-scoped users could still see write actions in several knowledge-network surfaces, and some auxiliary display/debug code called APIs outside the user's permission boundary.

---

## How

- Key implementation points:
  - Added shared helpers for knowledge-network record operations and per-network modify checks.
  - Added a route gate for create/edit/mapping/execution routes that require network `modify`.
  - Threaded `canModify` through workspace panels and detail scenes to hide write controls.
  - Used backend `operations` on knowledge-network records to drive card menu visibility.
  - Guarded admin user-directory lookup and data-catalog index-state lookup behind the matching permissions.
  - Updated MCP endpoint path to `/api/agent-retrieval/v1/mcp/` and made `get_kn_detail` MCP-only in the debugger.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Ran targeted tests:
  - `pnpm exec vitest --run src/modules/knowledge-network/services/context-loader.request.test.ts src/modules/knowledge-network/services/mcp-client-config.test.ts`
- Ran lightweight checks:
  - `git diff --check`
  - `node scripts/check-license-headers.mjs`
  - Targeted ESLint on edited files where practical
- Full test suite and full CI-equivalent checks were not run per requester instruction.
- Some broader local Vitest/ESLint attempts previously hit local Node/V8 OOM in this Windows environment.

---

## Risk & Rollback

- Potential risks:
  - Backend `operations` payload shape must be present for precise card action visibility; mock/default paths include full operations.
  - `get_kn_detail` is now treated as MCP-only in the debugger because the observed REST route returns 404.
  - Index-state precision falls back to object-type `hasIndex` when data-catalog permissions are unavailable.
- Rollback plan:
  - Revert this PR to restore previous UI visibility and request behavior.

---

## Additional Notes

- Follow-up #357 tracks returning precise object-type resource index state through knowledge-network APIs instead of crossing data-catalog permission boundaries.