### PR TITLE
fix(studio): hide paid badge for available role management capability

### DIFF
--- a/src/app/shell/SideNav.test.tsx
+++ b/src/app/shell/SideNav.test.tsx
@@ -20,4 +20,10 @@ describe("shouldAlwaysShowEditionBadge", () => {
   it("keeps a static product badge when no capability state is available", () => {
     expect(shouldAlwaysShowEditionBadge({})).toBe(true);
   });
+
+  it("keeps the badge for capabilities that are not reported by bkn-safe", () => {
+    expect(
+      shouldAlwaysShowEditionBadge({ paidCapability: CAPABILITIES.BUSINESS_PROVENANCE }),
+    ).toBe(true);
+  });
 });

--- a/src/app/shell/SideNav.test.tsx
+++ b/src/app/shell/SideNav.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { shouldAlwaysShowEditionBadge } from "@/app/shell/navigation/edition-badge";
+import { CAPABILITIES } from "@/framework/entitlement/capabilities";
+
+describe("shouldAlwaysShowEditionBadge", () => {
+  it("lets a known capability hide its paid badge once the entitlement is available", () => {
+    expect(
+      shouldAlwaysShowEditionBadge({ paidCapability: CAPABILITIES.RBAC_BASIC }),
+    ).toBe(false);
+  });
+
+  it("keeps a static product badge when no capability state is available", () => {
+    expect(shouldAlwaysShowEditionBadge({})).toBe(true);
+  });
+});

--- a/src/app/shell/SideNav.tsx
+++ b/src/app/shell/SideNav.tsx
@@ -16,6 +16,7 @@ import {
   consoleNavigation,
   findConsoleNavItemByPath,
 } from "@/app/shell/console-navigation";
+import { shouldAlwaysShowEditionBadge } from "@/app/shell/navigation/edition-badge";
 import { useConsoleNavigation } from "@/app/shell/navigation/use-console-navigation";
 import type { AppRouteHandle } from "@/app/shell/route-meta";
 import { accountSideNavigation } from "@/modules/account/navigation";
