### PR TITLE
fix(data-catalog): align analyzer hints with capabilities

### DIFF
--- a/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
@@ -102,6 +102,23 @@ describe("IndexConfigFormPanel", () => {
     expect(screen.queryByText("dataCatalog.build.analyzersLoading")).toBeNull();
   });
 
+  it("explains the Chinese-search limitation when no Chinese analyzer is enabled", async () => {
+    loadAnalyzerCapabilitiesMock.mockResolvedValue({
+      errorMessage: null,
+      options: ["standard", "english"],
+      state: "ready",
+    });
+
+    render(
+      <MemoryRouter>
+        <IndexConfigFormPanel active resource={resource} />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("dataCatalog.build.fulltextChineseAnalyzerUnavailableHint");
+    expect(screen.queryByText("dataCatalog.build.fulltextChineseAnalyzerAvailableHint")).toBeNull();
+  });
+
   it("keeps a vector-only resource saveable when analyzer capabilities are unavailable", async () => {
     const vectorResource: CatalogResource = {
       ...resource,

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
@@ -167,7 +167,9 @@ describe("IndexConfigFormPanel", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(loadAnalyzerCapabilitiesMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByText("dataCatalog.build.analyzersLoading")).toBeNull());
+    fireEvent.mouseDown(screen.getAllByRole("combobox")[0]);
+    await screen.findByText("dataCatalog.build.analyzers.english");
     expect(screen.queryByText("dataCatalog.build.fulltextChineseAnalyzerUnavailableHint")).toBeNull();
   });
 

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
@@ -103,6 +103,58 @@ describe("IndexConfigFormPanel", () => {
   });
 
   it("explains the Chinese-search limitation when no Chinese analyzer is enabled", async () => {
+    const fulltextResource: CatalogResource = {
+      ...resource,
+      schema: [{
+        features: [{ config: { analyzer: "standard" }, featureType: "fulltext" }],
+        name: "title",
+        type: "string",
+      }],
+    };
+    getCatalogResourceMock.mockResolvedValue(fulltextResource);
+    loadAnalyzerCapabilitiesMock.mockResolvedValue({
+      errorMessage: null,
+      options: ["standard", "english"],
+      state: "ready",
+    });
+
+    render(
+      <MemoryRouter>
+        <IndexConfigFormPanel active resource={fulltextResource} />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("dataCatalog.build.fulltextChineseAnalyzerUnavailableHint");
+    expect(screen.queryByText("dataCatalog.build.fulltextChineseAnalyzerAvailableHint")).toBeNull();
+  });
+
+  it("recognizes other IK analyzers returned by the server", async () => {
+    const fulltextResource: CatalogResource = {
+      ...resource,
+      schema: [{
+        features: [{ config: { analyzer: "ik_smart" }, featureType: "fulltext" }],
+        name: "title",
+        type: "string",
+      }],
+    };
+    getCatalogResourceMock.mockResolvedValue(fulltextResource);
+    loadAnalyzerCapabilitiesMock.mockResolvedValue({
+      errorMessage: null,
+      options: ["standard", "ik_smart"],
+      state: "ready",
+    });
+
+    render(
+      <MemoryRouter>
+        <IndexConfigFormPanel active resource={fulltextResource} />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("dataCatalog.build.fulltextChineseAnalyzerAvailableHint");
+    expect(screen.queryByText("dataCatalog.build.fulltextChineseAnalyzerUnavailableHint")).toBeNull();
+  });
+
+  it("does not show Chinese analyzer guidance for a resource without full-text fields", async () => {
     loadAnalyzerCapabilitiesMock.mockResolvedValue({
       errorMessage: null,
       options: ["standard", "english"],
@@ -115,8 +167,8 @@ describe("IndexConfigFormPanel", () => {
       </MemoryRouter>,
     );
 
-    await screen.findByText("dataCatalog.build.fulltextChineseAnalyzerUnavailableHint");
-    expect(screen.queryByText("dataCatalog.build.fulltextChineseAnalyzerAvailableHint")).toBeNull();
+    await waitFor(() => expect(loadAnalyzerCapabilitiesMock).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText("dataCatalog.build.fulltextChineseAnalyzerUnavailableHint")).toBeNull();
   });
 
   it("keeps a vector-only resource saveable when analyzer capabilities are unavailable", async () => {

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
@@ -55,6 +55,7 @@ export type IndexConfigFormPanelProps = {
 };
 
 const INHERIT_VALUE = "__inherit__";
+const CHINESE_ANALYZERS = new Set(["hanlp_index", "ik_max_word"]);
 
 const normalizeFieldType = (type: string) => type.trim().toLowerCase();
 const isFeatureConfigField = (type: string) => ["string", "text"].includes(normalizeFieldType(type));
@@ -176,6 +177,10 @@ export function IndexConfigFormPanel({
         value: analyzer,
       })),
     [analyzers, t],
+  );
+  const enabledChineseAnalyzers = useMemo(
+    () => analyzers.filter((analyzer) => CHINESE_ANALYZERS.has(analyzer)),
+    [analyzers],
   );
 
   const modelOptions = useMemo(
@@ -1034,6 +1039,15 @@ export function IndexConfigFormPanel({
                   <div className={formStyles.fieldHint}>
                     {t("dataCatalog.build.fulltextAnalyzerHint")}
                   </div>
+                  {analyzersLoadState === "ready" ? (
+                    <div className={formStyles.fieldHint}>
+                      {enabledChineseAnalyzers.length > 0
+                        ? t("dataCatalog.build.fulltextChineseAnalyzerAvailableHint", {
+                            analyzers: enabledChineseAnalyzers.join(", "),
+                          })
+                        : t("dataCatalog.build.fulltextChineseAnalyzerUnavailableHint")}
+                    </div>
+                  ) : null}
                   {analyzerSelectionDisabled ? (
                     <div className={formStyles.fieldHint}>
                       {analyzerSelectionDisabledReason}

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
@@ -55,7 +55,10 @@ export type IndexConfigFormPanelProps = {
 };
 
 const INHERIT_VALUE = "__inherit__";
-const CHINESE_ANALYZERS = new Set(["hanlp_index", "ik_max_word"]);
+
+function isChineseAnalyzer(analyzer: string): boolean {
+  return /^(?:ik|hanlp)(?:_|$)/.test(analyzer.trim().toLowerCase());
+}
 
 const normalizeFieldType = (type: string) => type.trim().toLowerCase();
 const isFeatureConfigField = (type: string) => ["string", "text"].includes(normalizeFieldType(type));
@@ -179,7 +182,7 @@ export function IndexConfigFormPanel({
     [analyzers, t],
   );
   const enabledChineseAnalyzers = useMemo(
-    () => analyzers.filter((analyzer) => CHINESE_ANALYZERS.has(analyzer)),
+    () => analyzers.filter(isChineseAnalyzer),
     [analyzers],
   );
 
@@ -1039,7 +1042,7 @@ export function IndexConfigFormPanel({
                   <div className={formStyles.fieldHint}>
                     {t("dataCatalog.build.fulltextAnalyzerHint")}
                   </div>
-                  {analyzersLoadState === "ready" ? (
+                  {fulltextFields.length > 0 && analyzersLoadState === "ready" ? (
                     <div className={formStyles.fieldHint}>
                       {enabledChineseAnalyzers.length > 0
                         ? t("dataCatalog.build.fulltextChineseAnalyzerAvailableHint", {

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -361,7 +361,11 @@ export const dataCatalogEnUS = {
       featureUnsupported: "Unsupported",
       defaultModelDimensions: "Default dimensions: {{dimensions}}",
       fulltextAnalyzerHint:
-        "(use ik / hanlp for Chinese data, standard for English / general)",
+        "Available options come from the current environment. standard is for English / general text; if available, english performs English stemming.",
+      fulltextChineseAnalyzerAvailableHint:
+        "Chinese-text analyzer enabled in this environment: {{analyzers}}.",
+      fulltextChineseAnalyzerUnavailableHint:
+        "No Chinese analyzer such as IK/HanLP is enabled in this environment. standard and english do not provide Chinese word segmentation, so Chinese search recall and relevance may be limited. Ask an administrator to enable a Chinese analyzer.",
       analyzerSelectionUnavailable: "Analyzer capabilities are unavailable.",
       analyzers: {
         standard: "standard · English / general",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -341,7 +341,11 @@ export const dataCatalogZhCN = {
       featureSummaryEmpty: "未配置特征",
       featureUnsupported: "暂不支持",
       defaultModelDimensions: "默认向量维度：{{dimensions}}",
-      fulltextAnalyzerHint: "(中文数据选 ik / hanlp,英文/通用选 standard)",
+      fulltextAnalyzerHint:
+        "实际可选项以当前环境服务端返回为准。standard 适用于英文/通用文本；若当前可选，english 用于英文词干分析。",
+      fulltextChineseAnalyzerAvailableHint: "当前已启用可用于中文文本的分词器：{{analyzers}}。",
+      fulltextChineseAnalyzerUnavailableHint:
+        "当前未启用 IK/HanLP 等中文分词器；standard 和 english 不提供中文分词能力，中文检索的召回和相关性可能受限。请联系管理员启用中文分词器。",
       analyzerSelectionUnavailable: "分词器能力当前不可用。",
       analyzers: {
         standard: "standard · 英文/通用",


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Update the index-config analyzer hint to reflect the server capability snapshot.
- [x] Add a regression test for environments with only `standard` and `english`.
- [x] Update Chinese and English locale copy.

---

## Why

- Related Issue: Closes #424
- Related Feature: N/A — bug fix.
- Background: The static hint recommended IK/HanLP even when the backend reported that neither analyzer was available.

---

## How

- Key implementation points: Detect the known Chinese analyzers (`ik_max_word`, `hanlp_index`) from the loaded server snapshot. Explain the enabled analyzer when present; otherwise explain the Chinese-search limitation and direct users to enable a Chinese analyzer.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally (`pnpm exec vitest --run`: 195 files, 1004 tests).
- [ ] Integration tests passed locally (not applicable; frontend-only copy and component state change).
- [ ] Verified in test environment (not performed).

Test notes:

- Added a component regression test for `standard` + `english` without a Chinese analyzer.
- Passed license-header check, typecheck, production build, and production dependency audit.

---

## Risk & Rollback

- Potential risks: The capability classification currently recognizes `ik_max_word` and `hanlp_index` as Chinese analyzers; unknown future analyzer IDs use the conservative unavailable guidance.
- Rollback plan: Revert commit `cec7c81`.

---

## Additional Notes

- Production build retains existing chunk-size warnings.
- `pnpm audit --prod` reports one ignored high-severity vulnerability and exits successfully.