### PR TITLE
fix(trace): pass interaction context for artifacts

### DIFF
--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
@@ -72,6 +72,7 @@ const requestSummary = {
   partialReasons: [],
   questionPreview: "客户 A 的风险为什么上升？",
   requestId: "req_business_001",
+  interactionId: "interaction_customer_risk",
   resultPreview: "近 7 天投诉增加，风险等级上升。",
   startedAt: "2026-07-27T09:00:00Z",
   status: "completed",
@@ -456,6 +457,16 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
     fireEvent.click(await screen.findByRole("button", { name: /客户 A 的风险为什么上升/ }));
 
     await waitFor(() => expect(getInteractionSummary).toHaveBeenCalledWith("interaction_customer_risk"));
+    expect(getEvidenceArtifact).toHaveBeenNthCalledWith(
+      1,
+      "art_question_001",
+      "interaction_customer_risk",
+    );
+    expect(getEvidenceArtifact).toHaveBeenNthCalledWith(
+      2,
+      "art_result_001",
+      "interaction_customer_risk",
+    );
     expect(await screen.findByText("客户 A 的风险为什么上升？（完整问题）")).not.toBeNull();
     expect(screen.getByText("近 7 天投诉增加 42%，因此风险等级从中升至高。（完整结论）")).not.toBeNull();
   });
@@ -584,6 +595,16 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
     expect(getEvidenceChain).toHaveBeenCalledWith({ requestId: "req_business_001", limit: 100 });
     expect(getBusinessGraph).toHaveBeenCalledWith({ requestId: "req_business_001", limit: 100 });
     await waitFor(() => expect(getEvidenceArtifact).toHaveBeenCalledTimes(2));
+    expect(getEvidenceArtifact).toHaveBeenNthCalledWith(
+      1,
+      "art_question_001",
+      "interaction_customer_risk",
+    );
+    expect(getEvidenceArtifact).toHaveBeenNthCalledWith(
+      2,
+      "art_result_001",
+      "interaction_customer_risk",
+    );
 
     expect(screen.queryByText("客户 A 的风险为什么上升？（完整问题）")).toBeNull();
     expect(screen.queryByText("近 7 天投诉增加 42%，因此风险等级从中升至高。（完整结论）")).toBeNull();

