### PR TITLE
chore(studio): bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bkn-studio",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.4",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE",
   "packageManager": "pnpm@11.5.1",


### PR DESCRIPTION
# Pull Request

## What Changed

将 bkn-studio 的版本号从 `0.1.3` 升级到 `0.1.4`。

- [x] package.json 中 `version` 字段更新

---

## Why

- Related Issue: 无
- Related Feature: 无
- Background:
  bkn-studio 顶部栏用户菜单显示的版本号取自 `package.json` 的 `version` 字段（经 `src/framework/runtime/app-version.ts` 导出 `APP_VERSION`，在 `TopBar.tsx` 渲染）。需将源头版本号同步至 `0.1.4`，重新构建后 UI 即显示新版本。

---

## How

- Key implementation points:
  仅修改 `package.json` 的 `version` 字段：`0.1.3` -> `0.1.4`。源码中无任何硬编码版本号，版本经 Vite 构建时从 `package.json` 内联进静态产物。
- Breaking changes (API, config, database, etc.): 无

---

## Testing

- [ ] Unit tests passed locally - 不适用（无逻辑变更）
- [ ] Integration tests passed locally - 不适用
- [ ] Verified in test environment - 待重新构建并部署后，顶部栏用户菜单应显示 `v0.1.4`

Test notes:
版本号在 Vite build 时内联进 JS bundle，需重新构建镜像并部署后生效；浏览器可能需硬刷新清缓存。

---

## Risk & Rollback

- Potential risks:
  极低。仅版本号字符串变更，不影响任何运行时逻辑。
- Rollback plan:
  将 `package.json` 的 `version` 改回 `0.1.3` 并重新构建部署即可。

---

## Additional Notes

- 改动仅涉及 `package.json` 单个文件