### PR TITLE
feat(data-catalog): add catalog deletion preflight

### DIFF
--- a/src/modules/data-catalog/components/BuildStatusTag.tsx
+++ b/src/modules/data-catalog/components/BuildStatusTag.tsx
@@ -75,7 +75,7 @@ export function BuildStatusTag({ plain = false, task }: BuildStatusTagProps) {
         ? styles.taskSucceeded
         : task.status === "listening"
           ? styles.modeStreaming
-          : task.status === "running"
+          : task.status === "running" || task.status === "stopping"
             ? styles.taskRunning
             : styles.taskPending;
 

--- a/src/modules/data-catalog/components/BuildTaskDetailDrawer.tsx
+++ b/src/modules/data-catalog/components/BuildTaskDetailDrawer.tsx
@@ -281,7 +281,9 @@ export function BuildTaskDetailDrawer({
                       ? sharedStyles.taskSucceeded
                       : task.status === "listening"
                         ? sharedStyles.modeStreaming
-                        : sharedStyles.taskRunning,
+                        : task.status === "cancelled"
+                          ? sharedStyles.taskPending
+                          : sharedStyles.taskRunning,
                 ].join(" ")}
               >
                 {statusLabel}

--- a/src/modules/data-catalog/components/CatalogTreePanel.tsx
+++ b/src/modules/data-catalog/components/CatalogTreePanel.tsx
@@ -25,7 +25,11 @@ import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { BusinessTree, BusinessTreePanel } from "@/framework/ui/common/BusinessTreePanel";
 import { isBuiltinLogicalCatalog } from "@/modules/data-catalog/lib/logical-catalog";
-import { createLogicalCatalog, deleteCatalog } from "@/shared/catalog";
+import {
+  createLogicalCatalog,
+  deleteCatalog,
+  previewCatalogDeletion,
+} from "@/shared/catalog";
 import type { CatalogRecord } from "@/shared/catalog";
 import type { DataConnectConnectorType } from "@/modules/data-connect/types/data-connect";
 
@@ -293,25 +297,49 @@ export function CatalogTreePanel({
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    void modal.confirm({
-                      title: t("dataCatalog.tree.deleteLogicalTitle"),
-                      content: t("dataCatalog.tree.deleteLogicalDescription", {
-                        name: catalog.name,
-                      }),
-                      okText: t("common.delete"),
-                      cancelText: t("common.cancel"),
-                      okButtonProps: { danger: true },
-                      onOk: async () => {
-                        try {
-                          await deleteCatalog(catalog.id);
-                          message.success(t("common.success"));
-                          await onRefresh();
-                        } catch (error) {
-                          void message.error(extractRequestErrorMessage(error));
-                          throw error;
-                        }
-                      },
-                    });
+                    void (async () => {
+                      let impact;
+                      try {
+                        impact = await previewCatalogDeletion(catalog.id);
+                      } catch (error) {
+                        void message.error(extractRequestErrorMessage(error));
+                        return;
+                      }
+
+                      if (!impact.canDelete) {
+                        void modal.warning({
+                          content: t("dataCatalog.tree.deleteLogicalBlockedDescription", {
+                            blocking: impact.semanticUnderstandingTasks.blocking,
+                            protected: impact.protectedResources,
+                          }),
+                          okText: t("common.confirm"),
+                          title: t("dataCatalog.tree.deleteLogicalBlockedTitle"),
+                        });
+                        return;
+                      }
+
+                      void modal.confirm({
+                        title: t("dataCatalog.tree.deleteLogicalTitle"),
+                        content: t("dataCatalog.tree.deleteLogicalDescription", {
+                          name: catalog.name,
+                          resources: impact.resources,
+                          semanticTasks: impact.semanticUnderstandingTasks.willCancel,
+                        }),
+                        okText: t("common.delete"),
+                        cancelText: t("common.cancel"),
+                        okButtonProps: { danger: true },
+                        onOk: async () => {
+                          try {
+                            await deleteCatalog(catalog.id);
+                            message.success(t("common.success"));
+                            await onRefresh();
+                          } catch (error) {
+                            void message.error(extractRequestErrorMessage(error));
+                            throw error;
+                          }
+                        },
+                      });
+                    })();
                   }}
                   title={t("common.delete")}
                   type="button"

--- a/src/modules/data-catalog/components/CatalogTreePanel.tsx
+++ b/src/modules/data-catalog/components/CatalogTreePanel.tsx
@@ -308,10 +308,33 @@ export function CatalogTreePanel({
 
                       if (!impact.canDelete) {
                         void modal.warning({
-                          content: t("dataCatalog.tree.deleteLogicalBlockedDescription", {
-                            blocking: impact.semanticUnderstandingTasks.blocking,
-                            protected: impact.protectedResources,
-                          }),
+                          content: (
+                            <div>
+                              <div>
+                                {t("dataCatalog.tree.deleteLogicalBlockedDescription")}
+                              </div>
+                              <ul>
+                                {impact.blockers.map((blocker) => {
+                                  const count =
+                                    blocker === "protected_resources"
+                                      ? impact.protectedResources
+                                      : blocker === "build_tasks_running_or_stopping"
+                                        ? impact.buildTasks.blocking
+                                        : blocker === "discover_tasks_running"
+                                          ? impact.discoverTasks.blocking
+                                          : impact.semanticUnderstandingTasks.blocking;
+                                  return (
+                                    <li key={blocker}>
+                                      {t(
+                                        `dataCatalog.tree.deleteLogicalBlockers.${blocker}`,
+                                        { count },
+                                      )}
+                                    </li>
+                                  );
+                                })}
+                              </ul>
+                            </div>
+                          ),
                           okText: t("common.confirm"),
                           title: t("dataCatalog.tree.deleteLogicalBlockedTitle"),
                         });

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -91,7 +91,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
 
   const columns = [
     { dataIndex: "id", title: t("dataCatalog.taskManagement.columns.task"), ellipsis: true },
-    { dataIndex: "status", title: t("common.status"), render: (value: string) => <Tag color={value === "failed" ? "error" : value === "succeeded" ? "success" : "processing"}>{t(`dataCatalog.taskManagement.semanticStatus.${value}`)}</Tag> },
+    { dataIndex: "status", title: t("common.status"), render: (value: string) => <Tag color={value === "failed" ? "error" : value === "succeeded" ? "success" : value === "cancelled" ? "default" : "processing"}>{t(`dataCatalog.taskManagement.semanticStatus.${value}`)}</Tag> },
     { dataIndex: "applyMode", title: t("dataCatalog.taskManagement.columns.applyMode"), render: (value: string) => t(`dataCatalog.taskManagement.applyMode.${value === "dry_run" ? "dryRun" : value === "fill_empty" ? "fillEmpty" : "force"}`) },
     { dataIndex: "confidence", title: t("dataCatalog.taskManagement.columns.confidence"), render: (value: number) => `${Math.round(value * 100)}%` },
     { dataIndex: "applied", title: t("dataCatalog.taskManagement.columns.applied"), render: (value: boolean) => <Tag color={value ? "success" : "default"}>{t(value ? "dataCatalog.taskManagement.applied.applied" : "dataCatalog.taskManagement.applied.notApplied")}</Tag> },

--- a/src/modules/data-catalog/components/SemanticUnderstandingTaskDetailDrawer.tsx
+++ b/src/modules/data-catalog/components/SemanticUnderstandingTaskDetailDrawer.tsx
@@ -137,7 +137,7 @@ export function SemanticUnderstandingTaskDetailDrawer({ onClose, open, taskId }:
   }
 
   const applyModeKey = task.applyMode === "dry_run" ? "dryRun" : task.applyMode === "force" ? "force" : "fillEmpty";
-  const statusClass = task.status === "failed" ? sharedStyles.taskFailed : task.status === "succeeded" ? sharedStyles.taskSucceeded : sharedStyles.taskRunning;
+  const statusClass = task.status === "failed" ? sharedStyles.taskFailed : task.status === "succeeded" ? sharedStyles.taskSucceeded : task.status === "cancelled" ? sharedStyles.taskPending : sharedStyles.taskRunning;
   const creator = task.creator.name || task.creator.id;
   const quality = getQuality(task.confidenceDetailJson, task.resultJson);
   const warnings = getWarnings(task.confidenceDetailJson, task.resultJson);

--- a/src/modules/data-catalog/lib/index-build-filters.ts
+++ b/src/modules/data-catalog/lib/index-build-filters.ts
@@ -8,11 +8,13 @@
 import type { BuildMode, BuildTaskStatus } from "@/modules/data-catalog/types/data-catalog";
 
 const STATUS_SET = new Set<BuildTaskStatus>([
+  "cancelled",
   "failed",
   "listening",
   "paused",
   "pending",
   "running",
+  "stopping",
   "succeeded",
 ]);
 

--- a/src/modules/data-catalog/lib/index-state.test.ts
+++ b/src/modules/data-catalog/lib/index-state.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { indexStateOf } from "@/modules/data-catalog/lib/index-state";
+import type { BuildTask } from "@/modules/data-catalog/types/data-catalog";
+
+function buildTask(
+  status: BuildTask["status"],
+  overrides: Partial<BuildTask> = {},
+): BuildTask {
+  return {
+    buildKeyFields: [],
+    createdAt: 1,
+    createTime: "-",
+    embeddingDegraded: false,
+    embeddingFields: [],
+    embeddingModel: "",
+    error: null,
+    failureDetail: "",
+    finishTime: null,
+    fulltextAnalyzer: "",
+    fulltextFields: [],
+    id: "task-1",
+    indexUsable: status === "succeeded",
+    lastEventAt: null,
+    mode: "batch",
+    modelDimensions: 0,
+    resourceId: "resource-1",
+    status,
+    syncedCount: status === "succeeded" ? 10 : 0,
+    totalCount: 10,
+    vectorizedCount: status === "succeeded" ? 10 : 0,
+    ...overrides,
+  };
+}
+
+describe("indexStateOf · stopping and cancelled tasks", () => {
+  it("keeps a stopping task in the active build bucket", () => {
+    expect(indexStateOf([buildTask("stopping")]).key).toBe("building");
+
+    const previous = buildTask("succeeded", { createdAt: 1, id: "completed" });
+    const stopping = buildTask("stopping", { createdAt: 2, id: "stopping" });
+    expect(indexStateOf([previous, stopping]).key).toBe("rebuilding");
+  });
+
+  it("does not treat a cancelled pending task as a failed index", () => {
+    expect(indexStateOf([buildTask("cancelled")]).key).toBe("none");
+
+    const previous = buildTask("succeeded", { createdAt: 1, id: "completed" });
+    const cancelled = buildTask("cancelled", { createdAt: 2, id: "cancelled" });
+    expect(indexStateOf([previous, cancelled]).key).toBe("built");
+  });
+});

--- a/src/modules/data-catalog/lib/index-state.ts
+++ b/src/modules/data-catalog/lib/index-state.ts
@@ -46,7 +46,11 @@ export function indexStateOf(tasks: BuildTask[]): IndexState {
     return { key: "none", latest: null, effective: null };
   }
 
-  if (latest.status === "running" || latest.status === "pending") {
+  if (
+    latest.status === "running" ||
+    latest.status === "pending" ||
+    latest.status === "stopping"
+  ) {
     return {
       key: effective && effective.id !== latest.id ? "rebuilding" : "building",
       latest,
@@ -63,6 +67,19 @@ export function indexStateOf(tasks: BuildTask[]): IndexState {
   }
 
   if (latest.status === "succeeded") {
+    return { key: "built", latest, effective };
+  }
+
+  if (latest.status === "cancelled") {
+    if (!effective) {
+      return { key: "none", latest, effective };
+    }
+    if (effective.status === "listening") {
+      return { key: "listening", latest, effective };
+    }
+    if (effective.status === "paused") {
+      return { key: "paused", latest, effective };
+    }
     return { key: "built", latest, effective };
   }
 

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -62,7 +62,7 @@ export const dataCatalogEnUS = {
       moreFilters: "More filters",
       moreFiltersWithCount: "More filters ({{count}})",
       clearAdvancedFilters: "Clear more filters",
-      semanticStatus: { pending: "Pending", running: "Running", succeeded: "Succeeded", failed: "Failed" },
+      semanticStatus: { pending: "Pending", running: "Running", succeeded: "Succeeded", failed: "Failed", cancelled: "Cancelled" },
       details: { taskInformation: "Task Information", scheduleId: "Schedule ID", startTime: "Started", message: "Message", agentId: "Agent ID", failureReason: "Failure Reason" },
       discover: { empty: "No discover tasks" },
       semantic: { empty: "No semantic-understanding tasks", deleteTitle: "Delete semantic-understanding task", deleteDescription: "Delete semantic-understanding task “{{id}}”?", detailSections: { task: "Task Information", execution: "Execution & Apply", quality: "Quality & Field Application", payload: "Input & Result", audit: "Audit Information" }, fields: { catalogId: "Catalog ID", resourceId: "Resource ID", agentTaskId: "Agent Task ID", confidenceThreshold: "Confidence Threshold", confidenceDetail: "Confidence Detail", appliedTime: "Applied At", applyDetail: "Apply Detail", inputHash: "Input Hash", input: "Input Snapshot", result: "Understanding Result", resourceEffective: "Resource Enhancement", fieldEffective: "Effective Field Enhancements", warnings: "Processing Notes", field: "Field", updated: "Updated Attributes", reason: "Reason" }, values: { effective: "Effective", notEffective: "No effective update", fieldEffective: "{{effective}} / {{total}} fields" }, fieldStatus: { updated: "Updated", partial: "Partially updated", unchanged: "Unchanged", skipped: "Skipped" } },
@@ -159,7 +159,10 @@ export const dataCatalogEnUS = {
       logicalDescriptionPlaceholder: "Optional description",
       deleteLogicalTitle: "Delete logical group",
       deleteLogicalDescription:
-        'Delete logical group "{{name}}"? Resources under it will also be removed.',
+        'Delete logical group "{{name}}"? This removes {{resources}} resources and cancels {{semanticTasks}} pending semantic tasks.',
+      deleteLogicalBlockedTitle: "Logical group cannot be deleted",
+      deleteLogicalBlockedDescription:
+        "There are {{protected}} protected resources and {{blocking}} running semantic tasks. Resolve them before trying again.",
       discovering: "Discovering",
       emptyPhysicalGroup: "No physical data source connections",
       emptyLogicalGroup: "No logical groups yet. Use + to add one.",
@@ -461,6 +464,7 @@ export const dataCatalogEnUS = {
       statuses: {
         pending: "Pending",
         running: "Building",
+        stopping: "Stopping",
         listening: "Listening",
         paused: "Paused",
         stopped: "Stopped",
@@ -469,6 +473,7 @@ export const dataCatalogEnUS = {
         embeddingFailed: "Vectorization failed",
         embeddingPartial: "Partial vectorization",
         failed: "Failed",
+        cancelled: "Cancelled",
       },
     },
   },

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -162,7 +162,13 @@ export const dataCatalogEnUS = {
         'Delete logical group "{{name}}"? This removes {{resources}} resources and cancels {{semanticTasks}} pending semantic tasks.',
       deleteLogicalBlockedTitle: "Logical group cannot be deleted",
       deleteLogicalBlockedDescription:
-        "There are {{protected}} protected resources and {{blocking}} running semantic tasks. Resolve them before trying again.",
+        "Resolve the following blockers before trying again:",
+      deleteLogicalBlockers: {
+        protected_resources: "{{count}} protected resources",
+        build_tasks_running_or_stopping: "{{count}} running or stopping build tasks",
+        discover_tasks_running: "{{count}} running discover tasks",
+        semantic_understanding_tasks_running: "{{count}} running semantic tasks",
+      },
       discovering: "Discovering",
       emptyPhysicalGroup: "No physical data source connections",
       emptyLogicalGroup: "No logical groups yet. Use + to add one.",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -59,7 +59,7 @@ export const dataCatalogZhCN = {
       moreFilters: "更多筛选",
       moreFiltersWithCount: "更多筛选（{{count}}）",
       clearAdvancedFilters: "清空更多筛选",
-      semanticStatus: { pending: "等待中", running: "执行中", succeeded: "已完成", failed: "失败" },
+      semanticStatus: { pending: "等待中", running: "执行中", succeeded: "已完成", failed: "失败", cancelled: "已取消" },
       details: { taskInformation: "任务信息", scheduleId: "计划 ID", startTime: "开始时间", message: "执行信息", agentId: "Agent ID", failureReason: "失败原因" },
       discover: { empty: "暂无探查任务" },
       semantic: { empty: "暂无语义理解任务", deleteTitle: "删除语义理解任务", deleteDescription: "确认删除语义理解任务“{{id}}”吗？", detailSections: { task: "任务信息", execution: "执行与应用", quality: "质量与字段应用", payload: "输入与结果", audit: "审计信息" }, fields: { catalogId: "目录 ID", resourceId: "资源 ID", agentTaskId: "Agent 任务 ID", confidenceThreshold: "置信度阈值", confidenceDetail: "置信度明细", appliedTime: "应用时间", applyDetail: "应用明细", inputHash: "输入哈希", input: "输入快照", result: "理解结果", resourceEffective: "资源语义增强", fieldEffective: "有效字段增强", warnings: "处理提示", field: "字段", updated: "已更新属性", reason: "原因" }, values: { effective: "有效", notEffective: "无有效更新", fieldEffective: "{{effective}} / {{total}} 个字段" }, fieldStatus: { updated: "已更新", partial: "部分更新", unchanged: "无变更", skipped: "已跳过" } },
@@ -152,7 +152,11 @@ export const dataCatalogZhCN = {
       logicalNamePlaceholder: "例如 team_analytics",
       logicalDescriptionPlaceholder: "可选，说明该逻辑分组用途",
       deleteLogicalTitle: "删除逻辑分组",
-      deleteLogicalDescription: '确认删除逻辑分组「{{name}}」吗？其下资源将一并删除。',
+      deleteLogicalDescription:
+        '确认删除逻辑分组「{{name}}」吗？将删除 {{resources}} 个资源，并取消 {{semanticTasks}} 个待执行语义理解任务。',
+      deleteLogicalBlockedTitle: "当前无法删除逻辑分组",
+      deleteLogicalBlockedDescription:
+        "存在 {{protected}} 个受保护资源和 {{blocking}} 个运行中的语义理解任务，请先处理后再试。",
       discovering: "探查中",
       emptyPhysicalGroup: "暂无物理数据源连接",
       emptyLogicalGroup: "暂无逻辑分组，可点击右上角新增",
@@ -435,6 +439,7 @@ export const dataCatalogZhCN = {
       statuses: {
         pending: "排队中",
         running: "构建中",
+        stopping: "停止中",
         listening: "监听中",
         paused: "已暂停",
         stopped: "已停止",
@@ -443,6 +448,7 @@ export const dataCatalogZhCN = {
         embeddingFailed: "向量化失败",
         embeddingPartial: "向量化部分失败",
         failed: "失败",
+        cancelled: "已取消",
       },
     },
   },

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -156,7 +156,13 @@ export const dataCatalogZhCN = {
         '确认删除逻辑分组「{{name}}」吗？将删除 {{resources}} 个资源，并取消 {{semanticTasks}} 个待执行语义理解任务。',
       deleteLogicalBlockedTitle: "当前无法删除逻辑分组",
       deleteLogicalBlockedDescription:
-        "存在 {{protected}} 个受保护资源和 {{blocking}} 个运行中的语义理解任务，请先处理后再试。",
+        "请先处理以下阻断项，然后重试：",
+      deleteLogicalBlockers: {
+        protected_resources: "受保护资源 {{count}} 个",
+        build_tasks_running_or_stopping: "运行中或停止中的构建任务 {{count}} 个",
+        discover_tasks_running: "运行中的探查任务 {{count}} 个",
+        semantic_understanding_tasks_running: "运行中的语义理解任务 {{count}} 个",
+      },
       discovering: "探查中",
       emptyPhysicalGroup: "暂无物理数据源连接",
       emptyLogicalGroup: "暂无逻辑分组，可点击右上角新增",

--- a/src/modules/data-catalog/scenes/IndexBuildListScene.tsx
+++ b/src/modules/data-catalog/scenes/IndexBuildListScene.tsx
@@ -60,9 +60,11 @@ const STATUS_OPTIONS: BuildTaskStatus[] = [
   "pending",
   "running",
   "listening",
+  "stopping",
   "paused",
   "succeeded",
   "failed",
+  "cancelled",
 ];
 
 function EllipsisText({ text, title }: { text: string; title?: string }) {
@@ -502,7 +504,7 @@ export function IndexBuildListScene() {
         if (canManageResourceTasks && record.status === "failed") {
           menuItems.push({ key: "retry", label: t("dataCatalog.task.rerun") });
         }
-        if (canManageResourceTasks) {
+        if (canManageResourceTasks && record.status !== "stopping") {
           menuItems.push({ danger: true, key: "delete", label: t("common.delete") });
         }
 

--- a/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
+++ b/src/modules/data-catalog/scenes/TaskManagementTaskPanels.tsx
@@ -256,7 +256,7 @@ export function DiscoverTaskListPanel() {
     },
     { dataIndex: "strategy", title: t("dataCatalog.taskManagement.columns.strategy"), width: 130, render: (value) => t(`dataConnect.discoverStrategies.${value}`) },
     { dataIndex: "triggerType", title: t("dataCatalog.taskManagement.columns.trigger"), width: 120, render: (value) => t(`dataConnect.discoverTriggerTypes.${value}`) },
-    { dataIndex: "status", title: t("common.status"), width: 120, render: (value) => <Tag color={value === "failed" ? "error" : value === "completed" ? "success" : "processing"}>{t(`dataConnect.discoverTaskStatuses.${value}`)}</Tag> },
+    { dataIndex: "status", title: t("common.status"), width: 120, render: (value) => <Tag color={value === "failed" ? "error" : value === "completed" ? "success" : value === "cancelled" ? "default" : "processing"}>{t(`dataConnect.discoverTaskStatuses.${value}`)}</Tag> },
     {
       dataIndex: "progress",
       title: t("dataCatalog.task.progress"),
@@ -312,7 +312,7 @@ export function DiscoverTaskListPanel() {
       <Select allowClear className={styles.select} filterOption={false} onSearch={setCatalogKeyword} options={catalogs.map((item) => ({ label: item.name, value: item.id }))} placeholder={t("dataCatalog.resource.catalog")} showSearch value={catalogId} onChange={(value) => { setCatalogId(value); setPage(1); }} />
       <Select allowClear className={styles.select} options={["full_sync", "create_only", "cleanup_only"].map((value) => ({ label: t(`dataConnect.discoverStrategies.${value}`), value }))} placeholder={t("dataCatalog.taskManagement.columns.strategy")} value={strategy} onChange={(value) => { setStrategy(value); setPage(1); }} />
       <Select allowClear className={styles.select} options={["manual", "scheduled"].map((value) => ({ label: t(`dataConnect.discoverTriggerTypes.${value}`), value }))} placeholder={t("dataCatalog.taskManagement.columns.trigger")} value={triggerType} onChange={(value) => { setTriggerType(value); setPage(1); }} />
-      <Select allowClear className={styles.select} options={["pending", "running", "completed", "failed"].map((value) => ({ label: t(`dataConnect.discoverTaskStatuses.${value}`), value }))} placeholder={t("common.status")} value={status} onChange={(value) => { setStatus(value); setPage(1); }} />
+      <Select allowClear className={styles.select} options={["pending", "running", "completed", "failed", "cancelled"].map((value) => ({ label: t(`dataConnect.discoverTaskStatuses.${value}`), value }))} placeholder={t("common.status")} value={status} onChange={(value) => { setStatus(value); setPage(1); }} />
     </Space></div>
     <TaskTable error={error} loading={loading} data={tasks} columns={columns} emptyTitle={t("dataCatalog.taskManagement.discover.empty")} onRetry={load} onTableChange={handleTableChange} selectedKeys={selectedKeys} onSelectionChange={setSelectedKeys} />
     <Pagination page={page} pageSize={pageSize} total={total} onChange={(nextPage, nextSize) => { setPage(nextPage); setPageSize(nextSize); }} />
@@ -465,7 +465,7 @@ export function SemanticUnderstandingTaskListPanel() {
           "-"
         ),
     },
-    { dataIndex: "status", title: t("common.status"), width: 120, render: (value) => <Tag color={value === "succeeded" ? "success" : value === "failed" ? "error" : "processing"}>{t(`dataCatalog.taskManagement.semanticStatus.${value}`)}</Tag> },
+    { dataIndex: "status", title: t("common.status"), width: 120, render: (value) => <Tag color={value === "succeeded" ? "success" : value === "failed" ? "error" : value === "cancelled" ? "default" : "processing"}>{t(`dataCatalog.taskManagement.semanticStatus.${value}`)}</Tag> },
     {
       dataIndex: "applyMode",
       title: t("dataCatalog.taskManagement.columns.applyMode"),
@@ -542,7 +542,7 @@ export function SemanticUnderstandingTaskListPanel() {
   return <TaskPanel><div className={styles.operationBar}><Space className={styles.toolbarActions}><AppButton icon={<ReloadOutlined />} onClick={() => void load()}>{t("common.refresh")}</AppButton><PermissionGate permissions="catalog:task_manage"><AppButton danger disabled={selectedKeys.length === 0} icon={<DeleteOutlined />} onClick={handleBatchDelete}>{selectedKeys.length > 0 ? `${t("dataCatalog.task.batchDelete")} (${selectedKeys.length})` : t("dataCatalog.task.batchDelete")}</AppButton></PermissionGate></Space><Space className={styles.toolbarFilters}>
     <Select allowClear className={styles.select} filterOption={false} onSearch={setCatalogKeyword} options={catalogs.map((item) => ({ label: item.name, value: item.id }))} placeholder={t("dataCatalog.resource.catalog")} showSearch value={catalogId} onChange={(value) => { setCatalogId(value); setResourceId(undefined); setPage(1); }} />
     <Select allowClear className={styles.select} disabled={scope === "catalog"} filterOption={false} onSearch={setResourceKeyword} options={resourceOptions} placeholder={t("dataCatalog.build.resource")} showSearch value={resourceId} onChange={(value) => { setResourceId(value); setPage(1); }} />
-    <Select allowClear className={styles.select} options={["pending", "running", "succeeded", "failed"].map((value) => ({ label: t(`dataCatalog.taskManagement.semanticStatus.${value}`), value }))} placeholder={t("common.status")} value={status} onChange={(value) => { setStatus(value); setPage(1); }} />
+    <Select allowClear className={styles.select} options={["pending", "running", "succeeded", "failed", "cancelled"].map((value) => ({ label: t(`dataCatalog.taskManagement.semanticStatus.${value}`), value }))} placeholder={t("common.status")} value={status} onChange={(value) => { setStatus(value); setPage(1); }} />
     <Popover content={advancedFilters} trigger="click"><AppButton icon={<FilterOutlined />}>{moreFiltersLabel}</AppButton></Popover>
   </Space></div><TaskTable error={error} loading={loading} data={tasks} columns={columns} emptyTitle={t("dataCatalog.taskManagement.semantic.empty")} onRetry={load} onTableChange={handleTableChange} selectedKeys={selectedKeys} onSelectionChange={setSelectedKeys} /><Pagination page={page} pageSize={pageSize} total={total} onChange={(nextPage, nextSize) => { setPage(nextPage); setPageSize(nextSize); }} />{detailTaskId ? <SemanticUnderstandingTaskDetailDrawer onClose={() => setDetailTaskId(null)} open taskId={detailTaskId} /> : null}</TaskPanel>;
 }

--- a/src/modules/data-catalog/services/build-task-status-param.test.ts
+++ b/src/modules/data-catalog/services/build-task-status-param.test.ts
@@ -7,28 +7,33 @@
 
 import { describe, expect, it } from "vitest";
 
-import { backendStatusParam } from "@/modules/data-catalog/services/build-task.service";
+import { backendStatusParams } from "@/modules/data-catalog/services/build-task.service";
 
 // Locks the frontend-normalized-state to backend-enum mapping; the real backend cannot be verified locally, so this protects the contract.
-describe("backendStatusParam — 前端状态 → 后端枚举(逗号多值)", () => {
-  it("paused 必须同时展开为 stopping,stopped", () => {
-    expect(backendStatusParam(["paused"])).toBe("stopping,stopped");
+describe("backendStatusParams — 前端状态 → 后端重复查询参数", () => {
+  it("区分 stopping 和可恢复的 stopped", () => {
+    expect(backendStatusParams(["stopping"])).toEqual(["stopping"]);
+    expect(backendStatusParams(["paused"])).toEqual(["stopped"]);
   });
 
-  it("pending→init, running→running, succeeded→completed, failed→failed", () => {
-    expect(backendStatusParam(["pending"])).toBe("init");
-    expect(backendStatusParam(["running"])).toBe("running");
-    expect(backendStatusParam(["succeeded"])).toBe("completed");
-    expect(backendStatusParam(["failed"])).toBe("failed");
+  it("映射前端归一化状态", () => {
+    expect(backendStatusParams(["pending"])).toEqual(["pending"]);
+    expect(backendStatusParams(["running"])).toEqual(["running"]);
+    expect(backendStatusParams(["succeeded"])).toEqual(["completed"]);
+    expect(backendStatusParams(["failed"])).toEqual(["failed"]);
+    expect(backendStatusParams(["cancelled"])).toEqual(["cancelled"]);
   });
 
   it("listening 也映射到后端 running,与 running 去重", () => {
-    expect(backendStatusParam(["running", "listening"])).toBe("running");
+    expect(backendStatusParams(["running", "listening"])).toEqual(["running"]);
   });
 
-  it("多状态拼接、去重", () => {
-    expect(backendStatusParam(["running", "paused", "failed"])).toBe(
-      "running,stopping,stopped,failed",
-    );
+  it("多状态展开并去重", () => {
+    expect(backendStatusParams(["running", "stopping", "paused", "failed"])).toEqual([
+      "running",
+      "stopping",
+      "stopped",
+      "failed",
+    ]);
   });
 });

--- a/src/modules/data-catalog/services/build-task.service.test.ts
+++ b/src/modules/data-catalog/services/build-task.service.test.ts
@@ -74,6 +74,12 @@ describe("mapBuildTask", () => {
 
     expect(task.executeType).toBeUndefined();
   });
+
+  it("keeps stopping distinct and preserves cancelled", () => {
+    expect(mapBuildTask({ id: "task-1", status: "stopping" }).status).toBe("stopping");
+    expect(mapBuildTask({ id: "task-2", status: "stopped" }).status).toBe("paused");
+    expect(mapBuildTask({ id: "task-3", status: "cancelled" }).status).toBe("cancelled");
+  });
 });
 
 describe("createBuildTask", () => {
@@ -110,6 +116,29 @@ describe("createBuildTask", () => {
       await expect(
         createWithAPI({ mode: "batch", resourceId: "resource-1" }),
       ).rejects.toThrow("Created build task task-1 could not be retrieved");
+    });
+
+    it("sends repeated backend status parameters without active", async () => {
+      getMock.mockResolvedValue({ data: { entries: [], total_count: 0 } });
+      const { listBuildTaskPage } = await import(
+        "@/modules/data-catalog/services/build-task.service"
+      );
+
+      await listBuildTaskPage({
+        page: 1,
+        pageSize: 20,
+        statuses: ["stopping", "paused", "cancelled"],
+      });
+
+      expect(getMock).toHaveBeenCalledOnce();
+      expect(getMock.mock.calls[0]?.[0]).toBe("/vega-backend/v1/build-tasks");
+      const config = getMock.mock.calls[0]?.[1] as {
+        params: Record<string, unknown>;
+        paramsSerializer: { indexes: null };
+      };
+      expect(config.params.status).toEqual(["stopping", "stopped", "cancelled"]);
+      expect(config.paramsSerializer).toEqual({ indexes: null });
+      expect(config.params).not.toHaveProperty("active");
     });
   });
 });

--- a/src/modules/data-catalog/services/build-task.service.ts
+++ b/src/modules/data-catalog/services/build-task.service.ts
@@ -108,8 +108,8 @@ function splitFields(value?: string | string[]): string[] {
 }
 
 /**
- * Vega backend enum values: init, running, completed, stopping, stopped, and failed.
- * In streaming mode, running means persistent listening, while stopped/stopping means paused.
+ * Vega backend enum values: pending, running, completed, stopping, stopped, failed, and cancelled.
+ * In streaming mode, running means persistent listening, while stopped is presented as paused.
  */
 function normalizeStatus(value: string | undefined, mode: BuildMode): BuildTaskStatus {
   switch (value) {
@@ -117,17 +117,19 @@ function normalizeStatus(value: string | undefined, mode: BuildMode): BuildTaskS
       return mode === "streaming" ? "listening" : "running";
     case "completed":
       return "succeeded";
-    case "stopping":
     case "stopped":
       return "paused";
+    case "stopping":
+      return "stopping";
     case "failed":
       return "failed";
+    case "cancelled":
+      return "cancelled";
     case "listening":
     case "paused":
     case "succeeded":
     case "pending":
       return value;
-    case "init":
     default:
       return "pending";
   }
@@ -299,7 +301,7 @@ export function mapBuildTask(item: BackendBuildTask): BuildTask {
     createdAt,
     createTime: createdAt ? formatMockTimestamp(createdAt) : "-",
     finishTime:
-      (status === "succeeded" || status === "failed") && item.update_time
+      (status === "succeeded" || status === "failed" || status === "cancelled") && item.update_time
         ? formatMockTimestamp(item.update_time)
         : null,
     updatedAt: item.update_time,
@@ -338,8 +340,9 @@ export async function listBuildTasks(
     return wait(filterTasks(tasks, query), 120);
   }
 
-  // The backend supports only one status value and uses different enum values, so load all and
-  // filter in the frontend by normalized status.
+  const backendStatuses = query.statuses?.length
+    ? backendStatusParams(query.statuses)
+    : undefined;
   const tasks: BuildTask[] = [];
   let offset = 0;
   let total = Number.POSITIVE_INFINITY;
@@ -353,7 +356,9 @@ export async function listBuildTasks(
           offset,
           resource_id: query.resourceId || undefined,
           catalog_id: query.catalogId || undefined,
+          status: backendStatuses,
         },
+        paramsSerializer: { indexes: null },
         skipErrorToast: query.silent,
       },
     );
@@ -370,27 +375,27 @@ export async function listBuildTasks(
   return filterTasks(tasks, query);
 }
 
-// Frontend normalized states mapped to backend enums. paused covers stopping/stopped; listening maps to backend running.
+// Frontend normalized states mapped to backend enums. paused maps to stopped; listening maps to running.
 const FE_TO_BACKEND_STATUS: Record<BuildTaskStatus, string[]> = {
-  pending: ["init"],
+  pending: ["pending"],
   running: ["running"],
   listening: ["running"],
   succeeded: ["completed"],
-  paused: ["stopping", "stopped"],
+  paused: ["stopped"],
+  stopping: ["stopping"],
   failed: ["failed"],
+  cancelled: ["cancelled"],
 };
 
-export function backendStatusParam(statuses: BuildTaskStatus[]): string {
+export function backendStatusParams(statuses: BuildTaskStatus[]): string[] {
   const set = new Set<string>();
   for (const status of statuses) {
     for (const backend of FE_TO_BACKEND_STATUS[status]) {
       set.add(backend);
     }
   }
-  return Array.from(set).join(",");
+  return Array.from(set);
 }
-
-const ACTIVE_FE_STATUSES = new Set<BuildTaskStatus>(["pending", "running", "listening"]);
 
 function sortMockTasks(
   items: BuildTask[],
@@ -398,17 +403,9 @@ function sortMockTasks(
   order: "asc" | "desc",
 ): BuildTask[] {
   const arr = [...items];
-  if (orderBy === "default") {
-    // Active builds first, then descending createdAt within each bucket.
-    return arr.sort((a, b) => {
-      const aActive = ACTIVE_FE_STATUSES.has(a.status) ? 0 : 1;
-      const bActive = ACTIVE_FE_STATUSES.has(b.status) ? 0 : 1;
-      return aActive !== bActive ? aActive - bActive : b.createdAt - a.createdAt;
-    });
-  }
   const dir = order === "asc" ? 1 : -1;
   const keyOf = (task: BuildTask): number =>
-    orderBy === "created_at"
+    orderBy === "created_at" || orderBy === "default"
       ? task.createdAt
       : (task.lastEventAt ?? task.createdAt);
   return arr.sort((a, b) => {
@@ -421,8 +418,7 @@ function sortMockTasks(
 }
 
 /**
- * Server-paginated list with sorting and status filtering. Integrates backend pagination through
- * limit/offset, order_by/order, comma-separated status values, and active=true for active builds only.
+ * Server-paginated list with sorting and repeated status query parameters.
  */
 export async function listBuildTaskPage(
   query: BuildTaskPageQuery,
@@ -446,9 +442,7 @@ export async function listBuildTaskPage(
     if (query.mode) {
       items = items.filter((task) => task.mode === query.mode);
     }
-    if (query.active) {
-      items = items.filter((task) => ACTIVE_FE_STATUSES.has(task.status));
-    } else if (query.statuses?.length) {
+    if (query.statuses?.length) {
       const set = new Set(query.statuses);
       items = items.filter((task) => set.has(task.status));
     }
@@ -469,15 +463,13 @@ export async function listBuildTaskPage(
     params.order_by = query.orderBy;
     params.order = query.order ?? "desc";
   }
-  if (query.active) {
-    params.active = true;
-  } else if (query.statuses?.length) {
-    params.status = backendStatusParam(query.statuses);
+  if (query.statuses?.length) {
+    params.status = backendStatusParams(query.statuses);
   }
 
   const response = await http.get<ListResponse<BackendBuildTaskSummary>>(
     "/vega-backend/v1/build-tasks",
-    { params },
+    { params, paramsSerializer: { indexes: null } },
   );
   return {
     items: response.data.entries.map(mapBuildTask),
@@ -503,7 +495,8 @@ function hasActiveTaskForResource(resourceId: string) {
       task.resourceId === resourceId &&
       (task.status === "pending" ||
         task.status === "running" ||
-        task.status === "listening"),
+        task.status === "listening" ||
+        task.status === "stopping"),
   );
 }
 

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.test.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.test.ts
@@ -75,7 +75,30 @@ describe("buildSemanticUnderstandingTaskListParams", () => {
       resource_id: "resource-1",
       scope: "resource",
       sort: "create_time",
-      status: "succeeded",
+      status: "completed",
     });
+  });
+
+  it("maps backend completed and cancelled states", () => {
+    const base = {
+      agent_id: "semantic-agent",
+      applied: false,
+      apply_mode: "dry_run" as const,
+      catalog_id: "catalog-1",
+      confidence: 0,
+      confidence_threshold: 0.8,
+      create_time: 100,
+      creator: { id: "user-1", name: "User", type: "user" },
+      id: "task-1",
+      scope: "catalog" as const,
+      update_time: 200,
+    };
+
+    expect(mapSemanticUnderstandingTaskSummary({ ...base, status: "completed" }).status).toBe(
+      "succeeded",
+    );
+    expect(mapSemanticUnderstandingTaskSummary({ ...base, status: "cancelled" }).status).toBe(
+      "cancelled",
+    );
   });
 });

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.ts
@@ -7,6 +7,13 @@
 
 import { http } from "@/framework/request/http";
 
+export type SemanticUnderstandingTaskStatus =
+  | "cancelled"
+  | "failed"
+  | "pending"
+  | "running"
+  | "succeeded";
+
 export type SemanticUnderstandingTaskSummary = {
   agentId: string;
   agentTaskId?: string;
@@ -23,7 +30,7 @@ export type SemanticUnderstandingTaskSummary = {
   resourceId?: string;
   resourceName?: string;
   scope: "catalog" | "resource";
-  status: "pending" | "running" | "succeeded" | "failed";
+  status: SemanticUnderstandingTaskStatus;
   updateTime?: number;
 };
 
@@ -52,7 +59,7 @@ export type BackendSemanticUnderstandingTaskSummary = {
   resource_id?: string;
   resource_name?: string;
   scope: SemanticUnderstandingTaskSummary["scope"];
-  status: SemanticUnderstandingTaskSummary["status"];
+  status: "cancelled" | "completed" | "failed" | "pending" | "running";
   update_time: number;
 };
 
@@ -75,7 +82,7 @@ export function mapSemanticUnderstandingTaskSummary(task: BackendSemanticUnderst
     resourceName: task.resource_name,
     agentId: task.agent_id,
     agentTaskId: task.agent_task_id,
-    status: task.status,
+    status: task.status === "completed" ? "succeeded" : task.status,
     applyMode: task.apply_mode,
     confidenceThreshold: task.confidence_threshold,
     confidence: task.confidence,
@@ -111,7 +118,7 @@ export function buildSemanticUnderstandingTaskListParams(
     scope: filters.scope,
     catalog_id: filters.catalogId,
     resource_id: filters.resourceId,
-    status: filters.status,
+    status: filters.status === "succeeded" ? "completed" : filters.status,
     apply_mode: filters.applyMode,
     applied: filters.applied,
   };

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -98,11 +98,13 @@ export type BuildMode = "batch" | "streaming";
 export type BuildTaskExecuteType = "full" | "incremental";
 
 export type BuildTaskStatus =
+  | "cancelled"
   | "failed"
   | "listening"
   | "paused"
   | "pending"
   | "running"
+  | "stopping"
   | "succeeded";
 
 /** Per-index health state from backend index_health: ok, partial failure, failure, or building. */
@@ -180,15 +182,13 @@ export type BuildTaskListQuery = {
   statuses?: BuildTaskStatus[];
 };
 
-/** Server-side sort dimension: default uses backend ordering with active builds first and omits order_by. */
+/** Server-side sort dimension; default omits order_by and uses backend creation-time ordering. */
 export type BuildTaskOrderBy =
   | "default"
   | "created_at"
   | "updated_at";
 
 export type BuildTaskPageQuery = {
-  /** Show only active builds: send active=true and omit status. */
-  active?: boolean;
   catalogId?: string;
   mode?: BuildMode;
   order?: "asc" | "desc";

--- a/src/modules/data-catalog/utils/build-task-guards.test.ts
+++ b/src/modules/data-catalog/utils/build-task-guards.test.ts
@@ -46,6 +46,8 @@ describe("build-task-guards", () => {
     expect(isActiveBuildTask(task("running"))).toBe(true);
     expect(isActiveBuildTask(task("listening"))).toBe(true);
     expect(isActiveBuildTask(task("paused"))).toBe(false);
+    expect(isActiveBuildTask(task("stopping"))).toBe(true);
+    expect(isActiveBuildTask(task("cancelled"))).toBe(false);
     expect(isActiveBuildTask(task("succeeded"))).toBe(false);
     expect(isActiveBuildTask(null)).toBe(false);
   });

--- a/src/modules/data-catalog/utils/build-task-guards.ts
+++ b/src/modules/data-catalog/utils/build-task-guards.ts
@@ -13,6 +13,7 @@ export const ACTIVE_BUILD_TASK_STATUSES = new Set<BuildTask["status"]>([
   "pending",
   "running",
   "listening",
+  "stopping",
 ]);
 
 export function isActiveBuildTask(task: BuildTask | null | undefined): boolean {

--- a/src/modules/data-catalog/utils/delete-guard.ts
+++ b/src/modules/data-catalog/utils/delete-guard.ts
@@ -7,7 +7,6 @@
 
 export { runningIdsFromError } from "@/framework/safety/delete-guard";
 export {
-  catalogBlastRadius,
   resourceBlastRadius,
   type CatalogBlastRadius as BlastRadius,
 } from "@/shared/catalog";

--- a/src/modules/data-connect/locales/en-US.ts
+++ b/src/modules/data-connect/locales/en-US.ts
@@ -98,12 +98,20 @@ export const dataConnectEnUS = {
     disableConfirmDescription:
       'Disable "{{name}}"? Discovery and data access for this connection will be unavailable.',
     dangerDelete: {
-      hasRunning: "A build task is still running. Stop it before deleting.",
-      catalogImpact: "Connection \"{{name}}\" has {{count}} index(es) built.",
+      blockedTitle: "Data connection cannot be deleted",
+      blockedWarning:
+        "Resolve protected resources or wait for running tasks to finish, then run the preflight again.",
+      catalogImpact: "Deleting connection \"{{name}}\" has the following impact:",
+      resources: "Resources: {{count}} ({{protected}} protected)",
+      schedules: "Schedules: {{discover}} discover, {{health}} health check",
+      buildTasks: "Build tasks: cancel {{willCancel}} pending, {{blocking}} blocking",
+      discoverTasks: "Discover tasks: cancel {{willCancel}} pending, {{blocking}} blocking",
+      semanticUnderstandingTasks:
+        "Semantic tasks: cancel {{willCancel}} pending, {{blocking}} blocking",
       impactWarning:
-        "Deleting will also remove all indexes and build tasks, and cannot be undone.",
+        "Resources and schedules will be deleted, and pending tasks will be cancelled. Task history and indexes are not deleted by this operation.",
       catalogEmpty:
-        "Connection \"{{name}}\" has no built indexes. Deletion cannot be undone.",
+        "Connection \"{{name}}\" has no cascading objects. Deletion still cannot be undone.",
     },
     discoverManage: "Discover",
     discoverTitle: "Discover Management",
@@ -208,6 +216,7 @@ export const dataConnectEnUS = {
       running: "Running",
       completed: "Completed",
       failed: "Failed",
+      cancelled: "Cancelled",
     },
     discoverTriggerTypes: {
       manual: "Manual",

--- a/src/modules/data-connect/locales/zh-CN.ts
+++ b/src/modules/data-connect/locales/zh-CN.ts
@@ -93,10 +93,18 @@ export const dataConnectZhCN = {
     disableConfirmDescription:
       '确认停用“{{name}}”吗？停用后该连接将不可用于探查与数据访问。',
     dangerDelete: {
-      hasRunning: "有构建任务正在运行,请先停止再删除。",
-      catalogImpact: "连接「{{name}}」下已构建 {{count}} 个索引。",
-      impactWarning: "删除将一并删除全部索引和构建任务,且不可恢复。",
-      catalogEmpty: "连接「{{name}}」下暂无已构建的索引,删除不可恢复。",
+      blockedTitle: "当前无法删除数据连接",
+      blockedWarning: "请先处理受保护资源或等待运行中的任务结束，然后重新预检。",
+      catalogImpact: "删除连接「{{name}}」将产生以下影响：",
+      resources: "资源：{{count}} 个（其中受保护资源 {{protected}} 个）",
+      schedules: "计划：探查 {{discover}} 个，健康检查 {{health}} 个",
+      buildTasks: "构建任务：取消待执行 {{willCancel}} 个，阻断 {{blocking}} 个",
+      discoverTasks: "探查任务：取消待执行 {{willCancel}} 个，阻断 {{blocking}} 个",
+      semanticUnderstandingTasks:
+        "语义理解任务：取消待执行 {{willCancel}} 个，阻断 {{blocking}} 个",
+      impactWarning:
+        "资源和计划将被删除，待执行任务将标记为已取消；任务历史和索引不会在此流程中删除。",
+      catalogEmpty: "连接「{{name}}」下没有需要级联处理的对象，删除仍不可恢复。",
     },
     discoverManage: "探查",
     discoverTitle: "探查管理",
@@ -197,6 +205,7 @@ export const dataConnectZhCN = {
       running: "执行中",
       completed: "已完成",
       failed: "已失败",
+      cancelled: "已取消",
     },
     discoverTriggerTypes: {
       manual: "手动",

--- a/src/modules/data-connect/scenes/DataConnectDiscoverScene.tsx
+++ b/src/modules/data-connect/scenes/DataConnectDiscoverScene.tsx
@@ -441,7 +441,7 @@ export function DataConnectDiscoverScene({
       dataIndex: "status",
       title: t("dataConnect.discoverTaskStatus"),
       width: 120,
-      render: (value: DataConnectDiscoverTaskStatus) => <Tag color={value === "failed" ? "error" : value === "completed" ? "success" : "processing"}>{t(`dataConnect.discoverTaskStatuses.${value}`)}</Tag>,
+      render: (value: DataConnectDiscoverTaskStatus) => <Tag color={value === "failed" ? "error" : value === "completed" ? "success" : value === "cancelled" ? "default" : "processing"}>{t(`dataConnect.discoverTaskStatuses.${value}`)}</Tag>,
     },
     {
       dataIndex: "progress",
@@ -783,6 +783,7 @@ export function DataConnectDiscoverScene({
                   value: "completed",
                 },
                 { label: t("dataConnect.discoverTaskStatuses.failed"), value: "failed" },
+                { label: t("dataConnect.discoverTaskStatuses.cancelled"), value: "cancelled" },
               ]}
               value={taskStatusFilter}
             />

--- a/src/modules/data-connect/scenes/DataConnectListScene.tsx
+++ b/src/modules/data-connect/scenes/DataConnectListScene.tsx
@@ -37,10 +37,65 @@ import {
   DeleteImpactAlert,
   useDangerDelete,
 } from "@/framework/safety/DangerDeleteModal";
-import { runningIdsFromError } from "@/framework/safety/delete-guard";
-import { catalogBlastRadius } from "@/shared/catalog";
+import {
+  previewCatalogDeletion,
+  type CatalogDeletionImpact,
+} from "@/shared/catalog";
 
 import styles from "./DataConnectListScene.module.css";
+
+function hasCascadeImpact(impact: CatalogDeletionImpact) {
+  return (
+    impact.resources > 0 ||
+    impact.catalogHealthCheckSchedules > 0 ||
+    impact.discoverSchedules > 0 ||
+    impact.buildTasks.willCancel > 0 ||
+    impact.discoverTasks.willCancel > 0 ||
+    impact.semanticUnderstandingTasks.willCancel > 0
+  );
+}
+
+function CatalogDeletionImpactDetails({
+  impact,
+  name,
+}: {
+  impact: CatalogDeletionImpact;
+  name: string;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <div>{t("dataConnect.dangerDelete.catalogImpact", { name })}</div>
+      <ul style={{ marginBottom: 0, marginTop: 8, paddingInlineStart: 20 }}>
+        <li>
+          {t("dataConnect.dangerDelete.resources", {
+            count: impact.resources,
+            protected: impact.protectedResources,
+          })}
+        </li>
+        <li>
+          {t("dataConnect.dangerDelete.schedules", {
+            discover: impact.discoverSchedules,
+            health: impact.catalogHealthCheckSchedules,
+          })}
+        </li>
+        <li>
+          {t("dataConnect.dangerDelete.buildTasks", impact.buildTasks)}
+        </li>
+        <li>
+          {t("dataConnect.dangerDelete.discoverTasks", impact.discoverTasks)}
+        </li>
+        <li>
+          {t(
+            "dataConnect.dangerDelete.semanticUnderstandingTasks",
+            impact.semanticUnderstandingTasks,
+          )}
+        </li>
+      </ul>
+    </div>
+  );
+}
 
 export function DataConnectListScene({
   defaultConnectorType,
@@ -195,13 +250,30 @@ export function DataConnectListScene({
 
   const deleteRecord = useCallback((record: DataConnectRecord) => {
     void (async () => {
-      let indexCount = 0;
+      let impact: CatalogDeletionImpact;
       try {
-        indexCount = (await catalogBlastRadius(record.id)).indexCount;
-      } catch {
-        indexCount = 0;
+        impact = await previewCatalogDeletion(record.id);
+      } catch (error) {
+        void message.error(extractRequestErrorMessage(error));
+        return;
       }
-      const highRisk = indexCount > 0;
+
+      const details = <CatalogDeletionImpactDetails impact={impact} name={record.name} />;
+      if (!impact.canDelete) {
+        void modal.warning({
+          content: (
+            <DeleteImpactAlert
+              detail={details}
+              warning={t("dataConnect.dangerDelete.blockedWarning")}
+            />
+          ),
+          okText: t("common.confirm"),
+          title: t("dataConnect.dangerDelete.blockedTitle"),
+        });
+        return;
+      }
+
+      const highRisk = hasCascadeImpact(impact);
       danger.open({
         title: t("dataConnect.deleteConfirmTitle"),
         targetName: record.name,
@@ -209,14 +281,7 @@ export function DataConnectListScene({
         impact: (
           <DeleteImpactAlert
             detail={
-              highRisk
-                ? t("dataConnect.dangerDelete.catalogImpact", {
-                    name: record.name,
-                    count: indexCount,
-                  })
-                : t("dataConnect.dangerDelete.catalogEmpty", {
-                    name: record.name,
-                  })
+              highRisk ? details : t("dataConnect.dangerDelete.catalogEmpty", { name: record.name })
             }
             warning={highRisk ? t("dataConnect.dangerDelete.impactWarning") : undefined}
           />
@@ -225,12 +290,7 @@ export function DataConnectListScene({
           try {
             await deleteDataConnectRecord(record.id);
           } catch (error) {
-            const running = runningIdsFromError(error);
-            void message.error(
-              running
-                ? t("dataConnect.dangerDelete.hasRunning")
-                : extractRequestErrorMessage(error),
-            );
+            void message.error(extractRequestErrorMessage(error));
             throw error;
           }
           void message.success(t("common.success"));
@@ -238,7 +298,7 @@ export function DataConnectListScene({
         },
       });
     })();
-  }, [danger, loadData, message, t]);
+  }, [danger, loadData, message, modal, t]);
 
   const buildActionMoreMenu = useCallback((record: DataConnectRecord): MenuProps => {
     const items: NonNullable<MenuProps["items"]> = [

--- a/src/modules/data-connect/services/discover.service.test.ts
+++ b/src/modules/data-connect/services/discover.service.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock },
+}));
+
+describe("discover.service · task status contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    getMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("preserves cancelled tasks returned by Vega", async () => {
+    getMock.mockResolvedValue({
+      data: {
+        entries: [
+          {
+            catalog_id: "catalog-1",
+            id: "task-1",
+            status: "cancelled",
+          },
+        ],
+        total_count: 1,
+      },
+    });
+    const { listDataConnectDiscoverTasks } = await import(
+      "@/modules/data-connect/services/discover.service"
+    );
+
+    const result = await listDataConnectDiscoverTasks({
+      page: 1,
+      pageSize: 20,
+      status: "cancelled",
+    });
+
+    expect(result.items[0]?.status).toBe("cancelled");
+    expect(getMock).toHaveBeenCalledOnce();
+    expect(getMock.mock.calls[0]?.[0]).toBe("/vega-backend/v1/discover-tasks");
+    const config = getMock.mock.calls[0]?.[1] as { params: Record<string, unknown> };
+    expect(config.params.status).toBe("cancelled");
+  });
+});

--- a/src/modules/data-connect/services/discover.service.ts
+++ b/src/modules/data-connect/services/discover.service.ts
@@ -220,6 +220,7 @@ function normalizeTaskStatus(value?: string): DataConnectDiscoverTaskStatus {
     case "running":
     case "completed":
     case "failed":
+    case "cancelled":
       return value;
     default:
       return "pending";

--- a/src/modules/data-connect/types/discover.ts
+++ b/src/modules/data-connect/types/discover.ts
@@ -11,6 +11,7 @@ export type DataConnectDiscoverStrategy =
   | "full_sync";
 
 export type DataConnectDiscoverTaskStatus =
+  | "cancelled"
   | "completed"
   | "failed"
   | "pending"

--- a/src/shared/catalog/blast-radius.ts
+++ b/src/shared/catalog/blast-radius.ts
@@ -21,10 +21,6 @@ function summarize(tasks: { id: string; status: string }[]): CatalogBlastRadius 
   };
 }
 
-export async function catalogBlastRadius(catalogId: string): Promise<CatalogBlastRadius> {
-  return summarize(await listBuildTasks({ catalogId }));
-}
-
 export async function resourceBlastRadius(resourceId: string): Promise<CatalogBlastRadius> {
   return summarize(await listBuildTasks({ resourceId }));
 }

--- a/src/shared/catalog/catalog.service.test.ts
+++ b/src/shared/catalog/catalog.service.test.ts
@@ -8,11 +8,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getMock = vi.hoisted(() => vi.fn());
+const deleteMock = vi.hoisted(() => vi.fn());
 const postMock = vi.hoisted(() => vi.fn());
 const putMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/framework/request/http", () => ({
-  http: { get: getMock, post: postMock, put: putMock },
+  http: { delete: deleteMock, get: getMock, post: postMock, put: putMock },
 }));
 
 function lastParams(): Record<string, unknown> {
@@ -48,6 +49,58 @@ describe("catalog.service · listCatalogs", () => {
     await listCatalogs({ keyword: "", page: 1, pageSize: 50, type: "all" });
 
     expect(lastParams()).toMatchObject({ type: undefined });
+  });
+});
+
+describe("catalog.service · deletion preflight", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    deleteMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("requests a dry run and maps the complete deletion impact", async () => {
+    deleteMock.mockResolvedValue({
+      data: {
+        blockers: ["discover_tasks_running"],
+        build_tasks: { blocking: 0, will_cancel: 1 },
+        can_delete: false,
+        catalog_health_check_schedules: 1,
+        catalog_id: "catalog-1",
+        discover_schedules: 2,
+        discover_tasks: { blocking: 1, will_cancel: 3 },
+        protected_resources: 0,
+        resources: 4,
+        semantic_understanding_tasks: { blocking: 0, will_cancel: 2 },
+      },
+    });
+    const { previewCatalogDeletion } = await import(
+      "@/shared/catalog/catalog.service"
+    );
+
+    await expect(previewCatalogDeletion("catalog-1")).resolves.toEqual({
+      blockers: ["discover_tasks_running"],
+      buildTasks: { blocking: 0, willCancel: 1 },
+      canDelete: false,
+      catalogHealthCheckSchedules: 1,
+      catalogId: "catalog-1",
+      discoverSchedules: 2,
+      discoverTasks: { blocking: 1, willCancel: 3 },
+      protectedResources: 0,
+      resources: 4,
+      semanticUnderstandingTasks: { blocking: 0, willCancel: 2 },
+    });
+    expect(deleteMock).toHaveBeenCalledWith(
+      "/vega-backend/v1/catalogs/catalog-1",
+      {
+        params: { dry_run: true },
+        skipErrorToast: true,
+      },
+    );
   });
 });
 

--- a/src/shared/catalog/catalog.service.ts
+++ b/src/shared/catalog/catalog.service.ts
@@ -23,6 +23,9 @@ import {
 import type {
   CatalogConnectionTestInput,
   CatalogConnectionTestResult,
+  CatalogDeletionBlocker,
+  CatalogDeletionImpact,
+  CatalogDeletionTaskImpact,
   CatalogHealthCheckSchedule,
   CatalogHealthCheckScheduleInput,
   CatalogListQuery,
@@ -42,6 +45,24 @@ type BackendCatalogHealthCheckSchedule = {
   last_run: number;
   mode: CatalogHealthCheckSchedule["mode"];
   next_run: number;
+};
+
+type BackendCatalogDeletionTaskImpact = {
+  blocking: number;
+  will_cancel: number;
+};
+
+type BackendCatalogDeletionImpact = {
+  blockers: CatalogDeletionBlocker[];
+  build_tasks: BackendCatalogDeletionTaskImpact;
+  can_delete: boolean;
+  catalog_health_check_schedules: number;
+  catalog_id: string;
+  discover_schedules: number;
+  discover_tasks: BackendCatalogDeletionTaskImpact;
+  protected_resources: number;
+  resources: number;
+  semantic_understanding_tasks: BackendCatalogDeletionTaskImpact;
 };
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
@@ -107,6 +128,51 @@ export async function deleteCatalog(id: string) {
   }
 
   await http.delete(`/vega-backend/v1/catalogs/${id}`);
+}
+
+export async function previewCatalogDeletion(id: string): Promise<CatalogDeletionImpact> {
+  if (useMock) {
+    return wait({
+      blockers: [],
+      buildTasks: { blocking: 0, willCancel: 0 },
+      canDelete: true,
+      catalogHealthCheckSchedules: 0,
+      catalogId: id,
+      discoverSchedules: 0,
+      discoverTasks: { blocking: 0, willCancel: 0 },
+      protectedResources: 0,
+      resources: 0,
+      semanticUnderstandingTasks: { blocking: 0, willCancel: 0 },
+    });
+  }
+
+  const response = await http.delete<BackendCatalogDeletionImpact>(
+    `/vega-backend/v1/catalogs/${id}`,
+    {
+      params: { dry_run: true },
+      skipErrorToast: true,
+    },
+  );
+  const impact = response.data;
+  const mapTaskImpact = (
+    taskImpact: BackendCatalogDeletionTaskImpact,
+  ): CatalogDeletionTaskImpact => ({
+    blocking: taskImpact.blocking,
+    willCancel: taskImpact.will_cancel,
+  });
+
+  return {
+    blockers: impact.blockers,
+    buildTasks: mapTaskImpact(impact.build_tasks),
+    canDelete: impact.can_delete,
+    catalogHealthCheckSchedules: impact.catalog_health_check_schedules,
+    catalogId: impact.catalog_id,
+    discoverSchedules: impact.discover_schedules,
+    discoverTasks: mapTaskImpact(impact.discover_tasks),
+    protectedResources: impact.protected_resources,
+    resources: impact.resources,
+    semanticUnderstandingTasks: mapTaskImpact(impact.semantic_understanding_tasks),
+  };
 }
 
 export async function setCatalogEnabled(id: string, enabled: boolean) {

--- a/src/shared/catalog/index.ts
+++ b/src/shared/catalog/index.ts
@@ -8,6 +8,9 @@
 export type {
   CatalogConnectionTestInput,
   CatalogConnectionTestResult,
+  CatalogDeletionBlocker,
+  CatalogDeletionImpact,
+  CatalogDeletionTaskImpact,
   CatalogHealthCheckSchedule,
   CatalogHealthCheckScheduleInput,
   CatalogHealthCheckScheduleMode,
@@ -29,6 +32,7 @@ export {
   getCatalogHealthCheckSchedule,
   getCatalog,
   listCatalogs,
+  previewCatalogDeletion,
   setCatalogEnabled,
   testCatalogConnection,
   testCatalogConnectionConfig,
@@ -38,7 +42,6 @@ export {
 } from "@/shared/catalog/catalog.service";
 
 export {
-  catalogBlastRadius,
   resourceBlastRadius,
   type CatalogBlastRadius,
 } from "@/shared/catalog/blast-radius";

--- a/src/shared/catalog/types.ts
+++ b/src/shared/catalog/types.ts
@@ -47,6 +47,30 @@ export type CatalogMutationOptions = {
   skipErrorToast?: boolean;
 };
 
+export type CatalogDeletionBlocker =
+  | "build_tasks_running_or_stopping"
+  | "discover_tasks_running"
+  | "protected_resources"
+  | "semantic_understanding_tasks_running";
+
+export type CatalogDeletionTaskImpact = {
+  blocking: number;
+  willCancel: number;
+};
+
+export type CatalogDeletionImpact = {
+  blockers: CatalogDeletionBlocker[];
+  buildTasks: CatalogDeletionTaskImpact;
+  canDelete: boolean;
+  catalogHealthCheckSchedules: number;
+  catalogId: string;
+  discoverSchedules: number;
+  discoverTasks: CatalogDeletionTaskImpact;
+  protectedResources: number;
+  resources: number;
+  semanticUnderstandingTasks: CatalogDeletionTaskImpact;
+};
+
 export type CatalogRecord = {
   category: string;
   connectorConfig: Record<string, unknown>;


### PR DESCRIPTION
## What Changed

- [x] Add Catalog deletion dry-run service and complete cascade-impact mapping
- [x] Add physical and logical Catalog deletion preflight dialogs and blocker handling
- [x] Align build, discover, and semantic task status/query contracts with Vega
- [x] Add cancelled/stopping UI states, filters, guards, translations, and regression tests

---

## Why

- Closes #346
- Catalog deletion now cascades resources and schedules and cancels pending tasks, so users need an accurate preflight before confirming deletion.

---

## How

- Call `DELETE /vega-backend/v1/catalogs/{id}?dry_run=true` before every Catalog deletion.
- Show resource, schedule, and task impact; block deletion when the response reports blockers.
- Require typed confirmation when cascading objects are affected.
- Remove the old build-index-only Catalog blast-radius check.
- Use repeated `status` query parameters for multi-status build-task filters and remove `active=true`.
- Map Vega task states including `pending`, `completed`, `stopping`, `stopped`, and `cancelled` into existing UI states.
- Breaking changes: the frontend now requires the Vega deletion dry-run contract and updated task status/list-query contract.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm run i18n:check`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run` — 180 files, 925 tests passed
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` — exits successfully; reports one ignored high-severity advisory

---

## Risk & Rollback

- Potential risks: deployment against an older Vega version will make Catalog deletion preflight fail; task filters also depend on the repeated-status contract.
- Rollback plan: revert commit `8aa00fe` to restore the previous deletion confirmation and task-query behavior.

---

## Additional Notes

- Production build succeeds with the existing large-chunk warnings.
- Task history and indexes are intentionally not deleted by the Catalog deletion flow.