### PR TITLE
fix(data-connect): filter unavailable connector types

### DIFF
--- a/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
+++ b/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
@@ -426,7 +426,7 @@ describe("DataConnectFormScene · connection preflight", () => {
         { skipErrorToast: true },
       );
     });
-  });
+  }, 20_000);
 });
 
 function connectorField(

--- a/src/modules/data-connect/services/data-connect.service.test.ts
+++ b/src/modules/data-connect/services/data-connect.service.test.ts
@@ -6,12 +6,17 @@
  */
 
 import axios from "axios";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import i18n from "@/app/locales/i18n";
 
 const testCatalogConnectionMock = vi.hoisted(() => vi.fn());
 const testCatalogConnectionConfigMock = vi.hoisted(() => vi.fn());
+const getMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock },
+}));
 
 vi.mock("@/shared/catalog", () => ({
   testCatalogConnection: testCatalogConnectionMock,
@@ -20,8 +25,35 @@ vi.mock("@/shared/catalog", () => ({
 
 describe("data-connect.service · test connection", () => {
   beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    getMock.mockReset();
     testCatalogConnectionMock.mockReset();
     testCatalogConnectionConfigMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("filters connector types to enabled implementations available in the backend", async () => {
+    getMock.mockResolvedValue({ data: { entries: [], total_count: 0 } });
+    const { listDataConnectConnectorTypes } = await import(
+      "@/modules/data-connect/services/data-connect.service"
+    );
+
+    await listDataConnectConnectorTypes();
+
+    expect(getMock).toHaveBeenCalledWith("/vega-backend/v1/connector-types", {
+      params: {
+        available: true,
+        direction: "asc",
+        enabled: true,
+        limit: 100,
+        offset: 0,
+        sort: "name",
+      },
+    });
   });
 
   it("recognizes only the backend connection-test failure code", async () => {

--- a/src/modules/data-connect/services/data-connect.service.ts
+++ b/src/modules/data-connect/services/data-connect.service.ts
@@ -265,6 +265,7 @@ export async function listDataConnectConnectorTypes() {
     "/vega-backend/v1/connector-types",
     {
       params: {
+        available: true,
         direction: "asc",
         enabled: true,
         limit: 100,


### PR DESCRIPTION
## What Changed

- [x] Filter connector types by `enabled=true` and `available=true`.
- [x] Add a service-layer regression test that locks the request parameters.
- [x] Raise the SQL Server create-flow test timeout from 10s to 20s to accommodate CI contention.
- [ ] Docs/doc 1 (not applicable)

---

## Why

- Related Issue: None
- Related Feature: Data connection connector type selection
- Background: The backend supports the `available` query parameter. The frontend must not offer connector implementations absent from the current backend binary.

---

## How

- Key implementation points: The shared connector-type request sends `enabled=true&available=true`. Existing known-type placeholders continue to show unavailable built-in types as disabled. The new service test asserts the exact request parameters.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable)
- [ ] Verified in test environment (not performed)

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run` — 156 files / 735 tests passed
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` — reports 1 existing ignored high vulnerability

---

## Risk & Rollback

- Potential risks: Unavailable connector types outside the frontend known-type list are hidden, rather than displayed as disabled. The unavailable label covers both administrative disablement and a missing binary implementation.
- Rollback plan: Revert commits `905a091` and `1870615`.

---

## Additional Notes

- Backend behavior confirmed: `available` is both returned and supported as a list query parameter.