### PR TITLE
fix(auth): stop concurrent tabs from clobbering the login CSRF cookie

### DIFF
--- a/src/app/locales/resources/auth/en-US.ts
+++ b/src/app/locales/resources/auth/en-US.ts
@@ -10,6 +10,9 @@ export const authEnUS = {
     signInSubtitle: "Sign in to access the business knowledge network console",
     signInButton: "Sign In",
     devTokenToggle: "Sign in with a token (dev mode)",
+    signInOtherTabTitle: "Another tab is signing in",
+    signInOtherTabHint:
+      "Finish signing in there, or use the button below to restart the sign-in from this tab.",
     callbackProcessing: "Completing sign-in…",
     callbackErrorTitle: "Sign-in failed",
     backToSignIn: "Back to sign-in",

--- a/src/app/locales/resources/auth/zh-CN.ts
+++ b/src/app/locales/resources/auth/zh-CN.ts
@@ -10,6 +10,8 @@ export const authZhCN = {
     signInSubtitle: "登录后访问业务知识网络控制台",
     signInButton: "登 录",
     devTokenToggle: "使用 Token 登录（开发模式）",
+    signInOtherTabTitle: "另一个标签页正在登录",
+    signInOtherTabHint: "请在那个标签页完成登录。也可以点击下方按钮，改由本页面重新发起登录。",
     callbackProcessing: "正在完成登录…",
     callbackErrorTitle: "登录失败",
     backToSignIn: "返回登录",

--- a/src/framework/auth/OAuthCallback.test.tsx
+++ b/src/framework/auth/OAuthCallback.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OAuthCallback } from "@/framework/auth/OAuthCallback";
+
+const oauth = vi.hoisted(() => ({
+  beginLogin: vi.fn(() => Promise.resolve()),
+  completeLogin: vi.fn(() => Promise.resolve("/studio/")),
+  consumeCsrfRetry: vi.fn(() => true),
+  getStoredReturnTo: vi.fn(() => "/studio/knowledge-network"),
+  isCsrfConflictCallback: vi.fn(() => false),
+  releaseFlowLock: vi.fn(),
+  stashCallbackError: vi.fn(),
+  takeStashedCallbackError: vi.fn(() => null as string | null),
+}));
+
+vi.mock("@/framework/auth/oauth", () => oauth);
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const original = await importOriginal<typeof import("react-i18next")>();
+  return { ...original, useTranslation: () => ({ t: (key: string) => key }) };
+});
+
+vi.mock("@/app/router/app-paths", () => ({
+  getAppHomePath: () => "/studio/",
+}));
+
+describe("OAuthCallback CSRF recovery wiring", () => {
+  beforeEach(() => {
+    for (const spy of Object.values(oauth)) {
+      if (typeof spy === "function" && "mockClear" in spy) {
+        spy.mockClear();
+      }
+    }
+    oauth.isCsrfConflictCallback.mockReturnValue(false);
+    oauth.consumeCsrfRetry.mockReturnValue(true);
+    oauth.completeLogin.mockResolvedValue("/studio/");
+    oauth.takeStashedCallbackError.mockReturnValue(null);
+  });
+
+  it("exchanges the code on a normal callback", () => {
+    render(<OAuthCallback />);
+
+    expect(oauth.completeLogin).toHaveBeenCalledTimes(1);
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+    // The retry budget must survive a successful callback.
+    expect(oauth.consumeCsrfRetry).not.toHaveBeenCalled();
+  });
+
+  it("restarts the flow instead of stranding the user on a stale-CSRF error", () => {
+    oauth.isCsrfConflictCallback.mockReturnValue(true);
+
+    render(<OAuthCallback />);
+
+    expect(oauth.beginLogin).toHaveBeenCalledWith("/studio/knowledge-network");
+    expect(oauth.completeLogin).not.toHaveBeenCalled();
+    expect(oauth.stashCallbackError).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through to the error page once the retry budget is spent", async () => {
+    oauth.isCsrfConflictCallback.mockReturnValue(true);
+    oauth.consumeCsrfRetry.mockReturnValue(false);
+    oauth.completeLogin.mockRejectedValue(new Error("second attempt failed"));
+    oauth.takeStashedCallbackError.mockReturnValue("the original reason");
+
+    render(<OAuthCallback />);
+
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+    expect(oauth.completeLogin).toHaveBeenCalledTimes(1);
+    // The retry's own message describes the retry, not the real cause.
+    expect(await screen.findByText("the original reason")).toBeTruthy();
+    expect(oauth.releaseFlowLock).toHaveBeenCalled();
+  });
+
+  it("releases the flow lock when the callback fails outright", async () => {
+    oauth.completeLogin.mockRejectedValue(new Error("OAuth state mismatch"));
+
+    render(<OAuthCallback />);
+
+    expect(await screen.findByText("OAuth state mismatch")).toBeTruthy();
+    expect(oauth.releaseFlowLock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/framework/auth/OAuthCallback.tsx
+++ b/src/framework/auth/OAuthCallback.tsx
@@ -10,7 +10,13 @@ import { Alert, Spin } from "antd";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { completeLogin } from "@/framework/auth/oauth";
+import {
+  beginLogin,
+  completeLogin,
+  consumeCsrfRetry,
+  getStoredReturnTo,
+  isCsrfConflictCallback,
+} from "@/framework/auth/oauth";
 import { AppButton } from "@/framework/ui/common/AppButton";
 
 import styles from "./SignInScreen.module.css";
@@ -26,6 +32,17 @@ export function OAuthCallback() {
       return;
     }
     startedRef.current = true;
+
+    // hydra rejected the authorize request because the browser's login CSRF
+    // cookie belongs to another flow. A fresh /oauth2/auth rewrites the cookie,
+    // so retry once instead of stranding the user on a dead error page — this
+    // is the path a forced first-login password change lands on.
+    if (isCsrfConflictCallback() && consumeCsrfRetry()) {
+      beginLogin(getStoredReturnTo()).catch((cause: unknown) => {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      });
+      return;
+    }
 
     completeLogin()
       .then((returnTo) => {

--- a/src/framework/auth/OAuthCallback.tsx
+++ b/src/framework/auth/OAuthCallback.tsx
@@ -16,6 +16,9 @@ import {
   consumeCsrfRetry,
   getStoredReturnTo,
   isCsrfConflictCallback,
+  releaseFlowLock,
+  stashCallbackError,
+  takeStashedCallbackError,
 } from "@/framework/auth/oauth";
 import { AppButton } from "@/framework/ui/common/AppButton";
 
@@ -37,10 +40,18 @@ export function OAuthCallback() {
     // cookie belongs to another flow. A fresh /oauth2/auth rewrites the cookie,
     // so retry once instead of stranding the user on a dead error page — this
     // is the path a forced first-login password change lands on.
+    const fail = (cause: unknown) => {
+      // This flow is dead — hand the lock back so other tabs stop waiting on
+      // it instead of sitting out the full TTL. Prefer the stashed reason: on
+      // a failed retry the current message describes the retry, not the cause.
+      releaseFlowLock();
+      const original = takeStashedCallbackError();
+      setError(original ?? (cause instanceof Error ? cause.message : String(cause)));
+    };
+
     if (isCsrfConflictCallback() && consumeCsrfRetry()) {
-      beginLogin(getStoredReturnTo()).catch((cause: unknown) => {
-        setError(cause instanceof Error ? cause.message : String(cause));
-      });
+      stashCallbackError();
+      beginLogin(getStoredReturnTo()).catch(fail);
       return;
     }
 
@@ -48,9 +59,7 @@ export function OAuthCallback() {
       .then((returnTo) => {
         window.location.replace(returnTo);
       })
-      .catch((cause: unknown) => {
-        setError(cause instanceof Error ? cause.message : String(cause));
-      });
+      .catch(fail);
   }, []);
 
   return (

--- a/src/framework/auth/SignInScreen.test.tsx
+++ b/src/framework/auth/SignInScreen.test.tsx
@@ -15,6 +15,7 @@ const oauth = vi.hoisted(() => {
   return {
     beginLogin: vi.fn(() => Promise.resolve()),
     canAutoStartLogin: vi.fn(() => true),
+    reloadForSharedAuthState: vi.fn(),
     /** Stand-in for the cross-tab `storage` event; `emit` fires the release. */
     subscribeFlowLockRelease: vi.fn((onRelease: () => void) => {
       listeners.add(onRelease);
@@ -83,7 +84,11 @@ describe("SignInScreen auto-redirect gating", () => {
   // Side-by-side windows are never hidden, so visibilitychange never fires for
   // them — without the lock-release signal they would sit on the wait screen
   // even after the owning tab finished and the credentials became available.
-  it("proceeds on its own once the owning tab releases the lock", async () => {
+  //
+  // A release reaches every waiting tab at once, so they must NOT each start
+  // their own flow: by then the owning tab has written the shared token cookie,
+  // and reloading picks it up without another /oauth2/auth on the wire.
+  it("reloads instead of racing when the owning tab releases the lock", async () => {
     oauth.canAutoStartLogin.mockReturnValue(false);
     render(<SignInScreen onDevTokenSaved={vi.fn()} />);
     expect(await screen.findByText("auth.signInOtherTabTitle")).toBeTruthy();
@@ -93,7 +98,8 @@ describe("SignInScreen auto-redirect gating", () => {
       oauth.emitFlowLockRelease();
     });
 
-    expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+    expect(oauth.reloadForSharedAuthState).toHaveBeenCalledTimes(1);
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
   });
 
   it("defers to another tab's in-flight login and offers a manual takeover", async () => {

--- a/src/framework/auth/SignInScreen.test.tsx
+++ b/src/framework/auth/SignInScreen.test.tsx
@@ -10,10 +10,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SignInScreen } from "@/framework/auth/SignInScreen";
 
-const oauth = vi.hoisted(() => ({
-  beginLogin: vi.fn(() => Promise.resolve()),
-  canAutoStartLogin: vi.fn(() => true),
-}));
+const oauth = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  return {
+    beginLogin: vi.fn(() => Promise.resolve()),
+    canAutoStartLogin: vi.fn(() => true),
+    /** Stand-in for the cross-tab `storage` event; `emit` fires the release. */
+    subscribeFlowLockRelease: vi.fn((onRelease: () => void) => {
+      listeners.add(onRelease);
+      return () => listeners.delete(onRelease);
+    }),
+    emitFlowLockRelease: () => {
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  };
+});
 
 vi.mock("@/framework/auth/oauth", () => oauth);
 
@@ -62,6 +75,22 @@ describe("SignInScreen auto-redirect gating", () => {
     setVisibility("visible");
     act(() => {
       document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+  });
+
+  // Side-by-side windows are never hidden, so visibilitychange never fires for
+  // them — without the lock-release signal they would sit on the wait screen
+  // even after the owning tab finished and the credentials became available.
+  it("proceeds on its own once the owning tab releases the lock", async () => {
+    oauth.canAutoStartLogin.mockReturnValue(false);
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+    expect(await screen.findByText("auth.signInOtherTabTitle")).toBeTruthy();
+
+    oauth.canAutoStartLogin.mockReturnValue(true);
+    act(() => {
+      oauth.emitFlowLockRelease();
     });
 
     expect(oauth.beginLogin).toHaveBeenCalledTimes(1);

--- a/src/framework/auth/SignInScreen.test.tsx
+++ b/src/framework/auth/SignInScreen.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SignInScreen } from "@/framework/auth/SignInScreen";
+
+const oauth = vi.hoisted(() => ({
+  beginLogin: vi.fn(() => Promise.resolve()),
+  canAutoStartLogin: vi.fn(() => true),
+}));
+
+vi.mock("@/framework/auth/oauth", () => oauth);
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const original = await importOriginal<typeof import("react-i18next")>();
+  return { ...original, useTranslation: () => ({ t: (key: string) => key }) };
+});
+
+/** jsdom reports "visible" by default; override per test. */
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+describe("SignInScreen auto-redirect gating", () => {
+  beforeEach(() => {
+    oauth.beginLogin.mockClear();
+    oauth.canAutoStartLogin.mockReset();
+    oauth.canAutoStartLogin.mockReturnValue(true);
+    setVisibility("visible");
+  });
+
+  it("redirects to hydra on its own when nothing else owns the flow", () => {
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+
+    expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+  });
+
+  // A background tab redirecting would rewrite the browser's single login CSRF
+  // cookie and break the tab the user is actually signing in on (issue #387).
+  it("stays put while the tab is hidden", () => {
+    setVisibility("hidden");
+
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+  });
+
+  it("redirects once the hidden tab is brought to the front", () => {
+    setVisibility("hidden");
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+
+    setVisibility("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers to another tab's in-flight login and offers a manual takeover", async () => {
+    oauth.canAutoStartLogin.mockReturnValue(false);
+
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+    expect(await screen.findByText("auth.signInOtherTabTitle")).toBeTruthy();
+
+    // Explicit intent wins: the user is on this tab, so it takes the flow over.
+    act(() => {
+      screen.getByRole("button", { name: "auth.signInButton" }).click();
+    });
+
+    expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/framework/auth/SignInScreen.tsx
+++ b/src/framework/auth/SignInScreen.tsx
@@ -10,7 +10,11 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { DevTokenSetupForm } from "@/framework/auth/DevTokenSetupForm";
-import { beginLogin, canAutoStartLogin } from "@/framework/auth/oauth";
+import {
+  beginLogin,
+  canAutoStartLogin,
+  subscribeFlowLockRelease,
+} from "@/framework/auth/oauth";
 import { AppButton } from "@/framework/ui/common/AppButton";
 
 import styles from "./SignInScreen.module.css";
@@ -64,10 +68,15 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
     setRedirecting(false);
     setDeferredToOtherTab(true);
 
+    // Two wake-ups: coming to the front, and the owning tab releasing the lock
+    // (side-by-side windows are never hidden, so visibilitychange alone would
+    // strand them on the wait screen after the other tab finished).
     const retry = () => void startIfAllowed();
     document.addEventListener("visibilitychange", retry);
+    const unsubscribe = subscribeFlowLockRelease(retry);
     return () => {
       document.removeEventListener("visibilitychange", retry);
+      unsubscribe();
     };
   }, [showDevTokenForm]);
 

--- a/src/framework/auth/SignInScreen.tsx
+++ b/src/framework/auth/SignInScreen.tsx
@@ -13,6 +13,7 @@ import { DevTokenSetupForm } from "@/framework/auth/DevTokenSetupForm";
 import {
   beginLogin,
   canAutoStartLogin,
+  reloadForSharedAuthState,
   subscribeFlowLockRelease,
 } from "@/framework/auth/oauth";
 import { AppButton } from "@/framework/ui/common/AppButton";
@@ -68,12 +69,13 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
     setRedirecting(false);
     setDeferredToOtherTab(true);
 
-    // Two wake-ups: coming to the front, and the owning tab releasing the lock
-    // (side-by-side windows are never hidden, so visibilitychange alone would
-    // strand them on the wait screen after the other tab finished).
+    // Two wake-ups, deliberately different. visibilitychange reaches one tab at
+    // a time, so that tab may start its own flow. A lock release reaches every
+    // waiting tab at once — starting there would put them all on the wire
+    // together, so they reload and pick up the shared cookie instead.
     const retry = () => void startIfAllowed();
     document.addEventListener("visibilitychange", retry);
-    const unsubscribe = subscribeFlowLockRelease(retry);
+    const unsubscribe = subscribeFlowLockRelease(reloadForSharedAuthState);
     return () => {
       document.removeEventListener("visibilitychange", retry);
       unsubscribe();

--- a/src/framework/auth/SignInScreen.tsx
+++ b/src/framework/auth/SignInScreen.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { DevTokenSetupForm } from "@/framework/auth/DevTokenSetupForm";
-import { beginLogin } from "@/framework/auth/oauth";
+import { beginLogin, canAutoStartLogin } from "@/framework/auth/oauth";
 import { AppButton } from "@/framework/ui/common/AppButton";
 
 import styles from "./SignInScreen.module.css";
@@ -24,30 +24,64 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
   const startedRef = useRef(false);
   const [redirecting, setRedirecting] = useState(true);
   const [redirectError, setRedirectError] = useState<string | null>(null);
+  const [deferredToOtherTab, setDeferredToOtherTab] = useState(false);
   const [showDevTokenForm, setShowDevTokenForm] = useState(false);
 
   useEffect(() => {
-    if (showDevTokenForm || startedRef.current) {
+    if (showDevTokenForm) {
       return;
     }
 
-    startedRef.current = true;
-    const { hash, pathname, search } = window.location;
+    // Redirecting to hydra rewrites the browser's single login CSRF cookie, so
+    // a background tab waking up mid-login would break the tab the user is
+    // actually looking at. Only a visible tab that no other flow owns may go on
+    // its own; otherwise wait and offer the manual button, which takes over.
+    const startIfAllowed = () => {
+      if (startedRef.current) {
+        return true;
+      }
+      if (document.visibilityState !== "visible" || !canAutoStartLogin()) {
+        return false;
+      }
 
-    beginLogin(`${pathname}${search}${hash}`).catch((cause: unknown) => {
-      setRedirectError(cause instanceof Error ? cause.message : String(cause));
-      setRedirecting(false);
-      startedRef.current = false;
-    });
+      startedRef.current = true;
+      setDeferredToOtherTab(false);
+      setRedirecting(true);
+      const { hash, pathname, search } = window.location;
+
+      beginLogin(`${pathname}${search}${hash}`).catch((cause: unknown) => {
+        setRedirectError(cause instanceof Error ? cause.message : String(cause));
+        setRedirecting(false);
+        startedRef.current = false;
+      });
+      return true;
+    };
+
+    if (startIfAllowed()) {
+      return;
+    }
+
+    setRedirecting(false);
+    setDeferredToOtherTab(true);
+
+    const retry = () => void startIfAllowed();
+    document.addEventListener("visibilitychange", retry);
+    return () => {
+      document.removeEventListener("visibilitychange", retry);
+    };
   }, [showDevTokenForm]);
 
   if (showDevTokenForm) {
     return <DevTokenSetupForm onSaved={onDevTokenSaved} />;
   }
 
+  // Explicit intent overrides the other-tab lock: the user is here, so this is
+  // the flow that should own the CSRF cookie.
   const handleSignIn = () => {
+    startedRef.current = true;
     setRedirecting(true);
     setRedirectError(null);
+    setDeferredToOtherTab(false);
     const { hash, pathname, search } = window.location;
     void beginLogin(`${pathname}${search}${hash}`).catch((cause: unknown) => {
       setRedirectError(cause instanceof Error ? cause.message : String(cause));
@@ -68,6 +102,25 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
               showIcon
               style={{ marginBottom: 20, textAlign: "left" }}
               type="error"
+            />
+            <AppButton
+              className={styles.submit}
+              loading={redirecting}
+              size="large"
+              type="primary"
+              onClick={handleSignIn}
+            >
+              {t("auth.signInButton")}
+            </AppButton>
+          </>
+        ) : deferredToOtherTab ? (
+          <>
+            <Alert
+              message={t("auth.signInOtherTabTitle")}
+              description={t("auth.signInOtherTabHint")}
+              showIcon
+              style={{ marginBottom: 20, textAlign: "left" }}
+              type="info"
             />
             <AppButton
               className={styles.submit}

--- a/src/framework/auth/oauth.test.ts
+++ b/src/framework/auth/oauth.test.ts
@@ -147,10 +147,10 @@ describe("login CSRF flow lock", () => {
     expect(canAutoStartLogin()).toBe(false);
   });
 
-  // sessionStorage is copied into tabs opened with window.open / "duplicate
-  // tab", so ownership must not be keyed on anything stored there — a clone
-  // would inherit the id and walk straight past the lock.
-  it("does not treat a cloned tab's sessionStorage as proof of ownership", () => {
+  // Ownership must never key on a *persistent* per-tab id: sessionStorage is
+  // copied into tabs opened with window.open / "duplicate tab", so such an id
+  // would hand every clone a permanent pass through the lock.
+  it("grants no ownership from a persistent tab id", () => {
     window.sessionStorage.setItem("bkn_oauth_tab_id", "cloned-tab");
     window.localStorage.setItem(
       FLOW_LOCK_KEY,
@@ -158,6 +158,20 @@ describe("login CSRF flow lock", () => {
     );
 
     expect(canAutoStartLogin()).toBe(false);
+  });
+
+  // The accepted edge of that trade-off, asserted so it stays deliberate: the
+  // owner record is also copied by a clone, so a tab duplicated while a flow
+  // is in the air does inherit ownership. Bounded by the flow's lifetime
+  // rather than permanent, and the callback's one-shot retry recovers from it.
+  it("does hand ownership to a tab cloned mid-flow", () => {
+    window.sessionStorage.setItem("bkn_oauth_flow_owner", "the-load-that-started-it");
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "the-load-that-started-it", startedAt: Date.now() }),
+    );
+
+    expect(canAutoStartLogin()).toBe(true);
   });
 
   it("releases an abandoned lock once it ages out", () => {

--- a/src/framework/auth/oauth.test.ts
+++ b/src/framework/auth/oauth.test.ts
@@ -10,8 +10,11 @@ import { webcrypto } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  canAutoStartLogin,
   completeLogin,
   computeCodeChallenge,
+  consumeCsrfRetry,
+  isCsrfConflictCallback,
   shouldUseOAuthGate,
 } from "@/framework/auth/oauth";
 
@@ -24,6 +27,7 @@ describe("oauth", () => {
       });
     }
     window.sessionStorage.clear();
+    window.localStorage.clear();
     for (const part of document.cookie ? document.cookie.split("; ") : []) {
       const name = part.split("=")[0];
       if (name) {
@@ -110,6 +114,125 @@ describe("oauth", () => {
     await expect(completeLogin("?code=abc&state=state-1")).rejects.toThrow(
       "invalid_grant",
     );
+  });
+});
+
+// Regression: forced first-login password change. The user sits on the
+// bkn-safe login + change-password pages for a minute or more, which is long
+// enough for another Studio tab to start its own /oauth2/auth and overwrite
+// the browser's single login CSRF cookie — hydra then rejects the original
+// flow with request_forbidden. See issue #387.
+describe("login CSRF flow lock", () => {
+  const FLOW_LOCK_KEY = "bkn_oauth_flow_lock";
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  function currentTabId() {
+    // canAutoStartLogin seeds the per-tab id on first use.
+    canAutoStartLogin();
+    return window.sessionStorage.getItem("bkn_oauth_tab_id") ?? "";
+  }
+
+  it("allows an automatic redirect when no flow is in progress", () => {
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("blocks an automatic redirect while another tab owns the flow", () => {
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ startedAt: Date.now(), tabId: "some-other-tab" }),
+    );
+
+    expect(canAutoStartLogin()).toBe(false);
+  });
+
+  it("ignores this tab's own lock so navigating back can restart the flow", () => {
+    const tabId = currentTabId();
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ startedAt: Date.now(), tabId }),
+    );
+
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("releases an abandoned lock once it ages out", () => {
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({
+        startedAt: Date.now() - 4 * 60 * 1000,
+        tabId: "some-other-tab",
+      }),
+    );
+
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("ignores a malformed lock rather than deadlocking sign-in", () => {
+    window.localStorage.setItem(FLOW_LOCK_KEY, "not json");
+    expect(canAutoStartLogin()).toBe(true);
+
+    window.localStorage.setItem(FLOW_LOCK_KEY, JSON.stringify({ tabId: 42 }));
+    expect(canAutoStartLogin()).toBe(true);
+  });
+});
+
+describe("callback CSRF recovery", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("recognises hydra's stale-CSRF rejection", () => {
+    expect(isCsrfConflictCallback("?error=request_forbidden")).toBe(true);
+    expect(
+      isCsrfConflictCallback(
+        "?error=some_other&error_description=" +
+          encodeURIComponent(
+            "The CSRF value from the token does not match the CSRF value from the data store.",
+          ),
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves unrelated callback errors alone", () => {
+    expect(isCsrfConflictCallback("?error=access_denied")).toBe(false);
+    expect(isCsrfConflictCallback("?code=abc&state=state-1")).toBe(false);
+  });
+
+  it("permits exactly one automatic retry per tab", () => {
+    expect(consumeCsrfRetry()).toBe(true);
+    expect(consumeCsrfRetry()).toBe(false);
+  });
+
+  it("clears the retry budget and the flow lock on a successful login", async () => {
+    window.sessionStorage.setItem("bkn_oauth_state", "state-1");
+    window.sessionStorage.setItem("bkn_oauth_verifier", "verifier-1");
+    window.localStorage.setItem(
+      "bkn_oauth_flow_lock",
+      JSON.stringify({ startedAt: Date.now(), tabId: "some-other-tab" }),
+    );
+    // Spend the retry budget, as a first failed attempt would.
+    expect(consumeCsrfRetry()).toBe(true);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "access-1" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+
+    await completeLogin("?code=abc&state=state-1");
+
+    expect(window.localStorage.getItem("bkn_oauth_flow_lock")).toBeNull();
+    expect(consumeCsrfRetry()).toBe(true);
   });
 });
 

--- a/src/framework/auth/oauth.test.ts
+++ b/src/framework/auth/oauth.test.ts
@@ -180,16 +180,45 @@ describe("login CSRF flow lock", () => {
     expect(canAutoStartLogin()).toBe(true);
   });
 
-  it("unblocks waiting tabs as soon as the lock is released", () => {
+  // The tab that started the flow keeps ownership across page loads, so
+  // pressing Back from the login page can restart it instead of being told to
+  // finish in "another tab" that does not exist.
+  it("lets a later page load in the starting tab reclaim the lock", () => {
+    window.sessionStorage.setItem("bkn_oauth_flow_owner", "the-load-that-started-it");
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "the-load-that-started-it", startedAt: Date.now() }),
+    );
+
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("releases a lock this tab owns", () => {
+    window.sessionStorage.setItem("bkn_oauth_flow_owner", "the-load-that-started-it");
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "the-load-that-started-it", startedAt: Date.now() }),
+    );
+
+    releaseFlowLock();
+
+    expect(window.localStorage.getItem(FLOW_LOCK_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem("bkn_oauth_flow_owner")).toBeNull();
+  });
+
+  // A stale callback page reloaded in some other tab must not delete a live
+  // flow's lock — that would free every waiting tab to overwrite its CSRF
+  // cookie while the user is still on the change-password page.
+  it("refuses to release a lock another tab owns", () => {
     window.localStorage.setItem(
       FLOW_LOCK_KEY,
       JSON.stringify({ loadId: "some-other-page-load", startedAt: Date.now() }),
     );
-    expect(canAutoStartLogin()).toBe(false);
 
     releaseFlowLock();
 
-    expect(canAutoStartLogin()).toBe(true);
+    expect(window.localStorage.getItem(FLOW_LOCK_KEY)).not.toBeNull();
+    expect(canAutoStartLogin()).toBe(false);
   });
 
   it("notifies subscribers when another tab releases the lock", () => {

--- a/src/framework/auth/oauth.test.ts
+++ b/src/framework/auth/oauth.test.ts
@@ -15,7 +15,11 @@ import {
   computeCodeChallenge,
   consumeCsrfRetry,
   isCsrfConflictCallback,
+  releaseFlowLock,
   shouldUseOAuthGate,
+  stashCallbackError,
+  subscribeFlowLockRelease,
+  takeStashedCallbackError,
 } from "@/framework/auth/oauth";
 
 describe("oauth", () => {
@@ -130,41 +134,38 @@ describe("login CSRF flow lock", () => {
     window.localStorage.clear();
   });
 
-  function currentTabId() {
-    // canAutoStartLogin seeds the per-tab id on first use.
-    canAutoStartLogin();
-    return window.sessionStorage.getItem("bkn_oauth_tab_id") ?? "";
-  }
-
   it("allows an automatic redirect when no flow is in progress", () => {
     expect(canAutoStartLogin()).toBe(true);
   });
 
-  it("blocks an automatic redirect while another tab owns the flow", () => {
+  it("blocks an automatic redirect while another page load owns the flow", () => {
     window.localStorage.setItem(
       FLOW_LOCK_KEY,
-      JSON.stringify({ startedAt: Date.now(), tabId: "some-other-tab" }),
+      JSON.stringify({ loadId: "some-other-page-load", startedAt: Date.now() }),
     );
 
     expect(canAutoStartLogin()).toBe(false);
   });
 
-  it("ignores this tab's own lock so navigating back can restart the flow", () => {
-    const tabId = currentTabId();
+  // sessionStorage is copied into tabs opened with window.open / "duplicate
+  // tab", so ownership must not be keyed on anything stored there — a clone
+  // would inherit the id and walk straight past the lock.
+  it("does not treat a cloned tab's sessionStorage as proof of ownership", () => {
+    window.sessionStorage.setItem("bkn_oauth_tab_id", "cloned-tab");
     window.localStorage.setItem(
       FLOW_LOCK_KEY,
-      JSON.stringify({ startedAt: Date.now(), tabId }),
+      JSON.stringify({ loadId: "cloned-tab", startedAt: Date.now() }),
     );
 
-    expect(canAutoStartLogin()).toBe(true);
+    expect(canAutoStartLogin()).toBe(false);
   });
 
   it("releases an abandoned lock once it ages out", () => {
     window.localStorage.setItem(
       FLOW_LOCK_KEY,
       JSON.stringify({
+        loadId: "some-other-page-load",
         startedAt: Date.now() - 4 * 60 * 1000,
-        tabId: "some-other-tab",
       }),
     );
 
@@ -175,8 +176,42 @@ describe("login CSRF flow lock", () => {
     window.localStorage.setItem(FLOW_LOCK_KEY, "not json");
     expect(canAutoStartLogin()).toBe(true);
 
-    window.localStorage.setItem(FLOW_LOCK_KEY, JSON.stringify({ tabId: 42 }));
+    window.localStorage.setItem(FLOW_LOCK_KEY, JSON.stringify({ loadId: 42 }));
     expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("unblocks waiting tabs as soon as the lock is released", () => {
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "some-other-page-load", startedAt: Date.now() }),
+    );
+    expect(canAutoStartLogin()).toBe(false);
+
+    releaseFlowLock();
+
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("notifies subscribers when another tab releases the lock", () => {
+    const onRelease = vi.fn();
+    const unsubscribe = subscribeFlowLockRelease(onRelease);
+
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: FLOW_LOCK_KEY, newValue: null }),
+    );
+    expect(onRelease).toHaveBeenCalledTimes(1);
+
+    // An unrelated key must not wake the wait screen.
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: "something_else", newValue: null }),
+    );
+    expect(onRelease).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: FLOW_LOCK_KEY, newValue: null }),
+    );
+    expect(onRelease).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -210,6 +245,34 @@ describe("callback CSRF recovery", () => {
   it("permits exactly one automatic retry per tab", () => {
     expect(consumeCsrfRetry()).toBe(true);
     expect(consumeCsrfRetry()).toBe(false);
+  });
+
+  // request_forbidden is not CSRF-specific, so a retry can be spent on an
+  // unrelated rejection. The user must still see why the first attempt failed.
+  it("keeps the first failure's reason across the retry", () => {
+    stashCallbackError(
+      "?error=request_forbidden&error_description=" + encodeURIComponent("login rejected"),
+    );
+
+    expect(takeStashedCallbackError()).toBe("login rejected");
+    expect(takeStashedCallbackError()).toBeNull();
+  });
+
+  it("clears the stashed reason on a successful login", async () => {
+    window.sessionStorage.setItem("bkn_oauth_state", "state-1");
+    window.sessionStorage.setItem("bkn_oauth_verifier", "verifier-1");
+    stashCallbackError("?error=request_forbidden");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "access-1" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+
+    await completeLogin("?code=abc&state=state-1");
+
+    expect(takeStashedCallbackError()).toBeNull();
   });
 
   it("clears the retry budget and the flow lock on a successful login", async () => {

--- a/src/framework/auth/oauth.ts
+++ b/src/framework/auth/oauth.ts
@@ -48,9 +48,15 @@ const CSRF_ORIGINAL_ERROR_KEY = "bkn_oauth_original_error";
 const FLOW_LOCK_KEY = "bkn_oauth_flow_lock";
 // Proof that *this tab* started the in-flight flow, so a later page load in
 // the same tab (the callback page, or a back-navigation to Studio) can claim
-// the lock the previous load wrote. Unlike a persistent tab id this exists
-// only while a flow is actually in the air, so a cloned tab can only inherit
-// it in the instant between writing the lock and navigating away.
+// the lock the previous load wrote.
+//
+// Known trade-off: sessionStorage is copied into a cloned tab, so a tab
+// duplicated between writeFlowLock and dropFlowLock — the whole flow,
+// including the minutes a forced password change takes — inherits ownership
+// and can start its own /oauth2/auth. That is narrower than a persistent tab
+// id (which would hand ownership to every clone forever) but wider than "an
+// instant". Accepted: cloning a tab mid-login is rare, and the callback's
+// one-shot retry recovers from it. See the paired tests in oauth.test.ts.
 const FLOW_OWNER_KEY = "bkn_oauth_flow_owner";
 
 // hydra keeps a single login CSRF cookie per browser, so a second

--- a/src/framework/auth/oauth.ts
+++ b/src/framework/auth/oauth.ts
@@ -46,6 +46,12 @@ const RETURN_TO_KEY = "bkn_oauth_return_to";
 const CSRF_RETRY_KEY = "bkn_oauth_csrf_retried";
 const CSRF_ORIGINAL_ERROR_KEY = "bkn_oauth_original_error";
 const FLOW_LOCK_KEY = "bkn_oauth_flow_lock";
+// Proof that *this tab* started the in-flight flow, so a later page load in
+// the same tab (the callback page, or a back-navigation to Studio) can claim
+// the lock the previous load wrote. Unlike a persistent tab id this exists
+// only while a flow is actually in the air, so a cloned tab can only inherit
+// it in the instant between writing the lock and navigating away.
+const FLOW_OWNER_KEY = "bkn_oauth_flow_owner";
 
 // hydra keeps a single login CSRF cookie per browser, so a second
 // /oauth2/auth overwrites the first flow's value and the older flow fails to
@@ -157,30 +163,57 @@ function readFlowLock(): FlowLock | null {
 
 function writeFlowLock() {
   const lock: FlowLock = { loadId: loadId(), startedAt: Date.now() };
+  window.sessionStorage.setItem(FLOW_OWNER_KEY, lock.loadId);
   window.localStorage.setItem(FLOW_LOCK_KEY, JSON.stringify(lock));
 }
 
+function ownsFlowLock(lock: FlowLock) {
+  return lock.loadId === loadId() || lock.loadId === window.sessionStorage.getItem(FLOW_OWNER_KEY);
+}
+
+function dropFlowLock() {
+  window.sessionStorage.removeItem(FLOW_OWNER_KEY);
+  window.localStorage.removeItem(FLOW_LOCK_KEY);
+}
+
 /**
- * Hand the lock back. Called when a flow reaches a terminal state — success or
- * failure — so other tabs stop waiting on a flow that is already dead instead
- * of sitting out the full TTL.
+ * Hand the lock back when a flow reaches a terminal state — success or failure
+ * — so other tabs stop waiting on a flow that is already dead instead of
+ * sitting out the full TTL. Only the owning tab may release: otherwise a stale
+ * callback page reloaded in some other tab would delete a live flow's lock and
+ * let the waiting tabs overwrite its CSRF cookie.
  */
 export function releaseFlowLock() {
-  window.localStorage.removeItem(FLOW_LOCK_KEY);
+  const lock = readFlowLock();
+  if (!lock || ownsFlowLock(lock)) {
+    dropFlowLock();
+  }
 }
 
 /**
  * Whether this page may redirect to hydra on its own. A page that started a
  * flow inside the lock window owns the browser's login CSRF cookie —
- * redirecting now would overwrite it and break that flow's callback.
+ * redirecting now would overwrite it and break that flow's callback. A later
+ * page load in the tab that started the flow still counts as the owner, so
+ * navigating back to Studio from the login page can restart it.
  */
 export function canAutoStartLogin() {
-  const self = loadId();
   const lock = readFlowLock();
-  if (!lock || lock.loadId === self) {
+  if (!lock || ownsFlowLock(lock)) {
     return true;
   }
   return Date.now() - lock.startedAt > FLOW_LOCK_TTL_MS;
+}
+
+/**
+ * Re-evaluate auth state from scratch after another tab's flow ended. Tokens
+ * live in cookies shared by same-origin tabs, so by the time the lock is
+ * released a waiting tab is usually already signed in and a reload drops it
+ * straight into the app. Racing to start our own flow instead would put every
+ * waiting tab on the wire at once — the very pile-up this lock exists to stop.
+ */
+export function reloadForSharedAuthState() {
+  window.location.reload();
 }
 
 /**
@@ -392,7 +425,8 @@ export function logout(mode: "hosted" | "standalone") {
   clearStoredTokens();
   window.sessionStorage.removeItem(CSRF_RETRY_KEY);
   window.sessionStorage.removeItem(CSRF_ORIGINAL_ERROR_KEY);
-  releaseFlowLock();
+  // Signing out is a deliberate global reset, so drop the lock whoever holds it.
+  dropFlowLock();
 
   if (!shouldUseOAuthGate(mode)) {
     // Mock / hosted mode has no hydra session to revoke.

--- a/src/framework/auth/oauth.ts
+++ b/src/framework/auth/oauth.ts
@@ -43,8 +43,8 @@ export const OAUTH_CALLBACK_PATH = getAppCallbackPath();
 const STATE_KEY = "bkn_oauth_state";
 const VERIFIER_KEY = "bkn_oauth_verifier";
 const RETURN_TO_KEY = "bkn_oauth_return_to";
-const TAB_ID_KEY = "bkn_oauth_tab_id";
 const CSRF_RETRY_KEY = "bkn_oauth_csrf_retried";
+const CSRF_ORIGINAL_ERROR_KEY = "bkn_oauth_original_error";
 const FLOW_LOCK_KEY = "bkn_oauth_flow_lock";
 
 // hydra keeps a single login CSRF cookie per browser, so a second
@@ -114,18 +114,21 @@ function redirectUri() {
   return `${window.location.origin}${getAppCallbackPath()}`;
 }
 
-/** Stable per-tab id (sessionStorage survives navigations within the tab). */
-function tabId() {
-  const existing = window.sessionStorage.getItem(TAB_ID_KEY);
-  if (existing) {
-    return existing;
-  }
-  const created = randomUrlSafeString();
-  window.sessionStorage.setItem(TAB_ID_KEY, created);
-  return created;
+/**
+ * Identifies this page load, held in memory only. sessionStorage is *cloned*
+ * into a tab opened via window.open / target="_blank" / "duplicate tab", so a
+ * sessionStorage-backed id would let a cloned tab mistake another tab's lock
+ * for its own — and cloned tabs are exactly the ones most likely to race on
+ * /oauth2/auth.
+ */
+let pageLoadId: string | null = null;
+
+function loadId() {
+  pageLoadId ??= randomUrlSafeString();
+  return pageLoadId;
 }
 
-type FlowLock = { startedAt: number; tabId: string };
+type FlowLock = { loadId: string; startedAt: number };
 
 function readFlowLock(): FlowLock | null {
   const raw = window.localStorage.getItem(FLOW_LOCK_KEY);
@@ -144,42 +147,69 @@ function readFlowLock(): FlowLock | null {
     return null;
   }
 
-  const { startedAt, tabId: owner } = parsed as Partial<FlowLock>;
+  const { loadId: owner, startedAt } = parsed as Partial<FlowLock>;
   if (typeof startedAt !== "number" || typeof owner !== "string") {
     return null;
   }
 
-  return { startedAt, tabId: owner };
+  return { loadId: owner, startedAt };
 }
 
 function writeFlowLock() {
-  const lock: FlowLock = { startedAt: Date.now(), tabId: tabId() };
+  const lock: FlowLock = { loadId: loadId(), startedAt: Date.now() };
   window.localStorage.setItem(FLOW_LOCK_KEY, JSON.stringify(lock));
 }
 
-function clearFlowLock() {
+/**
+ * Hand the lock back. Called when a flow reaches a terminal state — success or
+ * failure — so other tabs stop waiting on a flow that is already dead instead
+ * of sitting out the full TTL.
+ */
+export function releaseFlowLock() {
   window.localStorage.removeItem(FLOW_LOCK_KEY);
 }
 
 /**
- * Whether this tab may redirect to hydra on its own. A tab that started a flow
- * inside the lock window owns the browser's login CSRF cookie — redirecting
- * now would overwrite it and break that tab's callback. Our own stale lock
- * (the user navigated back to Studio in this same tab) never blocks us.
+ * Whether this page may redirect to hydra on its own. A page that started a
+ * flow inside the lock window owns the browser's login CSRF cookie —
+ * redirecting now would overwrite it and break that flow's callback.
  */
 export function canAutoStartLogin() {
-  const self = tabId();
+  const self = loadId();
   const lock = readFlowLock();
-  if (!lock || lock.tabId === self) {
+  if (!lock || lock.loadId === self) {
     return true;
   }
   return Date.now() - lock.startedAt > FLOW_LOCK_TTL_MS;
 }
 
 /**
- * True when hydra bounced the authorize request because the browser's login
- * CSRF cookie belongs to a different flow. Recoverable: a fresh /oauth2/auth
- * rewrites the cookie.
+ * Notifies when another tab releases the lock. `storage` fires only in *other*
+ * tabs, which is exactly the audience that needs waking: a tab that has been
+ * visible the whole time (side-by-side windows) never gets a visibilitychange
+ * to re-check on, and would otherwise sit on the wait screen after the owning
+ * tab has already finished.
+ */
+export function subscribeFlowLockRelease(onRelease: () => void) {
+  const handle = (event: StorageEvent) => {
+    // key === null is storage.clear(), which also drops the lock.
+    if ((event.key === FLOW_LOCK_KEY && event.newValue === null) || event.key === null) {
+      onRelease();
+    }
+  };
+
+  window.addEventListener("storage", handle);
+  return () => {
+    window.removeEventListener("storage", handle);
+  };
+}
+
+/**
+ * True when hydra bounced the authorize request in a way a fresh /oauth2/auth
+ * can plausibly clear — the browser's login CSRF cookie belonging to a
+ * different flow. `request_forbidden` is not CSRF-specific (hydra also uses it
+ * for rejected login/consent), so a retry can be spent on an unrelated
+ * rejection; stashCallbackError keeps the real reason for the error page.
  */
 export function isCsrfConflictCallback(search = window.location.search) {
   const params = new URLSearchParams(search);
@@ -188,6 +218,25 @@ export function isCsrfConflictCallback(search = window.location.search) {
     return false;
   }
   return error === "request_forbidden" || (params.get("error_description") ?? "").includes("CSRF");
+}
+
+/**
+ * Preserve the first failure's reason. If the retry fails too, the second
+ * callback's message describes the retry, not what actually went wrong — the
+ * user needs the original.
+ */
+export function stashCallbackError(search = window.location.search) {
+  const params = new URLSearchParams(search);
+  const reason = params.get("error_description") ?? params.get("error");
+  if (reason) {
+    window.sessionStorage.setItem(CSRF_ORIGINAL_ERROR_KEY, reason);
+  }
+}
+
+export function takeStashedCallbackError() {
+  const stashed = window.sessionStorage.getItem(CSRF_ORIGINAL_ERROR_KEY);
+  window.sessionStorage.removeItem(CSRF_ORIGINAL_ERROR_KEY);
+  return stashed;
 }
 
 /** One automatic CSRF recovery per tab, so a persistent failure cannot loop. */
@@ -302,7 +351,8 @@ export async function completeLogin(search = window.location.search) {
   window.sessionStorage.removeItem(STATE_KEY);
   window.sessionStorage.removeItem(VERIFIER_KEY);
   window.sessionStorage.removeItem(CSRF_RETRY_KEY);
-  clearFlowLock();
+  window.sessionStorage.removeItem(CSRF_ORIGINAL_ERROR_KEY);
+  releaseFlowLock();
 
   const returnTo = window.sessionStorage.getItem(RETURN_TO_KEY) ?? getAppHomePath();
   window.sessionStorage.removeItem(RETURN_TO_KEY);
@@ -341,7 +391,8 @@ export function logout(mode: "hosted" | "standalone") {
   const idToken = getStoredIdToken();
   clearStoredTokens();
   window.sessionStorage.removeItem(CSRF_RETRY_KEY);
-  clearFlowLock();
+  window.sessionStorage.removeItem(CSRF_ORIGINAL_ERROR_KEY);
+  releaseFlowLock();
 
   if (!shouldUseOAuthGate(mode)) {
     // Mock / hosted mode has no hydra session to revoke.

--- a/src/framework/auth/oauth.ts
+++ b/src/framework/auth/oauth.ts
@@ -43,6 +43,19 @@ export const OAUTH_CALLBACK_PATH = getAppCallbackPath();
 const STATE_KEY = "bkn_oauth_state";
 const VERIFIER_KEY = "bkn_oauth_verifier";
 const RETURN_TO_KEY = "bkn_oauth_return_to";
+const TAB_ID_KEY = "bkn_oauth_tab_id";
+const CSRF_RETRY_KEY = "bkn_oauth_csrf_retried";
+const FLOW_LOCK_KEY = "bkn_oauth_flow_lock";
+
+// hydra keeps a single login CSRF cookie per browser, so a second
+// /oauth2/auth overwrites the first flow's value and the older flow fails to
+// accept with "The CSRF value from the token does not match the CSRF value
+// from the data store". A forced first-login password change parks the user on
+// the login pages for a minute or more — long enough for another Studio tab
+// (session restore, a bfcache wake-up) to silently start its own flow. The
+// lock makes *automatic* redirects yield to a flow another tab already owns;
+// an explicit sign-in click always takes over.
+const FLOW_LOCK_TTL_MS = 3 * 60 * 1000;
 
 type TokenResponse = {
   access_token: string;
@@ -101,6 +114,95 @@ function redirectUri() {
   return `${window.location.origin}${getAppCallbackPath()}`;
 }
 
+/** Stable per-tab id (sessionStorage survives navigations within the tab). */
+function tabId() {
+  const existing = window.sessionStorage.getItem(TAB_ID_KEY);
+  if (existing) {
+    return existing;
+  }
+  const created = randomUrlSafeString();
+  window.sessionStorage.setItem(TAB_ID_KEY, created);
+  return created;
+}
+
+type FlowLock = { startedAt: number; tabId: string };
+
+function readFlowLock(): FlowLock | null {
+  const raw = window.localStorage.getItem(FLOW_LOCK_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+
+  const { startedAt, tabId: owner } = parsed as Partial<FlowLock>;
+  if (typeof startedAt !== "number" || typeof owner !== "string") {
+    return null;
+  }
+
+  return { startedAt, tabId: owner };
+}
+
+function writeFlowLock() {
+  const lock: FlowLock = { startedAt: Date.now(), tabId: tabId() };
+  window.localStorage.setItem(FLOW_LOCK_KEY, JSON.stringify(lock));
+}
+
+function clearFlowLock() {
+  window.localStorage.removeItem(FLOW_LOCK_KEY);
+}
+
+/**
+ * Whether this tab may redirect to hydra on its own. A tab that started a flow
+ * inside the lock window owns the browser's login CSRF cookie — redirecting
+ * now would overwrite it and break that tab's callback. Our own stale lock
+ * (the user navigated back to Studio in this same tab) never blocks us.
+ */
+export function canAutoStartLogin() {
+  const self = tabId();
+  const lock = readFlowLock();
+  if (!lock || lock.tabId === self) {
+    return true;
+  }
+  return Date.now() - lock.startedAt > FLOW_LOCK_TTL_MS;
+}
+
+/**
+ * True when hydra bounced the authorize request because the browser's login
+ * CSRF cookie belongs to a different flow. Recoverable: a fresh /oauth2/auth
+ * rewrites the cookie.
+ */
+export function isCsrfConflictCallback(search = window.location.search) {
+  const params = new URLSearchParams(search);
+  const error = params.get("error");
+  if (!error) {
+    return false;
+  }
+  return error === "request_forbidden" || (params.get("error_description") ?? "").includes("CSRF");
+}
+
+/** One automatic CSRF recovery per tab, so a persistent failure cannot loop. */
+export function consumeCsrfRetry() {
+  if (window.sessionStorage.getItem(CSRF_RETRY_KEY)) {
+    return false;
+  }
+  window.sessionStorage.setItem(CSRF_RETRY_KEY, "1");
+  return true;
+}
+
+export function getStoredReturnTo() {
+  return window.sessionStorage.getItem(RETURN_TO_KEY) ?? undefined;
+}
+
 export async function beginLogin(returnTo?: string) {
   const verifier = randomUrlSafeString();
   const state = randomUrlSafeString();
@@ -124,6 +226,9 @@ export async function beginLogin(returnTo?: string) {
     state,
   });
 
+  // Claim the browser's login CSRF cookie before navigating; other tabs stop
+  // auto-redirecting until this flow finishes or the lock ages out.
+  writeFlowLock();
   window.location.assign(`${gatewayOrigin()}${AUTHORIZE_PATH}?${params.toString()}`);
 }
 
@@ -196,6 +301,8 @@ export async function completeLogin(search = window.location.search) {
 
   window.sessionStorage.removeItem(STATE_KEY);
   window.sessionStorage.removeItem(VERIFIER_KEY);
+  window.sessionStorage.removeItem(CSRF_RETRY_KEY);
+  clearFlowLock();
 
   const returnTo = window.sessionStorage.getItem(RETURN_TO_KEY) ?? getAppHomePath();
   window.sessionStorage.removeItem(RETURN_TO_KEY);
@@ -233,6 +340,8 @@ export async function refreshOAuthTokens(): Promise<string | null> {
 export function logout(mode: "hosted" | "standalone") {
   const idToken = getStoredIdToken();
   clearStoredTokens();
+  window.sessionStorage.removeItem(CSRF_RETRY_KEY);
+  clearFlowLock();
 
   if (!shouldUseOAuthGate(mode)) {
     // Mock / hosted mode has no hydra session to revoke.


### PR DESCRIPTION
Fixes #387

## 根因

hydra 每个浏览器只保存一份 login CSRF cookie（`oauth2_authentication_csrf`）。任何第二次 `/oauth2/auth` 都会覆盖前一条流程的值，原流程随后 accept 时就报 `The CSRF value from the token does not match the CSRF value from the data store`（`request_forbidden`，HTTP 403）。

这些多余的 authorize 请求是 Studio 自己发的：`SignInScreen` 挂载即无条件跳 hydra，唯一的守卫是防 StrictMode 双调的 ref，没有任何跨标签页协调。会话恢复拉起的、或从 bfcache 唤醒的后台标签页，会在用户完全看不见的情况下重写 cookie，把用户正在操作的那个标签页搞挂。

这也解释了 issue 里"只能清 Cookie / 用无痕窗口"的现象：只要那个隐形标签页还在，正常标签页重试多少次都会被它再覆盖一次。

## 为什么是"首次登录改密码"暴露的

强制改密把一次登录从几秒拉长到一两分钟（登录页 + 改密页 + 三个密码输入框），是唯一一个用户会在登录中途停留到分钟级的场景，竞争窗口被放大两个数量级。普通登录快到基本撞不上。

**bkn-safe 侧没有问题**，已核实：`doLogin` 命中 `ErrMustChangePassword` 后直接渲染改密页、期间不调用 hydra；`ChangePassword` 复用同一个 `login_challenge`，只调用一次 `AcceptLogin`。`SetPassword` 也确实写了 `must_change_password: false`，不存在"标志位没清导致反复被打回改密页"。全流程一个 challenge、一次 accept。

## 改动

**消灭覆盖源** — `SignInScreen`
- 自动跳转现在需同时满足 `document.visibilityState === "visible"` 且 `canAutoStartLogin()`。后台标签页不再发 `/oauth2/auth`，改挂 `visibilitychange`，等用户切过来再发。
- 流程锁存 `localStorage`（`{startedAt, tabId}`，TTL 3 分钟，覆盖改密耗时）。被别的标签页挡下时渲染"另一个标签页正在登录"+ 登录按钮，不轮询。
- 点击登录按钮是显式意图，无条件接管流程 —— 用户永远有逃生出口，锁不会把人锁死。
- 自己这个标签页留下的锁不算数（用户按后退回到 Studio 要能重新发起）；锁过期、锁内容损坏一律放行。

**兜底恢复** — `OAuthCallback`
- 回调带 `request_forbidden`、或 `error_description` 含 CSRF 时，不再停在终态错误页，直接重发一次 `beginLogin`，由新流程覆盖陈旧 cookie。
- `sessionStorage` 标记保证每标签页只自动重试一次，重试仍失败才展示错误页，不会成环。
- 判错直接读 `window.location.search` 的 `error` 参数，不去 match `completeLogin` 抛出的 message（那层已把 error code 拍扁成一句话）。

`completeLogin` 成功和 `logout` 时清锁 + 清重试额度。tabId 存 `sessionStorage`，天然按标签页隔离。

改动全部在 Studio 前端三个文件 + 两个语言包，不触碰 bkn-safe 与 hydra，不影响已有用户登录、SSO 与退出登录。

## 测试

- `oauth.test.ts` +9 例：锁的四种状态（无锁 / 他人持有 / 自己持有 / 已过期）、损坏锁不死锁、CSRF 错误识别与误判防护、重试额度只给一次、成功登录后清锁清额度。
- 新增 `SignInScreen.test.tsx` 4 例：可见且无锁才自动跳、隐藏标签页不跳、切到前台补跳、被他人锁挡下后按钮能接管。
- 全量 `vitest run`：168 文件 / 863 例全过。`tsc -b` 干净，`eslint --config eslint.config.typechecked.js --max-warnings 0` 对改动目录干净。

## 部署后需要人工验证

新建用户 → 首次登录 → 强制改密 → 提交 → **直接落到 Studio 首页，全程不出现登录页和错误页**。

顺手看一眼 DevTools → Application → Cookies：`oauth2_authentication_csrf` 是**一条被改写**，还是**多条同名不同 Path 并存**。如果是后者（历史部署 cookie 属性变更遗留），浏览器会把两条都发出去、hydra 取错那条，前端重试永远救不回来，需要再开一个服务端 issue 统一 cookie path。目前倾向不成立 —— 真·首次登录用户浏览器里本不该有历史 hydra cookie。

## 建议同步调整 issue 验收项

下面两条基于"改密后重复发起 OAuth2 授权流程"这个不成立的根因，建议移除；按此改动会触及认证主链路，风险高于收益：

- ~~修改密码完成后不会重复创建或覆盖 OAuth2/CSRF 会话~~
- ~~重复点击登录按钮或页面重复跳转时，不会并发发起多个 `/oauth2/auth`~~

## 已知残留

非 Studio 发起的并发流程仍可能覆盖 cookie —— 例如 `openbkn auth login` 的浏览器登录走同一个 hydra host，或用户手上直开着一个 bkn-safe `/login` 页面。localStorage 锁在 Studio 页面里，看不见这些。概率低（普通用户首次登录不会装 CLI），且回调页的自动重试能兜住一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
