### PR TITLE
fix(knowledge-network): govern agent chat tools

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.module.css
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.module.css
@@ -362,6 +362,37 @@
 }
 
 /* 对比模式输入区：发送目标 + 对比报告 */
+.toolOption {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  line-height: 1.25;
+}
+
+.toolOptionName {
+  overflow: hidden;
+  color: var(--txt);
+  font-size: 13px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.toolOptionId {
+  overflow: hidden;
+  color: var(--txt2);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.paneMenu :global(.ant-select-item-option-content) {
+  min-width: 0;
+}
+
 .targetBar {
   max-width: 1080px;
   margin: 0 auto 6px;

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
@@ -21,7 +21,7 @@ import type { LlmModel } from "@/modules/model-resources/types/llm";
 
 import { ANSWER_OPEN } from "@/modules/knowledge-network/services/agent-chat.service";
 
-import { ChatPane, DEFAULT_PROMPT, KN_EVIDENCE_HINT, type ChatPaneHandle, type PaneProfile } from "./ChatPane";
+import { BASE_EVIDENCE_HINT, ChatPane, DEFAULT_PROMPT, KN_EVIDENCE_HINT, type ChatPaneHandle, type PaneProfile } from "./ChatPane";
 
 type AgentChatModule = typeof import("@/modules/knowledge-network/services/agent-chat.service");
 type LifecycleModule = typeof import("@/modules/knowledge-network/services/bkn-lifecycle.service");
@@ -58,6 +58,7 @@ const baseProfile: PaneProfile = {
   defaultPrompt: DEFAULT_PROMPT,
   injectKnContext: false,
   defaultToolNames: ["list_resources", "describe_resource", "run_sql"],
+  evidenceHint: BASE_EVIDENCE_HINT,
 };
 
 const toolDefs: McpToolDef[] = [{ name: "bkn_start_interaction" }, { name: "run_sql" }, { name: "bkn_finish_interaction" }];

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
@@ -50,7 +50,14 @@ const profile: PaneProfile = {
   defaultToolNames: null,
 };
 
-const toolDefs: McpToolDef[] = [{ name: "run_sql" }];
+const baseProfile: PaneProfile = {
+  paneKey: "base",
+  defaultPrompt: DEFAULT_PROMPT,
+  injectKnContext: false,
+  defaultToolNames: ["list_resources", "describe_resource", "run_sql"],
+};
+
+const toolDefs: McpToolDef[] = [{ name: "bkn_start_interaction" }, { name: "run_sql" }, { name: "bkn_finish_interaction" }];
 const models = [{ modelName: "qwen-test", default: true }] as unknown as LlmModel[];
 
 function stubLifecycle() {
@@ -86,21 +93,23 @@ function toolOptions() {
   return buildAgentTools.mock.calls[0][5];
 }
 
-function renderPane() {
+function renderPane(options: { profile?: PaneProfile; toolDefs?: McpToolDef[] } = {}) {
   const ref = createRef<ChatPaneHandle>();
+  const paneProfile = options.profile ?? profile;
+  const paneToolDefs = options.toolDefs ?? toolDefs;
   render(
     <ChatPane
       ref={ref}
       env={{ base: "https://platform.example.com", token: "token-1", knId: "kn-demo" }}
       tokenProvider={{ getToken: () => "token-1", refresh: () => Promise.resolve("token-1") }}
-      profile={profile}
+      profile={paneProfile}
       models={models}
       modelsLoaded
       knContext=""
       knSummary={null}
       suggestions={[]}
-      getTools={() => Promise.resolve(toolDefs)}
-      toolDefs={toolDefs}
+      getTools={() => Promise.resolve(paneToolDefs)}
+      toolDefs={paneToolDefs}
       pageScrollRef={createRef<HTMLDivElement>()}
     />,
   );
@@ -138,7 +147,38 @@ describe("ChatPane 受管生命周期接线", () => {
       session,
       turn: expect.objectContaining({ interactionId: "int_1" }) as unknown,
     });
+    expect(buildAgentTools.mock.calls[0][0]).toEqual([{ name: "run_sql" }]);
     expect(finish).toHaveBeenCalledWith("completed", "答复正文");
+  });
+
+  it("基础数据面板只向模型暴露基础数据工具", async () => {
+    stubLifecycle();
+    runAgentChat.mockImplementation(({ onChunk }) => {
+      onChunk({ type: "finish" });
+      return Promise.resolve();
+    });
+
+    const ref = renderPane({
+      profile: baseProfile,
+      toolDefs: [
+        { name: "bkn_start_interaction" },
+        { name: "list_resources" },
+        { name: "describe_resource" },
+        { name: "run_sql" },
+        { name: "search_schema" },
+        { name: "get_kn_detail" },
+      ],
+    });
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    expect(buildAgentTools.mock.calls[0][0]).toEqual([
+      { name: "list_resources" },
+      { name: "describe_resource" },
+      { name: "run_sql" },
+    ]);
   });
 
   it("执行失败时以 failed 终结", async () => {
@@ -152,6 +192,21 @@ describe("ChatPane 受管生命周期接线", () => {
     });
 
     expect(finish).toHaveBeenCalledWith("failed", "");
+  });
+
+  it("beginTurn 失败时不继续无上下文调用工具循环", async () => {
+    const { beginTurn, finish } = stubLifecycle();
+    beginTurn.mockRejectedValue(new Error("lifecycle failed"));
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    expect(buildAgentTools).not.toHaveBeenCalled();
+    expect(runAgentChat).not.toHaveBeenCalled();
+    expect(finish).not.toHaveBeenCalled();
   });
 
   it("用户中途停止时以 canceled 终结", async () => {

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -909,11 +909,10 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
             onChange={(next: string[]) => setDraftToolSelection(next)}
             options={toolOptions}
             showSearch
-            filterOption={(input, option) =>
-              String((option as { searchText?: unknown } | undefined)?.searchText ?? option?.value ?? "")
-                .toLowerCase()
-                .includes(input.trim().toLowerCase())
-            }
+            filterOption={(input, option) => {
+              const searchText = (option as { searchText?: unknown } | undefined)?.searchText;
+              return typeof searchText === "string" && searchText.toLowerCase().includes(input.trim().toLowerCase());
+            }}
             placeholder={toolDefs ? "选择工具" : "正在加载工具"}
             loading={!toolDefs}
             disabled={busy}

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -27,6 +27,7 @@ import {
   forwardRef,
   memo,
   type RefObject,
+  type ReactNode,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -42,6 +43,7 @@ import type { LlmModel } from "@/modules/model-resources/types/llm";
 import {
   buildAgentTools,
   effectiveToolArgs,
+  isModelVisibleMcpTool,
   runAgentChat,
   DEFAULT_AGENT_CONFIG,
   type AgentChatTurn,
@@ -57,9 +59,14 @@ import {
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import {
   CONTEXT_LOADER_OPS,
+  type ContextLoaderOp,
   type ContextLoaderEnv,
   type McpToolDef,
 } from "@/modules/knowledge-network/services/context-loader.service";
+import {
+  businessInfoOf,
+  type ToolBusinessGroupKey,
+} from "@/modules/knowledge-network/scenes/context-loader-tool-business-info";
 
 import styles from "./AgentChat.module.css";
 
@@ -89,6 +96,19 @@ const FALLBACK_SUGGESTIONS = [
   "帮我查最近活跃的高价值客户",
   "对象类之间是怎么关联的？",
 ];
+
+const TOOL_BUSINESS_GROUP_LABELS: Record<ToolBusinessGroupKey, string> = {
+  network: "知识网络信息",
+  model: "知识网络模型检索",
+  query: "对象实例与关系子图查询",
+  data: "数据资源与 SQL 查询",
+  logic: "逻辑属性与行动调用",
+  skill: "技能与动态工具",
+  other: "其他能力",
+  lifecycle: "交互生命周期",
+};
+
+const TOOL_BUSINESS_GROUP_ORDER: ToolBusinessGroupKey[] = ["data", "network", "model", "query", "logic", "skill", "other", "lifecycle"];
 
 export type PaneKey = "solo" | "base" | "kn";
 
@@ -665,8 +685,9 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
       try {
         turn = await lifecycle.beginTurn(question);
         const allTools = await getTools();
+        const modelVisibleTools = allTools.filter(isModelVisibleMcpTool);
         // 硬限定：只把勾选的工具传给模型（null = 全部）。
-        const activeTools = toolSelection ? allTools.filter((t) => toolSelection.includes(t.name)) : allTools;
+        const activeTools = toolSelection ? modelVisibleTools.filter((t) => toolSelection.includes(t.name)) : modelVisibleTools;
         const tools = buildAgentTools(activeTools, env, knId, config, tokenProvider, {
           resourceScope,
           session: lifecycle.session,
@@ -772,29 +793,55 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
     () => models.map((m) => ({ value: m.modelName, label: m.default ? `${m.modelName} · 默认` : m.modelName })),
     [models],
   );
+  const modelVisibleToolDefs = useMemo(() => {
+    if (!toolDefs) return null;
+    const visibleTools = toolDefs.filter(isModelVisibleMcpTool);
+    if (profile.paneKey !== "base" || !profile.defaultToolNames) return visibleTools;
+    const baseToolNames = new Set(profile.defaultToolNames);
+    return visibleTools.filter((toolDef) => baseToolNames.has(toolDef.name));
+  }, [profile.defaultToolNames, profile.paneKey, toolDefs]);
   // 与 MCP 侧栏同款分组：本地 op 定义带组名，线上新增的归 Knowledge Network。
   const toolOptions = useMemo(() => {
-    if (!toolDefs) return [];
-    const groupOf = (name: string) => CONTEXT_LOADER_OPS.find((op) => op.id === name)?.group ?? "Knowledge Network";
-    const order = [...new Set(CONTEXT_LOADER_OPS.map((op) => op.group))];
-    const buckets = new Map<string, { value: string; label: string }[]>();
-    for (const t of toolDefs) {
-      const group = groupOf(t.name);
+    if (!modelVisibleToolDefs) return [];
+    const opOf = (toolDef: McpToolDef): ContextLoaderOp =>
+      CONTEXT_LOADER_OPS.find((op) => op.id === toolDef.name) ?? {
+        id: toolDef.name,
+        group: "Knowledge Network",
+        summary: toolDef.description ?? toolDef.name,
+        path: "",
+        query: [],
+        body: null,
+        mcpOnly: true,
+      };
+    const buckets = new Map<ToolBusinessGroupKey, { value: string; label: ReactNode; title: string; searchText: string }[]>();
+    for (const t of modelVisibleToolDefs) {
+      const info = businessInfoOf(opOf(t));
+      const group = info.groupKey;
       if (!buckets.has(group)) buckets.set(group, []);
-      buckets.get(group)!.push({ value: t.name, label: t.name });
+      buckets.get(group)!.push({
+        value: t.name,
+        title: `${info.name} · ${t.name}`,
+        searchText: `${info.name} ${t.name}`,
+        label: (
+          <span className={styles.toolOption}>
+            <span className={styles.toolOptionName}>{info.name}</span>
+            <span className={styles.toolOptionId}>{t.name}</span>
+          </span>
+        ),
+      });
     }
     return [...buckets.keys()]
       .sort((a, b) => {
-        const ia = order.indexOf(a);
-        const ib = order.indexOf(b);
-        return (ia === -1 ? order.length : ia) - (ib === -1 ? order.length : ib);
+        const ia = TOOL_BUSINESS_GROUP_ORDER.indexOf(a);
+        const ib = TOOL_BUSINESS_GROUP_ORDER.indexOf(b);
+        return (ia === -1 ? TOOL_BUSINESS_GROUP_ORDER.length : ia) - (ib === -1 ? TOOL_BUSINESS_GROUP_ORDER.length : ib);
       })
-      .map((group) => ({ label: group, title: group, options: buckets.get(group)! }));
-  }, [toolDefs]);
+      .map((group) => ({ label: TOOL_BUSINESS_GROUP_LABELS[group], title: TOOL_BUSINESS_GROUP_LABELS[group], options: buckets.get(group)! }));
+  }, [modelVisibleToolDefs]);
   // 选择器展示值：null（全部）时显示当前已知的全部工具名。
   const draftToolValue = useMemo(
-    () => draftToolSelection ?? (toolDefs ? toolDefs.map((t) => t.name) : []),
-    [draftToolSelection, toolDefs],
+    () => draftToolSelection ?? (modelVisibleToolDefs ? modelVisibleToolDefs.map((t) => t.name) : []),
+    [draftToolSelection, modelVisibleToolDefs],
   );
 
   const empty = messages.length === 0;
@@ -861,6 +908,12 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
             value={draftToolValue}
             onChange={(next: string[]) => setDraftToolSelection(next)}
             options={toolOptions}
+            showSearch
+            filterOption={(input, option) =>
+              String((option as { searchText?: unknown } | undefined)?.searchText ?? option?.value ?? "")
+                .toLowerCase()
+                .includes(input.trim().toLowerCase())
+            }
             placeholder={toolDefs ? "选择工具" : "正在加载工具"}
             loading={!toolDefs}
             disabled={busy}
@@ -868,7 +921,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
             maxTagPlaceholder={() =>
               draftToolSelection === null
                 ? `全部 · ${draftToolValue.length}`
-                : `已选 ${draftToolValue.length}${toolDefs ? ` / ${toolDefs.length}` : ""}`
+                : `已选 ${draftToolValue.length}${modelVisibleToolDefs ? ` / ${modelVisibleToolDefs.length}` : ""}`
             }
             allowClear
             onClear={() => setDraftToolSelection(profile.defaultToolNames ? [...profile.defaultToolNames] : null)}

--- a/src/modules/knowledge-network/services/agent-chat-tools.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat-tools.test.ts
@@ -33,6 +33,18 @@ const runSql: McpToolDef = {
   },
 };
 
+const startInteraction: McpToolDef = {
+  name: "bkn_start_interaction",
+  description: "开始交互",
+  inputSchema: { type: "object", properties: { question: { type: "string" } } },
+};
+
+const finishInteraction: McpToolDef = {
+  name: "bkn_finish_interaction",
+  description: "结束交互",
+  inputSchema: { type: "object", properties: { interaction_id: { type: "string" } } },
+};
+
 function stubSession(result?: Partial<McpToolCallResult>) {
   const callTool = vi.fn<McpSession["callTool"]>().mockResolvedValue({
     ok: true,
@@ -55,6 +67,20 @@ function runTool(tool: unknown, input: unknown): Promise<string> {
 }
 
 describe("buildAgentTools", () => {
+  it("does not expose bkn lifecycle tools to the model", () => {
+    const session = stubSession();
+    const tools = buildAgentTools(
+      [startInteraction, runSql, finishInteraction],
+      env,
+      "kn-demo",
+      DEFAULT_AGENT_CONFIG,
+      tokenProvider,
+      { session },
+    );
+
+    expect(Object.keys(tools)).toEqual(["run_sql"]);
+  });
+
   it("hides bkn_context from the model", () => {
     const session = stubSession();
     const tools = buildAgentTools([runSql], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, { session });

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -202,6 +202,10 @@ export type AgentToolsOptions = {
   turn?: BknCallScope | null;
 };
 
+export function isModelVisibleMcpTool(tool: Pick<McpToolDef, "name">): boolean {
+  return !tool.name.startsWith("bkn_");
+}
+
 export function buildAgentTools(
   mcpTools: McpToolDef[],
   env: ContextLoaderEnv,
@@ -220,6 +224,7 @@ export function buildAgentTools(
   };
   for (const def of mcpTools) {
     if (!def.name) continue;
+    if (!isModelVisibleMcpTool(def)) continue;
     const schema =
       def.inputSchema && typeof def.inputSchema === "object"
         ? stripBknContextSchema(def.inputSchema as Record<string, unknown>)


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Prevent lifecycle MCP tools from being exposed to the language model.
- [x] Restrict the Base Data comparison pane to the three base data tools.
- [x] Align the agent tool picker with MCP business grouping and display names.

---

## Why

- Related Issue: Closes #350
- Related Feature: Agent chat comparison mode and managed BKN lifecycle.
- Background: Managed lifecycle calls must be owned by the host so every business-tool invocation receives a valid `bkn_context`.

---

## How

- Key implementation points: Filter `bkn_*` tools before model tool construction; begin and finish each chat turn through the lifecycle host; apply the Base Data allowlist; reuse MCP business metadata in the picker; add focused lifecycle and tool-scope regressions.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [x] Verified in local development environment

Test notes:

- Passed focused Vitest suites for ChatPane lifecycle, agent tools, and Context Loader business metadata (15 tests).
- Verified the local MCP handshake and a managed read-only `list_resources` call: initialize/start/tool call/finish all completed successfully.
- Full repository checks were not run at the requester's direction because local full checks can exhaust memory.

---

## Risk & Rollback

- Potential risks: Existing tool selections containing lifecycle tool names are ignored; Base Data saved selections are constrained to its allowlist.
- Rollback plan: Revert commit `c00797b`.

---

## Additional Notes

- The MCP sidebar keeps lifecycle tools for manual host/debug use; only model-visible tool scopes hide them.