### PR TITLE
fix(system-admin): refine read-only permission management access

### DIFF
--- a/src/app/shell/console-navigation.test.ts
+++ b/src/app/shell/console-navigation.test.ts
@@ -53,6 +53,18 @@ describe("filterNavByPermission — 系统管理按功能独立授权", () => {
     expect(keys(group!.children ?? [])).toEqual(["log-management"]);
   });
 
+  it("审计管理员的用户和部门只读权限 → 显示用户管理与审计日志", () => {
+    const group = systemGroup(
+      filterNavByPermission(consoleNavigation, [
+        "admin-audit:view",
+        "admin-user:view",
+        "admin-dept:view",
+      ]),
+    );
+    expect(group).toBeDefined();
+    expect(keys(group!.children ?? [])).toEqual(["user-management", "log-management"]);
+  });
+
   it("非系统类菜单不受权限过滤影响", () => {
     const filtered = filterNavByPermission(consoleNavigation, []);
     expect(keys(filtered)).toContain("general-business-knowledge-network");

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
@@ -118,6 +118,7 @@ export function ObjectAuthorizeDrawer({
     currentPermissions,
     requiredPermissions: authzPoints.revoke,
   });
+  const canManageGrants = canGrant || canRevoke;
   const [grants, setGrants] = useState<ObjectGrant[]>([]);
   const [departments, setDepartments] = useState<AdminDepartment[]>([]);
   const [lookupRevision, setLookupRevision] = useState(0);
@@ -401,7 +402,7 @@ export function ObjectAuthorizeDrawer({
 
       <div className={[styles.calloutBox, styles.sectionCalloutBottom].join(" ")}>
         <span>
-          {canGrant || canRevoke
+          {canManageGrants
             ? t("systemAdmin.objectGrants.drawerHint")
             : t("systemAdmin.objectGrants.drawerReadOnly")}
         </span>
@@ -442,8 +443,20 @@ export function ObjectAuthorizeDrawer({
       ) : grants.length ? (
         <section className={[styles.createPanel, styles.sectionCallout].join(" ")}>
           <div className={styles.createPanelHead}>
-            <h3 className={styles.createPanelTitle}>{t("systemAdmin.objectGrants.manage")}</h3>
-            <p className={styles.createPanelDesc}>{t("systemAdmin.objectGrants.drawerHint")}</p>
+            <h3 className={styles.createPanelTitle}>
+              {t(
+                canManageGrants
+                  ? "systemAdmin.objectGrants.manage"
+                  : "systemAdmin.objectGrants.viewDetail",
+              )}
+            </h3>
+            <p className={styles.createPanelDesc}>
+              {t(
+                canManageGrants
+                  ? "systemAdmin.objectGrants.drawerHint"
+                  : "systemAdmin.objectGrants.drawerReadOnly",
+              )}
+            </p>
           </div>
           <div className={styles.createPanelBody}>
             {hasProtectedGrant ? (
@@ -524,8 +537,20 @@ export function ObjectAuthorizeDrawer({
       ) : (
         <section className={[styles.createPanel, styles.sectionCallout].join(" ")}>
           <div className={styles.createPanelHead}>
-            <h3 className={styles.createPanelTitle}>{t("systemAdmin.objectGrants.manage")}</h3>
-            <p className={styles.createPanelDesc}>{t("systemAdmin.objectGrants.drawerHint")}</p>
+            <h3 className={styles.createPanelTitle}>
+              {t(
+                canManageGrants
+                  ? "systemAdmin.objectGrants.manage"
+                  : "systemAdmin.objectGrants.viewDetail",
+              )}
+            </h3>
+            <p className={styles.createPanelDesc}>
+              {t(
+                canManageGrants
+                  ? "systemAdmin.objectGrants.drawerHint"
+                  : "systemAdmin.objectGrants.drawerReadOnly",
+              )}
+            </p>
           </div>
           <div className={styles.createPanelBody}>
             <Empty

--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -109,6 +109,7 @@ export const systemAdminEnUS = {
       create: "New Permission Rule",
       authorize: "Configure Permissions",
       manage: "Manage",
+      viewDetail: "View details",
       revoke: "Revoke Permissions",
       remove: "Remove",
       add: "Add",

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -109,6 +109,7 @@ export const systemAdminZhCN = {
       create: "新建权限配置",
       authorize: "配置权限",
       manage: "管理",
+      viewDetail: "查看详情",
       revoke: "撤销权限",
       remove: "移除",
       add: "添加",

--- a/src/modules/system-admin/module.manifest.ts
+++ b/src/modules/system-admin/module.manifest.ts
@@ -9,11 +9,13 @@ export const systemAdminModuleManifest = {
   id: "system-admin",
   name: "System Admin",
   permissions: [
+    "admin-user:view",
     "admin-user:create",
     "admin-user:edit",
     "admin-user:delete",
     "admin-user:toggle",
     "admin-user:reset-password",
+    "admin-dept:view",
     "admin-dept:create",
     "admin-dept:edit",
     "admin-dept:delete",

--- a/src/modules/system-admin/permissions.test.ts
+++ b/src/modules/system-admin/permissions.test.ts
@@ -84,6 +84,7 @@ describe("授权面权限点", () => {
 
   it("审计管理员：只读审查进得去，授权面写动作一个都看不到", () => {
     const permissions = permissionsOf("audit");
+    expect(canEnter(permissions, systemAdminPermissions.users)).toBe(true);
     expect(can(permissions, authzPoints.review)).toBe(true);
     expect(canEnter(permissions, systemAdminPermissions.authorizations)).toBe(true);
     expect(canEnter(permissions, systemAdminPermissions.roles)).toBe(true);

--- a/src/modules/system-admin/permissions.ts
+++ b/src/modules/system-admin/permissions.ts
@@ -17,11 +17,13 @@ export const systemAdminPermissions: Record<
   string[]
 > = {
   users: [
+    "admin-user:view",
     "admin-user:create",
     "admin-user:edit",
     "admin-user:delete",
     "admin-user:toggle",
     "admin-user:reset-password",
+    "admin-dept:view",
     "admin-dept:create",
     "admin-dept:edit",
     "admin-dept:delete",

--- a/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
+++ b/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
@@ -88,6 +88,11 @@ export function ObjectAuthorizationScene() {
     currentPermissions: runtimeConfig.currentUser.permissions,
     requiredPermissions: authzPoints.revoke,
   });
+  const canGrant = hasPermissions({
+    currentPermissions: runtimeConfig.currentUser.permissions,
+    requiredPermissions: authzPoints.grant,
+  });
+  const canManageGrants = canGrant || canRevokeGrant;
   const { pageState, setPagination } = usePageState();
 
   const [grants, setGrants] = useState<ObjectGrant[]>([]);
@@ -385,7 +390,11 @@ export function ObjectAuthorizationScene() {
       items: [
         {
           key: "manage",
-          label: t("systemAdmin.objectGrants.manage"),
+          label: t(
+            canManageGrants
+              ? "systemAdmin.objectGrants.manage"
+              : "systemAdmin.objectGrants.viewDetail",
+          ),
         },
         canRevokeGrant
           ? {
@@ -411,7 +420,7 @@ export function ObjectAuthorizationScene() {
         }
       },
     }),
-    [canRevokeGrant, confirmRevoke, openDrawer, t],
+    [canManageGrants, canRevokeGrant, confirmRevoke, openDrawer, t],
   );
 
   const columns: ColumnsType<ObjectGrant> = useMemo(() => [
@@ -507,7 +516,11 @@ export function ObjectAuthorizationScene() {
                     icon={<KeyOutlined />}
                     onClick={() => openDrawer({ id: objId, name: objName, type: objType })}
                   >
-                    {t("systemAdmin.objectGrants.manage")}
+                    {t(
+                      canManageGrants
+                        ? "systemAdmin.objectGrants.manage"
+                        : "systemAdmin.objectGrants.viewDetail",
+                    )}
                   </AppButton>
                 </div>
                 <div className={styles.authzGroupBody}>


### PR DESCRIPTION
- Add view permissions for users and departments.
- Allow audit administrators to access user and department management pages in read-only mode.
- Show “View details” instead of “Manage” for users without grant or revoke permissions.
- Keep grant, revoke, and edit actions protected by their respective permission points.
- Update related permission tests and localized labels.

# Pull Request

## What Changed

- [x] 补充 `admin-user:view` 和 `admin-dept:view` 权限点
- [x] 支持审计管理员查看用户管理和部门管理页面
- [x] 审计管理员以只读模式访问权限管理
- [x] 无 `admin-authz:grant` / `admin-authz:revoke` 权限时，将“管理”改为“查看详情”
- [x] 隐藏只读用户的授权、撤权、添加和修改操作
- [x] 更新系统权限管理相关的中英文文案
- [x] 补充权限映射和菜单可见性测试

---

## Why

- Related Issue: N/A
- Related Feature: 系统管理权限分级与审计只读访问
- Background:

审计管理员拥有用户、部门、角色和系统权限的查看权限，但不具备修改、授权或撤权权限。此前前端未声明用户和部门的查看权限，导致相关菜单不显示；权限管理页面中的“管理”入口也容易让只读用户误以为可以修改权限。

本次调整使前端菜单、页面入口和操作按钮与后端实际权限保持一致。

---

## How

- Key implementation points:
  - 在系统管理模块清单中增加：
    - `admin-user:view`
    - `admin-dept:view`
  - 将用户与部门管理页面的进入条件调整为支持查看权限。
  - 根据当前用户是否拥有 `admin-authz:grant` 或 `admin-authz:revoke`，动态显示“管理”或“查看详情”。
  - 对权限配置抽屉中的新增、撤权、操作切换等写操作继续使用权限点控制。
  - 保持后端 API、资源类型、路由和权限标识兼容。

- Breaking changes (API, config, database, etc.):
  - 无。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally：未涉及后端集成测试
- [ ] Verified in test environment：待验证

Test notes:

```bash
pnpm exec eslint \
  src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx \
  src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx \
  src/modules/system-admin/locales/zh-CN.ts \
  src/modules/system-admin/locales/en-US.ts \
  src/modules/system-admin/permissions.ts \
  src/modules/system-admin/module.manifest.ts \
  src/app/shell/console-navigation.test.ts \
  src/modules/system-admin/permissions.test.ts \
  --config eslint.config.typechecked.js \
  --max-warnings 0

pnpm exec tsc -b --pretty false

git diff --check