### PR TITLE
fix(studio): 正确展示 Foundry 字段类型

### DIFF
--- a/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.test.tsx
+++ b/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.test.tsx
@@ -194,7 +194,7 @@ describe("BusinessProvenanceScene", { timeout: 30_000 }, () => {
     await screen.findByRole("columnheader", { name: "证据完整性" });
     expect(screen.getByRole("columnheader", { name: "用户问题" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: "业务结果" })).not.toBeNull();
-    expect(screen.getByText("完整可溯源")).not.toBeNull();
+    expect(await screen.findByText("完整可溯源")).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "查询采购订单" }));
     await waitFor(() => expect(getInteractions).toHaveBeenCalledWith(expect.objectContaining({ conversationId: "conv-1" })));
     expect(await screen.findByText("1 轮交互")).not.toBeNull();

--- a/src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.test.tsx
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.test.tsx
@@ -14,24 +14,61 @@ afterEach(() => {
   cleanup();
 });
 
+const STANDARD_TYPE_PRESENTATIONS = [
+  { expected: "[Str]", type: "string" },
+  { expected: "[Text]", type: "text" },
+  { expected: "int", type: "integer" },
+  { expected: "uint", type: "unsigned integer" },
+  { expected: "float", type: "float" },
+  { expected: "dec", type: "decimal" },
+  { expected: "date", type: "date" },
+  { expected: "time", type: "time" },
+  { expected: "datetime", type: "datetime" },
+  { expected: "timestamp", type: "timestamp" },
+  { expected: "[IP]", type: "ip" },
+  { expected: "bool", type: "boolean" },
+  { expected: "[Bin]", type: "binary" },
+  { expected: "[JSON]", type: "json" },
+  { expected: "[Point]", type: "point" },
+  { expected: "[Shape]", type: "shape" },
+  { expected: "[Vec]", type: "vector" },
+  { expected: "[Other]", type: "other" },
+] as const;
+
 describe("FieldTypeIcon", () => {
-  it.each(["float", "double", "decimal", "number", "numeric", "real"])(
-    "renders %s as floating numeric type",
-    (type) => {
+  it.each(STANDARD_TYPE_PRESENTATIONS)(
+    "renders the Foundry type $type as $expected",
+    ({ expected, type }) => {
       render(<FieldTypeIcon type={type} />);
 
-      expect(screen.getByText("float")).toBeTruthy();
-      expect(screen.queryByText("[Str]")).toBeNull();
+      expect(screen.getByTitle(type).textContent).toBe(expected);
     },
   );
 
-  it.each(["integer", "unsigned integer", "bigint", "smallint"])(
-    "renders %s as integer type",
-    (type) => {
-      render(<FieldTypeIcon type={type} />);
+  it.each([
+    { expected: "int", type: "bigint" },
+    { expected: "int", type: "smallint" },
+    { expected: "float", type: "double" },
+    { expected: "float", type: "number" },
+    { expected: "dec", type: "numeric" },
+    { expected: "float", type: "real" },
+  ])("keeps the legacy type $type compatible", ({ expected, type }) => {
+    render(<FieldTypeIcon type={type} />);
 
-      expect(screen.getByText("int")).toBeTruthy();
-      expect(screen.queryByText("[Str]")).toBeNull();
-    },
-  );
+    expect(screen.getByTitle(type).textContent).toBe(expected);
+  });
+
+  it("renders an unknown backend type explicitly", () => {
+    render(<FieldTypeIcon type="custom_type" />);
+
+    expect(screen.getByTitle("custom_type").textContent).toBe("[Unknown]");
+    expect(screen.queryByText("[Str]")).toBeNull();
+  });
+
+  it("renders a missing backend type explicitly", () => {
+    render(<FieldTypeIcon />);
+
+    expect(screen.getByTitle("unknown").textContent).toBe("[Unknown]");
+    expect(screen.queryByText("[Str]")).toBeNull();
+  });
 });

--- a/src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.tsx
+++ b/src/modules/knowledge-network/components/object-type/data-attribute/FieldTypeIcon.tsx
@@ -11,82 +11,100 @@ import {
   NumberOutlined,
 } from "@ant-design/icons";
 
+import { DATA_PROPERTY_TYPES } from "./constants";
 import styles from "./FieldTypeIcon.module.css";
 
 type FieldTypeIconProps = {
   type?: string;
 };
 
-function getFieldTypeLabel(type?: string) {
-  const normalized = (type ?? "string").toLowerCase();
+type DataPropertyType = (typeof DATA_PROPERTY_TYPES)[number];
+type TypeIcon = "boolean" | "date" | "number";
+type TypePresentation = {
+  icon?: TypeIcon;
+  label: string;
+};
 
-  if (
-    normalized === "integer" ||
-    normalized === "unsigned integer" ||
-    normalized === "bigint" ||
-    normalized === "smallint"
-  ) {
-    return "int";
-  }
+const TYPE_PRESENTATIONS = {
+  string: { label: "Str" },
+  text: { label: "Text" },
+  integer: { icon: "number", label: "int" },
+  "unsigned integer": { icon: "number", label: "uint" },
+  float: { icon: "number", label: "float" },
+  decimal: { icon: "number", label: "dec" },
+  date: { icon: "date", label: "date" },
+  time: { icon: "date", label: "time" },
+  datetime: { icon: "date", label: "datetime" },
+  timestamp: { icon: "date", label: "timestamp" },
+  ip: { label: "IP" },
+  boolean: { icon: "boolean", label: "bool" },
+  binary: { label: "Bin" },
+  json: { label: "JSON" },
+  point: { label: "Point" },
+  shape: { label: "Shape" },
+  vector: { label: "Vec" },
+  other: { label: "Other" },
+} satisfies Record<DataPropertyType, TypePresentation>;
 
-  if (
-    normalized === "float" ||
-    normalized === "double" ||
-    normalized === "decimal" ||
-    normalized === "number" ||
-    normalized === "numeric" ||
-    normalized === "real"
-  ) {
-    return "float";
-  }
+const TYPE_ALIASES: Record<string, DataPropertyType> = {
+  bigint: "integer",
+  smallint: "integer",
+  double: "float",
+  number: "float",
+  numeric: "decimal",
+  real: "float",
+};
 
-  if (normalized === "boolean") {
-    return "bool";
-  }
+const DATA_PROPERTY_TYPE_SET = new Set<string>(DATA_PROPERTY_TYPES);
 
-  if (normalized === "vector") {
-    return "vec";
-  }
-
-  if (normalized === "text") {
-    return "text";
-  }
-
-  return "Str";
+function isDataPropertyType(type: string): type is DataPropertyType {
+  return DATA_PROPERTY_TYPE_SET.has(type);
 }
 
-function isDateLikeType(type?: string) {
-  const normalized = (type ?? "").toLowerCase();
-  return ["date", "datetime", "time", "timestamp"].includes(normalized);
+function resolveTypePresentation(type?: string): TypePresentation {
+  const normalized = type?.trim().toLowerCase() ?? "";
+  const canonicalType = TYPE_ALIASES[normalized] ?? normalized;
+
+  if (isDataPropertyType(canonicalType)) {
+    return TYPE_PRESENTATIONS[canonicalType];
+  }
+
+  return { label: "Unknown" };
 }
 
 export function FieldTypeIcon({ type }: FieldTypeIconProps) {
-  if (isDateLikeType(type)) {
-    return <ClockCircleOutlined className={styles.dateIcon} />;
-  }
+  const { icon, label } = resolveTypePresentation(type);
+  const title = type?.trim() || "unknown";
 
-  const label = getFieldTypeLabel(type);
-
-  if (label === "int" || label === "float") {
+  if (icon === "number") {
     return (
-      <span className={styles.typeBadge} title={type}>
+      <span className={styles.typeBadge} title={title}>
         <NumberOutlined className={styles.typeBadgeIcon} />
         <span>{label}</span>
       </span>
     );
   }
 
-  if (label === "bool") {
+  if (icon === "boolean") {
     return (
-      <span className={styles.typeBadge} title={type}>
+      <span className={styles.typeBadge} title={title}>
         <FieldBinaryOutlined className={styles.typeBadgeIcon} />
-        <span>bool</span>
+        <span>{label}</span>
+      </span>
+    );
+  }
+
+  if (icon === "date") {
+    return (
+      <span className={styles.typeBadge} title={title}>
+        <ClockCircleOutlined className={styles.dateIcon} />
+        <span>{label}</span>
       </span>
     );
   }
 
   return (
-    <span className={styles.typeBadge} title={type}>
+    <span className={styles.typeBadge} title={title}>
       [{label}]
     </span>
   );


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 为 Foundry 18 种标准字段类型提供穷尽的展示映射
- [x] 将 `other` 和未知类型分别展示为 `[Other]`、`[Unknown]`，避免误显示为字符串
- [x] 补充标准类型、兼容别名和未知类型的回归测试，并稳定异步业务溯源测试

---

## Why

- Related Issue: Closes #419
- Related Feature: 知识网络字段类型展示
- Background: Studio 原实现把未识别类型统一回退为 `Str`，导致 Foundry 返回 `other` 时被错误展示成字符串；日期、数值等类型也缺少一一对应的展示语义。

---

## How

- Key implementation points:
  - 从 `DATA_PROPERTY_TYPES` 推导标准类型联合，并通过 `satisfies Record<...>` 对展示映射做编译期穷尽校验。
  - 保留 `bigint`、`smallint`、`double`、`numeric` 等历史别名兼容。
  - 未识别或缺失的后端类型统一显示为 `[Unknown]`，不再冒充字符串。
  - 日期时间类型保留时钟图标，同时显示具体类型名称。
- Breaking changes (API, config, database, etc.): 无。

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod`（1 个仓库已忽略的 high 项，命令退出码 0）

---

## Risk & Rollback

- Potential risks: 字段类型徽标文本比原展示更具体，部分列宽较窄的界面可能出现更紧凑的布局；未修改接口或持久化数据。
- Rollback plan: 回滚本 PR 提交即可恢复原展示逻辑。

---

## Additional Notes

- 本 PR 修复 Studio 的展示与兜底行为。SQL Server 别名类型在 Foundry 连接器中的上游识别仍需由 Foundry 侧单独修复。
- 未在测试环境进行人工验证。
