### PR TITLE
fix(auth): stop concurrent tabs from clobbering the login CSRF cookie (backport #388)

### DIFF
--- a/src/app/locales/resources/auth/en-US.ts
+++ b/src/app/locales/resources/auth/en-US.ts
@@ -10,6 +10,9 @@ export const authEnUS = {
     signInSubtitle: "Sign in to access the business knowledge network console",
     signInButton: "Sign In",
     devTokenToggle: "Sign in with a token (dev mode)",
+    signInOtherTabTitle: "Another tab is signing in",
+    signInOtherTabHint:
+      "Finish signing in there, or use the button below to restart the sign-in from this tab.",
     callbackProcessing: "Completing sign-in…",
     callbackErrorTitle: "Sign-in failed",
     backToSignIn: "Back to sign-in",

--- a/src/app/locales/resources/auth/zh-CN.ts
+++ b/src/app/locales/resources/auth/zh-CN.ts
@@ -10,6 +10,8 @@ export const authZhCN = {
     signInSubtitle: "登录后访问业务知识网络控制台",
     signInButton: "登 录",
     devTokenToggle: "使用 Token 登录（开发模式）",
+    signInOtherTabTitle: "另一个标签页正在登录",
+    signInOtherTabHint: "请在那个标签页完成登录。也可以点击下方按钮，改由本页面重新发起登录。",
     callbackProcessing: "正在完成登录…",
     callbackErrorTitle: "登录失败",
     backToSignIn: "返回登录",

--- a/src/framework/auth/OAuthCallback.test.tsx
+++ b/src/framework/auth/OAuthCallback.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OAuthCallback } from "@/framework/auth/OAuthCallback";
+
+const oauth = vi.hoisted(() => ({
+  beginLogin: vi.fn(() => Promise.resolve()),
+  completeLogin: vi.fn(() => Promise.resolve("/studio/")),
+  consumeCsrfRetry: vi.fn(() => true),
+  getStoredReturnTo: vi.fn(() => "/studio/knowledge-network"),
+  isCsrfConflictCallback: vi.fn(() => false),
+  releaseFlowLock: vi.fn(),
+  stashCallbackError: vi.fn(),
+  takeStashedCallbackError: vi.fn(() => null as string | null),
+}));
+
+vi.mock("@/framework/auth/oauth", () => oauth);
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const original = await importOriginal<typeof import("react-i18next")>();
+  return { ...original, useTranslation: () => ({ t: (key: string) => key }) };
+});
+
+vi.mock("@/app/router/app-paths", () => ({
+  getAppHomePath: () => "/studio/",
+}));
+
+describe("OAuthCallback CSRF recovery wiring", () => {
+  beforeEach(() => {
+    for (const spy of Object.values(oauth)) {
+      if (typeof spy === "function" && "mockClear" in spy) {
+        spy.mockClear();
+      }
+    }
+    oauth.isCsrfConflictCallback.mockReturnValue(false);
+    oauth.consumeCsrfRetry.mockReturnValue(true);
+    oauth.completeLogin.mockResolvedValue("/studio/");
+    oauth.takeStashedCallbackError.mockReturnValue(null);
+  });
+
+  it("exchanges the code on a normal callback", () => {
+    render(<OAuthCallback />);
+
+    expect(oauth.completeLogin).toHaveBeenCalledTimes(1);
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+    // The retry budget must survive a successful callback.
+    expect(oauth.consumeCsrfRetry).not.toHaveBeenCalled();
+  });
+
+  it("restarts the flow instead of stranding the user on a stale-CSRF error", () => {
+    oauth.isCsrfConflictCallback.mockReturnValue(true);
+
+    render(<OAuthCallback />);
+
+    expect(oauth.beginLogin).toHaveBeenCalledWith("/studio/knowledge-network");
+    expect(oauth.completeLogin).not.toHaveBeenCalled();
+    expect(oauth.stashCallbackError).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through to the error page once the retry budget is spent", async () => {
+    oauth.isCsrfConflictCallback.mockReturnValue(true);
+    oauth.consumeCsrfRetry.mockReturnValue(false);
+    oauth.completeLogin.mockRejectedValue(new Error("second attempt failed"));
+    oauth.takeStashedCallbackError.mockReturnValue("the original reason");
+
+    render(<OAuthCallback />);
+
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+    expect(oauth.completeLogin).toHaveBeenCalledTimes(1);
+    // The retry's own message describes the retry, not the real cause.
+    expect(await screen.findByText("the original reason")).toBeTruthy();
+    expect(oauth.releaseFlowLock).toHaveBeenCalled();
+  });
+
+  it("releases the flow lock when the callback fails outright", async () => {
+    oauth.completeLogin.mockRejectedValue(new Error("OAuth state mismatch"));
+
+    render(<OAuthCallback />);
+
+    expect(await screen.findByText("OAuth state mismatch")).toBeTruthy();
+    expect(oauth.releaseFlowLock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/framework/auth/OAuthCallback.tsx
+++ b/src/framework/auth/OAuthCallback.tsx
@@ -10,7 +10,16 @@ import { Alert, Spin } from "antd";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { completeLogin } from "@/framework/auth/oauth";
+import {
+  beginLogin,
+  completeLogin,
+  consumeCsrfRetry,
+  getStoredReturnTo,
+  isCsrfConflictCallback,
+  releaseFlowLock,
+  stashCallbackError,
+  takeStashedCallbackError,
+} from "@/framework/auth/oauth";
 import { AppButton } from "@/framework/ui/common/AppButton";
 
 import styles from "./SignInScreen.module.css";
@@ -27,13 +36,30 @@ export function OAuthCallback() {
     }
     startedRef.current = true;
 
+    // hydra rejected the authorize request because the browser's login CSRF
+    // cookie belongs to another flow. A fresh /oauth2/auth rewrites the cookie,
+    // so retry once instead of stranding the user on a dead error page — this
+    // is the path a forced first-login password change lands on.
+    const fail = (cause: unknown) => {
+      // This flow is dead — hand the lock back so other tabs stop waiting on
+      // it instead of sitting out the full TTL. Prefer the stashed reason: on
+      // a failed retry the current message describes the retry, not the cause.
+      releaseFlowLock();
+      const original = takeStashedCallbackError();
+      setError(original ?? (cause instanceof Error ? cause.message : String(cause)));
+    };
+
+    if (isCsrfConflictCallback() && consumeCsrfRetry()) {
+      stashCallbackError();
+      beginLogin(getStoredReturnTo()).catch(fail);
+      return;
+    }
+
     completeLogin()
       .then((returnTo) => {
         window.location.replace(returnTo);
       })
-      .catch((cause: unknown) => {
-        setError(cause instanceof Error ? cause.message : String(cause));
-      });
+      .catch(fail);
   }, []);
 
   return (

--- a/src/framework/auth/SignInScreen.test.tsx
+++ b/src/framework/auth/SignInScreen.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SignInScreen } from "@/framework/auth/SignInScreen";
+
+const oauth = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  return {
+    beginLogin: vi.fn(() => Promise.resolve()),
+    canAutoStartLogin: vi.fn(() => true),
+    reloadForSharedAuthState: vi.fn(),
+    /** Stand-in for the cross-tab `storage` event; `emit` fires the release. */
+    subscribeFlowLockRelease: vi.fn((onRelease: () => void) => {
+      listeners.add(onRelease);
+      return () => listeners.delete(onRelease);
+    }),
+    emitFlowLockRelease: () => {
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  };
+});
+
+vi.mock("@/framework/auth/oauth", () => oauth);
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const original = await importOriginal<typeof import("react-i18next")>();
+  return { ...original, useTranslation: () => ({ t: (key: string) => key }) };
+});
+
+/** jsdom reports "visible" by default; override per test. */
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+describe("SignInScreen auto-redirect gating", () => {
+  beforeEach(() => {
+    oauth.beginLogin.mockClear();
+    oauth.canAutoStartLogin.mockReset();
+    oauth.canAutoStartLogin.mockReturnValue(true);
+    setVisibility("visible");
+  });
+
+  it("redirects to hydra on its own when nothing else owns the flow", () => {
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+
+    expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+  });
+
+  // A background tab redirecting would rewrite the browser's single login CSRF
+  // cookie and break the tab the user is actually signing in on (issue #387).
+  it("stays put while the tab is hidden", () => {
+    setVisibility("hidden");
+
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+  });
+
+  it("redirects once the hidden tab is brought to the front", () => {
+    setVisibility("hidden");
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+
+    setVisibility("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+  });
+
+  // Side-by-side windows are never hidden, so visibilitychange never fires for
+  // them — without the lock-release signal they would sit on the wait screen
+  // even after the owning tab finished and the credentials became available.
+  //
+  // A release reaches every waiting tab at once, so they must NOT each start
+  // their own flow: by then the owning tab has written the shared token cookie,
+  // and reloading picks it up without another /oauth2/auth on the wire.
+  it("reloads instead of racing when the owning tab releases the lock", async () => {
+    oauth.canAutoStartLogin.mockReturnValue(false);
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+    expect(await screen.findByText("auth.signInOtherTabTitle")).toBeTruthy();
+
+    oauth.canAutoStartLogin.mockReturnValue(true);
+    act(() => {
+      oauth.emitFlowLockRelease();
+    });
+
+    expect(oauth.reloadForSharedAuthState).toHaveBeenCalledTimes(1);
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+  });
+
+  it("defers to another tab's in-flight login and offers a manual takeover", async () => {
+    oauth.canAutoStartLogin.mockReturnValue(false);
+
+    render(<SignInScreen onDevTokenSaved={vi.fn()} />);
+
+    expect(oauth.beginLogin).not.toHaveBeenCalled();
+    expect(await screen.findByText("auth.signInOtherTabTitle")).toBeTruthy();
+
+    // Explicit intent wins: the user is on this tab, so it takes the flow over.
+    act(() => {
+      screen.getByRole("button", { name: "auth.signInButton" }).click();
+    });
+
+    expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/framework/auth/SignInScreen.tsx
+++ b/src/framework/auth/SignInScreen.tsx
@@ -10,7 +10,12 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { DevTokenSetupForm } from "@/framework/auth/DevTokenSetupForm";
-import { beginLogin } from "@/framework/auth/oauth";
+import {
+  beginLogin,
+  canAutoStartLogin,
+  reloadForSharedAuthState,
+  subscribeFlowLockRelease,
+} from "@/framework/auth/oauth";
 import { AppButton } from "@/framework/ui/common/AppButton";
 
 import styles from "./SignInScreen.module.css";
@@ -24,30 +29,70 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
   const startedRef = useRef(false);
   const [redirecting, setRedirecting] = useState(true);
   const [redirectError, setRedirectError] = useState<string | null>(null);
+  const [deferredToOtherTab, setDeferredToOtherTab] = useState(false);
   const [showDevTokenForm, setShowDevTokenForm] = useState(false);
 
   useEffect(() => {
-    if (showDevTokenForm || startedRef.current) {
+    if (showDevTokenForm) {
       return;
     }
 
-    startedRef.current = true;
-    const { hash, pathname, search } = window.location;
+    // Redirecting to hydra rewrites the browser's single login CSRF cookie, so
+    // a background tab waking up mid-login would break the tab the user is
+    // actually looking at. Only a visible tab that no other flow owns may go on
+    // its own; otherwise wait and offer the manual button, which takes over.
+    const startIfAllowed = () => {
+      if (startedRef.current) {
+        return true;
+      }
+      if (document.visibilityState !== "visible" || !canAutoStartLogin()) {
+        return false;
+      }
 
-    beginLogin(`${pathname}${search}${hash}`).catch((cause: unknown) => {
-      setRedirectError(cause instanceof Error ? cause.message : String(cause));
-      setRedirecting(false);
-      startedRef.current = false;
-    });
+      startedRef.current = true;
+      setDeferredToOtherTab(false);
+      setRedirecting(true);
+      const { hash, pathname, search } = window.location;
+
+      beginLogin(`${pathname}${search}${hash}`).catch((cause: unknown) => {
+        setRedirectError(cause instanceof Error ? cause.message : String(cause));
+        setRedirecting(false);
+        startedRef.current = false;
+      });
+      return true;
+    };
+
+    if (startIfAllowed()) {
+      return;
+    }
+
+    setRedirecting(false);
+    setDeferredToOtherTab(true);
+
+    // Two wake-ups, deliberately different. visibilitychange reaches one tab at
+    // a time, so that tab may start its own flow. A lock release reaches every
+    // waiting tab at once — starting there would put them all on the wire
+    // together, so they reload and pick up the shared cookie instead.
+    const retry = () => void startIfAllowed();
+    document.addEventListener("visibilitychange", retry);
+    const unsubscribe = subscribeFlowLockRelease(reloadForSharedAuthState);
+    return () => {
+      document.removeEventListener("visibilitychange", retry);
+      unsubscribe();
+    };
   }, [showDevTokenForm]);
 
   if (showDevTokenForm) {
     return <DevTokenSetupForm onSaved={onDevTokenSaved} />;
   }
 
+  // Explicit intent overrides the other-tab lock: the user is here, so this is
+  // the flow that should own the CSRF cookie.
   const handleSignIn = () => {
+    startedRef.current = true;
     setRedirecting(true);
     setRedirectError(null);
+    setDeferredToOtherTab(false);
     const { hash, pathname, search } = window.location;
     void beginLogin(`${pathname}${search}${hash}`).catch((cause: unknown) => {
       setRedirectError(cause instanceof Error ? cause.message : String(cause));
@@ -68,6 +113,25 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
               showIcon
               style={{ marginBottom: 20, textAlign: "left" }}
               type="error"
+            />
+            <AppButton
+              className={styles.submit}
+              loading={redirecting}
+              size="large"
+              type="primary"
+              onClick={handleSignIn}
+            >
+              {t("auth.signInButton")}
+            </AppButton>
+          </>
+        ) : deferredToOtherTab ? (
+          <>
+            <Alert
+              message={t("auth.signInOtherTabTitle")}
+              description={t("auth.signInOtherTabHint")}
+              showIcon
+              style={{ marginBottom: 20, textAlign: "left" }}
+              type="info"
             />
             <AppButton
               className={styles.submit}

--- a/src/framework/auth/oauth.test.ts
+++ b/src/framework/auth/oauth.test.ts
@@ -10,9 +10,16 @@ import { webcrypto } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  canAutoStartLogin,
   completeLogin,
   computeCodeChallenge,
+  consumeCsrfRetry,
+  isCsrfConflictCallback,
+  releaseFlowLock,
   shouldUseOAuthGate,
+  stashCallbackError,
+  subscribeFlowLockRelease,
+  takeStashedCallbackError,
 } from "@/framework/auth/oauth";
 
 describe("oauth", () => {
@@ -24,6 +31,7 @@ describe("oauth", () => {
       });
     }
     window.sessionStorage.clear();
+    window.localStorage.clear();
     for (const part of document.cookie ? document.cookie.split("; ") : []) {
       const name = part.split("=")[0];
       if (name) {
@@ -110,6 +118,227 @@ describe("oauth", () => {
     await expect(completeLogin("?code=abc&state=state-1")).rejects.toThrow(
       "invalid_grant",
     );
+  });
+});
+
+// Regression: forced first-login password change. The user sits on the
+// bkn-safe login + change-password pages for a minute or more, which is long
+// enough for another Studio tab to start its own /oauth2/auth and overwrite
+// the browser's single login CSRF cookie — hydra then rejects the original
+// flow with request_forbidden. See issue #387.
+describe("login CSRF flow lock", () => {
+  const FLOW_LOCK_KEY = "bkn_oauth_flow_lock";
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("allows an automatic redirect when no flow is in progress", () => {
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("blocks an automatic redirect while another page load owns the flow", () => {
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "some-other-page-load", startedAt: Date.now() }),
+    );
+
+    expect(canAutoStartLogin()).toBe(false);
+  });
+
+  // Ownership must never key on a *persistent* per-tab id: sessionStorage is
+  // copied into tabs opened with window.open / "duplicate tab", so such an id
+  // would hand every clone a permanent pass through the lock.
+  it("grants no ownership from a persistent tab id", () => {
+    window.sessionStorage.setItem("bkn_oauth_tab_id", "cloned-tab");
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "cloned-tab", startedAt: Date.now() }),
+    );
+
+    expect(canAutoStartLogin()).toBe(false);
+  });
+
+  // The accepted edge of that trade-off, asserted so it stays deliberate: the
+  // owner record is also copied by a clone, so a tab duplicated while a flow
+  // is in the air does inherit ownership. Bounded by the flow's lifetime
+  // rather than permanent, and the callback's one-shot retry recovers from it.
+  it("does hand ownership to a tab cloned mid-flow", () => {
+    window.sessionStorage.setItem("bkn_oauth_flow_owner", "the-load-that-started-it");
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "the-load-that-started-it", startedAt: Date.now() }),
+    );
+
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("releases an abandoned lock once it ages out", () => {
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({
+        loadId: "some-other-page-load",
+        startedAt: Date.now() - 4 * 60 * 1000,
+      }),
+    );
+
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("ignores a malformed lock rather than deadlocking sign-in", () => {
+    window.localStorage.setItem(FLOW_LOCK_KEY, "not json");
+    expect(canAutoStartLogin()).toBe(true);
+
+    window.localStorage.setItem(FLOW_LOCK_KEY, JSON.stringify({ loadId: 42 }));
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  // The tab that started the flow keeps ownership across page loads, so
+  // pressing Back from the login page can restart it instead of being told to
+  // finish in "another tab" that does not exist.
+  it("lets a later page load in the starting tab reclaim the lock", () => {
+    window.sessionStorage.setItem("bkn_oauth_flow_owner", "the-load-that-started-it");
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "the-load-that-started-it", startedAt: Date.now() }),
+    );
+
+    expect(canAutoStartLogin()).toBe(true);
+  });
+
+  it("releases a lock this tab owns", () => {
+    window.sessionStorage.setItem("bkn_oauth_flow_owner", "the-load-that-started-it");
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "the-load-that-started-it", startedAt: Date.now() }),
+    );
+
+    releaseFlowLock();
+
+    expect(window.localStorage.getItem(FLOW_LOCK_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem("bkn_oauth_flow_owner")).toBeNull();
+  });
+
+  // A stale callback page reloaded in some other tab must not delete a live
+  // flow's lock — that would free every waiting tab to overwrite its CSRF
+  // cookie while the user is still on the change-password page.
+  it("refuses to release a lock another tab owns", () => {
+    window.localStorage.setItem(
+      FLOW_LOCK_KEY,
+      JSON.stringify({ loadId: "some-other-page-load", startedAt: Date.now() }),
+    );
+
+    releaseFlowLock();
+
+    expect(window.localStorage.getItem(FLOW_LOCK_KEY)).not.toBeNull();
+    expect(canAutoStartLogin()).toBe(false);
+  });
+
+  it("notifies subscribers when another tab releases the lock", () => {
+    const onRelease = vi.fn();
+    const unsubscribe = subscribeFlowLockRelease(onRelease);
+
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: FLOW_LOCK_KEY, newValue: null }),
+    );
+    expect(onRelease).toHaveBeenCalledTimes(1);
+
+    // An unrelated key must not wake the wait screen.
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: "something_else", newValue: null }),
+    );
+    expect(onRelease).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: FLOW_LOCK_KEY, newValue: null }),
+    );
+    expect(onRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("callback CSRF recovery", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("recognises hydra's stale-CSRF rejection", () => {
+    expect(isCsrfConflictCallback("?error=request_forbidden")).toBe(true);
+    expect(
+      isCsrfConflictCallback(
+        "?error=some_other&error_description=" +
+          encodeURIComponent(
+            "The CSRF value from the token does not match the CSRF value from the data store.",
+          ),
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves unrelated callback errors alone", () => {
+    expect(isCsrfConflictCallback("?error=access_denied")).toBe(false);
+    expect(isCsrfConflictCallback("?code=abc&state=state-1")).toBe(false);
+  });
+
+  it("permits exactly one automatic retry per tab", () => {
+    expect(consumeCsrfRetry()).toBe(true);
+    expect(consumeCsrfRetry()).toBe(false);
+  });
+
+  // request_forbidden is not CSRF-specific, so a retry can be spent on an
+  // unrelated rejection. The user must still see why the first attempt failed.
+  it("keeps the first failure's reason across the retry", () => {
+    stashCallbackError(
+      "?error=request_forbidden&error_description=" + encodeURIComponent("login rejected"),
+    );
+
+    expect(takeStashedCallbackError()).toBe("login rejected");
+    expect(takeStashedCallbackError()).toBeNull();
+  });
+
+  it("clears the stashed reason on a successful login", async () => {
+    window.sessionStorage.setItem("bkn_oauth_state", "state-1");
+    window.sessionStorage.setItem("bkn_oauth_verifier", "verifier-1");
+    stashCallbackError("?error=request_forbidden");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "access-1" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+
+    await completeLogin("?code=abc&state=state-1");
+
+    expect(takeStashedCallbackError()).toBeNull();
+  });
+
+  it("clears the retry budget and the flow lock on a successful login", async () => {
+    window.sessionStorage.setItem("bkn_oauth_state", "state-1");
+    window.sessionStorage.setItem("bkn_oauth_verifier", "verifier-1");
+    window.localStorage.setItem(
+      "bkn_oauth_flow_lock",
+      JSON.stringify({ startedAt: Date.now(), tabId: "some-other-tab" }),
+    );
+    // Spend the retry budget, as a first failed attempt would.
+    expect(consumeCsrfRetry()).toBe(true);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "access-1" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+
+    await completeLogin("?code=abc&state=state-1");
+
+    expect(window.localStorage.getItem("bkn_oauth_flow_lock")).toBeNull();
+    expect(consumeCsrfRetry()).toBe(true);
   });
 });
 

--- a/src/framework/auth/oauth.ts
+++ b/src/framework/auth/oauth.ts
@@ -43,6 +43,31 @@ export const OAUTH_CALLBACK_PATH = getAppCallbackPath();
 const STATE_KEY = "bkn_oauth_state";
 const VERIFIER_KEY = "bkn_oauth_verifier";
 const RETURN_TO_KEY = "bkn_oauth_return_to";
+const CSRF_RETRY_KEY = "bkn_oauth_csrf_retried";
+const CSRF_ORIGINAL_ERROR_KEY = "bkn_oauth_original_error";
+const FLOW_LOCK_KEY = "bkn_oauth_flow_lock";
+// Proof that *this tab* started the in-flight flow, so a later page load in
+// the same tab (the callback page, or a back-navigation to Studio) can claim
+// the lock the previous load wrote.
+//
+// Known trade-off: sessionStorage is copied into a cloned tab, so a tab
+// duplicated between writeFlowLock and dropFlowLock — the whole flow,
+// including the minutes a forced password change takes — inherits ownership
+// and can start its own /oauth2/auth. That is narrower than a persistent tab
+// id (which would hand ownership to every clone forever) but wider than "an
+// instant". Accepted: cloning a tab mid-login is rare, and the callback's
+// one-shot retry recovers from it. See the paired tests in oauth.test.ts.
+const FLOW_OWNER_KEY = "bkn_oauth_flow_owner";
+
+// hydra keeps a single login CSRF cookie per browser, so a second
+// /oauth2/auth overwrites the first flow's value and the older flow fails to
+// accept with "The CSRF value from the token does not match the CSRF value
+// from the data store". A forced first-login password change parks the user on
+// the login pages for a minute or more — long enough for another Studio tab
+// (session restore, a bfcache wake-up) to silently start its own flow. The
+// lock makes *automatic* redirects yield to a flow another tab already owns;
+// an explicit sign-in click always takes over.
+const FLOW_LOCK_TTL_MS = 3 * 60 * 1000;
 
 type TokenResponse = {
   access_token: string;
@@ -101,6 +126,171 @@ function redirectUri() {
   return `${window.location.origin}${getAppCallbackPath()}`;
 }
 
+/**
+ * Identifies this page load, held in memory only. sessionStorage is *cloned*
+ * into a tab opened via window.open / target="_blank" / "duplicate tab", so a
+ * sessionStorage-backed id would let a cloned tab mistake another tab's lock
+ * for its own — and cloned tabs are exactly the ones most likely to race on
+ * /oauth2/auth.
+ */
+let pageLoadId: string | null = null;
+
+function loadId() {
+  pageLoadId ??= randomUrlSafeString();
+  return pageLoadId;
+}
+
+type FlowLock = { loadId: string; startedAt: number };
+
+function readFlowLock(): FlowLock | null {
+  const raw = window.localStorage.getItem(FLOW_LOCK_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+
+  const { loadId: owner, startedAt } = parsed as Partial<FlowLock>;
+  if (typeof startedAt !== "number" || typeof owner !== "string") {
+    return null;
+  }
+
+  return { loadId: owner, startedAt };
+}
+
+function writeFlowLock() {
+  const lock: FlowLock = { loadId: loadId(), startedAt: Date.now() };
+  window.sessionStorage.setItem(FLOW_OWNER_KEY, lock.loadId);
+  window.localStorage.setItem(FLOW_LOCK_KEY, JSON.stringify(lock));
+}
+
+function ownsFlowLock(lock: FlowLock) {
+  return lock.loadId === loadId() || lock.loadId === window.sessionStorage.getItem(FLOW_OWNER_KEY);
+}
+
+function dropFlowLock() {
+  window.sessionStorage.removeItem(FLOW_OWNER_KEY);
+  window.localStorage.removeItem(FLOW_LOCK_KEY);
+}
+
+/**
+ * Hand the lock back when a flow reaches a terminal state — success or failure
+ * — so other tabs stop waiting on a flow that is already dead instead of
+ * sitting out the full TTL. Only the owning tab may release: otherwise a stale
+ * callback page reloaded in some other tab would delete a live flow's lock and
+ * let the waiting tabs overwrite its CSRF cookie.
+ */
+export function releaseFlowLock() {
+  const lock = readFlowLock();
+  if (!lock || ownsFlowLock(lock)) {
+    dropFlowLock();
+  }
+}
+
+/**
+ * Whether this page may redirect to hydra on its own. A page that started a
+ * flow inside the lock window owns the browser's login CSRF cookie —
+ * redirecting now would overwrite it and break that flow's callback. A later
+ * page load in the tab that started the flow still counts as the owner, so
+ * navigating back to Studio from the login page can restart it.
+ */
+export function canAutoStartLogin() {
+  const lock = readFlowLock();
+  if (!lock || ownsFlowLock(lock)) {
+    return true;
+  }
+  return Date.now() - lock.startedAt > FLOW_LOCK_TTL_MS;
+}
+
+/**
+ * Re-evaluate auth state from scratch after another tab's flow ended. Tokens
+ * live in cookies shared by same-origin tabs, so by the time the lock is
+ * released a waiting tab is usually already signed in and a reload drops it
+ * straight into the app. Racing to start our own flow instead would put every
+ * waiting tab on the wire at once — the very pile-up this lock exists to stop.
+ */
+export function reloadForSharedAuthState() {
+  window.location.reload();
+}
+
+/**
+ * Notifies when another tab releases the lock. `storage` fires only in *other*
+ * tabs, which is exactly the audience that needs waking: a tab that has been
+ * visible the whole time (side-by-side windows) never gets a visibilitychange
+ * to re-check on, and would otherwise sit on the wait screen after the owning
+ * tab has already finished.
+ */
+export function subscribeFlowLockRelease(onRelease: () => void) {
+  const handle = (event: StorageEvent) => {
+    // key === null is storage.clear(), which also drops the lock.
+    if ((event.key === FLOW_LOCK_KEY && event.newValue === null) || event.key === null) {
+      onRelease();
+    }
+  };
+
+  window.addEventListener("storage", handle);
+  return () => {
+    window.removeEventListener("storage", handle);
+  };
+}
+
+/**
+ * True when hydra bounced the authorize request in a way a fresh /oauth2/auth
+ * can plausibly clear — the browser's login CSRF cookie belonging to a
+ * different flow. `request_forbidden` is not CSRF-specific (hydra also uses it
+ * for rejected login/consent), so a retry can be spent on an unrelated
+ * rejection; stashCallbackError keeps the real reason for the error page.
+ */
+export function isCsrfConflictCallback(search = window.location.search) {
+  const params = new URLSearchParams(search);
+  const error = params.get("error");
+  if (!error) {
+    return false;
+  }
+  return error === "request_forbidden" || (params.get("error_description") ?? "").includes("CSRF");
+}
+
+/**
+ * Preserve the first failure's reason. If the retry fails too, the second
+ * callback's message describes the retry, not what actually went wrong — the
+ * user needs the original.
+ */
+export function stashCallbackError(search = window.location.search) {
+  const params = new URLSearchParams(search);
+  const reason = params.get("error_description") ?? params.get("error");
+  if (reason) {
+    window.sessionStorage.setItem(CSRF_ORIGINAL_ERROR_KEY, reason);
+  }
+}
+
+export function takeStashedCallbackError() {
+  const stashed = window.sessionStorage.getItem(CSRF_ORIGINAL_ERROR_KEY);
+  window.sessionStorage.removeItem(CSRF_ORIGINAL_ERROR_KEY);
+  return stashed;
+}
+
+/** One automatic CSRF recovery per tab, so a persistent failure cannot loop. */
+export function consumeCsrfRetry() {
+  if (window.sessionStorage.getItem(CSRF_RETRY_KEY)) {
+    return false;
+  }
+  window.sessionStorage.setItem(CSRF_RETRY_KEY, "1");
+  return true;
+}
+
+export function getStoredReturnTo() {
+  return window.sessionStorage.getItem(RETURN_TO_KEY) ?? undefined;
+}
+
 export async function beginLogin(returnTo?: string) {
   const verifier = randomUrlSafeString();
   const state = randomUrlSafeString();
@@ -124,6 +314,9 @@ export async function beginLogin(returnTo?: string) {
     state,
   });
 
+  // Claim the browser's login CSRF cookie before navigating; other tabs stop
+  // auto-redirecting until this flow finishes or the lock ages out.
+  writeFlowLock();
   window.location.assign(`${gatewayOrigin()}${AUTHORIZE_PATH}?${params.toString()}`);
 }
 
@@ -196,6 +389,9 @@ export async function completeLogin(search = window.location.search) {
 
   window.sessionStorage.removeItem(STATE_KEY);
   window.sessionStorage.removeItem(VERIFIER_KEY);
+  window.sessionStorage.removeItem(CSRF_RETRY_KEY);
+  window.sessionStorage.removeItem(CSRF_ORIGINAL_ERROR_KEY);
+  releaseFlowLock();
 
   const returnTo = window.sessionStorage.getItem(RETURN_TO_KEY) ?? getAppHomePath();
   window.sessionStorage.removeItem(RETURN_TO_KEY);
@@ -233,6 +429,10 @@ export async function refreshOAuthTokens(): Promise<string | null> {
 export function logout(mode: "hosted" | "standalone") {
   const idToken = getStoredIdToken();
   clearStoredTokens();
+  window.sessionStorage.removeItem(CSRF_RETRY_KEY);
+  window.sessionStorage.removeItem(CSRF_ORIGINAL_ERROR_KEY);
+  // Signing out is a deliberate global reset, so drop the lock whoever holds it.
+  dropFlowLock();
 
   if (!shouldUseOAuthGate(mode)) {
     // Mock / hosted mode has no hydra session to revoke.


### PR DESCRIPTION
Backport of #388（已合入 `main`，squash 提交 `782a689`）到 `release/0.1.3`。

Cherry-pick 干净，无冲突。`git diff origin/main HEAD -- src/framework/auth src/app/locales/resources/auth` 为空 —— 与 main 上的内容逐字节一致。

issue #387 报的就是 `bkn-studio:0.1.3-release` 部署（`14.103.77.23`），所以修复需要进这条发布线。

## 根因

hydra 每个浏览器只保存一份 login CSRF cookie（`oauth2_authentication_csrf`），任何第二次 `/oauth2/auth` 都会覆盖前一条流程的值，原流程 accept 时报 `request_forbidden` / HTTP 403。这些多余的 authorize 请求是 Studio 自己发的：`SignInScreen` 挂载即无条件跳 hydra，没有跨标签页协调，后台标签页醒来会在用户看不见的情况下重写 cookie。

强制改密把一次登录拉长到一两分钟，是唯一让用户在登录中途停留到分钟级的场景，把竞争窗口放大了两个数量级 —— 所以表现为「首次登录改密后必挂」。bkn-safe 侧无责：改密路径复用同一个 `login_challenge`，只调用一次 `AcceptLogin`。

## 改动

- `SignInScreen` 自动跳转加双重门：`document.visibilityState === "visible"` + localStorage 流程锁（TTL 3 分钟，覆盖改密耗时）。被挡下时渲染提示 + 接管按钮，显式点击无条件接管。
- 锁的归属键在内存 `loadId`，配合 `sessionStorage` 的 owner 记录支持「同标签页后退可重发」；释放按持有者鉴权，避免陈旧回调页误删在飞的锁。
- 锁释放通过 `storage` 事件唤醒等待方，动作是 reload 而非重发授权 —— 此时 token cookie 已就绪，且避免所有等待方同时上线。
- `OAuthCallback` 收到 `request_forbidden` / CSRF 类错误时自动重发一次，`sessionStorage` 标记限一次；重试前暂存首次失败原因，二次失败展示真实原因。

不触碰 bkn-safe 与 hydra，不影响已有用户登录、SSO 与退出登录。

## 测试

`vitest run` 169 文件 / 883 例全过（该分支基线比 main 多 8 例），`tsc -b` 干净，改动目录 `eslint --config eslint.config.typechecked.js --max-warnings 0` 干净。

## 部署后人工验证

- 主路径：新建用户 → 首次登录 → 强制改密 → 提交 → 直接落到 Studio 首页，不出现登录页和错误页。
- 兜底路径：CSRF 冲突已发生 → 回调页自动重发 → 用户会被送回 bkn-safe 登录页再输一次新密码，然后进入 Studio。预期是「能进去」，不是「无感」。

顺手确认 DevTools → Application → Cookies 里 `oauth2_authentication_csrf` 是一条被改写还是多条同名不同 Path 并存。若为后者（历史部署遗留），前端重试救不回来，需另开服务端 issue 统一 cookie path。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
