### PR TITLE
feat(studio): send selected locale to service APIs

### DIFF
--- a/src/framework/request/http.test.ts
+++ b/src/framework/request/http.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AxiosAdapter } from "axios";
+
+import { http } from "@/framework/request/http";
+import { createRuntimeConfig, setRuntimeConfig } from "@/framework/runtime/config";
+
+const adapter = vi.fn<AxiosAdapter>((config) => Promise.resolve({
+  config,
+  data: {},
+  headers: {},
+  status: 200,
+  statusText: "OK",
+}));
+
+describe("http request headers", () => {
+  beforeEach(() => {
+    adapter.mockClear();
+  });
+
+  afterEach(() => {
+    setRuntimeConfig(createRuntimeConfig());
+  });
+
+  it("sends the selected locale through the standard language header", async () => {
+    setRuntimeConfig(createRuntimeConfig({ locale: "en-US" }));
+
+    await http.get("/health", { adapter });
+
+    const headers = adapter.mock.calls[0]?.[0].headers;
+    expect(headers?.get("Accept-Language")).toBe("en-US");
+    expect(headers?.get("X-Language")).toBeUndefined();
+  });
+
+  it("overwrites a caller-supplied language after the UI locale changes", async () => {
+    setRuntimeConfig(createRuntimeConfig({ locale: "en-US" }));
+    await http.get("/first", {
+      adapter,
+      headers: { "Accept-Language": "zh-CN, en-US;q=0.8" },
+    });
+
+    setRuntimeConfig(createRuntimeConfig({ locale: "zh-CN" }));
+    await http.get("/second", {
+      adapter,
+      headers: { "Accept-Language": "en-US" },
+    });
+
+    expect(adapter.mock.calls[0]?.[0].headers?.get("Accept-Language")).toBe("en-US");
+    expect(adapter.mock.calls[1]?.[0].headers?.get("Accept-Language")).toBe("zh-CN");
+  });
+});

