### PR TITLE
fix(trace): render resolved business evidence

### DIFF
--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -67,6 +67,14 @@ export const bknTraceEnUS = {
       stage: "No visible facts in this stage.",
       artifacts: "No visible query, data, logic, or action artifacts.",
     },
+	evidenceBasis: {
+	  action: "Action evidence",
+	  data: "Data evidence",
+	  logic: "Logic evidence",
+	  noAction: "No action was executed in this interaction",
+	  noData: "No visible data evidence was recorded",
+	  noLogic: "No logic evidence was used in this interaction",
+	},
     complete: "Evidence chain complete",
     completeness: {
       complete: "Complete",
@@ -165,10 +173,12 @@ export const bknTraceEnUS = {
       relations: "Business relationships",
 	  requestDetail: "OpenBKN call details",
       interactionRequests: "OpenBKN calls in this interaction",
+	  interactionContext: "Question and result",
       snapshot: "Snapshot Preview",
       traceGraph: "Trace Graph",
       visibility: "Visibility",
     },
+	interactionCallCount: "{{count}} OpenBKN calls",
     stages: {
       action: "Action and result",
       claim: "Business claim",

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -66,6 +66,14 @@ export const bknTraceZhCN = {
       stage: "该阶段暂无可见事实",
       artifacts: "暂无可见的查询、数据、逻辑或行动制品",
     },
+	evidenceBasis: {
+	  action: "行动依据",
+	  data: "数据依据",
+	  logic: "逻辑依据",
+	  noAction: "本轮未执行行动",
+	  noData: "本轮未记录可见数据依据",
+	  noLogic: "本轮未使用逻辑依据",
+	},
     complete: "证据链完整",
     completeness: {
       complete: "完整",
@@ -164,10 +172,12 @@ export const bknTraceZhCN = {
       relations: "业务关系",
 	  requestDetail: "OpenBKN 调用详情",
       interactionRequests: "本轮 OpenBKN 调用",
+	  interactionContext: "本轮问题与结果",
       snapshot: "快照预览",
       traceGraph: "调用链",
       visibility: "可见性",
     },
+	interactionCallCount: "共 {{count}} 次 OpenBKN 调用",
     stages: {
       action: "行动与结果",
       claim: "业务结论",

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
@@ -432,6 +432,34 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
 	expect(window.location.search).toContain("interaction_id=interaction_customer_risk");
   });
 
+  it("进入交互轮次后按权限读取完整问题和完整结果", async () => {
+    vi.mocked(getInteractionSummary).mockResolvedValue({
+      conversationId: "conversation_customer_risk",
+      evidenceCompleteness: "complete",
+      interactionId: "interaction_customer_risk",
+      partialReasons: [],
+      questionArtifactRef: "artifact:art_question_001",
+      questionPreview: "客户 A 的风险为什么上升？",
+      requests: [requestSummary],
+      resultArtifactRef: "artifact:art_result_001",
+      resultPreview: "近 7 天投诉增加，风险等级上升。",
+      status: "completed",
+      traces: [],
+    });
+    window.history.replaceState(
+      {},
+      "",
+      "/observability/business-provenance?view=interactions&conversation_id=conversation_customer_risk",
+    );
+
+    render(<BknTraceRunsScene />);
+    fireEvent.click(await screen.findByRole("button", { name: /客户 A 的风险为什么上升/ }));
+
+    await waitFor(() => expect(getInteractionSummary).toHaveBeenCalledWith("interaction_customer_risk"));
+    expect(await screen.findByText("客户 A 的风险为什么上升？（完整问题）")).not.toBeNull();
+    expect(screen.getByText("近 7 天投诉增加 42%，因此风险等级从中升至高。（完整结论）")).not.toBeNull();
+  });
+
   it("丢弃晚到的旧层级响应，避免覆盖当前业务溯源视图", async () => {
     let resolveConversations!: (value: Awaited<ReturnType<typeof getConversationSummaries>>) => void;
     vi.mocked(getConversationSummaries).mockImplementationOnce(() => new Promise((resolve) => {
@@ -559,7 +587,7 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
 
     expect(screen.queryByText("客户 A 的风险为什么上升？（完整问题）")).toBeNull();
     expect(screen.queryByText("近 7 天投诉增加 42%，因此风险等级从中升至高。（完整结论）")).toBeNull();
-    expect(screen.getByText("客户风险")).not.toBeNull();
+    expect(screen.getAllByText("客户风险").length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByText("bknTrace.tabs.diagnostics"));
     fireEvent.click(await screen.findByRole("button", { name: "trace_001" }));
@@ -568,6 +596,48 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
     expect(await screen.findByText("bkn-agent.chat")).not.toBeNull();
     expect(screen.getByText("bkn-agent")).not.toBeNull();
   }, 30_000);
+
+  it("把已解析业务节点展示为数据、逻辑与行动依据", async () => {
+    vi.mocked(getBusinessGraph).mockResolvedValueOnce({
+      data: {
+        edges: [],
+        nodes: [{
+          display: { name: "产品BOM" },
+          id: "business:object:supplychain_hd0202:bom",
+          nodeType: "business_ref",
+          properties: {
+            ref_id: "object:supplychain_hd0202:supplychain_hd0202_bom",
+            ref_type: "object_type",
+          },
+          stage: "evidence",
+          visibility: "visible",
+        }],
+      },
+      page: { edgeCount: 0, nodeCount: 1, truncated: false },
+      conclusionScope: "trace",
+      partial: false,
+      partialReason: [],
+      requestId: requestSummary.requestId,
+      traceId: "trace_001",
+      visibilitySummary: {
+        authorizedRefCount: 1,
+        hiddenRefCount: 0,
+        omittedRefCount: 0,
+        redactedRefCount: 0,
+        unauthorizedRefCount: 0,
+        unresolvedRefCount: 0,
+      },
+    });
+    window.history.replaceState({}, "", "/observability/business-provenance?view=requests");
+
+    render(<BknTraceRunsScene />);
+    fireEvent.click(await screen.findByRole("button", { name: /客户 A 的风险为什么上升/ }));
+
+    expect(await screen.findByText("bknTrace.evidenceBasis.data")).not.toBeNull();
+    expect(screen.getAllByText("产品BOM").length).toBeGreaterThan(0);
+    expect(screen.getByText("bknTrace.evidenceBasis.noLogic")).not.toBeNull();
+    expect(screen.getByText("bknTrace.evidenceBasis.noAction")).not.toBeNull();
+  });
 
   it("OpenBKN 调用以业务操作区分，而不是重复本轮问题和答案", async () => {
 	vi.mocked(getRequestSummaries).mockResolvedValue({

--- a/src/modules/bkn-trace/scenes/BknTraceRunsScene.module.css
+++ b/src/modules/bkn-trace/scenes/BknTraceRunsScene.module.css
@@ -111,6 +111,22 @@
   border-left: 1px solid #d9dde5;
 }
 
+.interactionContext {
+  border-block: 1px solid #d9dde5;
+  padding-block: 16px;
+}
+
+.interactionContextHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.interactionContextHeader h5 {
+  margin: 0;
+}
+
 .contentText {
   font-size: 16px;
   line-height: 1.7;
@@ -191,6 +207,18 @@
   padding: 16px 0;
 }
 
+.evidenceBasisGrid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.evidenceBasis {
+  border-top: 3px solid #58708f;
+  min-width: 0;
+  padding-top: 10px;
+}
+
 @media (max-width: 900px) {
 	.scene,
 	.detail {
@@ -204,6 +232,10 @@
   .businessContent section + section {
     border-left: 0;
     border-top: 1px solid #d9dde5;
+  }
+
+  .evidenceBasisGrid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/modules/bkn-trace/scenes/BknTraceRunsScene.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceRunsScene.tsx
@@ -56,10 +56,12 @@ import {
   type TraceExecutionSummary,
   type TraceGraph,
   type TraceGraphNode,
+  type TraceBusinessNode,
 } from "@/modules/bkn-trace/services/trace.service";
 import {
-  businessStoryStages,
+  businessEvidenceGroups,
   businessNodePresentation,
+  businessStoryStages,
 } from "@/modules/bkn-trace/utils/trace-explainability";
 import { formatDuration } from "@/modules/bkn-trace/utils/duration";
 
@@ -74,6 +76,12 @@ type RequestDetail = {
 };
 
 type ProvenanceView = "conversations" | "interactions" | "requests";
+
+type InteractionContext = {
+  question: unknown;
+  result: unknown;
+  summary: InteractionSummary;
+};
 
 type ProvenanceListRow = {
   agentOrApp?: string;
@@ -120,9 +128,11 @@ export function BknTraceRunsScene() {
   const [page, setPage] = useState<SummaryPage<ProvenanceListRow>>();
   const [selectedRequestId, setSelectedRequestId] = useState<string>();
   const [detail, setDetail] = useState<RequestDetail>();
+  const [interactionContext, setInteractionContext] = useState<InteractionContext>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const detailRequestSequence = useRef(0);
+  const interactionRequestSequence = useRef(0);
   const provenanceRequestSequence = useRef(0);
   const deepLinkConsumed = useRef(false);
 
@@ -211,6 +221,25 @@ export function BknTraceRunsScene() {
     }
   }, [activeQuery, t, view]);
 
+  const loadInteractionContext = useCallback(async (interactionId: string) => {
+    const requestSequence = ++interactionRequestSequence.current;
+    try {
+      const summary = await getInteractionSummary(interactionId);
+      const [questionResult, answerResult] = await Promise.allSettled([
+        loadReferencedArtifact(summary.questionArtifactRef),
+        loadReferencedArtifact(summary.resultArtifactRef),
+      ]);
+      if (requestSequence !== interactionRequestSequence.current) return;
+      setInteractionContext({
+        question: settledValue(questionResult)?.content ?? summary.questionPreview,
+        result: settledValue(answerResult)?.content ?? summary.resultPreview,
+        summary,
+      });
+    } catch {
+      if (requestSequence === interactionRequestSequence.current) setInteractionContext(undefined);
+    }
+  }, []);
+
   useEffect(() => {
     void loadProvenance(initialState.view, { ...initialState.query, page: 1, pageSize: 20 });
   }, [initialState, loadProvenance]);
@@ -220,6 +249,15 @@ export function BknTraceRunsScene() {
     deepLinkConsumed.current = true;
     void openRequest(initialState.requestId);
   }, [initialState.requestId, openRequest]);
+
+  useEffect(() => {
+    if (view === "requests" && activeQuery.interactionId) {
+      void loadInteractionContext(activeQuery.interactionId);
+      return;
+    }
+    interactionRequestSequence.current += 1;
+    setInteractionContext(undefined);
+  }, [activeQuery.interactionId, loadInteractionContext, view]);
 
   function currentQuery(): RequestSummaryQuery {
     return {
@@ -523,6 +561,9 @@ export function BknTraceRunsScene() {
 		  ) : null}
 		</Space>
 	  </div>
+	  {view === "requests" && interactionContext ? (
+		<InteractionContextSummary context={interactionContext} />
+	  ) : null}
       <div
         aria-label={t("bknTrace.title")}
         className={styles.filters}
@@ -699,6 +740,30 @@ function OpenBKNCallContent({ summary }: { summary: RequestSummary }) {
   );
 }
 
+function InteractionContextSummary({ context }: { context: InteractionContext }) {
+  const { t } = useTranslation();
+  return (
+    <section className={styles.interactionContext}>
+      <div className={styles.interactionContextHeader}>
+        <Typography.Title level={5}>{t("bknTrace.sections.interactionContext")}</Typography.Title>
+        <Typography.Text type="secondary">
+          {t("bknTrace.interactionCallCount", { count: context.summary.requests.length })}
+        </Typography.Text>
+      </div>
+      <div className={styles.businessContent}>
+        <section>
+          <Typography.Text type="secondary">{t("bknTrace.fields.question")}</Typography.Text>
+          <ArtifactContent content={context.question} />
+        </section>
+        <section>
+          <Typography.Text type="secondary">{t("bknTrace.fields.result")}</Typography.Text>
+          <ArtifactContent content={context.result} />
+        </section>
+      </div>
+    </section>
+  );
+}
+
 function BusinessExplanation({
   artifacts,
   graph,
@@ -708,11 +773,9 @@ function BusinessExplanation({
 }) {
   const { t } = useTranslation();
   const stages = businessStoryStages(graph.data.nodes);
+  const evidenceGroups = businessEvidenceGroups(graph.data.nodes);
   const question = artifacts.find((artifact) => artifact.artifactType === "question")?.content;
   const result = artifacts.find((artifact) => artifact.artifactType === "result")?.content;
-  const supportingArtifacts = artifacts.filter(
-    (artifact) => !["question", "result"].includes(artifact.artifactType),
-  );
   return (
     <div className={styles.explanation}>
       <section className={styles.semanticChain}>
@@ -742,17 +805,73 @@ function BusinessExplanation({
       </section>
       <section className={styles.artifactSection}>
         <Typography.Title level={5}>{t("bknTrace.sections.artifacts")}</Typography.Title>
-        {supportingArtifacts.length ? supportingArtifacts.map((artifact) => (
-          <div className={styles.artifact} key={artifact.artifactId}>
-            <Space>
-              <Tag>{artifact.artifactType}</Tag>
-              <Typography.Text type="secondary">{artifact.observedAt}</Typography.Text>
-            </Space>
-            <ArtifactContent content={artifact.content} />
-          </div>
-        )) : <Empty description={t("bknTrace.emptyStates.artifacts")} />}
+        <div className={styles.evidenceBasisGrid}>
+          <EvidenceBasis
+            artifacts={artifacts.filter((artifact) => ["data", "data_result", "query"].includes(artifact.artifactType))}
+            emptyText={t("bknTrace.evidenceBasis.noData")}
+            nodes={evidenceGroups.data}
+            title={t("bknTrace.evidenceBasis.data")}
+          />
+          <EvidenceBasis
+            artifacts={artifacts.filter((artifact) => ["logic", "logic_execution"].includes(artifact.artifactType))}
+            emptyText={t("bknTrace.evidenceBasis.noLogic")}
+            nodes={evidenceGroups.logic}
+            title={t("bknTrace.evidenceBasis.logic")}
+          />
+          <EvidenceBasis
+            artifacts={artifacts.filter((artifact) => artifact.artifactType.startsWith("action"))}
+            emptyText={t("bknTrace.evidenceBasis.noAction")}
+            nodes={evidenceGroups.action}
+            title={t("bknTrace.evidenceBasis.action")}
+          />
+        </div>
       </section>
     </div>
+  );
+}
+
+function EvidenceBasis({
+  artifacts,
+  emptyText,
+  nodes,
+  title,
+}: {
+  artifacts: EvidenceArtifact[];
+  emptyText: string;
+  nodes: TraceBusinessNode[];
+  title: string;
+}) {
+  const { t } = useTranslation();
+  return (
+    <section className={styles.evidenceBasis}>
+      <Typography.Text strong>{title}</Typography.Text>
+      {nodes.map((node) => {
+        const presentation = businessNodePresentation(node);
+        return (
+          <div className={styles.node} key={node.id}>
+            <span className={styles.nodeTitle}>{presentation.title}</span>
+            <Typography.Text type="secondary">{presentation.subtitle}</Typography.Text>
+            <details className={styles.technicalDetails}>
+              <summary>{t("bknTrace.fields.technicalDetails")}</summary>
+              <Typography.Text copyable type="secondary">{presentation.technicalId}</Typography.Text>
+              <Typography.Text type="secondary">{node.nodeType}</Typography.Text>
+            </details>
+          </div>
+        );
+      })}
+      {artifacts.map((artifact) => (
+        <div className={styles.artifact} key={artifact.artifactId}>
+          <Space>
+            <Tag>{artifact.artifactType}</Tag>
+            <Typography.Text type="secondary">{artifact.observedAt}</Typography.Text>
+          </Space>
+          <ArtifactContent content={artifact.content} />
+        </div>
+      ))}
+      {!nodes.length && !artifacts.length ? (
+        <Typography.Text type="secondary">{emptyText}</Typography.Text>
+      ) : null}
+    </section>
   );
 }
 
@@ -907,6 +1026,11 @@ function ArtifactContent({ content }: { content: unknown }) {
 
 function artifactId(ref: string) {
   return ref.startsWith("artifact:") ? ref.slice("artifact:".length) : undefined;
+}
+
+function loadReferencedArtifact(ref?: string) {
+  const id = ref ? artifactId(ref) : undefined;
+  return id ? getEvidenceArtifact(id) : Promise.resolve(undefined);
 }
 
 function formatTime(value?: string) {

--- a/src/modules/bkn-trace/services/trace.service.test.ts
+++ b/src/modules/bkn-trace/services/trace.service.test.ts
@@ -556,7 +556,9 @@ describe("bkn-trace service", () => {
 		evidence_completeness: "complete",
 		partial_reasons: [],
 		question_preview: "查询六月需求预测",
+		question_artifact_ref: "artifact:question_june",
 		result_preview: "六月共 63 条",
+		result_artifact_ref: "artifact:result_june",
         status: "completed",
         requests: [
           { request_id: "req_schema", interaction_id: "interaction_june_forecast" },
@@ -592,7 +594,9 @@ describe("bkn-trace service", () => {
 	  effectiveSubjectId: "user-001",
 	  evidenceCompleteness: "complete",
 	  questionPreview: "查询六月需求预测",
+	  questionArtifactRef: "artifact:question_june",
 	  resultPreview: "六月共 63 条",
+	  resultArtifactRef: "artifact:result_june",
 	});
   });
 });

--- a/src/modules/bkn-trace/services/trace.service.ts
+++ b/src/modules/bkn-trace/services/trace.service.ts
@@ -323,8 +323,10 @@ export type InteractionSummary = {
   interactionId: string;
 	partialReasons: string[];
 	questionPreview?: string;
+	questionArtifactRef?: string;
   requests: RequestSummary[];
 	resultPreview?: string;
+	resultArtifactRef?: string;
   startedAt?: string;
   status: string;
   traces: TraceExecutionSummary[];
@@ -651,8 +653,10 @@ type BackendInteractionSummary = {
   interaction_id?: string;
 	partial_reasons?: string[];
 	question_preview?: string;
+	question_artifact_ref?: string;
   requests?: BackendRequestSummary[];
 	result_preview?: string;
+	result_artifact_ref?: string;
   started_at?: string;
   status?: string;
   traces?: BackendTraceExecutionSummary[];
@@ -793,8 +797,10 @@ export async function getInteractionSummary(
     interactionId: response.data.interaction_id ?? "",
 	partialReasons: response.data.partial_reasons ?? [],
 	questionPreview: response.data.question_preview,
+	questionArtifactRef: response.data.question_artifact_ref,
     requests: (response.data.requests ?? []).map(mapRequestSummary),
 	resultPreview: response.data.result_preview,
+	resultArtifactRef: response.data.result_artifact_ref,
     startedAt: response.data.started_at,
     status: normalizeExecutionStatus(response.data.status),
     traces: (response.data.traces ?? []).map(mapTraceExecutionSummary),

--- a/src/modules/bkn-trace/utils/trace-explainability.test.ts
+++ b/src/modules/bkn-trace/utils/trace-explainability.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  businessEvidenceGroups,
   businessRows,
   businessNodePresentation,
   businessStoryStages,
@@ -122,6 +123,45 @@ describe("trace explainability rows", () => {
     expect(stages.find((stage) => stage.stage === "evidence")?.nodes).toHaveLength(1);
   });
 
+  it("groups resolved business references as data, logic, or action evidence", () => {
+    const groups = businessEvidenceGroups([
+      {
+        id: "business:object:supplychain:bom",
+        nodeType: "business_ref",
+        display: { name: "产品BOM" },
+        properties: { ref_type: "object_type" },
+        stage: "evidence",
+        visibility: "visible",
+      },
+      {
+        id: "business:metric:supplychain:available_qty",
+        nodeType: "business_ref",
+        display: { name: "生产可用库存" },
+        properties: { ref_type: "metric" },
+        stage: "evidence",
+        visibility: "visible",
+      },
+      {
+        id: "business:action:supplychain:create_po",
+        nodeType: "business_ref",
+        display: { name: "创建采购申请" },
+        properties: { ref_type: "action_type" },
+        stage: "action",
+        visibility: "visible",
+      },
+      {
+        id: "operation:run-sql",
+        nodeType: "operation",
+        properties: { operation_name: "run_sql" },
+        stage: "execution",
+      },
+    ]);
+
+    expect(groups.data.map((node) => node.display?.name)).toEqual(["产品BOM"]);
+    expect(groups.logic.map((node) => node.display?.name)).toEqual(["生产可用库存"]);
+    expect(groups.action.map((node) => node.display?.name)).toEqual(["创建采购申请"]);
+  });
+
   it("uses backend display names before falling back to technical refs", () => {
     expect(businessNodePresentation({
       id: "evidence:evidence:kn:supplychain_hd0202",
@@ -137,7 +177,7 @@ describe("trace explainability rows", () => {
       },
     })).toMatchObject({
       title: "HD供应链业务知识网络_v3",
-      subtitle: "业务证据",
+      subtitle: "业务知识网络",
       technicalId: "evidence:kn:supplychain_hd0202",
     });
   });

--- a/src/modules/bkn-trace/utils/trace-explainability.ts
+++ b/src/modules/bkn-trace/utils/trace-explainability.ts
@@ -19,6 +19,52 @@ export type BusinessStoryStageGroup = {
   stage: BusinessStoryStage;
 };
 
+export type BusinessEvidenceGroups = {
+  action: TraceBusinessNode[];
+  data: TraceBusinessNode[];
+  logic: TraceBusinessNode[];
+};
+
+const dataEvidenceKinds = new Set([
+  "data_resource",
+  "evidence_ref",
+  "field",
+  "knowledge_network",
+  "object",
+  "object_instance",
+  "object_type",
+  "property",
+  "relation",
+  "relation_type",
+  "resource",
+  "row_ref",
+]);
+const logicEvidenceKinds = new Set([
+  "function",
+  "function_type",
+  "logic",
+  "logic_execution",
+  "metric",
+  "metric_type",
+]);
+const actionEvidenceKinds = new Set(["action", "action_instance", "action_type"]);
+
+export function businessEvidenceGroups(nodes: TraceBusinessNode[]): BusinessEvidenceGroups {
+  const groups: BusinessEvidenceGroups = { action: [], data: [], logic: [] };
+  for (const node of nodes) {
+    if (["hidden", "unauthorized"].includes(node.visibility ?? "")) continue;
+    const kind = businessNodeKind(node);
+    if (actionEvidenceKinds.has(kind) || node.stage === "action") {
+      groups.action.push(node);
+    } else if (logicEvidenceKinds.has(kind)) {
+      groups.logic.push(node);
+    } else if (dataEvidenceKinds.has(kind) && node.stage !== "intent") {
+      groups.data.push(node);
+    }
+  }
+  return groups;
+}
+
 export function businessStoryStages(nodes: TraceBusinessNode[]): BusinessStoryStageGroup[] {
   return stageOrder.map((stage) => ({
     nodes: nodes.filter((node) => effectiveBusinessStage(node) === stage),
@@ -100,11 +146,12 @@ export function businessNodePresentation(node: TraceBusinessNode): BusinessNodeP
   const technicalId = firstNonEmpty(refId, stringField(node.properties, "artifact_ref"), node.id);
   const resolved = resolveBusinessRef(refId || node.id);
   const displayName = node.display?.name || node.display?.controlledSummary || "";
+  const kindLabel = businessKindLabel(businessNodeKind(node));
 
   if (displayName) {
     return {
-      kind: businessKindLabel(node.nodeType),
-      subtitle: compactJoin([businessKindLabel(node.nodeType), node.display?.businessPath?.join(" / ") ?? ""]),
+      kind: kindLabel,
+      subtitle: compactJoin([kindLabel, node.display?.businessPath?.join(" / ") ?? ""]),
       technicalId,
       title: displayName,
     };
@@ -266,17 +313,40 @@ function businessKindLabel(nodeType: string): string {
     return "业务证据";
   case "interaction":
     return "交互意图";
+  case "knowledge_network":
+    return "业务知识网络";
   case "object":
+  case "object_type":
     return "业务对象";
   case "operation":
     return "执行过程";
   case "property":
+  case "field":
     return "业务属性";
+  case "relation":
+  case "relation_type":
+    return "业务关系";
   case "resource":
+  case "data_resource":
     return "数据资源";
+  case "metric":
+  case "metric_type":
+  case "function":
+  case "function_type":
+  case "logic":
+  case "logic_execution":
+    return "业务逻辑";
+  case "action":
+  case "action_instance":
+  case "action_type":
+    return "业务行动";
   default:
     return nodeType || "业务节点";
   }
+}
+
+function businessNodeKind(node: TraceBusinessNode): string {
+  return stringField(node.properties, "ref_type") || node.nodeType;
 }
 
 function scalarLike(value: unknown): string {


### PR DESCRIPTION
## Summary
- render data, logic, and action evidence from authorized business graph nodes and visible artifacts
- prefer readable resolver labels while preserving technical IDs in details
- show full interaction context once, without copying it into every OpenBKN call

## Verification
- vitest: 42 BKN Trace tests passed
- tsc -b --pretty false
- eslint src/modules/bkn-trace --max-warnings=0