### PR TITLE
fix(data-catalog): guard invalid index builds

### DIFF
--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.test.tsx
@@ -49,6 +49,7 @@ const resource: CatalogResource = {
   name: "orders",
   rowCount: 1,
   schema: [
+    { name: "id", type: "integer" },
     {
       features: [{ featureType: "vector" }],
       name: "content",
@@ -109,5 +110,27 @@ describe("BuildTaskLaunchPanel", () => {
     });
     expect(resumeBuildTaskMock).not.toHaveBeenCalled();
     expect(onStarted).toHaveBeenCalledWith({ id: "task-running", status: "running" });
+  });
+
+  it("blocks a build when the schema contains an other-type field", async () => {
+    const blockedResource: CatalogResource = {
+      ...resource,
+      schema: [...resource.schema, { name: "interests", originalType: "_text", type: "other" }],
+    };
+
+    render(
+      <BuildTaskLaunchPanel
+        active
+        onGoConfigure={vi.fn()}
+        onStarted={vi.fn()}
+        resource={blockedResource}
+      />,
+    );
+
+    expect(await screen.findByText("dataCatalog.build.unsupportedSchemaFields")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /dataCatalog\.build\.startBuild/ }).getAttribute("disabled"),
+    ).not.toBeNull();
+    expect(createBuildTaskMock).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
+++ b/src/modules/data-catalog/components/BuildTaskLaunchPanel.tsx
@@ -29,6 +29,10 @@ import type {
   CatalogResource,
 } from "@/modules/data-catalog/types/data-catalog";
 import { streamingNeedsBuildKey } from "@/modules/data-catalog/lib/build-task-launch-guards";
+import {
+  invalidBuildKeyFields,
+  unsupportedSchemaFields,
+} from "@/modules/data-catalog/lib/build-guards";
 import { indexFormValuesFromResource } from "@/modules/data-catalog/utils/resource-index-config";
 import { isActiveBuildTask } from "@/modules/data-catalog/utils/build-task-guards";
 import { listSmallModels } from "@/modules/model-resources/services/small-model.service";
@@ -91,6 +95,11 @@ export function BuildTaskLaunchPanel({
     config.embeddingFields.length > 0 || config.fulltextFields.length > 0;
   const batchNeedsBuildKey = mode === "batch" && config.buildKeyFields.length === 0;
   const streamingBuildKeyRequired = streamingNeedsBuildKey(mode, config.buildKeyFields);
+  const otherFields = useMemo(() => unsupportedSchemaFields(resource.schema), [resource.schema]);
+  const invalidConfiguredBuildKeys = useMemo(
+    () => invalidBuildKeyFields(resource.schema, config.buildKeyFields),
+    [config.buildKeyFields, resource.schema],
+  );
   const analyzerLabel = config.fulltextFields.length > 0 && config.fulltextAnalyzer
     ? t(`dataCatalog.build.analyzers.${config.fulltextAnalyzer}`, {
         defaultValue: config.fulltextAnalyzer,
@@ -151,9 +160,18 @@ export function BuildTaskLaunchPanel({
     existingActive?.mode === "streaming" && isActiveBuildTask(existingActive);
   const controlsDisabled = disabled || actionsLocked;
   const startDisabled =
-    controlsDisabled || !hasResourceConfig || batchNeedsBuildKey || streamingBuildKeyRequired;
+    controlsDisabled || !hasResourceConfig || batchNeedsBuildKey || streamingBuildKeyRequired ||
+    otherFields.length > 0 || invalidConfiguredBuildKeys.length > 0;
 
   const startBuild = async () => {
+    if (otherFields.length > 0) {
+      setError({ description: t("dataCatalog.build.unsupportedSchemaFields", { fields: otherFields.map((field) => field.name).join(", ") }) });
+      return;
+    }
+    if (invalidConfiguredBuildKeys.length > 0) {
+      setError({ description: t("dataCatalog.build.invalidBuildKeyFields", { fields: invalidConfiguredBuildKeys.join(", ") }) });
+      return;
+    }
     if (!hasResourceConfig) {
       setError({ description: t("dataCatalog.build.needConfigFirst") });
       return;
@@ -229,6 +247,26 @@ export function BuildTaskLaunchPanel({
             </AppButton>
           }
           message={t("dataCatalog.build.needConfigFirst")}
+          showIcon
+          type="warning"
+        />
+      ) : null}
+
+      {otherFields.length > 0 ? (
+        <Alert
+          message={t("dataCatalog.build.unsupportedSchemaFields", { fields: otherFields.map((field) => field.name).join(", ") })}
+          showIcon
+          type="error"
+        />
+      ) : null}
+      {otherFields.length === 0 && invalidConfiguredBuildKeys.length > 0 ? (
+        <Alert
+          action={
+            <AppButton onClick={onGoConfigure} size="small" type="link">
+              {t("dataCatalog.indexWorkspace.viewConfig")}
+            </AppButton>
+          }
+          message={t("dataCatalog.build.invalidBuildKeyFields", { fields: invalidConfiguredBuildKeys.join(", ") })}
           showIcon
           type="warning"
         />

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
@@ -173,6 +173,31 @@ describe("IndexConfigFormPanel", () => {
     expect(screen.queryByText("dataCatalog.build.fulltextChineseAnalyzerUnavailableHint")).toBeNull();
   });
 
+  it("allows removing a configured build key that no longer exists in the schema", async () => {
+    const staleBuildKeyResource: CatalogResource = {
+      ...resource,
+      indexConfig: { buildKeyFields: ["removed_order_no"] },
+    };
+    getCatalogResourceMock.mockResolvedValue(staleBuildKeyResource);
+
+    render(
+      <MemoryRouter>
+        <IndexConfigFormPanel active resource={staleBuildKeyResource} />
+      </MemoryRouter>,
+    );
+
+    const removeButton = await screen.findByRole("button", {
+      name: "dataCatalog.build.removeInvalidBuildKeyFields",
+    });
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "dataCatalog.build.removeInvalidBuildKeyFields" }),
+      ).toBeNull();
+    });
+  });
+
   it("keeps a vector-only resource saveable when analyzer capabilities are unavailable", async () => {
     const vectorResource: CatalogResource = {
       ...resource,

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
@@ -655,6 +655,10 @@ export function IndexConfigFormPanel({
     markDirty();
     const eligible = eligibleFields(role);
     if (columnAllOn(role)) {
+      if (role.buildKeyOnly) {
+        role.set([]);
+        return;
+      }
       const drop = new Set(eligible.map((field) => field.name));
       role.set(role.list.filter((name) => !drop.has(name)));
       if (role.onRemove) {
@@ -665,6 +669,15 @@ export function IndexConfigFormPanel({
       eligible.forEach((field) => next.add(field.name));
       role.set([...next]);
     }
+  };
+
+  const removeInvalidBuildKeys = () => {
+    if (actionsLocked) {
+      return;
+    }
+    const invalid = new Set(invalidSavedBuildKeyFields);
+    setBuildKeyFields((current) => current.filter((field) => !invalid.has(field)));
+    markDirty();
   };
 
   const cx = (...parts: Array<string | false | undefined>) =>
@@ -999,6 +1012,18 @@ export function IndexConfigFormPanel({
           message={t("dataCatalog.build.duplicateFeatureTypeUnsupported", { features: duplicateUnsupportedFeatureTypes.join(", ") })}
           showIcon
           type="error"
+        />
+      ) : null}
+      {invalidSavedBuildKeyFields.length > 0 ? (
+        <Alert
+          action={
+            <AppButton disabled={actionsLocked} onClick={removeInvalidBuildKeys} size="small" type="link">
+              {t("dataCatalog.build.removeInvalidBuildKeyFields")}
+            </AppButton>
+          }
+          message={t("dataCatalog.build.invalidBuildKeyFields", { fields: invalidSavedBuildKeyFields.join(", ") })}
+          showIcon
+          type="warning"
         />
       ) : null}
 

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
@@ -42,6 +42,10 @@ import {
   pickRegisteredEmbeddingModelId,
   type EmbeddingModelsLoadState,
 } from "@/modules/data-catalog/utils/embedding-model-options";
+import {
+  invalidBuildKeyFields,
+  isBuildKeyField,
+} from "@/modules/data-catalog/lib/build-guards";
 
 import formStyles from "./BuildTaskFormPanel.module.css";
 import styles from "./shared.module.css";
@@ -433,6 +437,10 @@ export function IndexConfigFormPanel({
     }
     return duplicates;
   }, [eligibleEmbeddingModelGroups, eligibleFulltextAnalyzerGroups]);
+  const invalidSavedBuildKeyFields = useMemo(
+    () => invalidBuildKeyFields(schema, buildKeyFields),
+    [buildKeyFields, schema],
+  );
 
   const toggleField = (
     field: string,
@@ -453,6 +461,10 @@ export function IndexConfigFormPanel({
   };
 
   const validateForm = () => {
+    if (invalidSavedBuildKeyFields.length > 0) {
+      setError(t("dataCatalog.build.invalidBuildKeyFields", { fields: invalidSavedBuildKeyFields.join(", ") }));
+      return false;
+    }
     if (duplicateUnsupportedFeatureTypes.length > 0) {
       setError(t("dataCatalog.build.duplicateFeatureTypeUnsupported", { features: duplicateUnsupportedFeatureTypes.join(", ") }));
       return false;
@@ -603,6 +615,7 @@ export function IndexConfigFormPanel({
       name: t("dataCatalog.build.roleBuildKey"),
       onRemove: undefined as ((fieldName: string) => void) | undefined,
       set: setBuildKeyFields,
+      buildKeyOnly: true,
       textOnly: false,
     },
   ];
@@ -624,7 +637,11 @@ export function IndexConfigFormPanel({
   const showFieldSearch = schema.length > 8;
 
   const eligibleFields = (role: (typeof roleDefs)[number]) =>
-    role.textOnly ? visibleFields.filter((field) => isTextField(field.type)) : visibleFields;
+    role.buildKeyOnly
+      ? visibleFields.filter(isBuildKeyField)
+      : role.textOnly
+        ? visibleFields.filter((field) => isTextField(field.type))
+        : visibleFields;
 
   const columnAllOn = (role: (typeof roleDefs)[number]) => {
     const eligible = eligibleFields(role);
@@ -684,8 +701,14 @@ export function IndexConfigFormPanel({
     );
   };
   const renderRoleCell = (field: ResourceSchemaField, role: (typeof roleDefs)[number]) => {
-    const disabled = actionsLocked || (role.textOnly && !isTextField(field.type));
     const checked = role.list.includes(field.name);
+    const unsupportedBuildKeyType = role.buildKeyOnly && !isBuildKeyField(field);
+    const disabled = actionsLocked || ((role.textOnly && !isTextField(field.type)) || unsupportedBuildKeyType) && !checked;
+    const disabledTitle = unsupportedBuildKeyType
+      ? t("dataCatalog.build.buildKeyTypeHint")
+      : role.textOnly && !isTextField(field.type)
+        ? t("dataCatalog.build.fulltextTypeHint")
+        : undefined;
     return (
       <td className={styles.frtCell} key={role.id}>
         <span
@@ -706,7 +729,7 @@ export function IndexConfigFormPanel({
               checked ? () => role.onRemove?.(field.name) : undefined,
             );
           }}
-          title={disabled ? t("dataCatalog.build.fulltextTypeHint") : undefined}
+          title={disabledTitle}
         >
           <span className={styles.frtMark}>{checkIcon}</span>
         </span>

--- a/src/modules/data-catalog/lib/build-guards.test.ts
+++ b/src/modules/data-catalog/lib/build-guards.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  invalidBuildKeyFields,
+  isBuildKeyField,
+  unsupportedSchemaFields,
+} from "./build-guards";
+
+const schema = [
+  { name: "id", type: "integer" },
+  { name: "updated_at", type: "timestamp" },
+  { name: "body", type: "text" },
+  { name: "interests", originalType: "_text", type: "other" },
+];
+
+describe("build guards", () => {
+  it("accepts only stable build-key field types", () => {
+    expect(isBuildKeyField(schema[0])).toBe(true);
+    expect(isBuildKeyField(schema[1])).toBe(true);
+    expect(isBuildKeyField(schema[2])).toBe(false);
+  });
+
+  it("identifies missing and unsupported configured build keys", () => {
+    expect(invalidBuildKeyFields(schema, ["id", "body", "missing"])).toEqual([
+      "body",
+      "missing",
+    ]);
+  });
+
+  it("identifies all other-type schema fields", () => {
+    expect(unsupportedSchemaFields(schema)).toEqual([schema[3]]);
+  });
+});

--- a/src/modules/data-catalog/lib/build-guards.ts
+++ b/src/modules/data-catalog/lib/build-guards.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ResourceSchemaField } from "@/modules/data-catalog/types/data-catalog";
+
+const BUILD_KEY_TYPES = new Set([
+  "integer",
+  "unsigned integer",
+  "string",
+  "date",
+  "datetime",
+  "timestamp",
+]);
+
+export function isBuildKeyField(field: ResourceSchemaField): boolean {
+  return BUILD_KEY_TYPES.has(field.type.trim().toLowerCase());
+}
+
+export function invalidBuildKeyFields(
+  schema: ResourceSchemaField[],
+  buildKeyFields: string[],
+): string[] {
+  const fieldsByName = new Map(schema.map((field) => [field.name, field]));
+  return buildKeyFields.filter((name) => !fieldsByName.get(name) || !isBuildKeyField(fieldsByName.get(name)!));
+}
+
+export function unsupportedSchemaFields(schema: ResourceSchemaField[]): ResourceSchemaField[] {
+  return schema.filter((field) => field.type.trim().toLowerCase() === "other");
+}

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -315,7 +315,10 @@ export const dataCatalogEnUS = {
         "Field used to detect incremental data in batch builds (e.g. updated_at, auto-increment ID); required.",
       roleBuildKeyHintStreaming: "Row ID field for streaming builds; required.",
       roleBuildKeyHintConfig:
-        "Used for incremental builds; required for both batch and streaming.",
+        "Used for incremental builds; required for both batch and streaming. Supported types are integer, unsigned integer, string, date, datetime, and timestamp.",
+      buildKeyTypeHint: "Build keys support integer, unsigned integer, string, date, datetime, and timestamp fields only.",
+      invalidBuildKeyFields: "Invalid build-key configuration: {{fields}}. Select schema fields with supported types.",
+      unsupportedSchemaFields: "This resource contains other-type fields unsupported for index builds: {{fields}}. Correct the source field type or its discovery mapping before building.",
       roleFulltextHint:
         "Text fields indexed for keyword full-text search; applied immediately during data sync.",
       selectAll: "Select all",

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -318,6 +318,7 @@ export const dataCatalogEnUS = {
         "Used for incremental builds; required for both batch and streaming. Supported types are integer, unsigned integer, string, date, datetime, and timestamp.",
       buildKeyTypeHint: "Build keys support integer, unsigned integer, string, date, datetime, and timestamp fields only.",
       invalidBuildKeyFields: "Invalid build-key configuration: {{fields}}. Select schema fields with supported types.",
+      removeInvalidBuildKeyFields: "Remove invalid build keys",
       unsupportedSchemaFields: "This resource contains other-type fields unsupported for index builds: {{fields}}. Correct the source field type or its discovery mapping before building.",
       roleFulltextHint:
         "Text fields indexed for keyword full-text search; applied immediately during data sync.",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -300,7 +300,10 @@ export const dataCatalogZhCN = {
         "批量构建时用于识别增量数据的字段（如更新时间、自增 ID）；必填。",
       roleBuildKeyHintStreaming: "流式构建时用于标识行的 ID 字段；必填。",
       roleBuildKeyHintConfig:
-        "增量构建使用；批量与流式均需指定。",
+        "增量构建使用；批量与流式均需指定。仅支持整数、无符号整数、字符串、日期和日期时间字段。",
+      buildKeyTypeHint: "构建键仅支持整数、无符号整数、字符串、日期和日期时间字段",
+      invalidBuildKeyFields: "构建键配置无效：{{fields}}。请选择存在于 schema 且类型受支持的字段。",
+      unsupportedSchemaFields: "资源包含不支持索引构建的 other 类型字段：{{fields}}。请修正源端字段类型或其发现映射后再构建。",
       roleFulltextHint: "建立关键词全文索引的文本字段，随数据同步即时生效。",
       selectAll: "全选",
       clearAll: "清空",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -300,9 +300,10 @@ export const dataCatalogZhCN = {
         "批量构建时用于识别增量数据的字段（如更新时间、自增 ID）；必填。",
       roleBuildKeyHintStreaming: "流式构建时用于标识行的 ID 字段；必填。",
       roleBuildKeyHintConfig:
-        "增量构建使用；批量与流式均需指定。仅支持整数、无符号整数、字符串、日期和日期时间字段。",
-      buildKeyTypeHint: "构建键仅支持整数、无符号整数、字符串、日期和日期时间字段",
+        "增量构建使用；批量与流式均需指定。仅支持整数、无符号整数、字符串、日期、日期时间和时间戳字段。",
+      buildKeyTypeHint: "构建键仅支持整数、无符号整数、字符串、日期、日期时间和时间戳字段",
       invalidBuildKeyFields: "构建键配置无效：{{fields}}。请选择存在于 schema 且类型受支持的字段。",
+      removeInvalidBuildKeyFields: "移除无效构建键",
       unsupportedSchemaFields: "资源包含不支持索引构建的 other 类型字段：{{fields}}。请修正源端字段类型或其发现映射后再构建。",
       roleFulltextHint: "建立关键词全文索引的文本字段，随数据同步即时生效。",
       selectAll: "全选",


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Disable index-build launch when a resource schema contains any `type=other` field.
- [x] Restrict build-key selection to the backend-supported field types and reject saved invalid selections.
- [x] Add localized guidance and regression tests for schema and build-key guards.

---

## Why

- Related Issue: Closes #298
- Related Feature: N/A
- Background: Unsupported `other` fields would otherwise reach OpenSearch mapping, and invalid build keys cannot provide a reliable incremental cursor.

---

## How

- Key implementation points: shared guard utilities keep the configuration and launch panels aligned with the backend whitelist. The configuration panel leaves existing invalid selections removable but blocks saving; the launch panel blocks task creation for any `other` field or invalid configured key.
- Breaking changes (API, config, database, etc.): The UI now prevents index builds for resources and build-key configurations that the backend rejects; no API or database schema changes.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (`pnpm exec vitest --run`)
- [ ] Verified in test environment — not run; no deployment in this PR.

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod`

---

## Risk & Rollback

- Potential risks: existing invalid build-key configurations are surfaced and must be corrected before an index build can start.
- Rollback plan: revert commit `97a211d`; no data migration is required.

---

## Additional Notes

- No screenshots: the change consists of disabled controls and inline alerts.
- `CODEOWNERS` is not present in this repository.
