### PR TITLE
fix: guard action MCP calls in agent chat

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -43,7 +43,6 @@ import {
   buildAgentTools,
   effectiveToolArgs,
   guardAgentToolArgs,
-  isClientGuardedActionTool,
   isTakenOverLifecycleTool,
   formatOutputContract,
   formatToolResultLimits,
@@ -634,7 +633,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
               (() => {
                 const bknContext = turnContextRef.current ?? undefined;
                 const effectiveArgs = effectiveToolArgs(chunk.name, chunk.args, knId, bknContext);
-                const clientBlocked = isClientGuardedActionTool(chunk.name) && !!guardAgentToolArgs(chunk.name, effectiveArgs);
+                const clientBlocked = !!guardAgentToolArgs(chunk.name, effectiveArgs);
                 return {
                   id: chunk.id,
                   name: chunk.name,
@@ -647,7 +646,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
                 // 照原样显示模型入参。判定必须用 isTakenOverLifecycleTool 而不是整片 bkn_
                 // 前缀——溯源类平台工具是直通后端的，它们的请求体真实存在，按前缀判会把
                 // 那些也显示成没有请求体，等于反向再造一次失真。没有 turn 时两类都直通。
-                  args: turnContextRef.current && (isTakenOverLifecycleTool(chunk.name) || clientBlocked) ? chunk.args : effectiveArgs,
+                  args: clientBlocked || (turnContextRef.current && isTakenOverLifecycleTool(chunk.name)) ? chunk.args : effectiveArgs,
                   status: "running" as const,
                   clientBlocked,
                   startedAt: performance.now(),

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -42,6 +42,8 @@ import type { LlmModel } from "@/modules/model-resources/types/llm";
 import {
   buildAgentTools,
   effectiveToolArgs,
+  guardAgentToolArgs,
+  isClientGuardedActionTool,
   isTakenOverLifecycleTool,
   formatOutputContract,
   formatToolResultLimits,
@@ -156,6 +158,7 @@ type ToolCallView = {
   status: "running" | "done" | "error";
   result?: string;
   error?: string;
+  clientBlocked?: boolean;
   startedAt: number;
   latencyMs?: number;
 };
@@ -333,7 +336,14 @@ function ToolCallCard({ call }: { call: ToolCallView }) {
   const statusDot =
     call.status === "running" ? styles.dotRunning : call.status === "error" ? styles.dotError : styles.dotOk;
   const statusText =
-    call.status === "running" ? "调用中…" : call.status === "error" ? "失败" : `200 · ${call.latencyMs ?? "—"}ms`;
+    call.clientBlocked
+      ? "客户端拦截"
+      : call.status === "running"
+        ? "调用中…"
+        : call.status === "error"
+          ? "失败"
+          : `200 · ${call.latencyMs ?? "—"}ms`;
+  const requestLabel = call.clientBlocked ? `模型入参 · 客户端拦截未发出 → ${call.name}` : `请求 · tools/call → ${call.name}`;
   return (
     <div className={`${styles.call} ${open ? styles.callOpen : ""}`}>
       <button type="button" className={styles.callHead} onClick={() => setOpen((v) => !v)}>
@@ -346,11 +356,11 @@ function ToolCallCard({ call }: { call: ToolCallView }) {
       {open ? (
         <div className={styles.callBody}>
           <div className={styles.callSec}>
-            <div className={styles.callLbl}>请求 · tools/call → {call.name}</div>
+            <div className={styles.callLbl}>{requestLabel}</div>
             <pre className={styles.callPre}>{formatArgs(call.args)}</pre>
           </div>
           <div className={styles.callSec}>
-            <div className={styles.callLbl}>{call.status === "error" ? "错误" : "响应"}</div>
+            <div className={styles.callLbl}>{call.clientBlocked ? "拦截原因" : call.status === "error" ? "错误" : "响应"}</div>
             <pre className={styles.callPre}>{call.status === "error" ? call.error : call.result ?? "—"}</pre>
           </div>
         </div>
@@ -621,9 +631,13 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
             ...m,
             toolCalls: [
               ...(m.toolCalls ?? []),
-              {
-                id: chunk.id,
-                name: chunk.name,
+              (() => {
+                const bknContext = turnContextRef.current ?? undefined;
+                const effectiveArgs = effectiveToolArgs(chunk.name, chunk.args, knId, bknContext);
+                const clientBlocked = isClientGuardedActionTool(chunk.name) && !!guardAgentToolArgs(chunk.name, effectiveArgs);
+                return {
+                  id: chunk.id,
+                  name: chunk.name,
                 // 展示实际发出的业务请求体（含注入的 kn_id、schema_brief 等默认值与 bkn_context），
                 // 而非模型原始入参。bkn_context 是 execute 里注入的，流式事件里没有，取自本轮 turn ——
                 // 少了它，面板看起来就像"前端没传上下文"，排查 conversation_required 时会指错方向。
@@ -633,13 +647,12 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
                 // 照原样显示模型入参。判定必须用 isTakenOverLifecycleTool 而不是整片 bkn_
                 // 前缀——溯源类平台工具是直通后端的，它们的请求体真实存在，按前缀判会把
                 // 那些也显示成没有请求体，等于反向再造一次失真。没有 turn 时两类都直通。
-                args:
-                  turnContextRef.current && isTakenOverLifecycleTool(chunk.name)
-                    ? chunk.args
-                    : effectiveToolArgs(chunk.name, chunk.args, knId, turnContextRef.current ?? undefined),
-                status: "running",
-                startedAt: performance.now(),
-              },
+                  args: turnContextRef.current && (isTakenOverLifecycleTool(chunk.name) || clientBlocked) ? chunk.args : effectiveArgs,
+                  status: "running" as const,
+                  clientBlocked,
+                  startedAt: performance.now(),
+                };
+              })(),
             ],
           }));
           break;

--- a/src/modules/knowledge-network/services/agent-chat-argument-guards.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat-argument-guards.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { buildAgentTools, DEFAULT_AGENT_CONFIG } from "@/modules/knowledge-network/services/agent-chat.service";
+import type {
+  McpSession,
+  McpToolCallResult,
+  McpToolDef,
+} from "@/modules/knowledge-network/services/context-loader.service";
+
+const env = { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" };
+const tokenProvider = { getToken: () => "token-1", refresh: () => Promise.resolve("token-1") };
+
+function stubSession(result?: Partial<McpToolCallResult>) {
+  const callTool = vi.fn<McpSession["callTool"]>().mockResolvedValue({
+    ok: true,
+    text: "ok",
+    latencyMs: 1,
+    isError: false,
+    ...result,
+  });
+  return { callTool } satisfies McpSession;
+}
+
+function managedTurn() {
+  return {
+    nextContext: () => ({ conversation_id: "conv_1", interaction_id: "int_1" }),
+    finish: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function runTool(tool: unknown, input: unknown): Promise<string> {
+  const execute = (tool as { execute: (input: unknown, options: unknown) => Promise<string> }).execute;
+  return execute(input, { toolCallId: "call-1", messages: [] });
+}
+
+function buildTool(name: string, session: McpSession) {
+  const toolDef: McpToolDef = { name };
+  const tools = buildAgentTools([toolDef], env, "kn-demo", DEFAULT_AGENT_CONFIG, tokenProvider, {
+    session,
+    turn: managedTurn(),
+  });
+  return tools[name];
+}
+
+describe("agent MCP argument guards", () => {
+  it("blocks get_action_info when instance identities are missing", async () => {
+    const session = stubSession();
+    const result = await runTool(buildTool("get_action_info", session), { at_id: "at_1" });
+
+    expect(session.callTool).not.toHaveBeenCalled();
+    expect(JSON.parse(result)).toMatchObject({
+      error: {
+        code: "missing_action_recall_scope",
+        required_fields: ["_instance_identities"],
+      },
+    });
+  });
+
+  it("allows get_action_info when the target instances are explicit", async () => {
+    const session = stubSession();
+    const result = await runTool(buildTool("get_action_info", session), {
+      at_id: "at_1",
+      _instance_identities: [{ id: "instance_1" }],
+    });
+
+    expect(result).toBe("ok");
+    expect(session.callTool).toHaveBeenCalledWith(
+      "get_action_info",
+      expect.objectContaining({
+        kn_id: "kn-demo",
+        at_id: "at_1",
+        _instance_identities: [{ id: "instance_1" }],
+        bkn_context: { conversation_id: "conv_1", interaction_id: "int_1" },
+      }),
+    );
+  });
+
+  it("blocks execute_action when target instances or dynamic params are missing", async () => {
+    const session = stubSession();
+    const result = await runTool(buildTool("execute_action", session), { at_id: "at_1" });
+
+    expect(session.callTool).not.toHaveBeenCalled();
+    expect(JSON.parse(result)).toMatchObject({
+      error: {
+        code: "unsafe_action_call",
+        required_fields: ["_instance_identities", "dynamic_params"],
+      },
+    });
+  });
+
+  it("allows execute_action when the execution target and params are explicit", async () => {
+    const session = stubSession();
+    const result = await runTool(buildTool("execute_action", session), {
+      at_id: "at_1",
+      _instance_identities: [{ id: "instance_1" }],
+      dynamic_params: {},
+    });
+
+    expect(result).toBe("ok");
+    expect(session.callTool).toHaveBeenCalledWith(
+      "execute_action",
+      expect.objectContaining({
+        kn_id: "kn-demo",
+        at_id: "at_1",
+        _instance_identities: [{ id: "instance_1" }],
+        dynamic_params: {},
+      }),
+    );
+  });
+});

--- a/src/modules/knowledge-network/services/agent-chat-argument-guards.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat-argument-guards.test.ts
@@ -52,15 +52,20 @@ function buildTool(name: string, session: McpSession) {
 describe("agent MCP argument guards", () => {
   it("blocks get_action_info when instance identities are missing", async () => {
     const session = stubSession();
-    const result = await runTool(buildTool("get_action_info", session), { at_id: "at_1" });
+    await expect(runTool(buildTool("get_action_info", session), { at_id: "at_1" })).rejects.toThrow(
+      "missing_action_recall_scope",
+    );
 
     expect(session.callTool).not.toHaveBeenCalled();
-    expect(JSON.parse(result)).toMatchObject({
-      error: {
-        code: "missing_action_recall_scope",
-        required_fields: ["_instance_identities"],
-      },
-    });
+  });
+
+  it("blocks get_action_info when instance identities are empty", async () => {
+    const session = stubSession();
+    await expect(
+      runTool(buildTool("get_action_info", session), { at_id: "at_1", _instance_identities: [] }),
+    ).rejects.toThrow("missing_action_recall_scope");
+
+    expect(session.callTool).not.toHaveBeenCalled();
   });
 
   it("allows get_action_info when the target instances are explicit", async () => {
@@ -84,15 +89,35 @@ describe("agent MCP argument guards", () => {
 
   it("blocks execute_action when target instances or dynamic params are missing", async () => {
     const session = stubSession();
-    const result = await runTool(buildTool("execute_action", session), { at_id: "at_1" });
+    await expect(runTool(buildTool("execute_action", session), { at_id: "at_1" })).rejects.toThrow("unsafe_action_call");
 
     expect(session.callTool).not.toHaveBeenCalled();
-    expect(JSON.parse(result)).toMatchObject({
-      error: {
-        code: "unsafe_action_call",
-        required_fields: ["_instance_identities", "dynamic_params"],
-      },
-    });
+  });
+
+  it("blocks execute_action when instance identities are empty", async () => {
+    const session = stubSession();
+    await expect(
+      runTool(buildTool("execute_action", session), {
+        at_id: "at_1",
+        _instance_identities: [],
+        dynamic_params: {},
+      }),
+    ).rejects.toThrow("unsafe_action_call");
+
+    expect(session.callTool).not.toHaveBeenCalled();
+  });
+
+  it("blocks execute_action when dynamic params are not an object", async () => {
+    const session = stubSession();
+    await expect(
+      runTool(buildTool("execute_action", session), {
+        at_id: "at_1",
+        _instance_identities: [{ id: "instance_1" }],
+        dynamic_params: null,
+      }),
+    ).rejects.toThrow("unsafe_action_call");
+
+    expect(session.callTool).not.toHaveBeenCalled();
   });
 
   it("allows execute_action when the execution target and params are explicit", async () => {
@@ -111,6 +136,20 @@ describe("agent MCP argument guards", () => {
         at_id: "at_1",
         _instance_identities: [{ id: "instance_1" }],
         dynamic_params: {},
+      }),
+    );
+  });
+
+  it("does not block non-action tools", async () => {
+    const session = stubSession();
+    const result = await runTool(buildTool("run_sql", session), { sql: "select 1" });
+
+    expect(result).toBe("ok");
+    expect(session.callTool).toHaveBeenCalledWith(
+      "run_sql",
+      expect.objectContaining({
+        kn_id: "kn-demo",
+        sql: "select 1",
       }),
     );
   });

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -155,6 +155,63 @@ export function effectiveToolArgs(
  * properties + required，原样喂给模型会让模型自己编 conversation/interaction id；
  * 真值由 execute 注入，模型不该看见这个字段。
  */
+function isNonEmptyArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.length > 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function toolGuardError(code: string, message: string, requiredFields: string[]): string {
+  return JSON.stringify({
+    error: {
+      code,
+      message,
+      required_fields: requiredFields,
+      retryable: false,
+    },
+  });
+}
+
+/**
+ * Blocks high-risk business tools when missing fields would broaden the call
+ * from an instance-level intent into broad recall, broad query, or execution.
+ */
+export function guardAgentToolArgs(name: string, args: Record<string, unknown>): string | null {
+  if (name === "get_action_info") {
+    const missing = [
+      ...(typeof args.at_id === "string" && args.at_id.trim() ? [] : ["at_id"]),
+      ...(isNonEmptyArray(args._instance_identities) ? [] : ["_instance_identities"]),
+    ];
+    if (missing.length) {
+      return toolGuardError(
+        "missing_action_recall_scope",
+        "get_action_info requires at_id and non-empty _instance_identities. Ask the user to select target instances, or query candidate instances first.",
+        missing,
+      );
+    }
+  }
+
+  if (name === "execute_action") {
+    const hasDynamicParams = Object.prototype.hasOwnProperty.call(args, "dynamic_params") && isPlainObject(args.dynamic_params);
+    const missing = [
+      ...(typeof args.at_id === "string" && args.at_id.trim() ? [] : ["at_id"]),
+      ...(isNonEmptyArray(args._instance_identities) ? [] : ["_instance_identities"]),
+      ...(hasDynamicParams ? [] : ["dynamic_params"]),
+    ];
+    if (missing.length) {
+      return toolGuardError(
+        "unsafe_action_call",
+        "execute_action was blocked because target instances or dynamic_params are missing. Confirm the execution target and parameters before executing the action.",
+        missing,
+      );
+    }
+  }
+
+  return null;
+}
+
 function stripBknContextSchema(schema: Record<string, unknown>): Record<string, unknown> {
   const properties = schema.properties;
   if (!properties || typeof properties !== "object" || !("bkn_context" in properties)) return schema;
@@ -340,6 +397,8 @@ export function buildAgentTools(
         const bknContext = turn?.nextContext();
         if (scopedList && scopeSet) return listResourcesScoped(call, input, knId, scopeSet, cfg, bknContext);
         const args = effectiveToolArgs(def.name, input, knId, bknContext);
+        const guardError = guardAgentToolArgs(def.name, args);
+        if (guardError) return guardError;
         return capToolResult(await call(def.name, args), def.name, cfg);
       },
     });

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -121,6 +121,10 @@ const TOOL_HINTS: Record<string, string> = {
   list_resources: " 【重要】用 catalog_id/type 过滤 + 小 limit 分页；结果过大会被截断。",
   search_schema:
     " 建议：用精确的 query，max_concepts 默认不超过 10；结果过大会被截断。schema_brief 默认 true（只返回概要），需要完整字段定义时显式传 schema_brief=false。",
+  get_action_info:
+    " 【重要】必须先从 query_object_instance 或 query_instance_subgraph 的 _instance_identity 取得真实实例标识，再传非空 _instance_identities；不要自己编实例标识。",
+  execute_action:
+    " 【重要】必须传非空 _instance_identities 和 dynamic_params；智能问答中不允许空实例扫描执行，目标实例必须来自上游查询返回的 _instance_identity。",
 };
 
 /** 所有工具通用的默认 arguments：TOON 紧凑文本比 JSON 省大量 token（模型显式传值优先）。 */
@@ -155,6 +159,18 @@ export function effectiveToolArgs(
  * properties + required，原样喂给模型会让模型自己编 conversation/interaction id；
  * 真值由 execute 注入，模型不该看见这个字段。
  */
+function stripBknContextSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const properties = schema.properties;
+  if (!properties || typeof properties !== "object" || !("bkn_context" in properties)) return schema;
+  const nextProperties = { ...(properties as Record<string, unknown>) };
+  delete nextProperties.bkn_context;
+  const next: Record<string, unknown> = { ...schema, properties: nextProperties };
+  if (Array.isArray(schema.required)) {
+    next.required = schema.required.filter((name) => name !== "bkn_context");
+  }
+  return next;
+}
+
 function isNonEmptyArray(value: unknown): value is unknown[] {
   return Array.isArray(value) && value.length > 0;
 }
@@ -187,7 +203,7 @@ export function guardAgentToolArgs(name: string, args: Record<string, unknown>):
     if (missing.length) {
       return toolGuardError(
         "missing_action_recall_scope",
-        "get_action_info requires at_id and non-empty _instance_identities. Ask the user to select target instances, or query candidate instances first.",
+        "get_action_info 需要 at_id 和非空 _instance_identities。请先让用户选择目标实例，或先查询候选实例并使用返回的 _instance_identity。",
         missing,
       );
     }
@@ -203,7 +219,7 @@ export function guardAgentToolArgs(name: string, args: Record<string, unknown>):
     if (missing.length) {
       return toolGuardError(
         "unsafe_action_call",
-        "execute_action was blocked because target instances or dynamic_params are missing. Confirm the execution target and parameters before executing the action.",
+        "execute_action 已被客户端拦截：缺少目标实例或 dynamic_params。请先确认执行对象和动态参数，再重新调用本工具。",
         missing,
       );
     }
@@ -212,16 +228,8 @@ export function guardAgentToolArgs(name: string, args: Record<string, unknown>):
   return null;
 }
 
-function stripBknContextSchema(schema: Record<string, unknown>): Record<string, unknown> {
-  const properties = schema.properties;
-  if (!properties || typeof properties !== "object" || !("bkn_context" in properties)) return schema;
-  const nextProperties = { ...(properties as Record<string, unknown>) };
-  delete nextProperties.bkn_context;
-  const next: Record<string, unknown> = { ...schema, properties: nextProperties };
-  if (Array.isArray(schema.required)) {
-    next.required = schema.required.filter((name) => name !== "bkn_context");
-  }
-  return next;
+export function isClientGuardedActionTool(name: string): boolean {
+  return name === "get_action_info" || name === "execute_action";
 }
 
 /**
@@ -398,7 +406,7 @@ export function buildAgentTools(
         if (scopedList && scopeSet) return listResourcesScoped(call, input, knId, scopeSet, cfg, bknContext);
         const args = effectiveToolArgs(def.name, input, knId, bknContext);
         const guardError = guardAgentToolArgs(def.name, args);
-        if (guardError) return guardError;
+        if (guardError) throw new Error(guardError);
         return capToolResult(await call(def.name, args), def.name, cfg);
       },
     });

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -228,10 +228,6 @@ export function guardAgentToolArgs(name: string, args: Record<string, unknown>):
   return null;
 }
 
-export function isClientGuardedActionTool(name: string): boolean {
-  return name === "get_action_info" || name === "execute_action";
-}
-
 /**
  * 步间驱逐旧工具结果：每步前只保留最近 keep 个工具结果的全文，更早的把内容替换成占位，
  * 但**保留 toolCallId / toolName 配对**（OpenAI 要求每个 tool_call 都有对应 tool 响应）。keep<=0 不驱逐。


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Add argument guards before agent chat calls high-risk action MCP tools
- [x] Block get_action_info when at_id or _instance_identities is missing
- [x] Block execute_action when at_id, _instance_identities, or dynamic_params is missing
- [x] Add focused regression tests for blocked and allowed calls

---

## Why

- Related Issue: N/A - release hardening for 0.1.3 action MCP behavior
- Related Feature: Knowledge Network intelligent Q&A action execution
- Background:
  Intelligent Q&A could call get_action_info with only at_id and without concrete instance identities, while MCP Debug examples include _instance_identities. This made action recall scope ambiguous and increased the risk of broad or unsafe action calls.

---

## How

- Key implementation points:
  - Inject kn_id and bkn_context as before, then validate effective tool arguments before calling MCP.
  - Require get_action_info to include at_id and non-empty _instance_identities.
  - Require execute_action to include at_id, non-empty _instance_identities, and dynamic_params.
  - Return structured JSON errors instead of calling MCP when required business arguments are missing.
- Breaking changes (API, config, database, etc.):
  - No backend API/config/database changes.
  - Behavior change in intelligent Q&A: action tools are more conservative and will not call get_action_info/execute_action without explicit target instances.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally - not run; UI/manual environment not available in this task
- [ ] Verified in test environment - not run; needs deployed environment

Test notes:

- Passed: `node scripts/check-license-headers.mjs`
- Passed: `git diff --check`
- Passed: `node --max-old-space-size=8192 .\\node_modules\\eslint\\bin\\eslint.js src/modules/knowledge-network/services/agent-chat.service.ts src/modules/knowledge-network/services/agent-chat-argument-guards.test.ts --config eslint.config.typechecked.js --max-warnings 0`
- Passed: `node --max-old-space-size=8192 .\\node_modules\\vitest\\vitest.mjs run src/modules/knowledge-network/services/agent-chat.service.test.ts src/modules/knowledge-network/services/agent-chat-tools.test.ts src/modules/knowledge-network/services/agent-chat-argument-guards.test.ts --pool=forks --poolOptions.forks.singleFork`
- Skipped by requester: full test suite / full quality gate.
- Earlier attempts at full typechecked ESLint, full Vitest, and tsc/build in this Windows environment failed with Node/V8 out-of-memory before producing code diagnostics.

---

## Risk & Rollback

- Potential risks:
  - Intelligent Q&A can no longer call get_action_info using only at_id.
  - Users must first provide/select instances or the agent must query candidate instances before recalling/executing actions.
  - Empty-instance scan execution is intentionally blocked in the intelligent Q&A path.
- Rollback plan:
  - Revert this commit to restore the previous permissive action MCP call behavior.

---

## Additional Notes

- Target branch: release/0.1.3