### PR TITLE
feat(observability): present domain BKN management audits

### DIFF
--- a/src/modules/bkn-trace/components/log-presentation.test.ts
+++ b/src/modules/bkn-trace/components/log-presentation.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { presentLogActor } from "@/modules/bkn-trace/components/log-presentation";
+import { presentLogAction, presentLogActor, presentLogTarget, presentTargetType } from "@/modules/bkn-trace/components/log-presentation";
 import type { LogRecord } from "@/modules/bkn-trace/services/observability.service";
 
 vi.mock("@/framework/runtime/config", () => ({
@@ -21,6 +21,30 @@ vi.mock("@/framework/runtime/config", () => ({
 
 const translate = (key: string) => key;
 
+const phase4BTranslations: Record<string, string> = {
+  "bknTrace.logs.domainAction": "{{action}}{{target}}",
+  "bknTrace.logs.domainAuditActions.add_members": "添加",
+  "bknTrace.logs.domainAuditActions.create": "创建",
+  "bknTrace.logs.domainAuditActions.delete": "删除",
+  "bknTrace.logs.domainAuditActions.import": "导入",
+  "bknTrace.logs.domainAuditActions.update": "更新",
+  "bknTrace.logs.targetTypes.action_schedule": "行动计划",
+  "bknTrace.logs.targetTypes.action_type": "行动类型",
+  "bknTrace.logs.targetTypes.concept_group": "概念分组",
+  "bknTrace.logs.targetTypes.knowledge_network": "业务知识网络",
+  "bknTrace.logs.targetTypes.metric": "指标",
+  "bknTrace.logs.targetTypes.object_type": "对象类",
+  "bknTrace.logs.targetTypes.relation_type": "关系类",
+  "bknTrace.logs.targetTypes.risk_type": "风险类型",
+};
+
+const textValue = (value: unknown) => typeof value === "string" || typeof value === "number" ? String(value) : "";
+
+const translatePhase4B = (key: string, options?: Record<string, unknown>) => {
+  const template = phase4BTranslations[key] ?? (textValue(options?.defaultValue) || key);
+  return template.replace(/{{(\w+)}}/g, (_match, name: string) => textValue(options?.[name]));
+};
+
 describe("log presentation", () => {
   it("uses the current authenticated username when an old event only contains its user id", () => {
     const record = {
@@ -33,5 +57,27 @@ describe("log presentation", () => {
     } as LogRecord;
 
     expect(presentLogActor(record, translate, new Map()).primary).toBe("Administrator");
+  });
+
+  it.each([
+    ["create", "object_type", "material", "物料", "创建对象类", "对象类"],
+    ["import", "knowledge_network", "supplychain", "供应链", "导入业务知识网络", "业务知识网络"],
+    ["update", "relation_type", "contains", "包含", "更新关系类", "关系类"],
+    ["delete", "action_type", "replenish", "补货", "删除行动类型", "行动类型"],
+    ["create", "metric", "inventory_turnover", "库存周转率", "创建指标", "指标"],
+    ["create", "risk_type", "inventory_risk", "库存风险", "创建风险类型", "风险类型"],
+    ["add_members", "concept_group", "supply", "供应链概念", "添加概念分组", "概念分组"],
+    ["update", "action_schedule", "schedule-a", "每日补货检查", "更新行动计划", "行动计划"],
+  ])("presents a readable Phase 4B %s %s fact", (action, targetType, id, name, expectedAction, expectedType) => {
+    const record = {
+      action,
+      businessModule: "domain_knowledge_network",
+      eventName: "resource_config.changed",
+      target: { id, name, type: targetType },
+    } as LogRecord;
+
+    expect(presentLogAction(record, translatePhase4B)).toBe(expectedAction);
+    expect(presentTargetType(record, translatePhase4B)).toBe(expectedType);
+    expect(presentLogTarget(record, translatePhase4B)).toEqual({ primary: name, secondary: id });
   });
 });

--- a/src/modules/bkn-trace/components/log-presentation.test.ts
+++ b/src/modules/bkn-trace/components/log-presentation.test.ts
@@ -8,6 +8,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { presentLogAction, presentLogActor, presentLogTarget, presentTargetType } from "@/modules/bkn-trace/components/log-presentation";
+import { bknTraceEnUS } from "@/modules/bkn-trace/locales/en-US";
+import { bknTraceZhCN } from "@/modules/bkn-trace/locales/zh-CN";
 import type { LogRecord } from "@/modules/bkn-trace/services/observability.service";
 
 vi.mock("@/framework/runtime/config", () => ({
@@ -21,29 +23,19 @@ vi.mock("@/framework/runtime/config", () => ({
 
 const translate = (key: string) => key;
 
-const phase4BTranslations: Record<string, string> = {
-  "bknTrace.logs.domainAction": "{{action}}{{target}}",
-  "bknTrace.logs.domainAuditActions.add_members": "添加",
-  "bknTrace.logs.domainAuditActions.create": "创建",
-  "bknTrace.logs.domainAuditActions.delete": "删除",
-  "bknTrace.logs.domainAuditActions.import": "导入",
-  "bknTrace.logs.domainAuditActions.update": "更新",
-  "bknTrace.logs.targetTypes.action_schedule": "行动计划",
-  "bknTrace.logs.targetTypes.action_type": "行动类型",
-  "bknTrace.logs.targetTypes.concept_group": "概念分组",
-  "bknTrace.logs.targetTypes.knowledge_network": "业务知识网络",
-  "bknTrace.logs.targetTypes.metric": "指标",
-  "bknTrace.logs.targetTypes.object_type": "对象类",
-  "bknTrace.logs.targetTypes.relation_type": "关系类",
-  "bknTrace.logs.targetTypes.risk_type": "风险类型",
-};
-
 const textValue = (value: unknown) => typeof value === "string" || typeof value === "number" ? String(value) : "";
 
-const translatePhase4B = (key: string, options?: Record<string, unknown>) => {
-  const template = phase4BTranslations[key] ?? (textValue(options?.defaultValue) || key);
+const createLocaleTranslator = (locale: unknown) => (key: string, options?: Record<string, unknown>) => {
+  const translated = key.split(".").reduce<unknown>((value, segment) => {
+    if (!value || typeof value !== "object") return undefined;
+    return (value as Record<string, unknown>)[segment];
+  }, locale);
+  const template = textValue(translated) || textValue(options?.defaultValue) || key;
   return template.replace(/{{(\w+)}}/g, (_match, name: string) => textValue(options?.[name]));
 };
+
+const translateZhCN = createLocaleTranslator(bknTraceZhCN);
+const translateEnUS = createLocaleTranslator(bknTraceEnUS);
 
 describe("log presentation", () => {
   it("uses the current authenticated username when an old event only contains its user id", () => {
@@ -66,7 +58,8 @@ describe("log presentation", () => {
     ["delete", "action_type", "replenish", "补货", "删除行动类型", "行动类型"],
     ["create", "metric", "inventory_turnover", "库存周转率", "创建指标", "指标"],
     ["create", "risk_type", "inventory_risk", "库存风险", "创建风险类型", "风险类型"],
-    ["add_members", "concept_group", "supply", "供应链概念", "添加概念分组", "概念分组"],
+    ["add_members", "concept_group", "supply", "供应链概念", "向概念分组添加成员", "概念分组"],
+    ["remove_members", "concept_group", "supply", "供应链概念", "从概念分组移除成员", "概念分组"],
     ["update", "action_schedule", "schedule-a", "每日补货检查", "更新行动计划", "行动计划"],
   ])("presents a readable Phase 4B %s %s fact", (action, targetType, id, name, expectedAction, expectedType) => {
     const record = {
@@ -76,8 +69,33 @@ describe("log presentation", () => {
       target: { id, name, type: targetType },
     } as LogRecord;
 
-    expect(presentLogAction(record, translatePhase4B)).toBe(expectedAction);
-    expect(presentTargetType(record, translatePhase4B)).toBe(expectedType);
-    expect(presentLogTarget(record, translatePhase4B)).toEqual({ primary: name, secondary: id });
+    expect(presentLogAction(record, translateZhCN)).toBe(expectedAction);
+    expect(presentTargetType(record, translateZhCN)).toBe(expectedType);
+    expect(presentLogTarget(record, translateZhCN)).toEqual({ primary: name, secondary: id });
+  });
+
+  it("uses the real English locale for concept-group membership actions", () => {
+    const record = {
+      action: "remove_members",
+      businessModule: "domain_knowledge_network",
+      eventName: "resource_config.changed",
+      target: { id: "supply", name: "Supply concepts", type: "concept_group" },
+    } as LogRecord;
+
+    expect(presentLogAction(record, translateEnUS)).toBe("Remove members from concept group");
+  });
+
+  it.each([
+    ["grant", "更新对象授权 对象类"],
+    ["publish", "publish 对象类"],
+  ])("falls back safely for an unregistered domain action %s", (action, expected) => {
+    const record = {
+      action,
+      businessModule: "domain_knowledge_network",
+      eventName: "resource_config.changed",
+      target: { id: "material", name: "物料", type: "object_type" },
+    } as LogRecord;
+
+    expect(presentLogAction(record, translateZhCN)).toBe(expected);
   });
 });

--- a/src/modules/bkn-trace/components/log-presentation.ts
+++ b/src/modules/bkn-trace/components/log-presentation.ts
@@ -18,6 +18,11 @@ export function isAgentConversationCreated(record: LogRecord) {
 
 export function presentLogAction(record: LogRecord, t: Translate) {
   if (isAgentConversationCreated(record)) return t("bknTrace.logs.auditActions.startAgentConversation");
+  if (record.businessModule === "domain_knowledge_network") {
+    const action = t(`bknTrace.logs.domainAuditActions.${record.action}`, { defaultValue: record.action });
+    const target = t(`bknTrace.logs.targetTypes.${record.target.type}`, { defaultValue: record.target.type });
+    return t("bknTrace.logs.domainAction", { action, target });
+  }
   return t(`bknTrace.logs.auditActions.${record.action}`, { defaultValue: record.action });
 }
 

--- a/src/modules/bkn-trace/components/log-presentation.ts
+++ b/src/modules/bkn-trace/components/log-presentation.ts
@@ -19,8 +19,14 @@ export function isAgentConversationCreated(record: LogRecord) {
 export function presentLogAction(record: LogRecord, t: Translate) {
   if (isAgentConversationCreated(record)) return t("bknTrace.logs.auditActions.startAgentConversation");
   if (record.businessModule === "domain_knowledge_network") {
-    const action = t(`bknTrace.logs.domainAuditActions.${record.action}`, { defaultValue: record.action });
+    const actionKey = `bknTrace.logs.domainAuditActions.${record.action}`;
     const target = t(`bknTrace.logs.targetTypes.${record.target.type}`, { defaultValue: record.target.type });
+    const action = t(actionKey, { defaultValue: "", target });
+    if (!action || action === actionKey) {
+      const fallback = t(`bknTrace.logs.auditActions.${record.action}`, { defaultValue: record.action });
+      return `${fallback} ${target}`;
+    }
+    if (record.action === "add_members" || record.action === "remove_members") return action;
     return t("bknTrace.logs.domainAction", { action, target });
   }
   return t(`bknTrace.logs.auditActions.${record.action}`, { defaultValue: record.action });

--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -148,7 +148,12 @@ export const bknTraceEnUS = {
         method: "Request method", operation: "Operation summary", operationStatus: "Operation status", operationType: "Operation type", rawFacts: "Raw facts (collapsed)", recordedAt: "Recorded at", source: "Source", statusCode: "Status code", target: "Target", targetId: "Target ID",
         rawAction: "Raw action", targetType: "Target type", technicalIds: "Technical identifiers", time: "Operation time", title: "Operation log details",
       },
-      targetTypes: { agentConversation: "Agent business conversation", conversation: "Business conversation" },
+      domainAction: "{{action}} {{target}}",
+      domainAuditActions: { add_members: "Add to", create: "Create", delete: "Delete", import: "Import", remove_members: "Remove from", update: "Update" },
+      targetTypes: {
+        action_schedule: "action schedule", action_type: "action type", agentConversation: "Agent business conversation", concept_group: "concept group",
+        conversation: "Business conversation", knowledge_network: "business knowledge network", metric: "metric", object_type: "object type", relation_type: "relation type", risk_type: "risk type",
+      },
       title: "Log Search",
       unnamedAgent: "Unnamed Agent",
     },

--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -149,7 +149,7 @@ export const bknTraceEnUS = {
         rawAction: "Raw action", targetType: "Target type", technicalIds: "Technical identifiers", time: "Operation time", title: "Operation log details",
       },
       domainAction: "{{action}} {{target}}",
-      domainAuditActions: { add_members: "Add to", create: "Create", delete: "Delete", import: "Import", remove_members: "Remove from", update: "Update" },
+      domainAuditActions: { add_members: "Add members to {{target}}", create: "Create", delete: "Delete", import: "Import", remove_members: "Remove members from {{target}}", update: "Update" },
       targetTypes: {
         action_schedule: "action schedule", action_type: "action type", agentConversation: "Agent business conversation", concept_group: "concept group",
         conversation: "Business conversation", knowledge_network: "business knowledge network", metric: "metric", object_type: "object type", relation_type: "relation type", risk_type: "risk type",

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -148,7 +148,12 @@ export const bknTraceZhCN = {
         method: "请求方法", operation: "操作摘要", operationStatus: "执行状态", operationType: "操作类型", rawFacts: "原始事实（默认收起）", recordedAt: "记录时间", source: "来源", statusCode: "状态码", target: "操作对象", targetId: "对象 ID",
         rawAction: "原始动作", targetType: "对象类型", technicalIds: "技术标识", time: "操作时间", title: "操作日志详情",
       },
-      targetTypes: { agentConversation: "Agent 业务会话", conversation: "业务会话" },
+      domainAction: "{{action}}{{target}}",
+      domainAuditActions: { add_members: "添加", create: "创建", delete: "删除", import: "导入", remove_members: "移除", update: "更新" },
+      targetTypes: {
+        action_schedule: "行动计划", action_type: "行动类型", agentConversation: "Agent 业务会话", concept_group: "概念分组",
+        conversation: "业务会话", knowledge_network: "业务知识网络", metric: "指标", object_type: "对象类", relation_type: "关系类", risk_type: "风险类型",
+      },
       title: "日志检索",
       unnamedAgent: "未命名 Agent",
     },

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -149,7 +149,7 @@ export const bknTraceZhCN = {
         rawAction: "原始动作", targetType: "对象类型", technicalIds: "技术标识", time: "操作时间", title: "操作日志详情",
       },
       domainAction: "{{action}}{{target}}",
-      domainAuditActions: { add_members: "添加", create: "创建", delete: "删除", import: "导入", remove_members: "移除", update: "更新" },
+      domainAuditActions: { add_members: "向{{target}}添加成员", create: "创建", delete: "删除", import: "导入", remove_members: "从{{target}}移除成员", update: "更新" },
       targetTypes: {
         action_schedule: "行动计划", action_type: "行动类型", agentConversation: "Agent 业务会话", concept_group: "概念分组",
         conversation: "业务会话", knowledge_network: "业务知识网络", metric: "指标", object_type: "对象类", relation_type: "关系类", risk_type: "风险类型",

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -15,15 +15,21 @@ import { getLogDetail, listLogPolicies, listLogs, listLogSources } from "@/modul
 import { getAccessProfile } from "@/modules/bkn-trace/services/trace.service";
 import { AuditLogPage } from "@/modules/system-admin/pages/AuditLogPage";
 
-const translate = (key: string) => ({
+const translate = (key: string, options?: Record<string, unknown>) => {
+  const value = ({
   "bknTrace.logs.authenticatedUser": "已认证用户",
   "bknTrace.logs.authMethods.api_key": "通过 API Key",
   "bknTrace.logs.businessConversationSuffix": " 的业务会话",
   "bknTrace.logs.conversationId": "Conversation ID",
   "bknTrace.logs.unnamedAgent": "未命名 Agent",
   "bknTrace.logs.modules.openbkn": "技术运行日志（非操作日志）",
+  "bknTrace.logs.domainAction": "{{action}}{{target}}",
+  "bknTrace.logs.domainAuditActions.create": "创建",
+  "bknTrace.logs.targetTypes.object_type": "对象类",
   "bknTrace.settings.status.healthy": "已接入",
-}[key] ?? key);
+  }[key] ?? key);
+  return value.replace(/{{(\w+)}}/g, (_match, name: string) => typeof options?.[name] === "string" ? options[name] : "");
+};
 
 vi.mock("react-i18next", async (importOriginal) => {
   const original = await importOriginal<typeof import("react-i18next")>();
@@ -123,6 +129,28 @@ describe("observability workspace scenes", () => {
     for (const column of ["time", "module", "action", "target", "actor", "outcome", "source"]) {
       expect(screen.getByText(`bknTrace.logs.columns.${column}`)).not.toBeNull();
     }
+  });
+
+  it("以业务语言展示领域知识网络管理事实", async () => {
+    vi.mocked(listLogs).mockResolvedValueOnce({
+      count: { accuracy: "exact", value: 1 },
+      data: [{
+        action: "create", actor: { id: "user-a", name: "供应链管理员", type: "user" }, authMethod: "api_key",
+        facts: { action: "create", targetId: "material", targetNameSnapshot: "物料", targetType: "object_type" },
+        eventId: "evt-a", eventName: "resource_config.changed", eventTime: "2026-08-13T08:00:00Z",
+        logCategory: "audit.admin", attributes: { method: "POST" }, businessModule: "domain_knowledge_network",
+        outcome: "success", recordedAt: "2026-08-13T08:00:01Z", requestId: "req-a", sourceChannel: "api", sourceId: "bkn-backend",
+        target: { id: "material", name: "物料", type: "object_type" },
+      }],
+      partial: false,
+      sourceStatus: [{ coveredModules: ["domain_knowledge_network"], reliability: "best_effort", sourceId: "bkn-backend", status: "healthy" }],
+    });
+
+    render(<ObservabilityLogsScene />);
+
+    expect(await screen.findByText("创建对象类")).not.toBeNull();
+    expect(screen.getByText("物料")).not.toBeNull();
+    expect(screen.getByText("供应链管理员")).not.toBeNull();
   });
 
   it("从链接恢复日志时间范围", async () => {


### PR DESCRIPTION
## Summary

- present domain knowledge network audit actions in concise business language
- add readable labels for knowledge networks, object/relation/action types, metrics, risks, concept groups, and action schedules
- retain technical IDs in the existing detail surface instead of exposing them as the primary list content
- verify the unified log workspace with a real BKN Backend resource-configuration fact

## Validation

- 22 targeted Vitest tests passed
- type-aware ESLint passed for all changed files
- license header check passed
- production TypeScript/Vite build passed

This PR does not add a second log workspace or mix runtime Trace facts into operation logs.

Refs #383
