### PR TITLE
fix(knowledge-network): 流式答复按块增量渲染 Markdown

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -70,6 +70,7 @@ import {
 import { buildMcpToolGroups, toolDisplayOf } from "@/modules/knowledge-network/services/mcp-tool-display";
 
 import styles from "./AgentChat.module.css";
+import { closeOpenMarkdown, splitMarkdownBlocks } from "./markdown-blocks";
 
 /**
  * 默认提示词只讲「这个面板是干什么的、工具怎么用」。
@@ -272,11 +273,26 @@ function formatArgs(args: unknown): string {
   }
 }
 
-/** Markdown 渲染（GFM：表格/删除线/任务列表）。对比报告的 AI 总结也复用。 */
-export const MarkdownView = memo(function MarkdownView({ text }: { text: string }) {
+/** 单个 Markdown 块。memo 是关键：流式下只有尾块的 text 在变，前面的块不会重新 parse。 */
+const MarkdownBlock = memo(function MarkdownBlock({ text }: { text: string }) {
+  return <Markdown remarkPlugins={[remarkGfm]}>{text}</Markdown>;
+});
+
+/**
+ * Markdown 渲染（GFM：表格/删除线/任务列表）。对比报告的 AI 总结也复用。
+ * streaming = 正文还在流：按块渲染 + 尾块补全未闭合语法，避免整段重 parse 的 O(n²)。
+ */
+export const MarkdownView = memo(function MarkdownView({ text, streaming = false }: { text: string; streaming?: boolean }) {
+  const blocks = useMemo(() => {
+    const bs = splitMarkdownBlocks(text);
+    if (!streaming || bs.length === 0) return bs;
+    return [...bs.slice(0, -1), closeOpenMarkdown(bs[bs.length - 1])];
+  }, [text, streaming]);
   return (
     <div className={styles.md}>
-      <Markdown remarkPlugins={[remarkGfm]}>{text}</Markdown>
+      {blocks.map((b, i) => (
+        <MarkdownBlock key={i} text={b} />
+      ))}
     </div>
   );
 });
@@ -1146,10 +1162,10 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
                       </div>
                     ) : null}
                     {m.content ? (
-                      // 流式进行中的最后一条用纯文本，结束后再渲染 Markdown：
-                      // 避免每来一个 token 就整段重新解析 Markdown（长答复 O(n²) 卡 UI）。
-                      m.role === "assistant" && !(busy && isLast) ? (
-                        <MarkdownView text={m.content} />
+                      // 流式进行中也渲染 Markdown：MarkdownView 按块 memo，只有尾块重 parse，
+                      // 不再是每来一个 token 就整段重解析（长答复 O(n²) 卡 UI）。
+                      m.role === "assistant" ? (
+                        <MarkdownView text={m.content} streaming={busy && isLast} />
                       ) : (
                         <div className={styles.txt}>{m.content}</div>
                       )

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -284,15 +284,21 @@ const MarkdownBlock = memo(function MarkdownBlock({ text }: { text: string }) {
  */
 export const MarkdownView = memo(function MarkdownView({ text, streaming = false }: { text: string; streaming?: boolean }) {
   const blocks = useMemo(() => {
+    // 非流式正文一次成型，没有重复 parse 的开销，就不该冒分块启发式的风险：
+    // 跨块构造（引用式链接定义、GFM 脚注）被切开会解析失败，而落在已完成的正文上
+    // 是永久错误显示，不像流式尾巴那样流一结束就自愈。整段 parse 走老路。
+    if (!streaming) return null;
     const bs = splitMarkdownBlocks(text);
-    if (!streaming || bs.length === 0) return bs;
+    if (bs.length === 0) return bs;
     return [...bs.slice(0, -1), closeOpenMarkdown(bs[bs.length - 1])];
   }, [text, streaming]);
   return (
     <div className={styles.md}>
-      {blocks.map((b, i) => (
-        <MarkdownBlock key={i} text={b} />
-      ))}
+      {blocks === null ? (
+        <Markdown remarkPlugins={[remarkGfm]}>{text}</Markdown>
+      ) : (
+        blocks.map((b, i) => <MarkdownBlock key={i} text={b} />)
+      )}
     </div>
   );
 });

--- a/src/modules/knowledge-network/components/agent-chat/MarkdownView.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/MarkdownView.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MarkdownView } from "./ChatPane";
+
+describe("MarkdownView", () => {
+  it("多块正文渲染成真正的块级元素（不是一坨纯文本）", () => {
+    const { container } = render(<MarkdownView text={"## 鹿岛体育场\n\n位于日本茨城县。\n\n- 甲\n- 乙"} />);
+    expect(screen.getByRole("heading", { level: 2 }).textContent).toBe("鹿岛体育场");
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+  });
+
+  it("流式中也渲染 Markdown，尾块的半截语法补全后不露原始标记", () => {
+    const { container } = render(<MarkdownView text={"## 结论\n\n最像动物的是 **鹿岛"} streaming />);
+    expect(screen.getByRole("heading", { level: 2 }).textContent).toBe("结论");
+    expect(container.querySelector("strong")?.textContent).toBe("鹿岛");
+    expect(container.textContent).not.toContain("**");
+  });
+
+  it("流式中未闭合的代码围栏渲染成 pre，而不是漏出 ```", () => {
+    const { container } = render(<MarkdownView text={"查询：\n\n```sql\nSELECT 1"} streaming />);
+    expect(container.querySelector("pre code")?.textContent?.trim()).toBe("SELECT 1");
+    expect(container.textContent).not.toContain("```");
+  });
+});

--- a/src/modules/knowledge-network/components/agent-chat/MarkdownView.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/MarkdownView.test.tsx
@@ -24,6 +24,14 @@ describe("MarkdownView", () => {
     expect(container.textContent).not.toContain("**");
   });
 
+  it("非流式不分块：跨块的引用式链接定义照常解析（分块会把它切坏）", () => {
+    const { container } = render(<MarkdownView text={"见 [文档][d] 说明。\n\n[d]: https://example.com"} />);
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+    expect(link?.textContent).toBe("文档");
+    expect(container.textContent).not.toContain("[d]");
+  });
+
   it("流式中未闭合的代码围栏渲染成 pre，而不是漏出 ```", () => {
     const { container } = render(<MarkdownView text={"查询：\n\n```sql\nSELECT 1"} streaming />);
     expect(container.querySelector("pre code")?.textContent?.trim()).toBe("SELECT 1");

--- a/src/modules/knowledge-network/components/agent-chat/markdown-blocks.test.ts
+++ b/src/modules/knowledge-network/components/agent-chat/markdown-blocks.test.ts
@@ -58,6 +58,22 @@ describe("closeOpenMarkdown", () => {
     expect(closeOpenMarkdown("**`run_sql")).toBe("**`run_sql`**");
   });
 
+  it("补跨行的加粗（只扫最后一行会漏）", () => {
+    expect(closeOpenMarkdown("**结论：这里是一段比较长的加粗\n还在往下写")).toBe(
+      "**结论：这里是一段比较长的加粗\n还在往下写**",
+    );
+  });
+
+  it("配对只看当前段落，前面已闭合的段落不参与", () => {
+    const block = "1. **甲**\n\n2. **乙";
+    expect(closeOpenMarkdown(block)).toBe(`${block}**`);
+  });
+
+  it("段里有围栏行就不配对（反引号会把计数带偏）", () => {
+    const block = "- 例子：\n\n  ```sql\n  SELECT 1\n  ```";
+    expect(closeOpenMarkdown(block)).toBe(block);
+  });
+
   it("成对的语法不动", () => {
     const done = "**鹿岛**体育场 `run_sql` 完事";
     expect(closeOpenMarkdown(done)).toBe(done);

--- a/src/modules/knowledge-network/components/agent-chat/markdown-blocks.test.ts
+++ b/src/modules/knowledge-network/components/agent-chat/markdown-blocks.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { closeOpenMarkdown, splitMarkdownBlocks } from "./markdown-blocks";
+
+describe("splitMarkdownBlocks", () => {
+  it("按空行切块，丢掉空行本身", () => {
+    expect(splitMarkdownBlocks("## 标题\n\n正文一\n\n正文二")).toEqual(["## 标题", "正文一", "正文二"]);
+  });
+
+  it("围栏代码块内部的空行不切", () => {
+    const text = "前言\n\n```sql\nSELECT 1\n\nFROM t\n```\n\n后记";
+    expect(splitMarkdownBlocks(text)).toEqual(["前言", "```sql\nSELECT 1\n\nFROM t\n```", "后记"]);
+  });
+
+  it("loose list 的项间空行不切（否则拆成两个列表、有序列表重新编号）", () => {
+    const text = "1. 甲\n\n2. 乙\n\n结尾";
+    expect(splitMarkdownBlocks(text)).toEqual(["1. 甲\n\n2. 乙", "结尾"]);
+  });
+
+  it("表格整块保留（GFM 表格内无空行）", () => {
+    const text = "| a | b |\n| --- | --- |\n| 1 | 2 |\n\n下一段";
+    expect(splitMarkdownBlocks(text)).toEqual(["| a | b |\n| --- | --- |\n| 1 | 2 |", "下一段"]);
+  });
+
+  it("流式增量下已完成的块保持同一字符串（memo 才拦得住重渲）", () => {
+    const head = splitMarkdownBlocks("## 标题\n\n正文一")[0];
+    const later = splitMarkdownBlocks("## 标题\n\n正文一\n\n正文二还在写")[0];
+    expect(later).toBe(head);
+  });
+});
+
+describe("closeOpenMarkdown", () => {
+  it("补未闭合的代码围栏", () => {
+    expect(closeOpenMarkdown("```sql\nSELECT 1")).toBe("```sql\nSELECT 1\n```");
+  });
+
+  it("已闭合的围栏不动", () => {
+    const done = "```sql\nSELECT 1\n```";
+    expect(closeOpenMarkdown(done)).toBe(done);
+  });
+
+  it("补未闭合的加粗", () => {
+    expect(closeOpenMarkdown("**鹿岛体育场")).toBe("**鹿岛体育场**");
+  });
+
+  it("补未闭合的行内代码", () => {
+    expect(closeOpenMarkdown("查询用 `SELECT")).toBe("查询用 `SELECT`");
+  });
+
+  it("代码在加粗里时先闭代码再闭加粗", () => {
+    expect(closeOpenMarkdown("**`run_sql")).toBe("**`run_sql`**");
+  });
+
+  it("成对的语法不动", () => {
+    const done = "**鹿岛**体育场 `run_sql` 完事";
+    expect(closeOpenMarkdown(done)).toBe(done);
+  });
+});

--- a/src/modules/knowledge-network/components/agent-chat/markdown-blocks.ts
+++ b/src/modules/knowledge-network/components/agent-chat/markdown-blocks.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/**
+ * 流式 Markdown 的分块与尾块补全。
+ *
+ * 为什么要分块：react-markdown 每次渲染都会把整段正文重新 parse 成 mdast，
+ * 流式下每来一个 token 就重来一次 = O(n²)，长答复直接卡死 UI。把正文切成
+ * 「已经写完的块」+「正在写的尾块」，稳定块用 memo 挡住重渲，只有尾块重 parse，
+ * 总成本回到 O(n)。
+ */
+
+/** 围栏行：``` 或 ~~~（允许最多 3 空格缩进）。 */
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+/** 列表项行：- * + 或 1. 1)。 */
+const LIST_RE = /^ {0,3}(?:[-*+]|\d{1,9}[.)])\s/;
+/** 列表项的续行（缩进 2 空格以上或 tab）。 */
+const LIST_CONT_RE = /^(?: {2,}|\t)\S/;
+
+function isListish(line: string): boolean {
+  return LIST_RE.test(line) || LIST_CONT_RE.test(line);
+}
+
+/**
+ * 把 Markdown 正文按块级边界（空行）切开。两处不切：
+ * - 围栏代码块内部的空行；
+ * - loose list 的项间空行（切了会变成两个 <ul>，有序列表还会重新从 1 编号）。
+ */
+export function splitMarkdownBlocks(text: string): string[] {
+  const lines = text.split("\n");
+  const blocks: string[] = [];
+  let cur: string[] = [];
+  let fence: string | null = null;
+
+  const flush = () => {
+    if (cur.length > 0) {
+      blocks.push(cur.join("\n"));
+      cur = [];
+    }
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (fence !== null) {
+      cur.push(line);
+      const closing = FENCE_RE.exec(line);
+      if (closing && closing[1][0] === fence[0] && closing[1].length >= fence.length) fence = null;
+      continue;
+    }
+
+    const opening = FENCE_RE.exec(line);
+    if (opening) {
+      fence = opening[1];
+      cur.push(line);
+      continue;
+    }
+
+    if (line.trim() === "") {
+      // 空行是块边界，除非它夹在同一个 loose list 的两个列表项之间。
+      const prev = [...cur].reverse().find((l) => l.trim() !== "");
+      const next = lines.slice(i + 1).find((l) => l.trim() !== "");
+      if (prev && next && isListish(prev) && isListish(next)) {
+        cur.push(line);
+        continue;
+      }
+      flush();
+      continue;
+    }
+
+    cur.push(line);
+  }
+
+  flush();
+  return blocks;
+}
+
+/** 正文里是否还有没闭合的围栏；有则返回该补的闭合标记。 */
+function openFenceMarker(text: string): string | null {
+  let fence: string | null = null;
+  for (const line of text.split("\n")) {
+    const m = FENCE_RE.exec(line);
+    if (!m) continue;
+    if (fence === null) fence = m[1];
+    else if (m[1][0] === fence[0] && m[1].length >= fence.length) fence = null;
+  }
+  return fence;
+}
+
+function countOccurrences(line: string, token: string): number {
+  let n = 0;
+  let at = line.indexOf(token);
+  while (at !== -1) {
+    n += 1;
+    at = line.indexOf(token, at + token.length);
+  }
+  return n;
+}
+
+/**
+ * 尾块补全：流式尾巴常停在半个语法上（``` 只开了头、`code 少一个反引号、
+ * **加粗 少两个星号），直接渲染会闪一下裸文本。补上闭合再渲染。
+ * 只补，不改原文——补出来的字符下一个 token 到了就被真实内容覆盖。
+ */
+export function closeOpenMarkdown(block: string): string {
+  const fence = openFenceMarker(block);
+  if (fence !== null) return `${block}${block.endsWith("\n") ? "" : "\n"}${fence}`;
+
+  const lines = block.split("\n");
+  const last = lines[lines.length - 1];
+  // 围栏行本身（``` 收尾）不参与行内语法配对，否则那三个反引号会被当成没闭合的行内代码。
+  if (last.trim() === "" || FENCE_RE.test(last)) return block;
+
+  let tail = "";
+  // 先补加粗再补行内代码：**`x 的闭合顺序是 `** 反过来。
+  if (countOccurrences(last, "**") % 2 === 1) tail = `**${tail}`;
+  const backticks = countOccurrences(last, "`") - countOccurrences(last, "``") * 2;
+  if (backticks % 2 === 1) tail = `\`${tail}`;
+  return tail ? block + tail : block;
+}

--- a/src/modules/knowledge-network/components/agent-chat/markdown-blocks.ts
+++ b/src/modules/knowledge-network/components/agent-chat/markdown-blocks.ts
@@ -25,10 +25,32 @@ function isListish(line: string): boolean {
   return LIST_RE.test(line) || LIST_CONT_RE.test(line);
 }
 
+/** 从 from 往前找最近的非空行。 */
+function lastNonBlank(lines: readonly string[], from: number): string | undefined {
+  for (let i = from; i >= 0; i--) {
+    if (lines[i].trim() !== "") return lines[i];
+  }
+  return undefined;
+}
+
+/** 从 from 往后找最近的非空行。 */
+function firstNonBlank(lines: readonly string[], from: number): string | undefined {
+  for (let i = from; i < lines.length; i++) {
+    if (lines[i].trim() !== "") return lines[i];
+  }
+  return undefined;
+}
+
 /**
  * 把 Markdown 正文按块级边界（空行）切开。两处不切：
  * - 围栏代码块内部的空行；
  * - loose list 的项间空行（切了会变成两个 <ul>，有序列表还会重新从 1 编号）。
+ *
+ * 已知边界：正文主体是一个长的松散列表时（LLM 答复很常见的「1. …\n\n2. …」），
+ * 整份列表始终是同一个尾块，那一段的重复 parse 并没有消掉，收益显著低于预期。
+ * 这是 loose list 语义逼出来的取舍——切了就断编号——不比切分前差，但别拿
+ * 「已经按块渲染了」当结论去排查这类答复的卡顿。真要根治得让已完成的项单独成块、
+ * 并给续接块补 `start=`，成本远超收益。
  */
 export function splitMarkdownBlocks(text: string): string[] {
   const lines = text.split("\n");
@@ -62,8 +84,10 @@ export function splitMarkdownBlocks(text: string): string[] {
 
     if (line.trim() === "") {
       // 空行是块边界，除非它夹在同一个 loose list 的两个列表项之间。
-      const prev = [...cur].reverse().find((l) => l.trim() !== "");
-      const next = lines.slice(i + 1).find((l) => l.trim() !== "");
+      // 前后各扫一次找最近的非空行，不切数组：这函数在流式热路径上每个 token 跑一次，
+      // 拷贝版本会给它自己加一个二次项。
+      const prev = lastNonBlank(cur, cur.length - 1);
+      const next = firstNonBlank(lines, i + 1);
       if (prev && next && isListish(prev) && isListish(next)) {
         cur.push(line);
         continue;
@@ -111,14 +135,27 @@ export function closeOpenMarkdown(block: string): string {
   if (fence !== null) return `${block}${block.endsWith("\n") ? "" : "\n"}${fence}`;
 
   const lines = block.split("\n");
-  const last = lines[lines.length - 1];
-  // 围栏行本身（``` 收尾）不参与行内语法配对，否则那三个反引号会被当成没闭合的行内代码。
-  if (last.trim() === "" || FENCE_RE.test(last)) return block;
+  // 行内语法按「当前正在写的这一段」配对，而不是只看最后一行：加粗/行内代码都可以跨行，
+  // 只扫最后一行会漏掉 `**开头在上一行、还没闭合` 这种，正是本该消掉的症状。
+  // 段落 = 尾块里最后一个空行之后的全部行（loose list 尾块里就是最后那个列表项）。
+  let start = 0;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].trim() === "") {
+      start = i + 1;
+      break;
+    }
+  }
+  const para = lines.slice(start);
+  if (para.length === 0 || para.join("").trim() === "") return block;
+  // 段里出现围栏行（列表项内嵌的代码块）就不配对：那些反引号会把计数带偏，
+  // 补错比不补更糟。
+  if (para.some((l) => FENCE_RE.test(l))) return block;
 
+  const text = para.join("\n");
   let tail = "";
   // 先补加粗再补行内代码：**`x 的闭合顺序是 `** 反过来。
-  if (countOccurrences(last, "**") % 2 === 1) tail = `**${tail}`;
-  const backticks = countOccurrences(last, "`") - countOccurrences(last, "``") * 2;
+  if (countOccurrences(text, "**") % 2 === 1) tail = `**${tail}`;
+  const backticks = countOccurrences(text, "`") - countOccurrences(text, "``") * 2;
   if (backticks % 2 === 1) tail = `\`${tail}`;
   return tail ? block + tail : block;
 }


### PR DESCRIPTION
## 问题

立即体验的问答输出，长答复在流式期间看着像 Markdown 渲染失效 —— 满屏 `##`、`**`、`>` 原始标记，要等整轮结束才翻成富文本。短答复秒结束，所以一直没暴露。

## 原因

渲染层刻意绕开了 Markdown：流式进行中的最后一条走纯文本分支（`ChatPane.tsx` 原 1148-1155 行），注释写明理由 —— react-markdown 每次渲染都会把整段正文重新 parse 成 mdast，每来一个 token 重来一次是 O(n²)，长答复会卡死 UI。

雪上加霜的是收尾还要等一次网络：`finally` 里先 `await turn.finish(...)` 才 `setBusy(false)`，流都停了还得再等 lifecycle 回来才翻成 Markdown。

## 改动

正面解决重复 parse，而不是绕开。

- 新增 `markdown-blocks.ts`
  - `splitMarkdownBlocks` —— 按空行切块。两处不切：围栏代码块内部的空行；loose list 的项间空行（切了会变成两个 `<ul>`，有序列表还会重新从 1 编号）。
  - `closeOpenMarkdown` —— 补全尾块没写完的语法：未闭合的 ```` ``` ````、行内代码、加粗。按"当前正在写的那一段"配对，跨行的加粗也补得上；嵌套时先闭内层（`` **`run_sql `` 补成 `` **`run_sql`** ``）。
- `MarkdownView` 在**流式路径**上每块渲染一个 memo 化的 `MarkdownBlock`。只有尾块的 text 在变，已完成的块 props 恒等、memo 直接挡住 —— 每个 token 的重复工作从「整段 mdast 重 parse」降到「一次线性切分 + 只 parse 尾块」。
- 非流式（对比报告的轮次回答、AI 总结，以及流结束后的最终渲染）整段 parse，不分块：它们一次成型没有重复 parse 的开销，不该冒分块启发式的风险 —— 跨块构造如引用式链接定义、GFM 脚注被切开会解析失败，落在已完成正文上是永久错误显示。
- assistant 消息一律走 `MarkdownView`，流式中传 `streaming`。

`busy` 状态未改动，生命周期的 `uq_..._interaction_active` 约束不受影响。`turn.finish()` 造成的那段延迟也不用再管 —— 流式期间本来就是 Markdown 了。

### 已知边界

正文主体是一个长的松散列表时（`1. …\n\n2. …`，LLM 答复常见），整份列表始终是同一个尾块，那一段的重复 parse 并没有消掉，收益低于其他形态。这是 loose list 语义逼出来的取舍（切了就断编号），不比改前差。已写进 `splitMarkdownBlocks` 注释。

## 验证

- 新增 18 个测试：分块 5、尾块补全 9、渲染 4，覆盖围栏代码块、loose list、GFM 表格、跨行加粗、流式增量下已完成块的字符串恒等（memo 生效的前提）、非流式下引用式链接定义正常解析。
- 全量 `vitest run`：786 passed。
- `tsc -b` + license header 检查通过。
- typechecked lint：`src/` 零报错。
- 已部署到本地 VM（`0.1.2-streaming-md`）实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)