### PR TITLE
fix(studio): make permission guards safe for standalone routes

### DIFF
--- a/src/framework/permission/RequirePermission.test.tsx
+++ b/src/framework/permission/RequirePermission.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AppProviders } from "@/app/providers/AppProviders";
+import { RequirePermission } from "@/framework/permission/RequirePermission";
+import { createRuntimeConfig } from "@/framework/runtime/config";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const original = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...original,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+function renderGuard(permissions: string[], children: ReactNode) {
+  const runtimeConfig = createRuntimeConfig({
+    currentUser: { permissions },
+  });
+
+  return render(
+    <AppProviders runtimeConfig={runtimeConfig} updateLocale={vi.fn()}>
+      {children}
+    </AppProviders>,
+  );
+}
+
+describe("RequirePermission", () => {
+  it("can guard a standalone route without the page-level app provider", () => {
+    renderGuard(
+      ["knowledge-network:view"],
+      <RequirePermission permissions="knowledge-network:view">
+        <div>standalone content</div>
+      </RequirePermission>,
+    );
+
+    expect(screen.getByText("standalone content")).toBeTruthy();
+  });
+
+  it("renders the permission result when the standalone user is unauthorized", () => {
+    renderGuard(
+      [],
+      <RequirePermission permissions="knowledge-network:view">
+        <div>standalone content</div>
+      </RequirePermission>,
+    );
+
+    expect(screen.queryByText("standalone content")).toBeNull();
+    expect(screen.getByText("403")).toBeTruthy();
+  });
+});

--- a/src/framework/permission/RequirePermission.tsx
+++ b/src/framework/permission/RequirePermission.tsx
@@ -9,7 +9,7 @@ import { Result } from "antd";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useAppServices } from "@/framework/context/use-app-services";
+import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
 import {
   hasPermissions,
   type PermissionCheckMode,
@@ -33,7 +33,11 @@ export function RequirePermission({
   permissions,
 }: RequirePermissionProps) {
   const { t } = useTranslation();
-  const { runtimeConfig } = useAppServices();
+  // Route guards also protect standalone routes, whose page-level Antd/App
+  // providers are mounted inside the guarded element. Read only the runtime
+  // context available above that boundary so the guard itself cannot fail
+  // before it has a chance to render the permission result.
+  const runtimeConfig = useRuntimeConfig();
   const allowed = hasPermissions({
     currentPermissions: runtimeConfig.currentUser.permissions,
     mode,


### PR DESCRIPTION
- Read runtime configuration directly from the outer app context in RequirePermission.
- Prevent standalone routes from accessing AppServices before their page-level providers mount.
- Preserve permission checks and 403 behavior for authorized and unauthorized users.
- Add regression tests covering standalone guards without the Ant Design provider bridge.
- Verify with targeted Vitest tests, ESLint, and TypeScript checks.

# Pull Request

## What Changed

修复知识网络 standalone 路由在权限守卫执行时缺少页面级 Provider，导致直接访问页面报错的问题。

- [x] 调整 `RequirePermission` 的运行时配置读取方式
- [x] 修复知识网络 standalone 路由的 Provider 层级兼容性
- [x] 新增权限守卫与知识网络路由工厂回归测试

---

## Why

- Related Issue: 无
- Related Feature: Studio 权限收口与知识网络 standalone 路由访问
- Background:

知识网络 standalone 路由位于 `AppShell` 之外，其页面级 `AntdProviders` 在被权限守卫的页面元素内部。

原 `RequirePermission` 通过 `useAppServices()` 获取运行时配置，该 Context 由 `AntdProviders` 内的桥接 Provider 提供。因此直接访问知识网络详情等 standalone 路由时，权限守卫会先于页面级 Provider 执行并抛出 Provider 缺失错误，页面无法正常加载。

---

## How

- Key implementation points:
  - `RequirePermission` 改为通过 `useRuntimeConfig()` 获取当前用户权限。
  - `useRuntimeConfig()` 只依赖应用根部的 `AppProviders`，可在 standalone 路由的页面级 `AntdProviders` 挂载前安全使用。
  - 保持原有权限判断、403 渲染和受保护页面不挂载的行为不变。
  - 新增真实 `AppProviders` 层级测试，覆盖有权限和无权限场景。
  - 新增知识网络路由工厂测试，覆盖直接渲染 standalone 路由元素的实际链路。
- Breaking changes (API, config, database, etc.):
  - 无 API、配置或数据库变更。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```text
pnpm exec vitest --run \
  src/framework/permission/RequirePermission.test.tsx \
  src/modules/knowledge-network/routes/route-factory.test.tsx \
  src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.test.tsx

pnpm exec eslint \
  src/framework/permission/RequirePermission.tsx \
  src/framework/permission/RequirePermission.test.tsx \
  src/modules/knowledge-network/routes/route-factory.test.tsx \
  --config eslint.config.typechecked.js --max-warnings 0

pnpm exec tsc -b --pretty false