### PR TITLE
fix(knowledge-network): preserve stored API tool fallbacks

### DIFF
--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx
@@ -269,6 +269,30 @@ describe("ActionTypeToolSelectModal catalog loading", () => {
     expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it("keeps a stored API-tool fallback when its toolbox is still available", async () => {
+    render(
+      <ActionTypeToolSelectModal
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        open
+        value={createSource({ toolId: "removed-tool", toolName: "Removed Tool" })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledWith("", "openapi");
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(listActionTypeExecutionFactoryCatalog).toHaveBeenCalledTimes(1);
+    const confirmButton = screen.getByText("common.confirm").closest("button");
+    expect(confirmButton).not.toBeNull();
+    expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it("does not reload when value object identity changes but source key stays the same", async () => {
     const onCancel = vi.fn();
     const onConfirm = vi.fn();

--- a/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.tsx
+++ b/src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.tsx
@@ -370,6 +370,7 @@ export function ActionTypeToolSelectModal({
             currentValue?.type === "tool" &&
             !toolboxMetadataType &&
             activeTab === "openapi" &&
+            !hasInitialGroup &&
             executionUnitTabs.includes("function")
           ) {
             setActiveTab("function");


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Preserve stored API-tool selections when the bound tool is unavailable.
- [ ] Feature/module 2 (not applicable)
- [ ] Docs/doc 1 (not applicable)

---

## Why

- Related Issue: Not provided.
- Related Feature: Knowledge Network execution-unit selector.
- Background: PR #395 added automatic function-set recovery for stored action sources. The recovery must not replace the existing API-tool fallback when its toolbox is still available.

---

## How

- Key implementation points: Only switch from the API toolset to the function set when the stored toolbox is absent from the API catalog. Retain the existing persisted-source fallback when the toolbox exists but the tool is missing.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run)
- [ ] Verified in test environment (not run)

Test notes:

- `pnpm exec vitest run src/modules/knowledge-network/components/action-type/ActionTypeToolSelectModal.test.tsx --maxWorkers=1 --minWorkers=1`
- Targeted ESLint and `git diff --check` passed.
- No full test suite, full ESLint, or build was run.

---

## Risk & Rollback

- Potential risks: Initial restoration of stored action execution-unit selections.
- Rollback plan: Revert commit `54c1ed3`.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: Follow-up to merged PR #395.