--- a/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceExplorerScene.test.tsx
@@ -584,6 +584,21 @@ describe("BknTraceExplorerScene", { timeout: 30_000 }, () => {
   });
 
   it("OpenBKN 调用详情不复制整轮问题和最终答案，并保留关联技术 Trace", async () => {
+    vi.mocked(getInteractionSummary).mockResolvedValueOnce({
+      evidenceCompleteness: "complete",
+      interactionId: "interaction_customer_risk",
+      partialReasons: [],
+      requests: [requestSummary],
+      status: "completed",
+      traces: [{
+        requestId: "req_business_001",
+        rootOperation: "bkn.agent.chat",
+        spanCount: 7,
+        spanCountStatus: "available",
+        status: "completed",
+        traceId: "trace_001",
+      }],
+    });
     window.history.replaceState({}, "", "/observability/business-provenance?view=requests");
     render(<BknTraceExplorerScene />);
 

--- a/src/modules/bkn-trace/scenes/BknTraceRunsScene.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceRunsScene.tsx
@@ -194,7 +194,7 @@ export function BknTraceRunsScene() {
           .filter((value): value is string => Boolean(value)),
       )];
       const artifactResults = await Promise.allSettled(
-        artifactIds.map((id) => getEvidenceArtifact(id)),
+		artifactIds.map((id) => getEvidenceArtifact(id, summary.interactionId)),
       );
       const artifacts = artifactResults.flatMap((result) =>
         result.status === "fulfilled" ? [result.value] : []
@@ -226,8 +226,8 @@ export function BknTraceRunsScene() {
     try {
       const summary = await getInteractionSummary(interactionId);
       const [questionResult, answerResult] = await Promise.allSettled([
-        loadReferencedArtifact(summary.questionArtifactRef),
-        loadReferencedArtifact(summary.resultArtifactRef),
+		loadReferencedArtifact(summary.questionArtifactRef, summary.interactionId),
+		loadReferencedArtifact(summary.resultArtifactRef, summary.interactionId),
       ]);
       if (requestSequence !== interactionRequestSequence.current) return;
       setInteractionContext({
@@ -1028,9 +1028,9 @@ function artifactId(ref: string) {
   return ref.startsWith("artifact:") ? ref.slice("artifact:".length) : undefined;
 }
 
-function loadReferencedArtifact(ref?: string) {
-  const id = ref ? artifactId(ref) : undefined;
-  return id ? getEvidenceArtifact(id) : Promise.resolve(undefined);
+function loadReferencedArtifact(ref?: string, interactionId?: string) {
+	const id = ref ? artifactId(ref) : undefined;
+	return id ? getEvidenceArtifact(id, interactionId) : Promise.resolve(undefined);
 }
 
 function formatTime(value?: string) {

--- a/src/modules/bkn-trace/scenes/BknTraceRunsScene.tsx
+++ b/src/modules/bkn-trace/scenes/BknTraceRunsScene.tsx
@@ -188,13 +188,14 @@ export function BknTraceRunsScene() {
       const businessGraph = settledValue(businessGraphResult);
       const snapshotPreview = settledValue(snapshotResult);
       const interaction = settledValue(interactionResult);
+      const interactionId = summary.interactionId ?? activeQuery.interactionId;
       const artifactIds = [...new Set(
         (evidenceChain?.data.artifactLinks ?? [])
           .map((link) => artifactId(link.artifactRef))
           .filter((value): value is string => Boolean(value)),
       )];
       const artifactResults = await Promise.allSettled(
-		artifactIds.map((id) => getEvidenceArtifact(id, summary.interactionId)),
+		artifactIds.map((id) => getEvidenceArtifact(id, interactionId)),
       );
       const artifacts = artifactResults.flatMap((result) =>
         result.status === "fulfilled" ? [result.value] : []
@@ -226,8 +227,8 @@ export function BknTraceRunsScene() {
     try {
       const summary = await getInteractionSummary(interactionId);
       const [questionResult, answerResult] = await Promise.allSettled([
-		loadReferencedArtifact(summary.questionArtifactRef, summary.interactionId),
-		loadReferencedArtifact(summary.resultArtifactRef, summary.interactionId),
+		loadReferencedArtifact(summary.questionArtifactRef, interactionId),
+		loadReferencedArtifact(summary.resultArtifactRef, interactionId),
       ]);
       if (requestSequence !== interactionRequestSequence.current) return;
       setInteractionContext({

--- a/src/modules/bkn-trace/services/trace.service.test.ts
+++ b/src/modules/bkn-trace/services/trace.service.test.ts
@@ -479,6 +479,23 @@ describe("bkn-trace service", () => {
           "bkn.account.id": "acct-1",
           "bkn.account.type": "user",
         },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          artifact_id: "art_question_001",
+          artifact_type: "question",
+          "bkn.request.id": "req_business_001",
+          trace_id: "trace_001",
+          content_type: "application/json",
+          schema_version: "2.2.0",
+          observed_at: "2026-07-27T09:00:00Z",
+          content_hash: "sha256:question",
+          content: { question: "业务问题" },
+          business_refs: ["bkn://customer/A"],
+          business_domain: "customer-risk",
+          "bkn.account.id": "acct-1",
+          "bkn.account.type": "user",
+        },
       });
     const { getEvidenceArtifact, getRequestSummary, getRequestTraces } = await import(
       "@/modules/bkn-trace/services/trace.service"
@@ -487,6 +504,7 @@ describe("bkn-trace service", () => {
     const summary = await getRequestSummary("req_business_001");
     const traces = await getRequestTraces("req_business_001", { limit: 30 });
 	const artifact = await getEvidenceArtifact("art_result_001", "int_business_001");
+	await getEvidenceArtifact("art_question_001");
 
     expect(getMock).toHaveBeenNthCalledWith(
       1,
@@ -502,6 +520,11 @@ describe("bkn-trace service", () => {
 		3,
 		"/agent-observability/v1/evidence/artifacts/art_result_001",
 		{ headers: { "x-business-domain": "bd_demo" }, params: { interaction_id: "int_business_001" } },
+	);
+	expect(getMock).toHaveBeenNthCalledWith(
+		4,
+		"/agent-observability/v1/evidence/artifacts/art_question_001",
+		{ headers: { "x-business-domain": "bd_demo" } },
 	);
     expect(summary.requestId).toBe("req_business_001");
     expect(traces.entries[0].requestId).toBe("req_business_001");

--- a/src/modules/bkn-trace/services/trace.service.test.ts
+++ b/src/modules/bkn-trace/services/trace.service.test.ts
@@ -486,7 +486,7 @@ describe("bkn-trace service", () => {
 
     const summary = await getRequestSummary("req_business_001");
     const traces = await getRequestTraces("req_business_001", { limit: 30 });
-    const artifact = await getEvidenceArtifact("art_result_001");
+	const artifact = await getEvidenceArtifact("art_result_001", "int_business_001");
 
     expect(getMock).toHaveBeenNthCalledWith(
       1,
@@ -498,11 +498,11 @@ describe("bkn-trace service", () => {
       "/agent-observability/v1/business-provenance/requests/req_business_001/traces",
       { headers: { "x-business-domain": "bd_demo" }, params: { limit: 30 } },
     );
-    expect(getMock).toHaveBeenNthCalledWith(
-      3,
-      "/agent-observability/v1/evidence/artifacts/art_result_001",
-      { headers: { "x-business-domain": "bd_demo" } },
-    );
+	expect(getMock).toHaveBeenNthCalledWith(
+		3,
+		"/agent-observability/v1/evidence/artifacts/art_result_001",
+		{ headers: { "x-business-domain": "bd_demo" }, params: { interaction_id: "int_business_001" } },
+	);
     expect(summary.requestId).toBe("req_business_001");
     expect(traces.entries[0].requestId).toBe("req_business_001");
     expect(artifact.content).toEqual({ conclusion: "业务结论", score: 0.91 });

--- a/src/modules/bkn-trace/services/trace.service.ts
+++ b/src/modules/bkn-trace/services/trace.service.ts
@@ -818,11 +818,16 @@ export async function getRequestTraces(
   return mapSummaryPage(response.data, mapTraceExecutionSummary);
 }
 
-export async function getEvidenceArtifact(artifactId: string): Promise<EvidenceArtifact> {
-  const response = await http.get<BackendEvidenceArtifact>(
-    `${OBSERVABILITY_API_PREFIX}/evidence/artifacts/${encodeURIComponent(artifactId)}`,
-    traceRequestConfig(),
-  );
+export async function getEvidenceArtifact(
+  artifactId: string,
+  interactionId?: string,
+): Promise<EvidenceArtifact> {
+	const response = await http.get<BackendEvidenceArtifact>(
+		`${OBSERVABILITY_API_PREFIX}/evidence/artifacts/${encodeURIComponent(artifactId)}`,
+		interactionId
+			? { ...traceRequestConfig(), params: { interaction_id: interactionId } }
+			: traceRequestConfig(),
+	);
   return mapEvidenceArtifact(response.data);
 }
 


### PR DESCRIPTION
## Summary
- send the current interaction_id when Studio loads evidence artifacts from a selected Trace detail
- apply the same request contract to business provenance and OpenBKN call detail pages
- retain existing behavior when no Interaction context is available

## Verification
- pnpm vitest run src/modules/bkn-trace/services/trace.service.test.ts --reporter=dot --silent
- pnpm run build

Related: openbkn-ai/bkn-foundry#743