### PR TITLE
fix(knowledge-network): restore stored function tools

### DIFF
--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
@@ -214,6 +214,61 @@ describe("ActionTypeToolSelectModal catalog loading", () => {
     expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it("restores a stored function tool by switching from the API toolset", async () => {
+    listActionTypeExecutionFactoryCatalog.mockImplementation(
+      (_keyword: string, metadataType?: string) => ({
+        mcpServers: [],
+        toolBoxes:
+          metadataType === "function"
+            ? [
+                {
+                  boxId: "function-box",
+                  boxName: "Function Box",
+                  description: "function set",
+                  tools: [],
+                },
+              ]
+            : [
+                {
+                  boxId: "openapi-box",
+                  boxName: "API Box",
+                  description: "API toolset",
+                  tools: [],
+                },
+              ],
+      }),
+    );
+    loadActionTypeToolBoxTools.mockImplementation((boxId: string) =>
+      boxId === "function-box"
+        ? [{ parameters: [], toolId: "function-tool", toolName: "Stored Function" }]
+        : [],
+    );
+
+    render(
+      <ActionTypeToolSelectModal
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open
+        value={createSource({
+          boxId: "function-box",
+          boxName: "Function Box",
+          toolId: "function-tool",
+          toolName: "Stored Function",
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listActionTypeExecutionFactoryCatalog).toHaveBeenLastCalledWith("", "function");
+    });
+    expect(await screen.findByText("Function Box")).toBeTruthy();
+    expect(loadActionTypeToolBoxTools).toHaveBeenCalledWith("function-box");
+
+    const confirmButton = screen.getByText("common.confirm").closest("button");
+    expect(confirmButton).not.toBeNull();
+    expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it("does not reload when value object identity changes but source key stays the same", async () => {
     const onCancel = vi.fn();
     const onConfirm = vi.fn();

--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
@@ -269,6 +269,30 @@ describe("ActionTypeToolSelectModal catalog loading", () => {
     expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it("keeps a stored API-tool fallback when its toolbox is still available", async () => {
+    render(
+      <ActionTypeToolSelectModal
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open
+        value={createSource({ toolId: "removed-tool", toolName: "Removed Tool" })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledWith("", "openapi");
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+    const confirmButton = screen.getByText("common.confirm").closest("button");
+    expect(confirmButton).not.toBeNull();
+    expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it("does not reload when value object identity changes but source key stays the same", async () => {
     const onCancel = vi.fn();
     const onConfirm = vi.fn();

--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.tsx
@@ -370,6 +370,7 @@ export function ActionTypeToolSelectModal({
             currentValue?.type === "tool" &&
             !toolboxMetadataType &&
             activeTab === "openapi" &&
+            !hasInitialGroup &&
             executionUnitTabs.includes("function")
           ) {
             setActiveTab("function");

--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.tsx
@@ -346,8 +346,14 @@ export function ActionTypeToolSelectModal({
               : currentValue?.type === "tool" && currentValue.boxId
                 ? `group:tool:${currentValue.boxId}`
                 : "";
+          const hasInitialGroup =
+            currentValue?.type === "mcp"
+              ? nextCatalog.mcpServers.some((server) => server.mcpId === currentValue.mcpId)
+              : currentValue?.type === "tool"
+                ? nextCatalog.toolBoxes.some((box) => box.boxId === currentValue.boxId)
+                : false;
 
-          if (initialGroupKey) {
+          if (initialGroupKey && hasInitialGroup) {
             setExpandedKeys([initialGroupKey]);
             await ensureGroupToolsLoadedRef.current(initialGroupKey);
             if (requestId !== catalogRequestIdRef.current) {
@@ -360,6 +366,14 @@ export function ActionTypeToolSelectModal({
           const initialSelection = buildSelectionFromValue(catalogRef.current, currentValue);
           if (initialSelection) {
             setSelectedSelection(initialSelection);
+          } else if (
+            currentValue?.type === "tool" &&
+            !toolboxMetadataType &&
+            activeTab === "openapi" &&
+            executionUnitTabs.includes("function")
+          ) {
+            setActiveTab("function");
+            return;
           } else if (currentValue?.type === "tool" && currentValue.boxId) {
             const box = catalogRef.current.toolBoxes.find((item) => item.boxId === currentValue.boxId);
             const fallbackTool = buildToolFromValue(currentValue);
@@ -406,7 +420,7 @@ export function ActionTypeToolSelectModal({
     return () => {
       catalogRequestIdRef.current += 1;
     };
-  }, [activeTab, debouncedKeyword, open, valueKey]);
+  }, [activeTab, debouncedKeyword, executionUnitTabs, open, toolboxMetadataType, valueKey]);
 
   const selectedKey = useMemo(
     () => (selectedSelection ? buildSelectionKey(selectedSelection) : null),


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Restore stored function-tool bindings when editing an action type.
- [ ] Feature/module 2 (not applicable)
- [ ] Docs/doc 1 (not applicable)

---

## Why

- Related Issue: Not provided.
- Related Feature: Knowledge Network execution-unit selector.
- Background: PR #393 changed the selector to separate API toolsets and function sets. Existing action sources do not persist the toolbox metadata type, so a stored function tool initially loads in the API tab and cannot be restored.

---

## How

- Key implementation points: Only preload a persisted source when its parent exists in the active catalog. When an existing tool source is not found in the API tab, automatically switch to the function tab and restore it there.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run)
- [ ] Verified in test environment (not run)

Test notes:

- `pnpm exec vitest run src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx --maxWorkers=1 --minWorkers=1`
- Targeted ESLint and `git diff --check` passed.
- No full test suite, full ESLint, or build was run.

---

## Risk & Rollback

- Potential risks: Stored execution-unit selection restoration in the action-type editor.
- Rollback plan: Revert commit `5ce8713`.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: Backport for the merged release PR #393.