### PR TITLE
fix(data-catalog): align semantic task list summary

### DIFF
--- a/src/framework/request/http.ts
+++ b/src/framework/request/http.ts
@@ -20,7 +20,7 @@ type RetryableRequestConfig = InternalAxiosRequestConfig & {
 type RequestErrorHandler = ((message: string) => void) | null;
 
 export const http = axios.create({
-  timeout: import.meta.env.DEV ? 30000 : 15000,
+  timeout: 30000,
 });
 
 let refreshPromise: Promise<string | null> | null = null;

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -20,7 +20,7 @@ import { AppTable } from "@/framework/ui/common/AppTable";
 import { EmptyStatePanel } from "@/framework/ui/common/EmptyStatePanel";
 import { TableSurface } from "@/framework/ui/common/TableSurface";
 import { SemanticUnderstandingTaskDetailDrawer } from "@/modules/data-catalog/components/SemanticUnderstandingTaskDetailDrawer";
-import { createResourceSemanticUnderstandingTask, deleteSemanticUnderstandingTask, listResourceSemanticUnderstandingTasks, type CreateSemanticUnderstandingTaskPayload, type SemanticUnderstandingTask } from "@/modules/data-catalog/services/semantic-understanding-task.service";
+import { createResourceSemanticUnderstandingTask, deleteSemanticUnderstandingTask, listResourceSemanticUnderstandingTasks, type CreateSemanticUnderstandingTaskPayload, type SemanticUnderstandingTaskSummary } from "@/modules/data-catalog/services/semantic-understanding-task.service";
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 
 import styles from "./ResourceSemanticUnderstandingPanel.module.css";
@@ -34,7 +34,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
   const { t } = useTranslation();
   const { message, modal } = useAppServices();
   const [form] = Form.useForm<CreateSemanticUnderstandingTaskPayload>();
-  const [tasks, setTasks] = useState<SemanticUnderstandingTask[]>([]);
+  const [tasks, setTasks] = useState<SemanticUnderstandingTaskSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
@@ -88,7 +88,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
     { dataIndex: "createTime", title: t("dataCatalog.task.createTime"), render: formatTime },
     {
       key: "actions", title: t("common.actions"), width: 160, fixed: "right" as const,
-      render: (_: unknown, task: SemanticUnderstandingTask) => <Space className={styles.actionGroup} size={4}>
+      render: (_: unknown, task: SemanticUnderstandingTaskSummary) => <Space className={styles.actionGroup} size={4}>
         <AppButton type="link" onClick={() => setDetailTaskId(task.id)}>{t("common.detail")}</AppButton>
         <PermissionGate permissions="resource:task_manage">
           <AppButton danger disabled={task.status === "pending" || task.status === "running"} type="link" onClick={() => void modal.confirm({

--- a/src/modules/data-catalog/components/SemanticUnderstandingTaskDetailDrawer.tsx
+++ b/src/modules/data-catalog/components/SemanticUnderstandingTaskDetailDrawer.tsx
@@ -141,7 +141,7 @@ export function SemanticUnderstandingTaskDetailDrawer({ onClose, open, taskId }:
 
   const applyModeKey = task.applyMode === "dry_run" ? "dryRun" : task.applyMode === "force" ? "force" : "fillEmpty";
   const statusClass = task.status === "failed" ? sharedStyles.taskFailed : task.status === "succeeded" ? sharedStyles.taskSucceeded : sharedStyles.taskRunning;
-  const creator = task.creator ? task.creator.name || task.creator.id : "-";
+  const creator = task.creator.name || task.creator.id;
   const quality = getQuality(task.confidenceDetailJson, task.resultJson);
   const warnings = getWarnings(task.confidenceDetailJson, task.resultJson);
   const fieldDetails = getFieldDetails(task.applyDetailJson);

--- a/src/modules/data-catalog/scenes/IndexBuildListScene.tsx
+++ b/src/modules/data-catalog/scenes/IndexBuildListScene.tsx
@@ -112,7 +112,7 @@ export function IndexBuildListScene() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const [orderBy, setOrderBy] = useState<BuildTaskOrderBy>("default");
+  const [orderBy, setOrderBy] = useState<BuildTaskOrderBy>("created_at");
   const [order, setOrder] = useState<"asc" | "desc">("desc");
   const [total, setTotal] = useState(0);
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
@@ -326,7 +326,7 @@ export function IndexBuildListScene() {
     };
   }, [resourceColumnWidth, taskColumnWidth]);
 
-  // 列头排序:有方向 → order_by=列key + order;清除 → 回 default(不显箭头)。
+  // 列头排序:有方向 → order_by=列key + order;清除 → 回创建时间倒序。
   const handleTableChange: TableProps<BuildTask>["onChange"] = (
     _pagination,
     _filters,
@@ -338,7 +338,7 @@ export function IndexBuildListScene() {
     }
     const single = Array.isArray(sorter) ? sorter[0] : sorter;
     if (!single || !single.order || !single.columnKey) {
-      setOrderBy("default");
+      setOrderBy("created_at");
       setOrder("desc");
     } else {
       setOrderBy(single.columnKey as BuildTaskOrderBy);

--- a/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
+++ b/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
@@ -63,6 +63,7 @@ let mockSemanticTasks: SemanticTask[] = [
     confidenceThreshold: 0.75,
     confidence: 0.94,
     applied: true,
+    creator: { id: "mock-user", name: "Mock User", type: "user" },
     createTime: Date.now() - 1000 * 60 * 45,
   },
   {
@@ -75,6 +76,7 @@ let mockSemanticTasks: SemanticTask[] = [
     confidenceThreshold: 0.75,
     confidence: 0,
     applied: false,
+    creator: { id: "mock-user", name: "Mock User", type: "user" },
     createTime: Date.now() - 1000 * 60 * 8,
   },
 ];

--- a/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
+++ b/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
@@ -38,15 +38,15 @@ import type {
   DataConnectDiscoverTaskTriggerType,
 } from "@/modules/data-connect/types/discover";
 import { listCatalogResourcePage } from "@/modules/data-catalog/services/resource.service";
-import { deleteSemanticUnderstandingTask, mapSemanticUnderstandingTask, type BackendSemanticUnderstandingTask, type SemanticUnderstandingTask } from "@/modules/data-catalog/services/semantic-understanding-task.service";
+import { deleteSemanticUnderstandingTask, mapSemanticUnderstandingTaskSummary, type BackendSemanticUnderstandingTaskSummary, type SemanticUnderstandingTaskSummary } from "@/modules/data-catalog/services/semantic-understanding-task.service";
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 import { listCatalogs } from "@/shared/catalog";
 import type { CatalogRecord } from "@/shared/catalog";
 
 import styles from "./TaskManagementTaskPanels.module.css";
 
-type SemanticTaskStatus = SemanticUnderstandingTask["status"];
-type SemanticTask = SemanticUnderstandingTask;
+type SemanticTaskStatus = SemanticUnderstandingTaskSummary["status"];
+type SemanticTask = SemanticUnderstandingTaskSummary;
 type SemanticTaskFilters = {
   scope?: SemanticTask["scope"];
   catalogId?: string;
@@ -55,7 +55,7 @@ type SemanticTaskFilters = {
   applyMode?: string;
   applied?: boolean;
   direction?: "asc" | "desc";
-  sort?: "create_time" | "default";
+  sort?: "create_time";
 };
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
@@ -303,10 +303,6 @@ async function listSemanticTasks(page: number, pageSize: number, filters: Semant
     );
     const direction = filters.direction === "asc" ? 1 : -1;
     const sorted = filtered.sort((left, right) => {
-      if (filters.sort === "default") {
-        const rank = { running: 1, pending: 2, failed: 3, succeeded: 4 };
-        return rank[left.status] - rank[right.status] || right.createTime - left.createTime;
-      }
       const leftValue = left.createTime;
       const rightValue = right.createTime;
       return leftValue > rightValue ? direction : leftValue < rightValue ? -direction : 0;
@@ -318,12 +314,12 @@ async function listSemanticTasks(page: number, pageSize: number, filters: Semant
     });
   }
 
-  const response = await http.get<{ entries: BackendSemanticUnderstandingTask[]; total_count: number }>("/vega-backend/v1/semantic-understanding-tasks", {
+  const response = await http.get<{ entries: BackendSemanticUnderstandingTaskSummary[]; total_count: number }>("/vega-backend/v1/semantic-understanding-tasks", {
     params: {
       direction: filters.direction ?? "desc",
       limit: pageSize,
       offset: (page - 1) * pageSize,
-      sort: filters.sort ?? "default",
+      sort: filters.sort ?? "create_time",
       scope: filters.scope,
       catalog_id: filters.catalogId,
       resource_id: filters.resourceId,
@@ -332,7 +328,7 @@ async function listSemanticTasks(page: number, pageSize: number, filters: Semant
       applied: filters.applied,
     },
   });
-  return { items: response.data.entries.map(mapSemanticUnderstandingTask), total: response.data.total_count };
+  return { items: response.data.entries.map(mapSemanticUnderstandingTaskSummary), total: response.data.total_count };
 }
 
 async function deleteSemanticTask(id: string) {
@@ -361,7 +357,7 @@ export function SemanticUnderstandingTaskListPanel() {
   const [status, setStatus] = useState<SemanticTaskStatus>();
   const [applyMode, setApplyMode] = useState<string>();
   const [applied, setApplied] = useState<boolean>();
-  const [sort, setSort] = useState<NonNullable<SemanticTaskFilters["sort"]>>("default");
+  const [sort, setSort] = useState<NonNullable<SemanticTaskFilters["sort"]>>("create_time");
   const [direction, setDirection] = useState<"asc" | "desc">("desc");
   const [loading, setLoading] = useState(true); const [error, setError] = useState<string | null>(null);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
@@ -406,7 +402,7 @@ export function SemanticUnderstandingTaskListPanel() {
   const handleTableChange: TableProps<SemanticTask>["onChange"] = (_pagination, _filters, sorter, extra) => {
     if (extra.action !== "sort") return;
     const single = Array.isArray(sorter) ? sorter[0] : sorter;
-    setSort(single?.columnKey as NonNullable<SemanticTaskFilters["sort"]> || "default");
+    setSort(single?.columnKey as NonNullable<SemanticTaskFilters["sort"]> || "create_time");
     setDirection(single?.order === "ascend" ? "asc" : "desc");
     setPage(1);
   };

--- a/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
+++ b/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
@@ -38,7 +38,7 @@ import type {
   DataConnectDiscoverTaskTriggerType,
 } from "@/modules/data-connect/types/discover";
 import { listCatalogResourcePage } from "@/modules/data-catalog/services/resource.service";
-import { deleteSemanticUnderstandingTask, mapSemanticUnderstandingTaskSummary, type BackendSemanticUnderstandingTaskSummary, type SemanticUnderstandingTaskSummary } from "@/modules/data-catalog/services/semantic-understanding-task.service";
+import { buildSemanticUnderstandingTaskListParams, deleteSemanticUnderstandingTask, mapSemanticUnderstandingTaskSummary, type BackendSemanticUnderstandingTaskSummary, type SemanticUnderstandingTaskListFilters, type SemanticUnderstandingTaskSummary } from "@/modules/data-catalog/services/semantic-understanding-task.service";
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 import { listCatalogs } from "@/shared/catalog";
 import type { CatalogRecord } from "@/shared/catalog";
@@ -47,16 +47,7 @@ import styles from "./TaskManagementTaskPanels.module.css";
 
 type SemanticTaskStatus = SemanticUnderstandingTaskSummary["status"];
 type SemanticTask = SemanticUnderstandingTaskSummary;
-type SemanticTaskFilters = {
-  scope?: SemanticTask["scope"];
-  catalogId?: string;
-  resourceId?: string;
-  status?: SemanticTaskStatus;
-  applyMode?: string;
-  applied?: boolean;
-  direction?: "asc" | "desc";
-  sort?: "create_time";
-};
+type SemanticTaskFilters = SemanticUnderstandingTaskListFilters;
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 
@@ -315,18 +306,7 @@ async function listSemanticTasks(page: number, pageSize: number, filters: Semant
   }
 
   const response = await http.get<{ entries: BackendSemanticUnderstandingTaskSummary[]; total_count: number }>("/vega-backend/v1/semantic-understanding-tasks", {
-    params: {
-      direction: filters.direction ?? "desc",
-      limit: pageSize,
-      offset: (page - 1) * pageSize,
-      sort: filters.sort ?? "create_time",
-      scope: filters.scope,
-      catalog_id: filters.catalogId,
-      resource_id: filters.resourceId,
-      status: filters.status,
-      apply_mode: filters.applyMode,
-      applied: filters.applied,
-    },
+    params: buildSemanticUnderstandingTaskListParams(page, pageSize, filters),
   });
   return { items: response.data.entries.map(mapSemanticUnderstandingTaskSummary), total: response.data.total_count };
 }

--- a/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
+++ b/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
@@ -32,9 +32,9 @@ import { DataConnectDiscoverTaskDrawer } from "@/modules/data-connect/components
 import type {
   DataConnectDiscoverSchedule,
   DataConnectDiscoverStrategy,
-  DataConnectDiscoverTask,
   DataConnectDiscoverTaskSort,
   DataConnectDiscoverTaskStatus,
+  DataConnectDiscoverTaskSummary,
   DataConnectDiscoverTaskTriggerType,
 } from "@/modules/data-connect/types/discover";
 import { listCatalogResourcePage } from "@/modules/data-catalog/services/resource.service";
@@ -115,7 +115,7 @@ function TaskPanel({ children }: { children: React.ReactNode }) {
   return <section className={styles.contentSurface}>{children}</section>;
 }
 
-function DiscoverTaskProgress({ task }: { task: DataConnectDiscoverTask }) {
+function DiscoverTaskProgress({ task }: { task: DataConnectDiscoverTaskSummary }) {
   const percent = Math.max(0, Math.min(100, task.progress));
   const fillClass =
     task.status === "completed"
@@ -143,7 +143,7 @@ export function DiscoverTaskListPanel() {
   const { t } = useTranslation();
   const { message, modal } = useAppServices();
   const navigate = useNavigate();
-  const [tasks, setTasks] = useState<DataConnectDiscoverTask[]>([]);
+  const [tasks, setTasks] = useState<DataConnectDiscoverTaskSummary[]>([]);
   const [catalogs, setCatalogs] = useState<CatalogRecord[]>([]);
   const [schedules, setSchedules] = useState<DataConnectDiscoverSchedule[]>([]);
   const [catalogKeyword, setCatalogKeyword] = useState("");
@@ -151,7 +151,7 @@ export function DiscoverTaskListPanel() {
   const [status, setStatus] = useState<DataConnectDiscoverTaskStatus>();
   const [strategy, setStrategy] = useState<DataConnectDiscoverStrategy>();
   const [triggerType, setTriggerType] = useState<DataConnectDiscoverTaskTriggerType>();
-  const [sort, setSort] = useState<DataConnectDiscoverTaskSort>("default");
+  const [sort, setSort] = useState<DataConnectDiscoverTaskSort>("create_time");
   const [direction, setDirection] = useState<"asc" | "desc">("desc");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
@@ -223,15 +223,15 @@ export function DiscoverTaskListPanel() {
     });
   };
   const sortOrderOf = (key: DataConnectDiscoverTaskSort) => sort === key ? (direction === "asc" ? "ascend" : "descend") : null;
-  const handleTableChange: TableProps<DataConnectDiscoverTask>["onChange"] = (_pagination, _filters, sorter, extra) => {
+  const handleTableChange: TableProps<DataConnectDiscoverTaskSummary>["onChange"] = (_pagination, _filters, sorter, extra) => {
     if (extra.action !== "sort") return;
     const single = Array.isArray(sorter) ? sorter[0] : sorter;
-    setSort(single?.columnKey as DataConnectDiscoverTaskSort || "default");
+    setSort(single?.columnKey as DataConnectDiscoverTaskSort || "create_time");
     setDirection(single?.order === "ascend" ? "asc" : "desc");
     setPage(1);
   };
 
-  const columns: ColumnsType<DataConnectDiscoverTask> = [
+  const columns: ColumnsType<DataConnectDiscoverTaskSummary> = [
     { dataIndex: "id", title: t("dataCatalog.taskManagement.columns.task"), width: 160, ellipsis: true },
     {
       dataIndex: "catalogId",

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -76,6 +76,11 @@ type BackendBuildTask = {
   vectorized_count?: number;
 };
 
+type BackendBuildTaskSummary = Omit<
+  BackendBuildTask,
+  "failure_detail" | "index_config"
+>;
+
 type ListResponse<T> = {
   entries: T[];
   total_count: number;
@@ -237,7 +242,10 @@ export function mapBuildTask(item: BackendBuildTask): BuildTask {
   const synced = item.synced_count ?? 0;
   const vectorized = item.vectorized_count ?? 0;
   const wantsEmbedding = snapshot.embeddingFields.length > 0;
-  const embeddingDegraded = wantsEmbedding && status === "succeeded" && vectorized < synced;
+  const embeddingDegraded =
+    item.index_health?.embedding === "failed" ||
+    item.index_health?.embedding === "partial" ||
+    (wantsEmbedding && status === "succeeded" && vectorized < synced);
 
   // 优先用后端真实 index_health;缺省则按计数兜底,保持与 embeddingDegraded 一致。
   const toHealthState = (value: string | undefined): IndexHealthState =>
@@ -337,7 +345,7 @@ export async function listBuildTasks(
   let total = Number.POSITIVE_INFINITY;
 
   while (tasks.length < total) {
-    const response = await http.get<ListResponse<BackendBuildTask>>(
+    const response = await http.get<ListResponse<BackendBuildTaskSummary>>(
       "/vega-backend/v1/build-tasks",
       {
         params: {
@@ -390,21 +398,11 @@ function sortMockTasks(
   order: "asc" | "desc",
 ): BuildTask[] {
   const arr = [...items];
-  if (orderBy === "default") {
-    // 构建中置顶,桶内按 createdAt 倒序。
-    return arr.sort((a, b) => {
-      const aActive = ACTIVE_FE_STATUSES.has(a.status) ? 0 : 1;
-      const bActive = ACTIVE_FE_STATUSES.has(b.status) ? 0 : 1;
-      return aActive !== bActive ? aActive - bActive : b.createdAt - a.createdAt;
-    });
-  }
   const dir = order === "asc" ? 1 : -1;
-  const keyOf = (task: BuildTask): number | string =>
+  const keyOf = (task: BuildTask): number =>
     orderBy === "created_at"
       ? task.createdAt
-      : orderBy === "updated_at"
-        ? (task.lastEventAt ?? task.createdAt)
-        : task.status;
+      : (task.lastEventAt ?? task.createdAt);
   return arr.sort((a, b) => {
     const ka = keyOf(a);
     const kb = keyOf(b);
@@ -446,7 +444,7 @@ export async function listBuildTaskPage(
       const set = new Set(query.statuses);
       items = items.filter((task) => set.has(task.status));
     }
-    items = sortMockTasks(items, query.orderBy ?? "default", query.order ?? "desc");
+    items = sortMockTasks(items, query.orderBy ?? "created_at", query.order ?? "desc");
     const total = items.length;
     const start = (page - 1) * pageSize;
     return wait({ items: items.slice(start, start + pageSize), total }, 120);
@@ -459,7 +457,7 @@ export async function listBuildTaskPage(
     catalog_id: query.catalogId || undefined,
     mode: query.mode || undefined,
   };
-  if (query.orderBy && query.orderBy !== "default") {
+  if (query.orderBy) {
     params.order_by = query.orderBy;
     params.order = query.order ?? "desc";
   }
@@ -469,7 +467,7 @@ export async function listBuildTaskPage(
     params.status = backendStatusParam(query.statuses);
   }
 
-  const response = await http.get<ListResponse<BackendBuildTask>>(
+  const response = await http.get<ListResponse<BackendBuildTaskSummary>>(
     "/vega-backend/v1/build-tasks",
     { params },
   );

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.test.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSemanticUnderstandingTaskListParams,
+  mapSemanticUnderstandingTaskSummary,
+} from "@/modules/data-catalog/services/semantic-understanding-task.service";
+
+describe("mapSemanticUnderstandingTaskSummary", () => {
+  it("maps the list contract without inventing fallback values", () => {
+    const summary = mapSemanticUnderstandingTaskSummary({
+      agent_id: "semantic-agent",
+      applied: false,
+      apply_mode: "dry_run",
+      catalog_id: "catalog-1",
+      confidence: 0,
+      confidence_threshold: 0.8,
+      create_time: 100,
+      creator: { id: "user-1", name: "User", type: "user" },
+      id: "task-1",
+      scope: "catalog",
+      status: "running",
+      update_time: 200,
+    });
+
+    expect(summary).toMatchObject({
+      agentId: "semantic-agent",
+      applied: false,
+      applyMode: "dry_run",
+      catalogId: "catalog-1",
+      confidence: 0,
+      confidenceThreshold: 0.8,
+      createTime: 100,
+      creator: { id: "user-1", name: "User", type: "user" },
+      id: "task-1",
+      scope: "catalog",
+      status: "running",
+      updateTime: 200,
+    });
+  });
+});
+
+describe("buildSemanticUnderstandingTaskListParams", () => {
+  it("defaults to creation time descending and computes the page offset", () => {
+    expect(buildSemanticUnderstandingTaskListParams(3, 20, {})).toMatchObject({
+      direction: "desc",
+      limit: 20,
+      offset: 40,
+      sort: "create_time",
+    });
+  });
+
+  it("preserves explicit filters and direction", () => {
+    expect(buildSemanticUnderstandingTaskListParams(1, 10, {
+      applied: true,
+      applyMode: "force",
+      catalogId: "catalog-1",
+      direction: "asc",
+      resourceId: "resource-1",
+      scope: "resource",
+      status: "succeeded",
+    })).toEqual({
+      applied: true,
+      apply_mode: "force",
+      catalog_id: "catalog-1",
+      direction: "asc",
+      limit: 10,
+      offset: 0,
+      resource_id: "resource-1",
+      scope: "resource",
+      sort: "create_time",
+      status: "succeeded",
+    });
+  });
+});

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.ts
@@ -18,7 +18,7 @@ export type SemanticUnderstandingTaskSummary = {
   confidence: number;
   confidenceThreshold: number;
   createTime: number;
-  creator?: { id: string; name?: string; type?: string };
+  creator: { id: string; name?: string; type: string };
   id: string;
   resourceId?: string;
   resourceName?: string;
@@ -153,7 +153,7 @@ export async function getSemanticUnderstandingTask(id: string) {
 
 export async function createResourceSemanticUnderstandingTask(payload: CreateSemanticUnderstandingTaskPayload) {
   if (useMock) {
-    const task = { id: `semantic-task-${Date.now()}`, scope: "resource" as const, catalogId: "", resourceId: payload.resourceId, agentId: "resource-semantic-understanding", status: "pending" as const, applyMode: payload.applyMode, confidenceThreshold: payload.confidenceThreshold ?? 0.75, confidence: 0, applied: false, createTime: Date.now() };
+    const task = { id: `semantic-task-${Date.now()}`, scope: "resource" as const, catalogId: "", resourceId: payload.resourceId, agentId: "resource-semantic-understanding", status: "pending" as const, applyMode: payload.applyMode, confidenceThreshold: payload.confidenceThreshold ?? 0.75, confidence: 0, applied: false, creator: { id: "mock-user", name: "Mock User", type: "user" }, createTime: Date.now() };
     mockTasks = [task, ...mockTasks];
     return task;
   }

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.ts
@@ -37,23 +37,23 @@ export type SemanticUnderstandingTask = SemanticUnderstandingTaskSummary & {
 };
 
 export type BackendSemanticUnderstandingTaskSummary = {
-  agent_id?: string;
+  agent_id: string;
   agent_task_id?: string;
-  applied?: boolean;
+  applied: boolean;
   applied_time?: number;
-  apply_mode?: SemanticUnderstandingTaskSummary["applyMode"];
-  catalog_id?: string;
+  apply_mode: SemanticUnderstandingTaskSummary["applyMode"];
+  catalog_id: string;
   catalog_name?: string;
-  confidence?: number;
-  confidence_threshold?: number;
-  create_time?: number;
-  creator?: { id?: string; name?: string; type?: string };
+  confidence: number;
+  confidence_threshold: number;
+  create_time: number;
+  creator: { id: string; name?: string; type: string };
   id: string;
   resource_id?: string;
   resource_name?: string;
-  scope?: SemanticUnderstandingTaskSummary["scope"];
+  scope: SemanticUnderstandingTaskSummary["scope"];
   status: SemanticUnderstandingTaskSummary["status"];
-  update_time?: number;
+  update_time: number;
 };
 
 export type BackendSemanticUnderstandingTask = BackendSemanticUnderstandingTaskSummary & {
@@ -68,22 +68,52 @@ export type BackendSemanticUnderstandingTask = BackendSemanticUnderstandingTaskS
 export function mapSemanticUnderstandingTaskSummary(task: BackendSemanticUnderstandingTaskSummary): SemanticUnderstandingTaskSummary {
   return {
     id: task.id,
-    scope: task.scope ?? "resource",
-    catalogId: task.catalog_id ?? "",
+    scope: task.scope,
+    catalogId: task.catalog_id,
     catalogName: task.catalog_name,
     resourceId: task.resource_id,
     resourceName: task.resource_name,
-    agentId: task.agent_id ?? "",
+    agentId: task.agent_id,
     agentTaskId: task.agent_task_id,
     status: task.status,
-    applyMode: task.apply_mode ?? "fill_empty",
-    confidenceThreshold: task.confidence_threshold ?? 0,
-    confidence: task.confidence ?? 0,
-    applied: task.applied ?? false,
+    applyMode: task.apply_mode,
+    confidenceThreshold: task.confidence_threshold,
+    confidence: task.confidence,
+    applied: task.applied,
     appliedTime: task.applied_time,
-    creator: task.creator?.id ? { id: task.creator.id, name: task.creator.name, type: task.creator.type } : undefined,
-    createTime: task.create_time ?? 0,
+    creator: { id: task.creator.id, name: task.creator.name, type: task.creator.type },
+    createTime: task.create_time,
     updateTime: task.update_time,
+  };
+}
+
+export type SemanticUnderstandingTaskListFilters = {
+  applied?: boolean;
+  applyMode?: string;
+  catalogId?: string;
+  direction?: "asc" | "desc";
+  resourceId?: string;
+  scope?: SemanticUnderstandingTaskSummary["scope"];
+  sort?: "create_time";
+  status?: SemanticUnderstandingTaskSummary["status"];
+};
+
+export function buildSemanticUnderstandingTaskListParams(
+  page: number,
+  pageSize: number,
+  filters: SemanticUnderstandingTaskListFilters,
+) {
+  return {
+    direction: filters.direction ?? "desc",
+    limit: pageSize,
+    offset: (page - 1) * pageSize,
+    sort: filters.sort ?? "create_time",
+    scope: filters.scope,
+    catalog_id: filters.catalogId,
+    resource_id: filters.resourceId,
+    status: filters.status,
+    apply_mode: filters.applyMode,
+    applied: filters.applied,
   };
 }
 

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.ts
@@ -7,59 +7,65 @@
 
 import { http } from "@/framework/request/http";
 
-export type SemanticUnderstandingTask = {
+export type SemanticUnderstandingTaskSummary = {
   agentId: string;
   agentTaskId?: string;
   applied: boolean;
   appliedTime?: number;
   applyMode: "dry_run" | "fill_empty" | "force";
-  applyDetailJson?: string;
   catalogId: string;
   catalogName?: string;
   confidence: number;
-  confidenceDetailJson?: string;
   confidenceThreshold: number;
   createTime: number;
   creator?: { id: string; name?: string; type?: string };
-  failureDetail?: string;
   id: string;
-  input?: string;
-  inputHash?: string;
   resourceId?: string;
   resourceName?: string;
-  resultJson?: string;
   scope: "catalog" | "resource";
   status: "pending" | "running" | "succeeded" | "failed";
   updateTime?: number;
 };
 
-export type BackendSemanticUnderstandingTask = {
+export type SemanticUnderstandingTask = SemanticUnderstandingTaskSummary & {
+  applyDetailJson?: string;
+  confidenceDetailJson?: string;
+  failureDetail?: string;
+  input?: string;
+  inputHash?: string;
+  resultJson?: string;
+};
+
+export type BackendSemanticUnderstandingTaskSummary = {
   agent_id?: string;
   agent_task_id?: string;
   applied?: boolean;
   applied_time?: number;
-  apply_detail_json?: string;
-  apply_mode?: SemanticUnderstandingTask["applyMode"];
+  apply_mode?: SemanticUnderstandingTaskSummary["applyMode"];
   catalog_id?: string;
   catalog_name?: string;
   confidence?: number;
-  confidence_detail_json?: string;
   confidence_threshold?: number;
   create_time?: number;
   creator?: { id?: string; name?: string; type?: string };
-  failure_detail?: string;
   id: string;
-  input?: string;
-  input_hash?: string;
   resource_id?: string;
   resource_name?: string;
-  result_json?: string;
-  scope?: SemanticUnderstandingTask["scope"];
-  status: SemanticUnderstandingTask["status"];
+  scope?: SemanticUnderstandingTaskSummary["scope"];
+  status: SemanticUnderstandingTaskSummary["status"];
   update_time?: number;
 };
 
-export function mapSemanticUnderstandingTask(task: BackendSemanticUnderstandingTask): SemanticUnderstandingTask {
+export type BackendSemanticUnderstandingTask = BackendSemanticUnderstandingTaskSummary & {
+  apply_detail_json?: string;
+  confidence_detail_json?: string;
+  failure_detail?: string;
+  input?: string;
+  input_hash?: string;
+  result_json?: string;
+};
+
+export function mapSemanticUnderstandingTaskSummary(task: BackendSemanticUnderstandingTaskSummary): SemanticUnderstandingTaskSummary {
   return {
     id: task.id,
     scope: task.scope ?? "resource",
@@ -73,17 +79,23 @@ export function mapSemanticUnderstandingTask(task: BackendSemanticUnderstandingT
     applyMode: task.apply_mode ?? "fill_empty",
     confidenceThreshold: task.confidence_threshold ?? 0,
     confidence: task.confidence ?? 0,
+    applied: task.applied ?? false,
+    appliedTime: task.applied_time,
+    creator: task.creator?.id ? { id: task.creator.id, name: task.creator.name, type: task.creator.type } : undefined,
+    createTime: task.create_time ?? 0,
+    updateTime: task.update_time,
+  };
+}
+
+export function mapSemanticUnderstandingTask(task: BackendSemanticUnderstandingTask): SemanticUnderstandingTask {
+  return {
+    ...mapSemanticUnderstandingTaskSummary(task),
     confidenceDetailJson: task.confidence_detail_json,
     input: task.input,
     inputHash: task.input_hash,
     resultJson: task.result_json,
     applyDetailJson: task.apply_detail_json,
-    applied: task.applied ?? false,
-    appliedTime: task.applied_time,
     failureDetail: task.failure_detail,
-    creator: task.creator?.id ? { id: task.creator.id, name: task.creator.name, type: task.creator.type } : undefined,
-    createTime: task.create_time ?? 0,
-    updateTime: task.update_time,
   };
 }
 
@@ -97,10 +109,10 @@ export type CreateSemanticUnderstandingTaskPayload = {
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 let mockTasks: Array<SemanticUnderstandingTask & { resourceId: string }> = [];
 
-export async function listResourceSemanticUnderstandingTasks(resourceId: string) {
+export async function listResourceSemanticUnderstandingTasks(resourceId: string): Promise<SemanticUnderstandingTaskSummary[]> {
   if (useMock) return mockTasks.filter((task) => task.resourceId === resourceId).sort((left, right) => right.createTime - left.createTime);
-  const response = await http.get<{ entries: BackendSemanticUnderstandingTask[] }>("/vega-backend/v1/semantic-understanding-tasks", { params: { resource_id: resourceId, scope: "resource", limit: 100, offset: 0, sort: "create_time", direction: "desc" } });
-  return response.data.entries.map(mapSemanticUnderstandingTask);
+  const response = await http.get<{ entries: BackendSemanticUnderstandingTaskSummary[] }>("/vega-backend/v1/semantic-understanding-tasks", { params: { resource_id: resourceId, scope: "resource", limit: 100, offset: 0, sort: "create_time", direction: "desc" } });
+  return response.data.entries.map(mapSemanticUnderstandingTaskSummary);
 }
 
 export async function getSemanticUnderstandingTask(id: string) {

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -180,11 +180,8 @@ export type BuildTaskListQuery = {
   statuses?: BuildTaskStatus[];
 };
 
-/** 服务端排序维度:default=后端默认(构建中置顶),不传 order_by。 */
-export type BuildTaskOrderBy =
-  | "default"
-  | "created_at"
-  | "updated_at";
+/** 服务端排序维度；缺省按创建时间倒序。 */
+export type BuildTaskOrderBy = "created_at" | "updated_at";
 
 export type BuildTaskPageQuery = {
   /** 只看构建中:传 active=true,且不再传 status。 */

--- a/src/modules/data-connect/scenes/DataConnectDiscoverScene.tsx
+++ b/src/modules/data-connect/scenes/DataConnectDiscoverScene.tsx
@@ -39,6 +39,7 @@ import type {
   DataConnectDiscoverSchedule,
   DataConnectDiscoverSchedulePayload,
   DataConnectDiscoverTask,
+  DataConnectDiscoverTaskSummary,
   DataConnectDiscoverTaskStatus,
 } from "@/modules/data-connect/types/discover";
 import {
@@ -66,7 +67,7 @@ function renderTableTime(value?: string) {
   return <span className={styles.timeText}>{value || "-"}</span>;
 }
 
-function DiscoverTaskProgress({ task }: { task: DataConnectDiscoverTask }) {
+function DiscoverTaskProgress({ task }: { task: DataConnectDiscoverTaskSummary }) {
   const percent = Math.max(0, Math.min(100, task.progress));
   const fillClass = task.status === "completed" ? sharedStyles.progressFillDone : task.status === "failed" ? sharedStyles.progressFillFailed : sharedStyles.progressFillVector;
   return <div className={sharedStyles.progressWrapCompact}><div className={sharedStyles.progressTrack}><span className={[sharedStyles.progressFill, fillClass].join(" ")} style={{ width: `${percent}%` }} /></div><div className={sharedStyles.progressMetaCompact}><span>{`${percent}%`}</span></div></div>;
@@ -95,7 +96,7 @@ export function DataConnectDiscoverScene({
     useState<TaskTriggerTypeFilterValue>("all");
   const [catalogs, setCatalogs] = useState<DataConnectRecord[]>([]);
   const [schedules, setSchedules] = useState<DataConnectDiscoverSchedule[]>([]);
-  const [tasks, setTasks] = useState<DataConnectDiscoverTask[]>([]);
+  const [tasks, setTasks] = useState<DataConnectDiscoverTaskSummary[]>([]);
   const [schedulePage, setSchedulePage] = useState(1);
   const [schedulePageSize, setSchedulePageSize] = useState(10);
   const [scheduleTotal, setScheduleTotal] = useState(0);
@@ -416,7 +417,7 @@ export function DataConnectDiscoverScene({
     },
   ];
 
-  const taskColumns: ColumnsType<DataConnectDiscoverTask> = [
+  const taskColumns: ColumnsType<DataConnectDiscoverTaskSummary> = [
     { dataIndex: "id", title: "ID", width: 160, ellipsis: true },
     {
       dataIndex: "scheduleId",
@@ -428,13 +429,13 @@ export function DataConnectDiscoverScene({
       dataIndex: "strategy",
       title: t("dataConnect.discoverStrategy"),
       width: 130,
-      render: (value: DataConnectDiscoverTask["strategy"]) => t(`dataConnect.discoverStrategies.${value}`),
+      render: (value: DataConnectDiscoverTaskSummary["strategy"]) => t(`dataConnect.discoverStrategies.${value}`),
     },
     {
       dataIndex: "triggerType",
       title: t("dataConnect.discoverTriggerType"),
       width: 120,
-      render: (value: DataConnectDiscoverTask["triggerType"]) => t(`dataConnect.discoverTriggerTypes.${value}`),
+      render: (value: DataConnectDiscoverTaskSummary["triggerType"]) => t(`dataConnect.discoverTriggerTypes.${value}`),
     },
     {
       dataIndex: "status",
@@ -830,7 +831,7 @@ export function DataConnectDiscoverScene({
             title={t("dataConnect.discoverTaskEmpty")}
           />
         ) : (
-          <AppTable<DataConnectDiscoverTask>
+          <AppTable<DataConnectDiscoverTaskSummary>
             columns={taskColumns}
             dataSource={tasks}
             loading={loadingTasks}

--- a/src/modules/data-connect/services/discover.service.ts
+++ b/src/modules/data-connect/services/discover.service.ts
@@ -17,6 +17,7 @@ import type {
   DataConnectDiscoverTaskListQuery,
   DataConnectDiscoverTaskListResult,
   DataConnectDiscoverTaskStatus,
+  DataConnectDiscoverTaskSummary,
   DataConnectDiscoverTaskTriggerType,
 } from "@/modules/data-connect/types/discover";
 
@@ -67,6 +68,10 @@ type BackendDiscoverTask = {
   status?: string;
   strategy?: string;
   trigger_type?: string;
+};
+
+type BackendDiscoverTaskSummary = Omit<BackendDiscoverTask, "message" | "result"> & {
+  result?: Omit<NonNullable<BackendDiscoverTask["result"]>, "message">;
 };
 
 type ListResponse<T> = {
@@ -276,6 +281,43 @@ function mapTask(item: BackendDiscoverTask): DataConnectDiscoverTask {
   };
 }
 
+function toTaskSummary(task: DataConnectDiscoverTask): DataConnectDiscoverTaskSummary {
+  const fullResult = task.result;
+  const result = fullResult
+    ? {
+        catalogId: fullResult.catalogId,
+        failedCount: fullResult.failedCount,
+        newCount: fullResult.newCount,
+        restoredCount: fullResult.restoredCount,
+        staleCount: fullResult.staleCount,
+        unchangedCount: fullResult.unchangedCount,
+        updatedCount: fullResult.updatedCount,
+      }
+    : undefined;
+
+  return {
+    catalogId: task.catalogId,
+    catalogName: task.catalogName,
+    createTime: task.createTime,
+    creatorName: task.creatorName,
+    finishTime: task.finishTime,
+    finishTimeValue: task.finishTimeValue,
+    id: task.id,
+    progress: task.progress,
+    result,
+    scheduleId: task.scheduleId,
+    startTime: task.startTime,
+    startTimeValue: task.startTimeValue,
+    status: task.status,
+    strategy: task.strategy,
+    triggerType: task.triggerType,
+  };
+}
+
+function mapTaskSummary(item: BackendDiscoverTaskSummary): DataConnectDiscoverTaskSummary {
+  return toTaskSummary(mapTask(item));
+}
+
 function filterSchedules(
   items: DataConnectDiscoverSchedule[],
   query: DataConnectDiscoverScheduleListQuery,
@@ -311,10 +353,6 @@ function filterTasks(items: DataConnectDiscoverTask[], query: DataConnectDiscove
       matchesTriggerType
     );
   });
-  if (query.sort === "default") {
-    const rank = { running: 1, pending: 2, failed: 3, completed: 4 };
-    return filtered.sort((left, right) => rank[left.status] - rank[right.status] || right.createTime.localeCompare(left.createTime));
-  }
   const direction = query.direction === "asc" ? 1 : -1;
   const valueOf = (item: DataConnectDiscoverTask) => item.createTime;
   return filtered.sort((left, right) => (valueOf(left) > valueOf(right) ? direction : valueOf(left) < valueOf(right) ? -direction : 0));
@@ -484,12 +522,12 @@ export async function listDataConnectDiscoverTasks(
     const startIndex = (query.page - 1) * query.pageSize;
 
     return wait({
-      items: filtered.slice(startIndex, startIndex + query.pageSize),
+      items: filtered.slice(startIndex, startIndex + query.pageSize).map(toTaskSummary),
       total: filtered.length,
     });
   }
 
-  const response = await http.get<ListResponse<BackendDiscoverTask>>(
+  const response = await http.get<ListResponse<BackendDiscoverTaskSummary>>(
     "/vega-backend/v1/discover-tasks",
     {
       params: {
@@ -507,7 +545,7 @@ export async function listDataConnectDiscoverTasks(
   );
 
   return {
-    items: response.data.entries.map(mapTask),
+    items: response.data.entries.map(mapTaskSummary),
     total: response.data.total_count,
   };
 }

--- a/src/modules/data-connect/types/discover.ts
+++ b/src/modules/data-connect/types/discover.ts
@@ -17,7 +17,7 @@ export type DataConnectDiscoverTaskStatus =
   | "running";
 
 export type DataConnectDiscoverTaskTriggerType = "manual" | "scheduled";
-export type DataConnectDiscoverTaskSort = "create_time" | "default";
+export type DataConnectDiscoverTaskSort = "create_time";
 
 export type DataConnectDiscoverSchedule = {
   catalogId: string;
@@ -60,6 +60,13 @@ export type DataConnectDiscoverTask = {
   triggerType: DataConnectDiscoverTaskTriggerType;
 };
 
+export type DataConnectDiscoverTaskSummary = Omit<
+  DataConnectDiscoverTask,
+  "message" | "result"
+> & {
+  result?: DataConnectDiscoverTaskResultSummary;
+};
+
 export type DataConnectDiscoverResult = {
   catalogId: string;
   failedCount: number;
@@ -70,6 +77,11 @@ export type DataConnectDiscoverResult = {
   unchangedCount: number;
   updatedCount: number;
 };
+
+export type DataConnectDiscoverTaskResultSummary = Omit<
+  DataConnectDiscoverResult,
+  "message"
+>;
 
 export type DataConnectDiscoverScheduleListQuery = {
   catalogId?: string;
@@ -97,7 +109,7 @@ export type DataConnectDiscoverScheduleListResult = {
 };
 
 export type DataConnectDiscoverTaskListResult = {
-  items: DataConnectDiscoverTask[];
+  items: DataConnectDiscoverTaskSummary[];
   total: number;
 };
 


### PR DESCRIPTION
## What Changed

- [x] 语义理解、探查和索引构建三个任务列表改为消费各自的 Summary 契约；详情抽屉/详情接口继续使用完整类型。
- [x] 收紧语义理解 Summary 的必返字段契约，移除会渲染成虚假数据的默认值，并补齐 mapper/查询参数单测。
- [x] 对齐必返的 `creator` 契约，移除详情抽屉的冗余空值分支，并补齐 mock 数据。
- [x] 三类任务列表默认统一按创建时间倒序；移除前端的 `default` 排序分支。
- [x] 将全局 HTTP 请求超时调整为 30 秒。

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#752
- Related Feature: N/A
- Background: 后端列表接口已收敛为 Summary，Studio 不能继续依赖详情字段；大响应会造成任务列表超时，需要为请求预留合理处理时间。

---

## How

- Key implementation points: 保留完整任务类型与详情 mapper；List 使用 Summary 类型；用 `index_health` 处理索引构建列表缺少 index config 的状态展示；查询参数统一默认 `create_time desc` / `created_at desc`。
- Breaking changes (API, config, database, etc.): 全局 HTTP 超时从 15 秒增至 30 秒；前端不再发送或支持 `default` 任务排序值。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable)
- [ ] Verified in test environment (not run)

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run` (167 test files / 850 tests)
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` (1 high vulnerability is marked ignored; command exited successfully)

---

## Risk & Rollback

- Potential risks: API-compatible backend/frontend versions must be deployed together; global timeout makes failures surface later; callers sending old `default` sort values will receive a backend validation error after backend upgrade.
- Rollback plan: Revert commits `a1e7d7c`, `12813be`, `272a3b5`, `8887f7f`, and `2e97978`.

---

## Additional Notes

- Merge/deploy with Foundry PR 754 so Summary contracts and consumers remain compatible.