### PR TITLE
fix(data-catalog): avoid duplicate build task start

### DIFF
--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx
@@ -5,8 +5,8 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 
@@ -24,11 +24,15 @@ vi.mock("@/framework/context/use-app-services", () => ({
   useAppServices: () => ({ message: { success: vi.fn() } }),
 }));
 
+const createBuildTaskMock = vi.hoisted(() => vi.fn());
+const listBuildTasksMock = vi.hoisted(() => vi.fn());
+const resumeBuildTaskMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@/modules/data-catalog/services/build-task.service", () => ({
   BuildTaskConflictError: class BuildTaskConflictError extends Error {},
-  createBuildTask: vi.fn(),
-  listBuildTasks: vi.fn().mockResolvedValue([]),
-  resumeBuildTask: vi.fn(),
+  createBuildTask: createBuildTaskMock,
+  listBuildTasks: listBuildTasksMock,
+  resumeBuildTask: resumeBuildTaskMock,
 }));
 
 vi.mock("@/modules/model-resources/services/small-model.service", () => ({
@@ -57,8 +61,15 @@ const resource: CatalogResource = {
 };
 
 describe("BuildTaskLaunchPanel", () => {
-	it("keeps streaming disabled and exposes the persisted incremental batch entry", () => {
-	expect(STREAMING_BUILD_ENTRY_ENABLED).toBe(false);
+  beforeEach(() => {
+    createBuildTaskMock.mockReset();
+    listBuildTasksMock.mockReset();
+    listBuildTasksMock.mockResolvedValue([]);
+    resumeBuildTaskMock.mockReset();
+  });
+
+  it("keeps streaming disabled and exposes the persisted incremental batch entry", () => {
+    expect(STREAMING_BUILD_ENTRY_ENABLED).toBe(false);
 
     render(
       <BuildTaskLaunchPanel
@@ -71,6 +82,32 @@ describe("BuildTaskLaunchPanel", () => {
 
     expect(screen.getByText("dataCatalog.build.batchLabel")).toBeTruthy();
     expect(screen.queryByText("dataCatalog.build.streamingLabel")).toBeNull();
-	expect(screen.getByText("dataCatalog.build.executeIncremental")).toBeTruthy();
+    expect(screen.getByText("dataCatalog.build.executeIncremental")).toBeTruthy();
+  });
+
+  it("does not issue a second start request after task creation", async () => {
+    const onStarted = vi.fn();
+    createBuildTaskMock.mockResolvedValue({ id: "task-running", status: "running" });
+
+    render(
+      <BuildTaskLaunchPanel
+        active
+        onGoConfigure={vi.fn()}
+        onStarted={onStarted}
+        resource={resource}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.build\.startBuild/ }));
+
+    await waitFor(() => {
+      expect(createBuildTaskMock).toHaveBeenCalledWith({
+        executeType: "full",
+        mode: "batch",
+        resourceId: resource.id,
+      });
+    });
+    expect(resumeBuildTaskMock).not.toHaveBeenCalled();
+    expect(onStarted).toHaveBeenCalledWith({ id: "task-running", status: "running" });
   });
 });

--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
@@ -21,7 +21,6 @@ import {
   BuildTaskConflictError,
   createBuildTask,
   listBuildTasks,
-  resumeBuildTask,
 } from "@/modules/data-catalog/services/build-task.service";
 import type {
   BuildMode,
@@ -184,11 +183,6 @@ export function BuildTaskLaunchPanel({
         resourceId: resource.id,
         executeType: mode === "batch" ? executeType : undefined,
       });
-      try {
-        await resumeBuildTask(task.id);
-      } catch {
-        // Creation may already have transitioned the task to running.
-      }
       message.success(t("dataCatalog.build.created", { id: task.id }));
       onStarted(task);
     } catch (persistError) {


### PR DESCRIPTION
## What Changed

- [x] Data catalog: remove the redundant start request after a build task is created.
- [x] Tests: cover a newly created running task and assert no second start request is issued.
- [x] Docs: not applicable; behavior is internal to the task launch flow.

---

## Why

- Related Issue: [openbkn-ai/bkn-foundry#860](https://github.com/openbkn-ai/bkn-foundry/issues/860)
- Related Feature: Data Catalog index build tasks
- Background: the UI submitted start after task creation even when Vega had already transitioned the task to running, producing an invalid-state error while the task continued successfully.

Closes openbkn-ai/bkn-foundry#860

---

## How

- Key implementation points: treat create as the launch action; refresh the task state after creation without issuing an additional start request.
- Breaking changes (API, config, database, etc.): none.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (full Vitest suite)
- [ ] Verified in test environment — not performed; no test-environment access in this change.

Test notes:

- node scripts/check-license-headers.mjs
- pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
- pnpm exec vitest --run
- pnpm exec tsc -b --pretty false
- pnpm exec vite build
- pnpm audit --prod

---

## Risk & Rollback

- Potential risks: relies on the existing Vega contract that task creation launches the task.
- Rollback plan: revert commit d28cdbf to restore the prior create-then-start flow.

---

## Additional Notes

- Existing full-suite jsdom/Ant Design warnings and Vite chunk-size warnings were emitted but did not fail their commands.
- Production dependency audit exited successfully and reported one ignored high-severity finding.