### PR TITLE
Fix object type mapping line interactions

### DIFF
--- a/src/modules/knowledge-network/components/object-type/data-attribute/ObjectTypeDataAttributeEditor.tsx
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/ObjectTypeDataAttributeEditor.tsx
@@ -11,6 +11,7 @@ import {
   DeleteOutlined,
   DisconnectOutlined,
   EllipsisOutlined,
+  EditOutlined,
   InfoCircleFilled,
   MinusOutlined,
   NodeIndexOutlined,
@@ -27,6 +28,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -75,6 +77,7 @@ import {
   countMappedProperties,
   filterPropertyRows,
   filterViewFieldRows,
+  isMappedPropertyConnectionVisible,
   type ConnectionPoint,
   type MappingFilter,
 } from "./object-type-data-attribute-editor.utils";
@@ -408,6 +411,16 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
     );
   }, [dataProperties, fieldSearch, mappingFilter, propertySearch, viewFields]);
 
+  const visibleViewFieldNames = useMemo(
+    () => new Set(filteredViewFields.map((row) => row.item.name)),
+    [filteredViewFields],
+  );
+
+  const visiblePropertyNames = useMemo(
+    () => new Set(filteredProperties.map((row) => row.item.name)),
+    [filteredProperties],
+  );
+
   const mappedPropertyCount = useMemo(
     () => countMappedProperties(validProperties),
     [validProperties],
@@ -495,7 +508,14 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
     const nextConnections: ConnectionPoint[] = [];
 
     validProperties.forEach((property) => {
-      if (!property.mappedField) {
+      if (
+        !property.mappedField ||
+        !isMappedPropertyConnectionVisible(
+          property,
+          visibleViewFieldNames,
+          visiblePropertyNames,
+        )
+      ) {
         return;
       }
 
@@ -511,19 +531,35 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
       nextConnections.push({
         propertyName: property.name,
         viewFieldName: property.mappedField.name,
-        x1: viewRect.left + viewRect.width / 2 - canvasRect.left,
-        y1: viewRect.top + viewRect.height / 2 - canvasRect.top,
-        x2: propertyRect.left + propertyRect.width / 2 - canvasRect.left,
-        y2: propertyRect.top + propertyRect.height / 2 - canvasRect.top,
+        x1:
+          viewRect.left +
+          viewRect.width / 2 -
+          canvasRect.left +
+          canvas.scrollLeft,
+        y1:
+          viewRect.top +
+          viewRect.height / 2 -
+          canvasRect.top +
+          canvas.scrollTop,
+        x2:
+          propertyRect.left +
+          propertyRect.width / 2 -
+          canvasRect.left +
+          canvas.scrollLeft,
+        y2:
+          propertyRect.top +
+          propertyRect.height / 2 -
+          canvasRect.top +
+          canvas.scrollTop,
       });
     });
 
     setConnections((current) =>
       areConnectionsEqual(current, nextConnections) ? current : nextConnections,
     );
-  }, [validProperties]);
+  }, [validProperties, visiblePropertyNames, visibleViewFieldNames]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     recalculateConnections();
     const timer = window.setTimeout(() => {
       recalculateConnections();
@@ -692,11 +728,24 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
   const disconnectPropertyMapping = (name: string, event: React.MouseEvent) => {
     event.stopPropagation();
     const property = validProperties.find((item) => item.name === name);
+    const connectionId = property?.mappedField
+      ? buildConnectionId(property.mappedField.name, property.name)
+      : null;
     if (
       property?.mappedField &&
-      selectedConnectionId === buildConnectionId(property.mappedField.name, property.name)
+      selectedConnectionId === connectionId
     ) {
       clearSelectedConnection();
+    }
+    if (hoveredConnection === connectionId) {
+      setHoveredConnection(null);
+    }
+    if (connectionId) {
+      setConnections((current) =>
+        current.filter(
+          (item) => buildConnectionId(item.viewFieldName, item.propertyName) !== connectionId,
+        ),
+      );
     }
     updateProperties(
       dataProperties.map((item) =>
@@ -704,6 +753,15 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
       ),
     );
     void message.success(t("knowledgeNetwork.objectTypeMappingCleared"));
+  };
+
+  const editPropertyFromRow = (property: ObjectTypeDataProperty, event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (logicNameSet.has(property.name)) {
+      return;
+    }
+    setEditingProperty(property);
+    setDrawerOpen(true);
   };
 
   const connectProperty = (property: ObjectTypeDataProperty) => {
@@ -1454,6 +1512,12 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
                           ) : null}
                         </div>
                         <div className={styles.itemIconsActions}>
+                          <Tooltip title={t("knowledgeNetwork.objectTypeEditDataProperty")}>
+                            <EditOutlined
+                              className={styles.rowActionIcon}
+                              onClick={(event) => editPropertyFromRow(property, event)}
+                            />
+                          </Tooltip>
                           {property.mappedField ? (
                             <Tooltip title={t("knowledgeNetwork.objectTypeClearMapping")}>
                               <DisconnectOutlined
@@ -1466,35 +1530,45 @@ export const ObjectTypeDataAttributeEditor = forwardRef<
                           ) : null}
                           {canBeDisplayKey(property.type) ? (
                             property.displayKey ? (
-                              <StarFilled
-                                className={styles.rowActionIconActiveTitle}
-                                onClick={(event) =>
-                                  togglePropertyDisplayKey(property.name, event)
-                                }
-                              />
+                              <Tooltip title={t("knowledgeNetwork.objectTypeDisplayKeyShort")}>
+                                <StarFilled
+                                  className={styles.rowActionIconActiveTitle}
+                                  onClick={(event) =>
+                                    togglePropertyDisplayKey(property.name, event)
+                                  }
+                                />
+                              </Tooltip>
                             ) : (
-                              <StarOutlined
-                                className={styles.rowActionIcon}
-                                onClick={(event) =>
-                                  togglePropertyDisplayKey(property.name, event)
-                                }
-                              />
+                              <Tooltip title={t("knowledgeNetwork.objectTypeDisplayKeyShort")}>
+                                <StarOutlined
+                                  className={styles.rowActionIcon}
+                                  onClick={(event) =>
+                                    togglePropertyDisplayKey(property.name, event)
+                                  }
+                                />
+                              </Tooltip>
                             )
                           ) : null}
                           {canBePrimaryKey(property.type) ? (
-                            <BookOutlined
-                              className={
-                                property.primaryKey
-                                  ? styles.rowActionIconActivePrimary
-                                  : styles.rowActionIcon
-                              }
-                              onClick={(event) => togglePropertyPrimaryKey(property.name, event)}
-                            />
+                            <Tooltip title={t("knowledgeNetwork.objectTypePrimaryKey")}>
+                              <BookOutlined
+                                className={
+                                  property.primaryKey
+                                    ? styles.rowActionIconActivePrimary
+                                    : styles.rowActionIcon
+                                }
+                                onClick={(event) => togglePropertyPrimaryKey(property.name, event)}
+                              />
+                            </Tooltip>
                           ) : null}
-                          <DeleteOutlined
-                            className={styles.rowActionIcon}
-                            onClick={(event) => handleDeletePropertyFromRow(property.name, event)}
-                          />
+                          <Tooltip title={t("common.delete")}>
+                            <DeleteOutlined
+                              className={styles.rowActionIcon}
+                              onClick={(event) =>
+                                handleDeletePropertyFromRow(property.name, event)
+                              }
+                            />
+                          </Tooltip>
                         </div>
                       </div>
                       </div>

--- a/src/modules/knowledge-network/components/object-type/data-attribute/object-type-data-attribute-editor.utils.test.ts
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/object-type-data-attribute-editor.utils.test.ts
@@ -25,6 +25,7 @@ import {
   countMappedProperties,
   filterPropertyRows,
   filterViewFieldRows,
+  isMappedPropertyConnectionVisible,
 } from "./object-type-data-attribute-editor.utils";
 
 function createProperty(
@@ -191,6 +192,38 @@ describe("countMappedProperties", () => {
         createProperty({ name: "b" }),
       ]),
     ).toBe(1);
+  });
+});
+
+describe("isMappedPropertyConnectionVisible", () => {
+  it("renders a mapped connection only when both endpoints are visible", () => {
+    const property = createProperty({
+      mappedField: { displayName: "Sender name", name: "sender_name", type: "string" },
+      name: "sender_name",
+    });
+
+    expect(
+      isMappedPropertyConnectionVisible(
+        property,
+        new Set(["sender_name"]),
+        new Set(["sender_name"]),
+      ),
+    ).toBe(true);
+
+    expect(
+      isMappedPropertyConnectionVisible(
+        property,
+        new Set(["sender_name"]),
+        new Set(["sender_phone"]),
+      ),
+    ).toBe(false);
+    expect(
+      isMappedPropertyConnectionVisible(
+        property,
+        new Set(["sender_phone"]),
+        new Set(["sender_name"]),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/modules/knowledge-network/components/object-type/data-attribute/object-type-data-attribute-editor.utils.ts
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/object-type-data-attribute-editor.utils.ts
@@ -191,6 +191,18 @@ export function countMappedProperties(properties: ObjectTypeDataProperty[]) {
   return properties.filter((property) => Boolean(property.mappedField)).length;
 }
 
+export function isMappedPropertyConnectionVisible(
+  property: ObjectTypeDataProperty,
+  visibleViewFieldNames: ReadonlySet<string>,
+  visiblePropertyNames: ReadonlySet<string>,
+) {
+  return (
+    Boolean(property.mappedField) &&
+    visiblePropertyNames.has(property.name) &&
+    visibleViewFieldNames.has(property.mappedField?.name ?? "")
+  );
+}
+
 export function areConnectionsEqual(left: ConnectionPoint[], right: ConnectionPoint[]) {
   return (
     left.length === right.length &&


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Stabilize object type data-attribute mapping line rendering after disconnect/reconnect interactions
- [x] Add an explicit edit action for mapped data properties
- [x] Add consistent tooltips for data-property row actions

---

## Why

- Related Issue: Closes #350
- Related Feature: Knowledge network object type editor
- Background:
  Clearing a data-field mapping and connecting it again could leave connection lines visually misaligned. Mapped data properties also had no obvious edit affordance because row clicks select the connection.

---

## How

- Key implementation points:
  - Draw mapping connections only when both endpoints are visible.
  - Recalculate line positions before paint and after disconnect/reconnect layout changes.
  - Include canvas scroll offsets when computing SVG connection coordinates.
  - Add a dedicated edit icon for mapped data-property rows.
  - Add tooltips for edit, clear mapping, title key, primary key, and delete actions.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Ran focused tests for the changed mapping editor utilities:
  `node --max-old-space-size=1024 .\node_modules\vitest\vitest.mjs run src/modules/knowledge-network/components/object-type/data-attribute/object-type-data-attribute-editor.utils.test.ts --pool=forks --maxWorkers=1 --minWorkers=1`
- Result: 21 tests passed.
- Full CI was not run per requester instruction to run only tests related to this change.

---

## Risk & Rollback

- Potential risks:
  - The change affects only the object type data-attribute mapping editor UI.
  - Connection line rendering depends on browser layout timing; this PR recalculates before paint and schedules post-layout recalculation for mapping changes.
- Rollback plan:
  - Revert this PR to restore the previous mapping-line rendering and row action behavior.

---

## Additional Notes

- This PR was recreated from the latest `origin/main` and contains only the object type mapping fix.
- Temporary local changes that opened the object type edit entry are not included.