### PR TITLE
fix(entitlement): 核实不了镜像的能力以证书为准

### DIFF
--- a/src/app/locales/resources/common/en-US.ts
+++ b/src/app/locales/resources/common/en-US.ts
@@ -85,7 +85,6 @@ export const commonEnUS = {
       notLicensedTitle: "Not covered by the current licence",
       notLicensedDescription:
         "This deployment ships the capability, but the installed certificate's edition does not cover it. Import a higher edition and it becomes available — no restart needed.",
-      continueAnyway: "Already upgraded — continue anyway",
       unknownTitle: "Licence status unavailable",
       unknownDescription:
         "Could not read the cluster's licence state, so paid capabilities are unavailable for now. Please retry shortly.",

--- a/src/app/locales/resources/common/en-US.ts
+++ b/src/app/locales/resources/common/en-US.ts
@@ -71,9 +71,11 @@ export const commonEnUS = {
         'This is a high-risk action. Type "{{name}}" to confirm deletion.',
     },
     entitlement: {
-      imageLikelyHint: "Your licence is already {{edition}} — upgrade to the {{edition}} image to unlock this capability.",
-      imageMissingTitle: "{{edition}} licence — community image, upgrade needed",
-      imageMissingHint: "Your licence is already {{edition}} — upgrade to the {{edition}} image to unlock this capability.",
+      imageMissingTitle: "{{edition}} licence — capability not present in this deployment",
+      imageMissingHint:
+        "Your licence covers this capability, but no implementation of it is present in this deployment. Upgrade to a {{edition}} image that includes it.",
+      imageLikelyHint:
+        "Your licence covers this capability, but this deployment does not report an implementation of it. Most likely the service providing it has not been upgraded to a {{edition}} image.",
       unlockTitle: "Unlock {{edition}}",
       upgradeTo: "Upgrade to {{edition}}",
       compareEditions: "Compare editions",

--- a/src/app/locales/resources/common/zh-CN.ts
+++ b/src/app/locales/resources/common/zh-CN.ts
@@ -82,12 +82,6 @@ export const commonZhCN = {
       notLicensedTitle: "当前授权未包含该功能",
       notLicensedDescription:
         "这套部署具备该功能,但当前证书的版本不覆盖它。导入更高版本的证书后即可使用,无需重启服务。",
-      /*
-        判不出镜像状态时的出口。别的服务实现的能力(业务溯源、语义理解)在 bkn-safe 的
-        清单里从来没有,缺席说明不了任何事;买了并且换过包的客户会照样撞上蒙版。没有这
-        条出口,那就是把已付费功能永久锁死,而不是提示。
-      */
-      continueAnyway: "已升级,仍要继续",
       unknownTitle: "无法确认授权状态",
       unknownDescription: "读取集群授权状态失败,付费功能暂时不可用。请稍后重试。",
       /**

--- a/src/app/locales/resources/common/zh-CN.ts
+++ b/src/app/locales/resources/common/zh-CN.ts
@@ -69,9 +69,17 @@ export const commonZhCN = {
       typeNameToConfirm: "此操作高危,请输入名称「{{name}}」以确认删除。",
     },
     entitlement: {
-      imageLikelyHint: "已经是{{edition}}证书,请升级{{edition}}镜像以解锁该能力。",
-      imageMissingTitle: "{{edition}}授权 — 社区版镜像,需要升级",
-      imageMissingHint: "已经是{{edition}}证书,请升级{{edition}}镜像以解锁该能力。",
+      /*
+        按**能力**说,不按镜像说。`extensions[]` 现在是部署级的(vega 也登记进来了),
+        某个 key 缺席只说明那个能力的 ee 代码不在这套部署里,推不出「整套是社区版镜像」
+        ——企业镜像上 business_provenance 照样不在里面,因为它还没实现。
+      */
+      imageMissingTitle: "{{edition}}授权 — 该能力尚未在本部署提供",
+      imageMissingHint:
+        "证书已包含该能力,但当前部署里没有它的实现。请升级到包含该能力的{{edition}}镜像。",
+      // 判不出实况时(端点报不了这个 key)的说法。断言不了「没有实现」,只能给方向。
+      imageLikelyHint:
+        "证书已包含该能力,但当前部署没有报告它的实现。多半是提供该能力的服务还没升级到{{edition}}镜像。",
       unlockTitle: "解锁{{edition}}能力",
       upgradeTo: "升级到{{edition}}",
       compareEditions: "查看版本对比",

--- a/src/framework/entitlement/CapabilityUpgradeDialog.tsx
+++ b/src/framework/entitlement/CapabilityUpgradeDialog.tsx
@@ -15,7 +15,7 @@ import type { Edition } from "@/framework/entitlement/edition";
 import { useEntitlementContext } from "@/framework/entitlement/use-entitlement";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { upgradeReason } from "@/framework/entitlement/upgrade-reason";
-import { capabilityServedByBknSafe } from "@/modules/subscription/capability-catalog";
+import { capabilityReportedByEndpoint } from "@/modules/subscription/capability-catalog";
 
 /** 授权门户。与版本页同一个去处:申请与续期都在那边办。 */
 const LICENSE_PORTAL_URL = "https://license.openbkn.ai/";
@@ -69,7 +69,7 @@ export function CapabilityUpgradeDialog({
     capability,
     snapshot,
     minEdition,
-    capabilityServedByBknSafe(capability),
+    capabilityReportedByEndpoint(capability),
   );
   const imageIssue = reason !== "buy";
   const bullets = BULLET_KEYS.map((key) =>

--- a/src/framework/entitlement/EditionBadge.tsx
+++ b/src/framework/entitlement/EditionBadge.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 import type { Edition } from "@/framework/entitlement/edition";
 import { capabilitySatisfied } from "@/framework/entitlement/upgrade-reason";
 import { useEntitlementContext } from "@/framework/entitlement/use-entitlement";
-import { capabilityServedByBknSafe } from "@/modules/subscription/capability-catalog";
+import { capabilityReportedByEndpoint } from "@/modules/subscription/capability-catalog";
 
 /**
  * 「这项能力从哪一档起提供」的标签。
@@ -52,7 +52,7 @@ export function EditionBadge({
     capability ?? "",
     snapshot,
     edition,
-    capability ? capabilityServedByBknSafe(capability) : false,
+    capability ? capabilityReportedByEndpoint(capability) : false,
   );
 
   if (!alwaysShow && satisfied) {

--- a/src/framework/entitlement/RequireEdition.test.tsx
+++ b/src/framework/entitlement/RequireEdition.test.tsx
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CAPABILITIES } from "@/framework/entitlement/capabilities";
@@ -44,8 +44,6 @@ function entitlement(overrides: Partial<Entitlement>): Entitlement {
   };
 }
 
-const CONTINUE = "common.entitlement.continueAnyway";
-
 beforeEach(() => {
   contextState.loading = false;
   contextState.snapshot = null;
@@ -81,13 +79,13 @@ describe("RequireEdition · 快照缺席", () => {
   });
 });
 
-describe("RequireEdition · 判不出镜像状态时留出口", () => {
+describe("RequireEdition · 核实不了镜像的能力以证书为准", () => {
   /*
-    业务溯源由 bkn-trace 实现,bkn-safe 的清单里从来没有它(ee-design.md §6)。买了企业证、
-    也换过企业包的客户照样会走到蒙版,而前端永远确认不了——没有出口就是把已付费功能永久
-    锁死,而不是提示。
+    业务溯源由 bkn-trace 实现,bkn-safe 的清单里从来没有它(ee-design.md §6)。前端核实
+    不了那个包,不等于那个包没装——买了企业版证、也换了企业版包的客户,不该被自己付过钱
+    的功能挡在门外。
   */
-  it("档位够但确认不了 → 可以「仍要继续」", () => {
+  it("档位够 → 直接放行,不盖蒙版", () => {
     contextState.snapshot = entitlement({
       edition: "enterprise",
       licensed: true,
@@ -96,19 +94,18 @@ describe("RequireEdition · 判不出镜像状态时留出口", () => {
 
     renderGuard(CAPABILITIES.BUSINESS_PROVENANCE, "enterprise");
 
-    expect(screen.queryByText("protected")).not.toBeNull(); // 蒙版底下照常渲染
-    fireEvent.click(screen.getByRole("button", { name: CONTINUE }));
-
-    expect(screen.queryByText("common.entitlement.imageLikelyHint")).toBeNull();
+    expect(screen.queryByText("protected")).not.toBeNull();
+    expect(screen.queryByText("common.entitlement.imageMissingTitle")).toBeNull();
+    expect(screen.queryByText("common.entitlement.unlockTitle")).toBeNull();
   });
 
-  // 档位不够是前端能确定的事,放进去服务端也会拒——这时给出口只会让人白跑一趟。
-  it("档位不够 → 不给出口", () => {
+  // 档位不够是前端能确定的事,这时候拦得住,也该拦。
+  it("档位不够 → 拦下并给升级引导", () => {
     contextState.snapshot = entitlement({});
 
     renderGuard(CAPABILITIES.BUSINESS_PROVENANCE, "enterprise");
 
-    expect(screen.queryByRole("button", { name: CONTINUE })).toBeNull();
+    expect(screen.getByText("common.entitlement.unlockTitle")).toBeTruthy();
   });
 });
 

--- a/src/framework/entitlement/RequireEdition.tsx
+++ b/src/framework/entitlement/RequireEdition.tsx
@@ -16,7 +16,7 @@ import type { Edition } from "@/framework/entitlement/edition";
 import { capabilitySatisfied, upgradeReason } from "@/framework/entitlement/upgrade-reason";
 import { useEntitlementContext } from "@/framework/entitlement/use-entitlement";
 import { AppButton } from "@/framework/ui/common/AppButton";
-import { capabilityServedByBknSafe } from "@/modules/subscription/capability-catalog";
+import { capabilityReportedByEndpoint } from "@/modules/subscription/capability-catalog";
 
 const LICENSE_PORTAL_URL = "https://license.openbkn.ai/";
 
@@ -60,13 +60,13 @@ export function RequireEdition({ capability, children, minEdition }: RequireEdit
     );
   }
 
-  const servedByBknSafe = capabilityServedByBknSafe(capability);
+  const reportedByEndpoint = capabilityReportedByEndpoint(capability);
   /*
     与升级弹窗共用同一条判定和同一批文案:同一件事在两处说成两样,客户会以为是两个问题。
   */
-  const reason = upgradeReason(capability, snapshot, minEdition, servedByBknSafe);
+  const reason = upgradeReason(capability, snapshot, minEdition, reportedByEndpoint);
 
-  if (capabilitySatisfied(capability, snapshot, minEdition, servedByBknSafe)) {
+  if (capabilitySatisfied(capability, snapshot, minEdition, reportedByEndpoint)) {
     return <>{children}</>;
   }
 

--- a/src/framework/entitlement/RequireEdition.tsx
+++ b/src/framework/entitlement/RequireEdition.tsx
@@ -129,12 +129,15 @@ export function RequireEdition({ capability, children, minEdition }: RequireEdit
               {t("common.entitlement.compareEditions")}
             </AppButton>
           </div>
+          {/*
+            这里取不到 image-likely:那条 reason 的唯一来路是「端点报不出 + 档位够」,
+            而那种情况上面已经放行了。整页守卫只会拦下档位不够(buy)与端点说没装(image)
+            两种。判不出镜像的说法仍留在 CapabilityUpgradeDialog——连接器那条路走得到。
+          */}
           <p className="console-upgrade-note">
             {reason === "image"
               ? t("common.entitlement.imageMissingHint", { edition: currentEditionName })
-              : reason === "image-likely"
-                ? t("common.entitlement.imageLikelyHint", { edition: currentEditionName })
-                : ""}
+              : ""}
           </p>
         </div>
       </div>

--- a/src/framework/entitlement/RequireEdition.tsx
+++ b/src/framework/entitlement/RequireEdition.tsx
@@ -7,7 +7,7 @@
 
 import { CrownOutlined } from "@ant-design/icons";
 import { Result, Skeleton } from "antd";
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
@@ -28,25 +28,20 @@ type RequireEditionProps = {
 };
 
 /**
- * 整页守卫。放行条件是「证够了 **且** 这项能力真的可用」,与档位徽标闭嘴的条件同一个。
+ * 整页守卫。放行条件与档位徽标闭嘴的条件同一个:`capabilitySatisfied`。
  *
  * 用于 `capabilities[]` 答不了的付费面:业务溯源由 bkn-trace 实现、语义理解在数据目录侧,
- * bkn-safe 的那份清单里从来没有它们(ee-design.md §6「A 答不了 B」)。这类能力判不出镜像
- * 状态,所以默认拦下,但蒙版上留一条「已升级,仍要继续」——判不了的事不能当成判定结果:
- * 买了并且换过包的客户照样会走到这里,没有出口就不是提示,是把已付费功能永久锁死。
+ * bkn-safe 的那份清单里从来没有它们(ee-design.md §6「A 答不了 B」)。这类能力核实不了
+ * 镜像,判据退到证书:档位够就放行。前端核实不了别人的包,不等于那个包没装——把「核实
+ * 不了」当「没装」,买了企业版证、也换了企业版包的客户会被自己付过钱的功能挡在门外。
  *
- * 档位不够则不给出口:那是前端能确定的事,放进去服务端也会拒。真正的强制力始终在服务端,
- * 这层只是体验。等 §6.2 的每服务自述端点落地,这条出口就该撤掉。
+ * 真正的强制力始终在服务端,这层只是体验。等 §6.2 的每服务自述端点落地,这里就能和
+ * bkn-safe 自己的能力走同一条判据。
  */
 export function RequireEdition({ capability, children, minEdition }: RequireEditionProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { loading, snapshot } = useEntitlementContext();
-  /*
-    「我已经升过了」的出口,见下面 image-likely 分支。只在本次挂载内有效:这是一次用户
-    声明,不是判定结果,不该被记下来当成事实。
-  */
-  const [dismissed, setDismissed] = useState(false);
 
   /*
     快照没到不能白屏。null 有两种来路:这一次请求还在飞,以及 fetchEntitlement() 抛错后
@@ -65,32 +60,13 @@ export function RequireEdition({ capability, children, minEdition }: RequireEdit
     );
   }
 
-  /*
-    放行的条件与徽标闭嘴的条件是同一个:证够了 **且** 这项能力真的可用。只看档位会在
-    「证是专业版、跑的还是社区包」时放行到一个用不了的页面——那正是客户最常处在的状态。
-
-    代价:别的服务实现的能力确认不了镜像(§6「A 答不了 B」),所以它们**永远**判为不满足,
-    即使客户已经换过包也照样盖蒙版。等 §6.2 的每服务自述端点落地才解得开;在那之前,
-    宁可让买了的人多看一层提示,也好过把付费能力对所有人白开。
-  */
   const servedByBknSafe = capabilityServedByBknSafe(capability);
   /*
     与升级弹窗共用同一条判定和同一批文案:同一件事在两处说成两样,客户会以为是两个问题。
   */
   const reason = upgradeReason(capability, snapshot, minEdition, servedByBknSafe);
-  /*
-    判不出镜像状态时(reason === "image-likely":档位够了,但这项能力由别的服务实现,
-    bkn-safe 答不了),蒙版只能是提示,不能是终点。买了企业证、也换过企业包的客户照样
-    会走到这里,而前端永远确认不了——没有出口就等于把已付费功能永久锁死。
 
-    档位不够(reason === "buy")不给出口:那是前端能确定的事,放进去服务端也会拒。
-  */
-  const canOverride = reason === "image-likely";
-
-  if (
-    (canOverride && dismissed) ||
-    capabilitySatisfied(capability, snapshot, minEdition, servedByBknSafe)
-  ) {
+  if (capabilitySatisfied(capability, snapshot, minEdition, servedByBknSafe)) {
     return <>{children}</>;
   }
 
@@ -152,19 +128,6 @@ export function RequireEdition({ capability, children, minEdition }: RequireEdit
             >
               {t("common.entitlement.compareEditions")}
             </AppButton>
-            {/*
-              判不出镜像状态时给的出口。已经换过包的客户点这里就能进去用;真没换的点进去
-              也只会撞上服务端的拒绝——那才是强制力所在,这一层从来只是体验。
-            */}
-            {canOverride ? (
-              <AppButton
-                onClick={() => {
-                  setDismissed(true);
-                }}
-              >
-                {t("common.entitlement.continueAnyway")}
-              </AppButton>
-            ) : null}
           </div>
           <p className="console-upgrade-note">
             {reason === "image"

--- a/src/framework/entitlement/upgrade-reason.test.ts
+++ b/src/framework/entitlement/upgrade-reason.test.ts
@@ -106,6 +106,21 @@ describe("capabilitySatisfied — 核实到哪一步就按哪一步判", () => {
     expect(capabilitySatisfied("semantic_task", licensed, "professional", false)).toBe(true);
   });
 
+  /*
+    档位是端点报不出时的唯一判据,而「异常一律回落 community」是后端的兜底行为、不是这里
+    能保证的事。再问一次 licensed,免得某天失效证仍报出证面档位时付费页照开。
+  */
+  it("端点报不出的能力：证失效就不算满足", () => {
+    const expired = deployment({ edition: "professional", licensed: false, state: "invalid" });
+
+    expect(capabilitySatisfied("semantic_task", expired, "professional", false)).toBe(false);
+  });
+
+  // 社区档能力例外:无证部署的 licensed 本来就是 false,一并要求会把免费能力也拦掉。
+  it("端点报不出的社区档能力：无证也算满足", () => {
+    expect(capabilitySatisfied("bkn_trace", deployment({}), "community", false)).toBe(true);
+  });
+
   it("别的服务实现的能力：档位不够仍不算满足", () => {
     expect(capabilitySatisfied("business_provenance", licensed, "enterprise", false)).toBe(
       false,

--- a/src/framework/entitlement/upgrade-reason.test.ts
+++ b/src/framework/entitlement/upgrade-reason.test.ts
@@ -95,13 +95,21 @@ describe("upgradeReason — 快照缺席", () => {
   });
 });
 
-describe("capabilitySatisfied — 判不了就不算满足", () => {
+describe("capabilitySatisfied — 核实到哪一步就按哪一步判", () => {
   const licensed = deployment({ edition: "professional", licensed: true, state: "valid" });
 
-  // 别的服务的能力确认不了镜像；「证够了但包没换」恰恰是客户最常处在的状态，
-  // 当成满足会让标记消失，客户以为一切正常，点下去才发现用不了。
-  it("别的服务实现的能力：档位够也不算满足", () => {
-    expect(capabilitySatisfied("semantic_task", licensed, "professional", false)).toBe(false);
+  /*
+    别的服务实现的能力核实不了镜像(§6「A 答不了 B」)。核实不了不等于没装:把它判成
+    不满足,买了证也换了包的客户会被自己付过钱的功能永久挡在门外。这时以证书为准。
+  */
+  it("别的服务实现的能力：档位够就算满足", () => {
+    expect(capabilitySatisfied("semantic_task", licensed, "professional", false)).toBe(true);
+  });
+
+  it("别的服务实现的能力：档位不够仍不算满足", () => {
+    expect(capabilitySatisfied("business_provenance", licensed, "enterprise", false)).toBe(
+      false,
+    );
   });
 
   it("bkn-safe 的能力：证够 + 装了才算满足", () => {

--- a/src/framework/entitlement/upgrade-reason.ts
+++ b/src/framework/entitlement/upgrade-reason.ts
@@ -68,5 +68,16 @@ export function capabilitySatisfied(
     return false;
   }
 
-  return reportedByEndpoint ? capabilityState(capability, snapshot) === "available" : true;
+  if (reportedByEndpoint) {
+    return capabilityState(capability, snapshot) === "available";
+  }
+
+  /*
+    端点报不出时,档位是唯一判据——但不能只看它。`edition.ts` 记着「后端在一切异常下都
+    回落 community」,那是别人的兜底行为,不是这里能保证的事;万一某天失效证仍报出证面上
+    的档位,付费页就会对着一张废证打开。再问一次 `licensed` 把这条腿钉住。
+
+    社区档的能力例外:无证部署的 `licensed` 本来就是 false,一并要求会把免费能力也拦掉。
+  */
+  return minEdition === "community" || snapshot.licensed;
 }

--- a/src/framework/entitlement/upgrade-reason.ts
+++ b/src/framework/entitlement/upgrade-reason.ts
@@ -45,11 +45,17 @@ export function upgradeReason(
 }
 
 /**
- * 这项能力在当前部署上是不是**真的可用**——证够了 **且** 镜像里有。徽标据此闭嘴:
- * 只满足一半的时候仍要提示,因为客户此刻还用不了。
+ * 这项能力在当前部署上是不是**真的可用**。徽标与整页守卫据此放行。
  *
- * 别的服务实现的能力没法确认镜像(ee-design.md §6「A 答不了 B」),只能退到档位;
- * 那种情况下「档位够」就是我们能拿到的最强判据。
+ * 判据按「能核实到什么程度」分两档:
+ *
+ * - **bkn-safe 自己实现的**:`capabilities[]` 就是它这个进程的实况,证够了还得在册才算数。
+ * - **别的服务实现的**:它们从来不出现在这两个列表里,缺席说明不了任何事(ee-design.md
+ *   §6「A 答不了 B」)。这时以证书为准——买了企业版证、也换了企业版包的客户,前端永远
+ *   核实不了那个包,拿「核实不了」当「没装」就是把已付费能力锁死在门外。
+ *
+ * 少数几个「档位够但确实用不了」的位置有更强的信号(比如连接器有后端给的 `enabled`),
+ * 由调用点自己判,不该让所有人陪着一起被拦。
  */
 export function capabilitySatisfied(
   capability: string,
@@ -61,9 +67,5 @@ export function capabilitySatisfied(
     return false;
   }
 
-  // 判不了就不算满足。别的服务的能力确认不了镜像(ee-design.md §6「A 答不了 B」),
-  // 而「证够了但包没换」恰恰是客户最常处在的状态——把它当满足会让标记消失,客户以为
-  // 一切正常,点下去才发现用不了。有更强信号的调用点(比如连接器有后端的 enabled)自己
-  // 决定要不要画。
-  return servedByBknSafe && capabilityState(capability, snapshot) === "available";
+  return servedByBknSafe ? capabilityState(capability, snapshot) === "available" : true;
 }

--- a/src/framework/entitlement/upgrade-reason.ts
+++ b/src/framework/entitlement/upgrade-reason.ts
@@ -17,7 +17,7 @@ import type { EntitlementView } from "@/framework/entitlement/types";
  * | 证书 | 镜像 | reason | 客户要做什么 |
  * |---|---|---|---|
  * | 档位不够 | 任意 | `buy` | 买/换证书 |
- * | 档位够 | 社区版 | `image` | 升级镜像(bkn-safe 的能力能确定判出) |
+ * | 档位够 | 社区版 | `image` | 升级镜像(端点报得出的能力能确定判出) |
  * | 档位够 | 未知 | `image-likely` | 多半是别的服务的镜像还没升(判不了,给方向) |
  * | 档位够 | 企业版 | — | 能用,根本不会弹这个窗 |
  */
@@ -27,19 +27,19 @@ export function upgradeReason(
   capability: string,
   snapshot: EntitlementView | null,
   minEdition: Edition,
-  servedByBknSafe: boolean,
+  reportedByEndpoint: boolean,
 ): UpgradeReason {
   // 快照没到就按「还没买」说——不能凭空断言客户的证书已经够了。
   if (!snapshot || !atLeast(snapshot.edition, minEdition)) {
     return "buy";
   }
 
-  // bkn-safe 自己的能力:extensions[] 是它这个进程的装配表,缺席即确定没装。
-  if (servedByBknSafe) {
+  // 端点报得出的能力:extensions[] 就是这套部署的装配实况,缺席即确定没装。
+  if (reportedByEndpoint) {
     return capabilityState(capability, snapshot) === "not-installed" ? "image" : "buy";
   }
 
-  // 别的服务的能力从来不出现在这两个列表里,缺席说明不了任何事(ee-design.md §6
+  // 端点报不出的能力不会出现在那两个列表里,缺席说明不了任何事(ee-design.md §6
   // 「A 答不了 B」)。档位够却仍走到这里,最可能是那个服务的镜像没升——只能给方向。
   return "image-likely";
 }
@@ -49,10 +49,11 @@ export function upgradeReason(
  *
  * 判据按「能核实到什么程度」分两档:
  *
- * - **bkn-safe 自己实现的**:`capabilities[]` 就是它这个进程的实况,证够了还得在册才算数。
- * - **别的服务实现的**:它们从来不出现在这两个列表里,缺席说明不了任何事(ee-design.md
- *   §6「A 答不了 B」)。这时以证书为准——买了企业版证、也换了企业版包的客户,前端永远
- *   核实不了那个包,拿「核实不了」当「没装」就是把已付费能力锁死在门外。
+ * - **端点报得出的**(`reportedByEndpoint`):`capabilities[]` 就是这套部署的实况,证够了
+ *   还得在册才算数——那份名单能分清「换镜像」和「买证书」。
+ * - **端点报不出的**:它们不会出现在那两个列表里,缺席说明不了任何事(ee-design.md §6
+ *   「A 答不了 B」)。这时以证书为准——买了企业版证、也换了企业版包的客户,前端核实不了
+ *   那个包,拿「核实不了」当「没装」就是把已付费能力锁死在门外。
  *
  * 少数几个「档位够但确实用不了」的位置有更强的信号(比如连接器有后端给的 `enabled`),
  * 由调用点自己判,不该让所有人陪着一起被拦。
@@ -61,11 +62,11 @@ export function capabilitySatisfied(
   capability: string,
   snapshot: EntitlementView | null,
   minEdition: Edition,
-  servedByBknSafe: boolean,
+  reportedByEndpoint: boolean,
 ): boolean {
   if (!snapshot || !atLeast(snapshot.edition, minEdition)) {
     return false;
   }
 
-  return servedByBknSafe ? capabilityState(capability, snapshot) === "available" : true;
+  return reportedByEndpoint ? capabilityState(capability, snapshot) === "available" : true;
 }

--- a/src/modules/data-connect/components/ConnectorTypePicker.tsx
+++ b/src/modules/data-connect/components/ConnectorTypePicker.tsx
@@ -24,7 +24,7 @@ import type { Edition } from "@/framework/entitlement/edition";
 import { EditionBadge } from "@/framework/entitlement/EditionBadge";
 import { capabilitySatisfied } from "@/framework/entitlement/upgrade-reason";
 import { useEntitlementContext } from "@/framework/entitlement/use-entitlement";
-import { capabilityServedByBknSafe } from "@/modules/subscription/capability-catalog";
+import { capabilityReportedByEndpoint } from "@/modules/subscription/capability-catalog";
 import type { DataConnectConnectorType } from "@/modules/data-connect/types/data-connect";
 
 import styles from "./ConnectorTypePicker.module.css";
@@ -142,7 +142,7 @@ export function ConnectorTypePicker({
                   CAPABILITIES.CONNECTOR_CERTIFIED,
                   snapshot,
                   CERTIFIED_MIN_EDITION,
-                  capabilityServedByBknSafe(CAPABILITIES.CONNECTOR_CERTIFIED),
+                  capabilityReportedByEndpoint(CAPABILITIES.CONNECTOR_CERTIFIED),
                 );
               const active = item.enabled && !locked && item.type === value;
               const templateMeta = getConnectorTemplateMeta(item);

--- a/src/modules/data-connect/components/ConnectorTypePicker.tsx
+++ b/src/modules/data-connect/components/ConnectorTypePicker.tsx
@@ -48,7 +48,7 @@ export function ConnectorTypePicker({
   const [tag, setTag] = useState<string>();
   const [family, setFamily] = useState<DataSourceFamilyKey>("structured");
   const [upgradeOpen, setUpgradeOpen] = useState(false);
-  const { snapshot } = useEntitlementContext();
+  const { loading, snapshot } = useEntitlementContext();
 
   const familyOptions = getPrimaryDataSourceFamilies().filter(
     (item) => item.key === "structured",
@@ -120,24 +120,29 @@ export function ConnectorTypePicker({
             {filtered.map((item) => {
               const certified = isCertifiedConnectorType(item.type);
               /*
-                能不能用**只信后端的 enabled**,不看 capabilities[]:认证连接器由 Vega
-                实现,不在 bkn-safe 的装配表里,那个端点永远不报这个 key
-                (ee-design.md §6「A 答不了 B」)——照它判会让 SQL Server 在所有部署上都
-                点不进去,包括买了的。
+                后端关掉认证连接器,原因分两种,得看这套部署的授权实况:
 
-                后端关掉认证连接器,原因分两种,得看客户手上的证:
+                - **没买 / 镜像里没有** → 画档位徽标 + 点击给升级引导,客户看得见才知道
+                  有东西可买。
+                - **买了也装了** → 那就不是授权的事。Vega 的 `enabled` 是运维开关
+                  (`POST /connector-types/:type/enable`),`available` 才是「这个二进制
+                  里有没有这段实现」,两者都不由证书推导。这时照普通连接器画「暂不可用」:
+                  对一个已经买了企业版的客户说「请升级镜像」,是拿授权去解释一个跟授权
+                  无关的开关。
 
-                - **证不够** → 几乎一定是「没买」。这时画档位徽标 + 点击给升级引导,
-                  客户看得见才知道有东西可买。
-                - **证够了** → 那就不是钱的事,是这套部署还没提供它。这时照普通连接器
-                  画「暂不可用」:对一个已经买了企业版的客户说「请升级镜像」,既指错了
-                  方向,也把 bkn-safe 的镜像状态硬安到 Vega 头上。
+                判据用 capabilities[]:vega 的 ee 构建已经把 `connector_certified` 登记进
+                装配表(2026-08-08 实测端点报得出),所以这里不再需要退到档位。
 
                 普通连接器的 enabled: false 一直是真不可用,照旧禁用。
+
+                快照没到时不当作「没买」:那段窗口里企业集群会先闪一下专业版徽标,点开正是
+                本轮要修掉的那句话。窗口长短取决于 Vega 与 bkn-safe 两个后端的相对延迟,
+                连接器列表先回来就看得见。
               */
               const locked =
                 certified &&
                 !item.enabled &&
+                !loading &&
                 !capabilitySatisfied(
                   CAPABILITIES.CONNECTOR_CERTIFIED,
                   snapshot,

--- a/src/modules/data-connect/components/ConnectorTypePicker.tsx
+++ b/src/modules/data-connect/components/ConnectorTypePicker.tsx
@@ -20,10 +20,17 @@ import {
 } from "@/modules/data-connect/lib/connector-template";
 import { CapabilityUpgradeDialog } from "@/framework/entitlement/CapabilityUpgradeDialog";
 import { CAPABILITIES } from "@/framework/entitlement/capabilities";
+import type { Edition } from "@/framework/entitlement/edition";
 import { EditionBadge } from "@/framework/entitlement/EditionBadge";
+import { capabilitySatisfied } from "@/framework/entitlement/upgrade-reason";
+import { useEntitlementContext } from "@/framework/entitlement/use-entitlement";
+import { capabilityServedByBknSafe } from "@/modules/subscription/capability-catalog";
 import type { DataConnectConnectorType } from "@/modules/data-connect/types/data-connect";
 
 import styles from "./ConnectorTypePicker.module.css";
+
+/** 认证连接器的门槛档,与能力登记表一致(`connector_certified` 属 Professional)。 */
+const CERTIFIED_MIN_EDITION: Edition = "professional";
 
 type ConnectorTypePickerProps = {
   onChange: (value: string) => void;
@@ -41,6 +48,7 @@ export function ConnectorTypePicker({
   const [tag, setTag] = useState<string>();
   const [family, setFamily] = useState<DataSourceFamilyKey>("structured");
   const [upgradeOpen, setUpgradeOpen] = useState(false);
+  const { snapshot } = useEntitlementContext();
 
   const familyOptions = getPrimaryDataSourceFamilies().filter(
     (item) => item.key === "structured",
@@ -117,11 +125,25 @@ export function ConnectorTypePicker({
                 (ee-design.md §6「A 答不了 B」)——照它判会让 SQL Server 在所有部署上都
                 点不进去,包括买了的。
 
-                认证连接器被后端关掉时,原因几乎一定是「没买」而不是「坏了」,所以那种
-                情况不画「暂不可用」,画档位徽标 + 点击给升级引导。普通连接器的
-                enabled: false 仍是真不可用,照旧禁用。
+                后端关掉认证连接器,原因分两种,得看客户手上的证:
+
+                - **证不够** → 几乎一定是「没买」。这时画档位徽标 + 点击给升级引导,
+                  客户看得见才知道有东西可买。
+                - **证够了** → 那就不是钱的事,是这套部署还没提供它。这时照普通连接器
+                  画「暂不可用」:对一个已经买了企业版的客户说「请升级镜像」,既指错了
+                  方向,也把 bkn-safe 的镜像状态硬安到 Vega 头上。
+
+                普通连接器的 enabled: false 一直是真不可用,照旧禁用。
               */
-              const locked = certified && !item.enabled;
+              const locked =
+                certified &&
+                !item.enabled &&
+                !capabilitySatisfied(
+                  CAPABILITIES.CONNECTOR_CERTIFIED,
+                  snapshot,
+                  CERTIFIED_MIN_EDITION,
+                  capabilityServedByBknSafe(CAPABILITIES.CONNECTOR_CERTIFIED),
+                );
               const active = item.enabled && !locked && item.type === value;
               const templateMeta = getConnectorTemplateMeta(item);
 

--- a/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
+++ b/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
@@ -429,6 +429,28 @@ describe("DataConnectFormScene · connection preflight", () => {
   }, HEAVY_SCENE_TIMEOUT_MS);
 
   /**
+   * 企业证 + 社区 vega:能力两个列表里都没有,是 `not-installed` 而不是 `unknown`。
+   * 该说的是「换镜像」,不是「买证书」——客户已经买过了,弹窗里不该再出购买按钮。
+   */
+  it("证够了但镜像不含 → 说换镜像,不出购买按钮", async () => {
+    permissionState.values = new Set(["catalog:create"]);
+    entitlementState.snapshot = {
+      capabilities: ["rbac_basic"],
+      edition: "enterprise",
+      extensions: ["rbac_basic"],
+    };
+
+    render(<DataConnectFormScene mode="create" />);
+
+    fireEvent.click(await findConnectorCard("SQL Server"));
+
+    expect(screen.getAllByText("common.entitlement.imageMissingTitle").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText("common.entitlement.upgradeTo")).toBeNull();
+  }, HEAVY_SCENE_TIMEOUT_MS);
+
+  /**
    * 企业镜像 + 社区证:能力在 `extensions[]` 里、不在 `capabilities[]` 里。这是唯一
    * 「换一张证就能用」的状态,也是唯一该出商务信息的地方。
    */

--- a/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
+++ b/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
@@ -14,6 +14,11 @@ import { DataConnectFormScene } from "@/modules/data-connect/scenes/DataConnectF
 const permissionState = vi.hoisted(() => ({
   values: new Set<string>(),
 }));
+/** 集群档位。默认没有快照——社区部署,也是卖点该出现的那一侧。 */
+const entitlementState = vi.hoisted(() => ({
+  loading: false,
+  snapshot: null as { capabilities: string[]; edition: string; extensions: string[] } | null,
+}));
 const createDataConnectRecordMock = vi.hoisted(() => vi.fn());
 const getDataConnectRecordMock = vi.hoisted(() => vi.fn());
 const listDataConnectConnectorTypesMock = vi.hoisted(() => vi.fn());
@@ -31,6 +36,10 @@ vi.mock("@/framework/context/use-app-services", () => ({
       confirm: vi.fn(),
     },
   }),
+}));
+
+vi.mock("@/framework/entitlement/use-entitlement", () => ({
+  useEntitlementContext: () => entitlementState,
 }));
 
 vi.mock("@/framework/permission/PermissionGate", () => ({
@@ -117,6 +126,7 @@ describe("DataConnectFormScene · connection preflight", () => {
 
   beforeEach(() => {
     permissionState.values = new Set(["catalog:modify"]);
+    entitlementState.snapshot = null;
     messageSuccessMock.mockReset();
     createDataConnectRecordMock.mockReset();
     createDataConnectRecordMock.mockResolvedValue(undefined);
@@ -393,6 +403,29 @@ describe("DataConnectFormScene · connection preflight", () => {
     fireEvent.click(screen.getByRole("button", { name: "common.next" }));
 
     expect(screen.queryByPlaceholderText("例如 供应链主库")).toBeNull();
+  }, HEAVY_SCENE_TIMEOUT_MS);
+
+  /**
+   * 证书已经覆盖这项能力时,后端仍然关着它就不是钱的事,是这套部署没提供。这时说
+   * 「请升级镜像」既指错方向,也把 bkn-safe 的镜像状态硬安到 Vega 头上。
+   */
+  it("证书已覆盖时不再推销,照普通连接器画「暂不可用」", async () => {
+    permissionState.values = new Set(["catalog:create"]);
+    entitlementState.snapshot = {
+      capabilities: ["rbac_basic"],
+      edition: "enterprise",
+      extensions: ["rbac_basic"],
+    };
+
+    render(<DataConnectFormScene mode="create" />);
+
+    const sqlServerButton = await findConnectorCard("SQL Server");
+
+    expect(sqlServerButton.hasAttribute("disabled")).toBe(true);
+    expect(sqlServerButton.textContent).toContain("dataConnect.connectorTypeUnavailable");
+    expect(sqlServerButton.textContent).not.toContain(
+      "common.entitlement.editionsShort.professional",
+    );
   }, HEAVY_SCENE_TIMEOUT_MS);
 
   it("creates a SQL Server catalog with the default port", async () => {

--- a/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
+++ b/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { configure, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -91,6 +91,13 @@ vi.mock("@/modules/data-connect/services/data-connect.service", () => ({
  * CI 的 runner 慢上数倍,那点余量不够——已经因此红过一次。这两条是真的重,不是卡住了。
  */
 const HEAVY_SCENE_TIMEOUT_MS = 30_000;
+
+/*
+  `findBy*` 默认只等 1s。这一整页是真场景渲染 + antd 的异步表单校验,CI 的 runner 慢上
+  数倍,断言会在提示渲染出来之前就放弃——已经因此红过一次(「rejects invalid JSON
+  options」找不到 dataConnect.jsonObjectInvalid)。放宽只影响失败路径要多等多久。
+*/
+configure({ asyncUtilTimeout: 5_000 });
 
 /**
  * 按名字取连接器卡片。

--- a/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
+++ b/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
@@ -409,12 +409,12 @@ describe("DataConnectFormScene · connection preflight", () => {
    * 证书已经覆盖这项能力时,后端仍然关着它就不是钱的事,是这套部署没提供。这时说
    * 「请升级镜像」既指错方向,也把 bkn-safe 的镜像状态硬安到 Vega 头上。
    */
-  it("证书已覆盖时不再推销,照普通连接器画「暂不可用」", async () => {
+  it("装了且证够时不再推销,照普通连接器画「暂不可用」", async () => {
     permissionState.values = new Set(["catalog:create"]);
     entitlementState.snapshot = {
-      capabilities: ["rbac_basic"],
+      capabilities: ["connector_certified", "rbac_basic"],
       edition: "enterprise",
-      extensions: ["rbac_basic"],
+      extensions: ["connector_certified", "rbac_basic"],
     };
 
     render(<DataConnectFormScene mode="create" />);
@@ -424,6 +424,28 @@ describe("DataConnectFormScene · connection preflight", () => {
     expect(sqlServerButton.hasAttribute("disabled")).toBe(true);
     expect(sqlServerButton.textContent).toContain("dataConnect.connectorTypeUnavailable");
     expect(sqlServerButton.textContent).not.toContain(
+      "common.entitlement.editionsShort.professional",
+    );
+  }, HEAVY_SCENE_TIMEOUT_MS);
+
+  /**
+   * 企业镜像 + 社区证:能力在 `extensions[]` 里、不在 `capabilities[]` 里。这是唯一
+   * 「换一张证就能用」的状态,也是唯一该出商务信息的地方。
+   */
+  it("装了没买 → 画档位徽标并给升级引导", async () => {
+    permissionState.values = new Set(["catalog:create"]);
+    entitlementState.snapshot = {
+      capabilities: [],
+      edition: "community",
+      extensions: ["connector_certified", "rbac_basic"],
+    };
+
+    render(<DataConnectFormScene mode="create" />);
+
+    const sqlServerButton = await findConnectorCard("SQL Server");
+
+    expect(sqlServerButton.hasAttribute("disabled")).toBe(false);
+    expect(sqlServerButton.textContent).toContain(
       "common.entitlement.editionsShort.professional",
     );
   }, HEAVY_SCENE_TIMEOUT_MS);

--- a/src/modules/subscription/capability-catalog.test.ts
+++ b/src/modules/subscription/capability-catalog.test.ts
@@ -48,16 +48,23 @@ describe("capability catalog", () => {
   });
 
   /**
-   * `/api/safe/v1/capabilities` 只描述 bkn-safe 自己的镜像(ee-design.md §6「A 答不了 B」),
-   * 所以标成 bkn-safe 的那几条必须与 ee-features.md 的能力总账一致——多标一条,页面就会对
-   * 别的服务的能力下「当前镜像不含」的错误结论。
+   * 标成「端点报得出」的必须恰好是后端真登记了的那几个:多标一条,页面就会对一个端点答
+   * 不了的能力下「当前镜像不含」的错误结论(ee-design.md §6「A 答不了 B」);少标一条,
+   * 本可以按实况判的能力白白退回只看档位。
+   *
+   * 与后端装配表对齐(2026-08-08 实测 VM 返回):`connector_certified` 由 vega 登记进来,
+   * 加上 bkn-safe 自己的两个。`business_provenance` 上游仍是 planned,没有真实现。
    */
-  it("只有 bkn-safe 实现的能力标为可实测", () => {
-    const served = CAPABILITY_CATALOG.filter((entry) => entry.servedBy === "bkn-safe").map(
+  it("标为可实测的能力与后端装配表一致", () => {
+    const served = CAPABILITY_CATALOG.filter((entry) => entry.reportedByEndpoint).map(
       (entry) => entry.key,
     );
 
-    expect(served.sort()).toEqual(["perm_object_level", "rbac_basic"]);
+    expect(served.sort()).toEqual([
+      "connector_certified",
+      "perm_object_level",
+      "rbac_basic",
+    ]);
   });
 
   // 常量表里的每个 key 都要在册,否则页面上少一行在售能力。

--- a/src/modules/subscription/capability-catalog.ts
+++ b/src/modules/subscription/capability-catalog.ts
@@ -42,17 +42,18 @@ export type CapabilityCatalogEntry = {
   key: string;
   minEdition: Edition;
   /**
-   * 哪个服务实现它(取自 `ee-features.md` 的能力总账)。
+   * `/api/safe/v1/capabilities` 报不报得出这一项。
    *
-   * 决定这一项能不能显示实况:`/api/safe/v1/capabilities` 的 `capabilities[]` /
-   * `extensions[]` 只反映 **bkn-safe 自己进程**的装配表。ee-design.md §6 开篇写死了这条
-   * ——「集群里完全可能 bkn-safe 已换企业镜像、某个业务服务还是社区镜像……**A 答不了 B**」,
-   * 而每服务的形态自述(B)延后未做。
+   * 注意问的**不是**「谁实现的」:能力在别的服务里实现,只要那个服务的 ee 构建把它登记进
+   * 装配表,这个端点就能一并报出来(`connector_certified` 由 vega 实现,2026-08-08 起已在
+   * 两个列表里)。报得出就以 `capabilities[]` / `extensions[]` 为准——那是实况,能分清
+   * 「换镜像」和「买证书」。
    *
-   * 所以别的服务的能力在这个端点里永远缺席,把它渲染成「当前镜像不含」是错误结论:真相是
-   * 这个端点答不了。
+   * 报不出的只能退到证书档位。ee-design.md §6「A 答不了 B」说的是这种:端点里的缺席说明
+   * 不了任何事,当成「当前镜像不含」就会把买了的客户挡在门外。等每服务自述(§6.2)或各服务
+   * 补登记之后,这个字段会归零,判定收敛成一条 `capabilityState()`。
    */
-  servedBy: "bkn-safe" | "other";
+  reportedByEndpoint: boolean;
   /** 首次可签发的产品版本。有值时列表里标「新增」。 */
   sinceVersion?: string;
 };
@@ -69,11 +70,12 @@ export const CAPABILITY_CATEGORIES: CapabilityCategory[] = [
 
 export const CAPABILITY_CATALOG: CapabilityCatalogEntry[] = [
   { category: "permission", key: CAPABILITIES.RBAC_BASIC,
-    servedBy: "bkn-safe", minEdition: "professional" },
+    reportedByEndpoint: true, minEdition: "professional" },
   {
     category: "dataConnect",
     key: "connector_certified",
-    servedBy: "other",
+    // vega 侧已登记(2026-08-08 实测两个列表里都有),判定回到端点实况。
+    reportedByEndpoint: true,
     minEdition: "professional",
     sinceVersion: "0.1.3",
   },
@@ -82,23 +84,24 @@ export const CAPABILITY_CATALOG: CapabilityCatalogEntry[] = [
     // 查询本来就列在社区行。留在表里是为了让对比矩阵显示「三档都有」,不是付费项。
     category: "observability",
     key: "bkn_trace",
-    servedBy: "other",
+    reportedByEndpoint: false,
     minEdition: "community",
     sinceVersion: "0.1.3",
   },
   {
     category: "semantic",
     key: "semantic_task",
-    servedBy: "other",
+    reportedByEndpoint: false,
     minEdition: "professional",
     sinceVersion: "0.1.3",
   },
   { category: "permission", key: CAPABILITIES.PERM_OBJECT_LEVEL,
-    servedBy: "bkn-safe", minEdition: "enterprise" },
+    reportedByEndpoint: true, minEdition: "enterprise" },
   {
     category: "observability",
     key: CAPABILITIES.BUSINESS_PROVENANCE,
-    servedBy: "other",
+    // 上游状态仍是 planned,没有真实现,端点里自然没有它;今天由前端按档位判。
+    reportedByEndpoint: false,
     minEdition: "enterprise",
     sinceVersion: "0.1.3",
   },
@@ -126,11 +129,11 @@ export function capabilityMinEdition(key: string): Edition | null {
 }
 
 /**
- * 这个能力是不是 bkn-safe 自己实现的。
+ * `/api/safe/v1/capabilities` 报不报得出这一项。
  *
- * 只有它成立时,`capabilities[]` / `extensions[]` 的缺席才说明得了问题——别的服务的能力
- * 从来不出现在那两个列表里(ee-design.md §6「A 答不了 B」),缺席是常态而不是结论。
+ * 只有它成立时,`capabilities[]` / `extensions[]` 的缺席才说明得了问题;报不出的能力缺席
+ * 是常态而不是结论(ee-design.md §6「A 答不了 B」),那时只能退到证书档位。
  */
-export function capabilityServedByBknSafe(key: string): boolean {
-  return CAPABILITY_CATALOG.find((entry) => entry.key === key)?.servedBy === "bkn-safe";
+export function capabilityReportedByEndpoint(key: string): boolean {
+  return CAPABILITY_CATALOG.find((entry) => entry.key === key)?.reportedByEndpoint === true;
 }

--- a/src/modules/subscription/scenes/SubscriptionScene.tsx
+++ b/src/modules/subscription/scenes/SubscriptionScene.tsx
@@ -114,7 +114,7 @@ export function SubscriptionScene() {
     // 只有 bkn-safe 自己实现的能力才有实况可报:capabilities/extensions 是它自己进程的
     // 装配表,别的服务的能力在这个端点里永远缺席(ee-design.md §6「A 答不了 B」)。
     const clusterStatus =
-      entry.servedBy === "bkn-safe" ? capabilityState(entry.key, snapshot) : null;
+      entry.reportedByEndpoint ? capabilityState(entry.key, snapshot) : null;
 
     return (
       <tr key={entry.key}>


### PR DESCRIPTION
Enterprise certificate, enterprise image, and business provenance was still masked. Four fixes, verified against the VM's real `/api/safe/v1/capabilities`.

## The judgement was unsatisfiable

The guard required a capability to appear in bkn-safe's `capabilities[]`. Capabilities implemented by other services never appeared there, so the condition could not be met by any deployment — a customer was blocked from a feature they had paid for.

Being unable to verify someone else's image is not evidence that the image is missing. Judgement now splits on **whether the endpoint can speak for a capability**, not on who implements it:

- **Reported** — `capabilities[]` is the real state; a certificate alone is not enough, it has to be in the list. This is what tells "change the image" apart from "buy a certificate".
- **Not reported** — absence means nothing, so the certificate decides.

`connector_certified` moved into the first group during this branch: vega's ee build calls `entitlement.MarkAssembled("connector_certified", …)`, and the VM now returns it in both lists. `business_provenance` stays in the second — upstream still has it `planned`, nothing implements it, and the front end is currently its only gate.

The catalog field was renamed `servedBy: "bkn-safe" | "other"` → `reportedByEndpoint: boolean` to match. The old name asked the wrong question and would have sent the next reader looking for a bkn-safe implementation of a vega connector.

## Certified connectors no longer blame the image

A disabled certified connector means two different things. Without a covering certificate it means "not bought" — badge it, offer the upgrade. With one it means this deployment does not offer the connector, which no purchase fixes. Vega's `Enabled` is an operator switch (`POST /connector-types/:type/enable`) and its `Available` is "is the implementation in this binary"; neither is derived from the licence, so the licence-flavoured wording was wrong on both counts.

## Copy speaks per capability

"Enterprise licence — community image, upgrade needed" was written when the endpoint could only speak for bkn-safe. It is deployment-wide now, so a missing key says nothing about the image — this very cluster is the counterexample.

## Also

Removes the "already upgraded — continue anyway" escape from #374. It existed to keep the unsatisfiable check from being a dead end; there is no dead end left.

## Verification

`npx tsc -b`, `pnpm lint:types`, `pnpm test` — 844 passing. Deployed to the VM and checked against a live enterprise certificate. New tests cover the three deployment combinations for the connector card (absent from both lists / installed but unlicensed / installed and licensed) and the guard's skeleton, unknown, pass-through and block paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