@@ -133,7 +134,10 @@ export function SideNav({ collapsed, onToggleCollapsed }: SideNavProps) {
                         {item.lockedEdition ?? item.paidEdition ? (
                           <span className="console-sidenav-tier">
                             <EditionBadge
-                              alwaysShow={Boolean(item.paidEdition)}
+                              // A paid capability can report its live entitlement state. Do not keep
+                              // its tier badge after it is available, otherwise an authorized role
+                              // manager is incorrectly told that role management still needs an upgrade.
+                              alwaysShow={shouldAlwaysShowEditionBadge(item)}
                               capability={item.paidCapability}
                               edition={(item.lockedEdition ?? item.paidEdition)!}
                             />
@@ -180,7 +184,7 @@ export function SideNav({ collapsed, onToggleCollapsed }: SideNavProps) {
                         {item.lockedEdition ?? item.paidEdition ? (
                           <span className="console-sidenav-tier">
                             <EditionBadge
-                              alwaysShow={Boolean(item.paidEdition)}
+                              alwaysShow={shouldAlwaysShowEditionBadge(item)}
                               capability={item.paidCapability}
                               edition={(item.lockedEdition ?? item.paidEdition)!}
                             />
@@ -234,7 +238,7 @@ export function SideNav({ collapsed, onToggleCollapsed }: SideNavProps) {
                               {child.lockedEdition ?? child.paidEdition ? (
                           <span className="console-sidenav-tier">
                             <EditionBadge
-                              alwaysShow={Boolean(child.paidEdition)}
+                              alwaysShow={shouldAlwaysShowEditionBadge(child)}
                               capability={child.paidCapability}
                               edition={(child.lockedEdition ?? child.paidEdition)!}
                             />

--- a/src/app/shell/navigation/edition-badge.ts
+++ b/src/app/shell/navigation/edition-badge.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/**
+ * A nav item's static tier label is useful only when the frontend cannot
+ * determine whether its capability is currently available. When the item has
+ * a capability key, EditionBadge can use the entitlement snapshot instead.
+ */
+export function shouldAlwaysShowEditionBadge(item: { paidCapability?: string }) {
+  return !item.paidCapability;
+}

--- a/src/app/shell/navigation/edition-badge.ts
+++ b/src/app/shell/navigation/edition-badge.ts
@@ -11,5 +11,6 @@
  * a capability key, EditionBadge can use the entitlement snapshot instead.
  */
 export function shouldAlwaysShowEditionBadge(item: { paidCapability?: string }) {
-  return !item.paidCapability;
+  return !item.paidCapability || !capabilityReportedByEndpoint(item.paidCapability);
 }
+import { capabilityReportedByEndpoint } from "@/modules/subscription/capability-catalog";

--- a/src/framework/entitlement/EditionBadge.test.tsx
+++ b/src/framework/entitlement/EditionBadge.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EditionBadge } from "@/framework/entitlement/EditionBadge";
+import { CAPABILITIES } from "@/framework/entitlement/capabilities";
+import type { Entitlement } from "@/framework/entitlement/types";
+
+const contextState = vi.hoisted(() => ({ snapshot: null as Entitlement | null }));
+
+vi.mock("@/framework/entitlement/use-entitlement", () => ({
+  useEntitlementContext: () => contextState,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function entitlement(overrides: Partial<Entitlement> = {}): Entitlement {
+  return {
+    capabilities: [],
+    edition: "community",
+    extensions: [],
+    features: [],
+    licensed: false,
+    limits: {},
+    state: "unlicensed",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  contextState.snapshot = null;
+});
+
+describe("EditionBadge", () => {
+  it("hides a reported capability badge when the capability is available", () => {
+    contextState.snapshot = entitlement({
+      capabilities: [CAPABILITIES.RBAC_BASIC],
+      edition: "professional",
+      extensions: [CAPABILITIES.RBAC_BASIC],
+      licensed: true,
+      state: "valid",
+    });
+
+    render(<EditionBadge capability={CAPABILITIES.RBAC_BASIC} edition="professional" />);
+
+    expect(screen.queryByText("common.entitlement.editionsShort.professional")).toBeNull();
+  });
+
+  it("keeps the badge when the reported capability is unavailable", () => {
+    contextState.snapshot = entitlement({
+      edition: "professional",
+      extensions: [CAPABILITIES.RBAC_BASIC],
+      licensed: true,
+      state: "valid",
+    });
+
+    render(<EditionBadge capability={CAPABILITIES.RBAC_BASIC} edition="professional" />);
+
+    expect(screen.getByText("common.entitlement.editionsShort.professional")).toBeTruthy();
+  });
+
+  it("keeps the badge while the entitlement snapshot is unknown", () => {
+    render(<EditionBadge capability={CAPABILITIES.RBAC_BASIC} edition="professional" />);
+
+    expect(screen.getByText("common.entitlement.editionsShort.professional")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
- Hide the Professional edition badge when rbac_basic is available.
- Preserve static edition badges when entitlement state cannot be determined.
- Add regression coverage for paid capability badge behavior.
- Verify with focused Vitest and ESLint checks.

# Pull Request

## What Changed

修复角色管理菜单在 `rbac_basic` 能力已可用时仍显示“专业版”标签的问题。

- [x] 系统管理 / 角色管理菜单
- [x] 版本标签显示逻辑
- [x] 回归测试

---

## Why

- Related Issue: 无
- Related Feature: 系统管理权限与版本能力展示优化
- Background:

角色管理菜单原本强制显示“专业版”标签，即使当前部署已经具备 `rbac_basic` 能力，且用户拥有角色管理权限，也会产生需要升级的误导。

---

## How

- Key implementation points:
  - 当菜单配置了可判定的付费能力时，根据实际 entitlement 状态控制版本标签显示。
  - `rbac_basic` 可用时隐藏“专业版”标签。
  - 能力未授权、未部署或状态未知时，继续保留版本提示。
  - 新增版本标签显示逻辑的回归测试。
- Breaking changes (API, config, database, etc.):
  - 无 API、配置或数据库变更。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```text
pnpm exec vitest --run src/app/shell/SideNav.test.tsx
pnpm exec eslint src/app/shell/SideNav.tsx src/app/shell/navigation/edition-badge.ts src/app/shell/SideNav.test.tsx --config eslint.config.typechecked.js --max-warnings 0

Risk & Rollback
Potential risks:仅影响侧边栏版本标签的展示，不影响角色管理菜单权限、页面访问权限或后端接口。
能力状态未知时仍显示版本标签，避免错误隐藏升级提示。

Rollback plan:恢复 SideNav 中版本标签的显示判断逻辑即可。

Additional Notes
本次修改未涉及角色权限模型和授权接口。
已保留未授权场景下的“专业版”提示。