### PR TITLE
fix(i18n): correct data resource network label

### DIFF
--- a/src/app/locales/resources/shell/en-US.ts
+++ b/src/app/locales/resources/shell/en-US.ts
@@ -28,7 +28,7 @@ export const shellEnUS = {
       domainKnowledgeNetwork: "Domain Knowledge Network",
       knowledgeNetworkManagement: "Knowledge Network Management",
       knowledgeNetworkIntegration: "Knowledge Network Integration",
-      generalBusinessKnowledgeNetwork: "Data Semantic Governance",
+      generalBusinessKnowledgeNetwork: "Data Resource Knowledge Network",
       dataConnection: "Data Connection",
       dataCatalog: "Data Catalog",
       indexBuild: "Task Management",


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Corrected the English shell navigation label for `数据资源知识网络`.
- [ ] Feature/module 2 (not applicable: locale-label-only correction).
- [ ] Docs/doc 1 (not applicable: no documentation change required).

---

## Why

- Related Issue: Closes #368
- Related Feature: Global i18n readiness
- Background: The previous English label changed the product concept from data resource knowledge network to semantic governance.

---

## How

- Key implementation points: Updated the existing `generalBusinessKnowledgeNetwork` English locale value to `Data Resource Knowledge Network`.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: locale resource only).
- [ ] Verified in test environment (not applicable: no deployed test environment used).

Test notes:

- `vitest --run src/app/locales/locale-parity.test.ts src/framework/i18n/format.test.ts` (7/7 passed)

---

## Risk & Rollback

- Potential risks: Low; only the English label for one shell navigation item changes.
- Rollback plan: Revert this single commit.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: The PR is based on current `main` and intentionally excludes all changes already merged through PR #402.