### PR TITLE
fix(data-catalog): sync resource title after detail refresh

### DIFF
--- a/src/modules/data-catalog/components/ResourceDetailPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceDetailPanel.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
+
+const getCatalogResourceMock = vi.hoisted(() => vi.fn());
+const messageMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({ message: messageMock }),
+}));
+
+vi.mock("@/modules/data-catalog/services/resource.service", () => ({
+  getCatalogResource: getCatalogResourceMock,
+  updateCatalogResource: vi.fn(),
+}));
+
+import { ResourceDetailPanel } from "./ResourceDetailPanel";
+
+const resource: CatalogResource = {
+  catalogId: "catalog-1",
+  category: "table",
+  columnCount: 1,
+  description: "",
+  id: "resource-1",
+  name: "orders",
+  rowCount: 1,
+  schema: [{ name: "id", type: "string" }],
+  sourceIdentifier: "orders",
+  updateTime: "2026-08-11T00:00:00Z",
+  updatedAt: 0,
+};
+
+describe("ResourceDetailPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+  });
+
+  it("returns the resource fetched after returning to the detail tab to its parent", async () => {
+    const latestResource = { ...resource, name: "Orders" };
+    const onResourceRefreshed = vi.fn();
+    getCatalogResourceMock.mockResolvedValue(latestResource);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <ResourceDetailPanel active={false} catalog={null} onResourceRefreshed={onResourceRefreshed} resource={resource} />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {});
+
+    rerender(
+      <MemoryRouter>
+        <ResourceDetailPanel active catalog={null} onResourceRefreshed={onResourceRefreshed} resource={resource} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(onResourceRefreshed).toHaveBeenCalledWith(latestResource));
+    expect(getCatalogResourceMock).toHaveBeenCalledWith(resource.id);
+  });
+});

--- a/src/modules/data-catalog/components/ResourceDetailPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceDetailPanel.test.tsx
@@ -81,4 +81,42 @@ describe("ResourceDetailPanel", () => {
     await waitFor(() => expect(onResourceRefreshed).toHaveBeenCalledWith(latestResource));
     expect(getCatalogResourceMock).toHaveBeenCalledWith(resource.id);
   });
+
+  it("ignores a detail refresh superseded by a parent resource update", async () => {
+    const parentResource = { ...resource, name: "Orders", updatedAt: 1 };
+    const onResourceRefreshed = vi.fn();
+    let resolveRequest: (value: CatalogResource | null) => void;
+    getCatalogResourceMock.mockImplementation(
+      () => new Promise<CatalogResource | null>((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <ResourceDetailPanel active={false} catalog={null} onResourceRefreshed={onResourceRefreshed} resource={resource} />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {});
+
+    rerender(
+      <MemoryRouter>
+        <ResourceDetailPanel active catalog={null} onResourceRefreshed={onResourceRefreshed} resource={resource} />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(getCatalogResourceMock).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <MemoryRouter>
+        <ResourceDetailPanel active catalog={null} onResourceRefreshed={onResourceRefreshed} resource={parentResource} />
+      </MemoryRouter>,
+    );
+    act(() => {
+      resolveRequest(resource);
+    });
+    await Promise.resolve();
+
+    expect(onResourceRefreshed).not.toHaveBeenCalled();
+  });
 });

--- a/src/modules/data-catalog/components/ResourceDetailPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceDetailPanel.tsx
@@ -30,6 +30,7 @@ type ResourceDetailPanelProps = {
   active: boolean;
   catalog: CatalogRecord | null;
   onEditingChange?: (editing: boolean) => void;
+  onResourceRefreshed?: (resource: CatalogResource) => void;
   onUpdated?: () => Promise<void> | void;
   resource: CatalogResource;
 };
@@ -38,6 +39,7 @@ export function ResourceDetailPanel({
   active,
   catalog,
   onEditingChange,
+  onResourceRefreshed,
   onUpdated,
   resource: resourceProp,
 }: ResourceDetailPanelProps) {
@@ -88,6 +90,7 @@ export function ResourceDetailPanel({
       .then((latestResource) => {
         if (!cancelled && latestResource) {
           setResource(latestResource);
+          onResourceRefreshed?.(latestResource);
         }
       })
       .catch((error) => {
@@ -104,7 +107,7 @@ export function ResourceDetailPanel({
     return () => {
       cancelled = true;
     };
-  }, [active, message, resourceProp.id]);
+  }, [active, message, onResourceRefreshed, resourceProp.id]);
 
   useEffect(() => {
     setSchemaPage(1);

--- a/src/modules/data-catalog/components/ResourceDetailPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceDetailPanel.tsx
@@ -107,7 +107,7 @@ export function ResourceDetailPanel({
     return () => {
       cancelled = true;
     };
-  }, [active, message, onResourceRefreshed, resourceProp.id]);
+  }, [active, message, onResourceRefreshed, resourceProp]);
 
   useEffect(() => {
     setSchemaPage(1);

--- a/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
+++ b/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
@@ -125,11 +125,7 @@ export function ResourceWorkspaceScene({
     : t("dataCatalog.gate.catalogDisabledShort");
 
   const handleResourceRefreshed = useCallback((latestResource: CatalogResource) => {
-    setResource((currentResource) =>
-      currentResource && currentResource.updatedAt > latestResource.updatedAt
-        ? currentResource
-        : latestResource,
-    );
+    setResource(latestResource);
   }, []);
 
   const handleTabChange = (key: string) => {

--- a/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
+++ b/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
@@ -124,6 +124,14 @@ export function ResourceWorkspaceScene({
     ? t("dataCatalog.gate.catalogDisabled", { name: catalog.name })
     : t("dataCatalog.gate.catalogDisabledShort");
 
+  const handleResourceRefreshed = useCallback((latestResource: CatalogResource) => {
+    setResource((currentResource) =>
+      currentResource && currentResource.updatedAt > latestResource.updatedAt
+        ? currentResource
+        : latestResource,
+    );
+  }, []);
+
   const handleTabChange = (key: string) => {
     const nextTab = key as ResourceWorkspaceTab;
     if (tab === "detail" && nextTab !== "detail" && detailEditing) {
@@ -248,6 +256,7 @@ export function ResourceWorkspaceScene({
                     active={tab === "detail"}
                     catalog={catalog}
                     onEditingChange={setDetailEditing}
+                    onResourceRefreshed={handleResourceRefreshed}
                     onUpdated={loadAll}
                     resource={resource}
                   />


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] The resource detail panel now returns its existing refresh response to the workspace parent.
- [x] The workspace updates the header from that response and rejects an older response version.
- [x] Added a regression test for returning from another tab to the detail tab.

---

## Why

- Related Issue: Closes #339
- Related Feature: Data Catalog resource workspace
- Background: After semantic understanding applied a business name, the detail panel could show the new name while the workspace header retained the stale parent resource name.

---

## How

- Key implementation points: Reuse the existing detail-tab `getCatalogResource` request; pass its result to `ResourceWorkspaceScene` through a callback; retain the newer parent state when a delayed response is older.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: UI state-only change)
- [ ] Verified in test environment (not run)

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm run i18n:check`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` (reports one ignored high-severity vulnerability; exits successfully)

---

## Risk & Rollback

- Potential risks: The header is synchronized when the user returns to the detail tab, not immediately while remaining on the semantic-understanding tab.
- Rollback plan: Revert commit `386dac1`.

---

## Additional Notes

- No new polling or resource request was introduced.
- The local production build reported existing chunk-size warnings; it completed successfully.