--- a/src/modules/bkn-trace/business-provenance/business-provenance.service.test.ts
+++ b/src/modules/bkn-trace/business-provenance/business-provenance.service.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/framework/request/http", () => ({ http: { get: getMock, post: postMoc
 vi.mock("@/framework/runtime/config", () => ({
   getRuntimeConfig: () => ({
     apiBaseUrl: "/api",
+    locale: "en-US",
     currentUser: { businessDomainId: "bd_demo" },
     auth: { tokenManager: { getAccessToken: () => "token", refreshAccessToken: vi.fn() } },
   }),
@@ -88,7 +89,7 @@ describe("EE business provenance service", () => {
     expect(tokens).toEqual(["正在分析"]);
     const request = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(request[0]).toBe("/api/agent-observability/v1/business-provenance/interactions/int-1/analysis");
-    expect(request[1]).toMatchObject({ method: "POST", body: JSON.stringify({ markdown: "# 已确认 Markdown" }), headers: { Authorization: "Bearer token", Accept: "text/event-stream", "Content-Type": "application/json" } });
+    expect(request[1]).toMatchObject({ method: "POST", body: JSON.stringify({ markdown: "# 已确认 Markdown" }), headers: { Authorization: "Bearer token", Accept: "text/event-stream", "Accept-Language": "en-US", "Content-Type": "application/json" } });
   });
 
   it("shows the normalized stream failure without exposing an empty result", async () => {

--- a/src/modules/bkn-trace/business-provenance/business-provenance.service.ts
+++ b/src/modules/bkn-trace/business-provenance/business-provenance.service.ts
@@ -198,6 +198,7 @@ export async function streamBusinessProvenanceAnalysis(
       headers: {
         Accept: "text/event-stream",
         "Content-Type": "application/json",
+        "Accept-Language": runtime.locale,
         "x-business-domain": runtime.currentUser.businessDomainId ?? "bd_public",
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },

--- a/src/modules/knowledge-network/services/agent-chat.fetch.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat.fetch.test.ts
@@ -10,8 +10,9 @@
  * either hits a busy gateway unnecessarily or buffers a whole streaming response and destroys typing behavior.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createRuntimeConfig, setRuntimeConfig } from "@/framework/runtime/config";
 import { makeAuthedFetch } from "@/modules/knowledge-network/services/agent-chat.service";
 
 const provider = { getToken: () => "t", refresh: () => Promise.resolve("t") };
@@ -32,12 +33,27 @@ function neverEndingStream(contentType: string | null): Response {
   });
 }
 
+beforeEach(() => {
+  setRuntimeConfig(createRuntimeConfig({ locale: "en-US" }));
+});
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
+  setRuntimeConfig(createRuntimeConfig());
 });
 
 describe("makeAuthedFetch 退避重试", () => {
+  it("uses the current UI locale for every gateway request", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse(200, { choices: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await makeAuthedFetch(provider)("https://example.test/v1/chat/completions", { method: "POST" });
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(request.headers).get("Accept-Language")).toBe("en-US");
+  });
+
   it("200 裹着可重试业务码时重试，拿到成功响应就停", async () => {
     const busy = { code: "X", description: '{"code":50508,"message":"System is too busy now."}' };
     const fetchMock = vi
@@ -117,5 +133,6 @@ describe("makeAuthedFetch 退避重试", () => {
     expect(response.status).toBe(200);
     const retried = fetchMock.mock.calls[1][1] as RequestInit;
     expect(new Headers(retried.headers).get("Authorization")).toBe("Bearer fresh");
+    expect(new Headers(retried.headers).get("Accept-Language")).toBe("en-US");
   });
 });

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -17,6 +17,7 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { jsonSchema, stepCountIs, streamText, tool, type ModelMessage, type ToolSet } from "ai";
 
+import { getRuntimeConfig } from "@/framework/runtime/config";
 import {
   isRetryableStatus,
   normalizeAgentError,
@@ -562,6 +563,7 @@ export function makeAuthedFetch(provider: AgentTokenProvider): typeof fetch {
       }
     }
     const headers = new Headers(init?.headers);
+    headers.set("Accept-Language", getRuntimeConfig().locale);
     if (token) headers.set("Authorization", `Bearer ${token}`);
     return fetch(input, { ...init, headers, body });
   };

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -5,14 +5,16 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createRuntimeConfig, setRuntimeConfig } from "@/framework/runtime/config";
 import {
   CONTEXT_LOADER_OPS,
   buildCurl,
   createMcpSession,
   fetchMcpObjectTypes,
   fetchKnDetail,
+  fetchKnDetailRestLegacy,
   listMcpTools,
   sendRequest,
 } from "@/modules/knowledge-network/services/context-loader.service";
@@ -38,8 +40,13 @@ function jsonRpcBody(init: RequestInit | undefined): Record<string, unknown> {
   return JSON.parse(init.body) as Record<string, unknown>;
 }
 
+beforeEach(() => {
+  setRuntimeConfig(createRuntimeConfig({ locale: "en-US" }));
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
+  setRuntimeConfig(createRuntimeConfig());
 });
 
 describe("sendRequest", () => {
@@ -57,10 +64,10 @@ describe("sendRequest", () => {
       controller.signal,
     );
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining("/kn/search_schema"),
-      expect.objectContaining({ signal: controller.signal }),
-    );
+    expect(fetchSpy.mock.calls[0]?.[0]).toContain("/kn/search_schema");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+    expect(init.headers).toMatchObject({ "Accept-Language": "en-US" });
   });
 
   it("completes the MCP initialize, initialized notification, and tools/call handshake", async () => {
@@ -86,6 +93,9 @@ describe("sendRequest", () => {
     expect(jsonRpcBody(fetchSpy.mock.calls[1][1])).toMatchObject({ method: "notifications/initialized" });
     expect(jsonRpcBody(fetchSpy.mock.calls[2][1])).toMatchObject({ method: "tools/call" });
     expect(fetchSpy.mock.calls[2][1]?.headers).toMatchObject({ "Mcp-Session-Id": "session-1" });
+    fetchSpy.mock.calls.forEach(([, init]) => {
+      expect(init?.headers).toMatchObject({ "Accept-Language": "en-US" });
+    });
   });
 
   it("carries the managed context into the REST body", async () => {
@@ -173,6 +183,18 @@ describe("fetchKnDetail", () => {
   });
 });
 
+describe("legacy context-loader REST requests", () => {
+  it("uses the current UI locale", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "kn-demo", object_types: [], concept_groups: [], relation_types: [] }), { status: 200 }),
+    );
+
+    await fetchKnDetailRestLegacy({ base: "https://platform.example.com", token: "", knId: "kn-demo" });
+
+    expect(fetchSpy.mock.calls[0]?.[1]?.headers).toMatchObject({ "Accept-Language": "en-US" });
+  });
+});
+
 describe("fetchMcpObjectTypes", () => {
   it("uses get_object_types with the managed context and returns related metrics", async () => {
     const session = {
@@ -222,6 +244,7 @@ describe("buildCurl", () => {
     );
 
     expect(curl).toContain('"bkn_context":{"conversation_id":"conv_1"');
+    expect(curl).toContain("Accept-Language: en-US");
   });
 
   it("keeps a half-written request body readable instead of showing it as empty", () => {
@@ -310,8 +333,12 @@ describe("listMcpTools", () => {
     ).resolves.toEqual([]);
 
     expect(fetchSpy).toHaveBeenCalledTimes(3);
-    fetchSpy.mock.calls.forEach(([, init]) => {
-      expect(init).toMatchObject({ signal: controller.signal });
+    fetchSpy.mock.calls.forEach((call) => {
+      const init = call[1] as RequestInit;
+      expect(init).toMatchObject({
+        signal: controller.signal,
+        headers: { "Accept-Language": "en-US" },
+      });
     });
   });
 });
@@ -335,5 +362,8 @@ describe("createMcpSession", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(6);
     expect(fetchSpy.mock.calls[2][1]?.headers).toMatchObject({ "Mcp-Session-Id": "session-old" });
     expect(fetchSpy.mock.calls[5][1]?.headers).toMatchObject({ "Mcp-Session-Id": "session-new" });
+    fetchSpy.mock.calls.forEach(([, init]) => {
+      expect(init?.headers).toMatchObject({ "Accept-Language": "en-US" });
+    });
   });
 });

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -12,6 +12,8 @@
  * Send Request performs real HTTP calls, same-origin by default to avoid CORS.
  */
 
+import { getRuntimeConfig } from "@/framework/runtime/config";
+
 export type ContextLoaderMode = "agent" | "rest" | "mcp";
 
 export type OpQueryParam = {
@@ -38,6 +40,10 @@ export const REST_PREFIX = "/api/agent-retrieval/v1";
 
 /** MCP endpoint; the gateway route is /api/agent-retrieval/v1/mcp, not root /mcp. */
 export const MCP_PATH = "/api/agent-retrieval/v1/mcp/";
+
+function languageHeaders(): Record<"Accept-Language", string> {
+  return { "Accept-Language": getRuntimeConfig().locale };
+}
 
 export type RequestDataAssistantKind = "concept-group" | "object-type" | "resource" | "relation";
 
@@ -563,7 +569,7 @@ export function buildCurl(
 ): string {
   if (mode === "mcp") {
     const url = mcpBase(env);
-    const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream", ...authHeaders(env) };
+    const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream", ...languageHeaders(), ...authHeaders(env) };
     const args = mcpCallArgs(bodyText, queryValues, bknContext);
     const payload = { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: op.id, arguments: args } };
     let curl = `curl -X POST '${url}'`;
@@ -574,7 +580,7 @@ export function buildCurl(
     return curl;
   }
   const url = buildRestUrl(env, op, queryValues);
-  const headers = { "Content-Type": "application/json", ...authHeaders(env) };
+  const headers = { "Content-Type": "application/json", ...languageHeaders(), ...authHeaders(env) };
   let curl = `curl -X POST '${url}'`;
   Object.entries(headers).forEach(([key, value]) => {
     curl += ` \\\n  -H '${key}: ${value}'`;
@@ -622,6 +628,7 @@ export async function sendRequest(
       const baseHeaders = {
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
+        ...languageHeaders(),
         ...bearer,
       };
       const initResp = await fetch(url, {
@@ -678,7 +685,7 @@ export async function sendRequest(
       };
     }
     const url = buildRestUrl(env, op, queryValues);
-    const headers = { "Content-Type": "application/json", ...bearer };
+    const headers = { "Content-Type": "application/json", ...languageHeaders(), ...bearer };
     const init: RequestInit = { method: "POST", headers, signal };
     if (op.body !== null) {
       init.body = JSON.stringify(withBknContext(strictBodyObject(bodyText), bknContext));
@@ -754,6 +761,7 @@ export async function listMcpTools(env: ContextLoaderEnv, auth?: McpAuth, signal
     const baseHeaders: Record<string, string> = {
       "Content-Type": "application/json",
       Accept: "application/json, text/event-stream",
+      ...languageHeaders(),
     };
     if (token) baseHeaders.Authorization = `Bearer ${token}`;
     const initResp = await fetch(url, {
@@ -924,6 +932,7 @@ export function createMcpSession(env: ContextLoaderEnv, auth?: McpAuth): McpSess
     return {
       "Content-Type": "application/json",
       Accept: "application/json, text/event-stream",
+      ...languageHeaders(),
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     };
   };
@@ -1113,7 +1122,7 @@ async function restPost(
   signal?: AbortSignal,
 ): Promise<Response> {
   const doFetch = (token: string) => {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const headers: Record<string, string> = { "Content-Type": "application/json", ...languageHeaders() };
     if (token) headers.Authorization = `Bearer ${token}`;
     return fetch(url, { method: "POST", headers, body: JSON.stringify(body), signal });
   };


### PR DESCRIPTION
## What Changed

- [x] Send the selected `Accept-Language` value through every Studio business API path.
- [x] Cover Axios, Context Loader REST/MCP, Agent Chat, and SSE fetch paths with regression tests.
- [ ] Docs/doc 1 (not applicable)

---

## Why

- Related Issue: Closes #799
- Related Feature: HTTP internationalization P0
- Background: Backend services now negotiate locale through `Accept-Language`. Direct browser `fetch` paths bypass the shared Axios interceptor and must send the same selected locale.

---

## How

- Key implementation points: Axios overwrites caller-provided language with the current runtime locale. Direct business fetch, MCP session, and streaming requests set the same header.
- Breaking changes (API, config, database, etc.): Removes no public API; Studio no longer relies on `X-Language`.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (requires deployed service stack)
- [ ] Verified in test environment (pending end-to-end joint testing)

Test notes:

- Passed focused Vitest suite: 29 tests covering Axios, Context Loader, MCP, Agent Chat, and SSE paths.
- Passed type-aware ESLint for changed files, `tsc -b --pretty false`, and `git diff --check`.
- The full repository ESLint command exceeded the local execution time limit; CI will run the full gate.

---

## Risk & Rollback

- Potential risks: CORS must allow `Accept-Language` on cross-origin gateway routes.
- Rollback plan: Revert this single commit; the backend keeps the service default fallback.

---

## Additional Notes

- Follow-up: run Studio main with merged backend images to verify browser requests, localized errors, SSE, and response headers end to end.