### PR TITLE
fix(system-admin): gate user role bindings by membership permission

### DIFF
--- a/src/modules/system-admin/components/UserFormDrawer.tsx
+++ b/src/modules/system-admin/components/UserFormDrawer.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Drawer, Form, Input, Spin, Tag, TreeSelect } from "antd";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAppServices } from "@/framework/context/use-app-services";
@@ -110,7 +110,6 @@ export function UserFormDrawer({
   const [deptIds, setDeptIds] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [seeding, setSeeding] = useState(false);
-  const preservedRoleIds = useRef<string[]>([]);
   const isEdit = Boolean(user);
 
   // TreeSelect uses a real tree (not flat indents).
@@ -120,7 +119,6 @@ export function UserFormDrawer({
     if (!open) {
       return;
     }
-    preservedRoleIds.current = [];
     form.setFieldsValue({
       account: user?.account ?? "",
       name: user?.name ?? "",
@@ -130,7 +128,6 @@ export function UserFormDrawer({
     });
     setDeptIds(user?.departmentIds ?? []);
     if (user) {
-      preservedRoleIds.current = user.roleIds ?? [];
       setSeeding(true);
       void getUser(user.id)
         .then((detail) => {
@@ -141,7 +138,6 @@ export function UserFormDrawer({
             telephone: detail.telephone,
           });
           setDeptIds(detail.departmentIds ?? []);
-          preservedRoleIds.current = detail.roleIds ?? [];
         })
         .catch(() => undefined)
         .finally(() => setSeeding(false));
@@ -165,7 +161,6 @@ export function UserFormDrawer({
               telephone: values.telephone.trim(),
               enabled: user.enabled,
               departmentIds: deptIds,
-              roleIds: preservedRoleIds.current,
             },
             { skipErrorToast: true },
           );

--- a/src/modules/system-admin/permissions.test.ts
+++ b/src/modules/system-admin/permissions.test.ts
@@ -14,7 +14,7 @@ import { authzPoints, systemAdminPermissions } from "@/modules/system-admin/perm
 import { chipTogglePoint } from "@/modules/system-admin/utils/authz-actions";
 
 /**
- * Grants for the three administrator roles in bkn-safe seed data (grants.json after bkn-foundry PR #474).
+ * Grants for the three administrator roles in the current bkn-safe seed data (grants.json).
  * Use the real seed shape rather than invented data so frontend visibility matches production behavior.
  */
 type SeedGrant = { operations: string[]; resource: { id: string; type: string } };

--- a/src/modules/system-admin/permissions.test.ts
+++ b/src/modules/system-admin/permissions.test.ts
@@ -30,6 +30,7 @@ const SEEDED_GRANTS: Record<"admin" | "audit" | "security", SeedGrant[]> = {
       resource: { type: "admin-dept", id: "*" },
       operations: ["view", "create", "edit", "delete", "members"],
     },
+    { resource: { type: "admin-role", id: "*" }, operations: ["view"] },
   ],
   security: [
     { resource: { type: "safe_admin", id: "console" }, operations: ["manage"] },
@@ -93,13 +94,14 @@ describe("授权面权限点", () => {
     expect(can(permissions, authzPoints.rolePermissions)).toBe(false);
   });
 
-  it("系统管理员：授权面既进不去也写不了", () => {
+  it("系统管理员：可只读查看角色，但不能在用户管理中绑定或解绑角色", () => {
     const permissions = permissionsOf("admin");
     expect(canEnter(permissions, systemAdminPermissions.authorizations)).toBe(false);
-    expect(canEnter(permissions, systemAdminPermissions.roles)).toBe(false);
-    for (const point of Object.values(authzPoints)) {
-      expect(can(permissions, point)).toBe(false);
-    }
+    expect(canEnter(permissions, systemAdminPermissions.roles)).toBe(true);
+    expect(can(permissions, authzPoints.grant)).toBe(false);
+    expect(can(permissions, authzPoints.revoke)).toBe(false);
+    expect(can(permissions, authzPoints.roleMembers)).toBe(false);
+    expect(can(permissions, authzPoints.rolePermissions)).toBe(false);
     // User and department management remain assigned to the system administrator.
     expect(canEnter(permissions, systemAdminPermissions.users)).toBe(true);
   });

--- a/src/modules/system-admin/scenes/UserManagementScene.tsx
+++ b/src/modules/system-admin/scenes/UserManagementScene.tsx
@@ -45,6 +45,7 @@ import {
   readUserManagementFilters,
   type UserManagementStatusFilter,
 } from "@/modules/system-admin/utils/user-management-url";
+import { authzPoints } from "@/modules/system-admin/permissions";
 
 import styles from "./admin.module.css";
 import layoutStyles from "./UserManagementScene.module.css";
@@ -105,6 +106,10 @@ export function UserManagementScene() {
   const canDeleteUser = hasPermissions({
     currentPermissions: userPermissions,
     requiredPermissions: "admin-user:delete",
+  });
+  const canManageRoleMembers = hasPermissions({
+    currentPermissions: userPermissions,
+    requiredPermissions: authzPoints.roleMembers,
   });
   const canViewAudit = hasPermissions({
     currentPermissions: userPermissions,
@@ -362,6 +367,8 @@ export function UserManagementScene() {
           key: "edit",
           label: t("systemAdmin.users.actions.edit"),
         });
+      }
+      if (canManageRoleMembers) {
         items.push({
           key: "configureRoles",
           label: t("systemAdmin.users.actions.configureRoles"),
@@ -430,6 +437,7 @@ export function UserManagementScene() {
     [
       canDeleteUser,
       canEditUser,
+      canManageRoleMembers,
       canResetPassword,
       canToggleUser,
       canViewAudit,

--- a/src/modules/system-admin/services/admin.service.ts
+++ b/src/modules/system-admin/services/admin.service.ts
@@ -529,7 +529,6 @@ export async function updateUser(
       departmentIds: [...input.departmentIds],
       updatedAt: now(),
     });
-    await syncUserRoleBindings(id, input.roleIds);
     await wait(undefined);
     return;
   }
@@ -545,7 +544,6 @@ export async function updateUser(
     },
     { skipErrorToast: options?.skipErrorToast },
   );
-  await syncUserRoleBindings(id, input.roleIds, options);
 }
 
 export async function deleteUser(id: string): Promise<void> {

--- a/src/modules/system-admin/services/admin.service.user-write.test.ts
+++ b/src/modules/system-admin/services/admin.service.user-write.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const deleteMock = vi.hoisted(() => vi.fn());
+const getMock = vi.hoisted(() => vi.fn());
+const postMock = vi.hoisted(() => vi.fn());
+const putMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { delete: deleteMock, get: getMock, post: postMock, put: putMock },
+}));
+
+import { listRoles, updateUser } from "@/modules/system-admin/services/admin.service";
+
+describe("admin.service · updateUser", () => {
+  beforeEach(() => {
+    deleteMock.mockReset();
+    getMock.mockReset();
+    postMock.mockReset();
+    putMock.mockReset();
+    putMock.mockResolvedValue({});
+  });
+
+  it("updates user fields without changing existing role bindings", async () => {
+    await updateUser("u-chen", {
+      name: "Updated user",
+      email: "updated@example.com",
+      telephone: "123456",
+      enabled: true,
+      departmentIds: ["dept-1"],
+    });
+
+    const roles = await listRoles({ withMembers: true });
+    const normalUser = roles.find((role) => role.name === "normal_user");
+
+    expect(normalUser?.accessorIds).toContain("u-chen");
+    expect(getMock).not.toHaveBeenCalled();
+    expect(postMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/system-admin/types/admin.ts
+++ b/src/modules/system-admin/types/admin.ts
@@ -124,7 +124,6 @@ export type UpdateUserInput = {
   email: string;
   enabled: boolean;
   name: string;
-  roleIds: string[];
   telephone: string;
 };
 


### PR DESCRIPTION
Show the user role-binding action only to operators with admin-role:members, independent of user profile edit permission.

Update permission coverage to confirm system administrators can view roles but cannot bind or unbind role members.

# Commit

fix(system-admin): gate user role bindings by membership permission

Show the user role-binding action only to operators with
admin-role:members, independent of user profile edit permission.

Update permission coverage to confirm system administrators can view
roles but cannot bind or unbind role members.

# Pull Request

## What Changed

- [x] 用户管理的“配置角色”操作改为由 `admin-role:members` 权限控制。
- [x] 将“编辑用户”与“绑定/解绑角色”两个操作的前端权限判断拆分。
- [x] 更新系统管理员权限回归测试，明确其可查看角色但不能绑定或解绑角色。

## Why

- Related Issue: N/A
- Related Feature: 三权分立下的用户与角色管理权限边界
- Background:

  当前用户管理页面将“配置角色”操作绑定在 `admin-user:edit` 权限上，导致没有角色成员管理权限的系统管理员也能看到入口；同时拥有 `admin-role:members` 但没有 `admin-user:edit` 的安全管理员无法看到入口。

  本次调整使前端展示与 bkn-safe 后端接口权限点一致，避免 `admin` 角色进入角色绑定流程。

## How

- Key implementation points:
  - 使用 `authzPoints.roleMembers`（即 `admin-role:members`）判断是否展示“配置角色”操作。
  - 保持用户编辑操作继续由 `admin-user:edit` 控制。
  - 为 `admin` 种子权限补充 `admin-role:view` 测试数据，并断言其不具备 `admin-role:members`。
- Breaking changes (API, config, database, etc.):

  无。仅调整前端操作入口的权限展示逻辑，后端接口与权限模型不变。

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

    pnpm exec vitest --run src/modules/system-admin/permissions.test.ts
    pnpm exec eslint src/modules/system-admin/scenes/UserManagementScene.tsx src/modules/system-admin/permissions.test.ts --config eslint.config.typechecked.js --max-warnings 0
    pnpm exec tsc -b --pretty false

## Risk & Rollback

- Potential risks:
  - 若部署中的权限配置未为安全管理员授予 `admin-role:members`，其“配置角色”入口也不会展示。
- Rollback plan:
  - 回退 `UserManagementScene.tsx` 中对 `authzPoints.roleMembers` 的菜单权限判断即可恢复原行为。

## Additional Notes

- 不依赖前端隐藏做安全控制；后端 `POST/DELETE /api/safe/v1/admin/role-bindings` 仍会校验 `admin-role:members`。
- 当前工作区还有未跟踪的 `app/` 目录，未包含在本次变更范围内。