### PR TITLE
fix: render semantic business provenance rounds

### DIFF
--- a/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.test.tsx
+++ b/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.test.tsx
@@ -314,8 +314,8 @@ describe("BusinessProvenanceScene", { timeout: 30_000 }, () => {
     const firstMarkdown = new Promise<string>((resolve) => { resolveFirstMarkdown = resolve; });
     getConversations.mockResolvedValue({ entries: [{ conversationId: "conv-1", questionPreview: "连续查询", interactionCount: 2, agentName: "Supply Agent" }], total: 1 });
     getInteractions.mockResolvedValue({ entries: [
-      { interactionId: "int-1", questionPreview: "第一轮查询" },
-      { interactionId: "int-2", questionPreview: "第二轮查询" },
+      { interactionId: "int-2", questionPreview: "第二轮查询", roundNumber: 2 },
+      { interactionId: "int-1", questionPreview: "第一轮查询", roundNumber: 1 },
     ], total: 2 });
     getInteraction.mockImplementation((interactionId: string) => Promise.resolve({ interactionId, conversationContext: [], derivedFacts: [], contextRelations: [], operations: [] }));
     getMarkdown.mockImplementation((interactionId: string) => interactionId === "int-1" ? firstMarkdown : Promise.resolve("# 第二轮过程事实"));

--- a/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.test.tsx
+++ b/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.test.tsx
@@ -70,6 +70,18 @@ describe("BusinessProvenanceScene", { timeout: 30_000 }, () => {
     expect(await screen.findByText("关联轮次")).not.toBeNull();
   });
 
+  it("does not invent a semantic round number when the API omits it", async () => {
+    getConversations.mockResolvedValue({ entries: [{ conversationId: "conv-legacy", questionPreview: "历史会话", interactionCount: 3 }], total: 1 });
+    getInteractions.mockResolvedValue({ entries: [{ interactionId: "int-legacy", questionPreview: "历史轮次" }], total: 1 });
+    getInteraction.mockResolvedValue({ interactionId: "int-legacy", conversationContext: [], derivedFacts: [], contextRelations: [], operations: [] });
+
+    render(<BusinessProvenanceScene />);
+    fireEvent.click(await screen.findByRole("button", { name: "历史会话" }));
+
+    expect(await screen.findByText("轮次未记录")).not.toBeNull();
+    expect(screen.queryByText("第 1 轮")).toBeNull();
+  });
+
   beforeAll(() => {
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -253,7 +265,7 @@ describe("BusinessProvenanceScene", { timeout: 30_000 }, () => {
     expect(await screen.findByText("完整可溯源")).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "查询采购订单" }));
     await waitFor(() => expect(getInteractions).toHaveBeenCalledWith(expect.objectContaining({ conversationId: "conv-1" })));
-    expect(await screen.findByText("1 轮交互")).not.toBeNull();
+    expect(await screen.findByText("2 轮交互")).not.toBeNull();
     expect(await screen.findByText("交互轮次")).not.toBeNull();
     expect(await screen.findByText("调整查询后仍无匹配记录。")).not.toBeNull();
     expect(screen.queryByRole("heading", { name: "业务会话" })).toBeNull();

--- a/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.tsx
+++ b/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.tsx
@@ -71,10 +71,9 @@ function statusLabel(value?: string) {
   return value || bpText("notRecorded");
 }
 
-function roundNumber(item: BusinessProvenanceInteractionListItem | undefined, index: number, total: number) {
-  // The API owns the semantic round number. The fallback keeps a coherent
-  // display while a Studio deployment is temporarily ahead of the API.
-  return item?.roundNumber ?? Math.max(1, total - index);
+function roundLabel(item: BusinessProvenanceInteractionListItem | undefined) {
+  if (item?.roundNumber && item.roundNumber > 0) return bpText("roundLabel", { index: item.roundNumber });
+  return bpText("roundNotRecorded");
 }
 
 function operationTitle(operation: OperationResolution) {
@@ -450,17 +449,17 @@ export function BusinessProvenanceScene() {
     <section className={styles.workspace}>
       <header className={styles.workspaceHeader}>
         <Button type="link" className={styles.backButton} onClick={() => { setSelectedConversation(undefined); setSelectedInteraction(undefined); setProjection(undefined); }}>← {bpText("actions.back")}</Button>
-        <div className={styles.conversationHeading}><h1>{conversationTitle(selectedConversation)}</h1><span>{selectedConversation.conversationId}</span><span>{bpText("interactionCount", { count: interactions.length || selectedConversation.interactionCount || 0 })}</span><span>{bpText("callCount", { count: projection?.operations.length ?? 0 })}</span><span>{selectedConversation.agentName || bpText("agentNotRecorded")}</span></div>
+        <div className={styles.conversationHeading}><h1>{conversationTitle(selectedConversation)}</h1><span>{selectedConversation.conversationId}</span><span>{bpText("interactionCount", { count: selectedConversation.interactionCount ?? interactionTotal })}</span><span>{bpText("callCount", { count: projection?.operations.length ?? 0 })}</span><span>{selectedConversation.agentName || bpText("agentNotRecorded")}</span></div>
       </header>
       <aside className={styles.roundSidebar}>
-        <div className={styles.roundSidebarTitle}><div><h3>{bpText("rounds.title")}</h3><span>{interactionListLoading ? bpText("rounds.loading") : bpText("rounds.summary", { total: interactionTotal, current: selectedInteraction ? roundNumber(selectedInteraction, interactions.findIndex((item) => item.interactionId === selectedInteraction.interactionId), interactionTotal) : 0 })}</span></div></div>
+        <div className={styles.roundSidebarTitle}><div><h3>{bpText("rounds.title")}</h3><span>{interactionListLoading ? bpText("rounds.loading") : bpText("rounds.summary", { total: selectedConversation.interactionCount ?? interactionTotal, current: selectedInteraction?.roundNumber && selectedInteraction.roundNumber > 0 ? selectedInteraction.roundNumber : bpText("roundNotRecorded") })}</span></div></div>
         <Input value={interactionKeyword} onChange={(event) => setInteractionKeyword(event.target.value)} prefix={<SearchOutlined />} placeholder={bpText("rounds.search")} />
-        <div className={styles.roundList}>{interactionListLoading ? <div className={styles.roundLoading}><Spin size="small" />{bpText("rounds.loading")}</div> : interactionListError ? <Alert type="error" showIcon message={bpText("errors.interactionsLoad")} /> : interactions.map((item, index) => <button key={item.interactionId} className={item.interactionId === selectedInteraction?.interactionId ? styles.roundSelected : ""} onClick={() => setSelectedInteraction(item)}><b>{bpText("roundLabel", { index: roundNumber(item, index, interactionTotal) })}</b><strong>{item.questionPreview || bpText("questionNotRecorded")}</strong><small>{formatClock(item.startedAt)} · {formatDuration(item.durationMs)} · {statusLabel(item.status)}</small></button>)}</div>
+        <div className={styles.roundList}>{interactionListLoading ? <div className={styles.roundLoading}><Spin size="small" />{bpText("rounds.loading")}</div> : interactionListError ? <Alert type="error" showIcon message={bpText("errors.interactionsLoad")} /> : interactions.map((item) => <button key={item.interactionId} className={item.interactionId === selectedInteraction?.interactionId ? styles.roundSelected : ""} onClick={() => setSelectedInteraction(item)}><b>{roundLabel(item)}</b><strong>{item.questionPreview || bpText("questionNotRecorded")}</strong><small>{formatClock(item.startedAt)} · {formatDuration(item.durationMs)} · {statusLabel(item.status)}</small></button>)}</div>
       </aside>
       <section className={styles.analysisPane}>
         {interactionListLoading ? <div className={styles.workspaceEmpty}><Spin size="large" /><span>{bpText("rounds.loading")}</span></div> : interactionDetailLoading ? <div className={styles.workspaceEmpty}><Spin size="large" /><span>{bpText("rounds.loadingFacts")}</span></div> : interactionDetailError ? <Result status="error" title={bpText("errors.factsLoad")} extra={<Button type="primary" onClick={() => setInteractionReload((value) => value + 1)}>{t("bknTrace.businessProvenance.retry")}</Button>} /> : projection ? <>
           <section className={styles.interactionSummary}>
-            <header><span>{bpText("roundLabel", { index: roundNumber(selectedInteraction, interactions.findIndex((item) => item.interactionId === selectedInteraction?.interactionId), interactionTotal) })}</span><h2>{selectedInteraction?.questionPreview || bpText("roundQuestionNotRecorded")}</h2><small>{selectedConversation.agentName || bpText("agentNotRecorded")} · {formatTime(selectedInteraction?.startedAt)} · {formatDuration(selectedInteraction?.durationMs)} · {bpText("callCount", { count: projection.operations.length })} · {statusLabel(selectedInteraction?.status)}</small></header>
+            <header><span>{roundLabel(selectedInteraction)}</span><h2>{selectedInteraction?.questionPreview || bpText("roundQuestionNotRecorded")}</h2><small>{selectedConversation.agentName || bpText("agentNotRecorded")} · {formatTime(selectedInteraction?.startedAt)} · {formatDuration(selectedInteraction?.durationMs)} · {bpText("callCount", { count: projection.operations.length })} · {statusLabel(selectedInteraction?.status)}</small></header>
             <div className={styles.sourceTexts}><div><h4>{bpText("rounds.inputOriginal")}</h4><p>{selectedInteraction?.questionPreview || bpText("inputNotRecorded")}</p></div><div><h4>{bpText("rounds.outputOriginal")}</h4><p>{selectedInteraction?.resultPreview || bpText("resultNotRecorded")}</p></div></div>
             <footer><Button icon={<CopyOutlined />} disabled={analysisMarkdownLoading || !analysisMarkdown} onClick={() => void copyMarkdown()}>{bpText("actions.copyMarkdown")}</Button><Button icon={<DownloadOutlined />} disabled={analysisMarkdownLoading || !analysisMarkdown} onClick={() => void downloadMarkdown()}>{bpText("actions.downloadMarkdown")}</Button><Button type="primary" onClick={() => { setDetailOperation(undefined); setKnowledgeSelection(undefined); setAnalysisPanelOpen(true); }}>{bpText("actions.analyze")}</Button></footer>
           </section>
@@ -514,7 +513,7 @@ export function BusinessProvenanceScene() {
           </header>
           <p className={styles.agentIntro}>{bpText("agent.intro")}</p>
           <div className={styles.agentSource}>
-            <strong>{bpText("roundLabel", { index: roundNumber(selectedInteraction, interactions.findIndex((item) => item.interactionId === selectedInteraction?.interactionId), interactionTotal) })} · {selectedInteraction?.questionPreview || bpText("roundQuestionNotRecorded")}</strong>
+            <strong>{roundLabel(selectedInteraction)} · {selectedInteraction?.questionPreview || bpText("roundQuestionNotRecorded")}</strong>
             <small>{selectedInteraction?.interactionId}<br />{formatTime(selectedInteraction?.startedAt)} · {formatDuration(selectedInteraction?.durationMs)} · {bpText("callCount", { count: projection?.operations.length ?? 0 })}</small>
           </div>
           {analysisHistory.length ? <Select aria-label={bpText("agent.history")} value={analysisHistory.find((item) => item.result === analysisResult)?.analysisId ?? analysisHistory[0]?.analysisId} options={analysisHistory.map((item, index) => ({ value: item.analysisId, label: bpText("agent.historyItem", { index: analysisHistory.length - index, time: formatTime(item.startedAt), status: item.status === "completed" ? statusLabel("completed") : item.status === "failed" ? statusLabel("failed") : bpText("agent.analyzing") }) }))} onChange={(analysisId) => { const selected = analysisHistory.find((item) => item.analysisId === analysisId); setAnalysisResult(selected?.result); setAnalysisError(selected?.status === "failed" ? bpText("agent.failureWithReason", { reason: selected.failureMessage || bpText("agent.failureReasonMissing") }) : undefined); }} /> : null}

--- a/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.tsx
+++ b/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.tsx
@@ -71,6 +71,12 @@ function statusLabel(value?: string) {
   return value || bpText("notRecorded");
 }
 
+function roundNumber(item: BusinessProvenanceInteractionListItem | undefined, index: number, total: number) {
+  // The API owns the semantic round number. The fallback keeps a coherent
+  // display while a Studio deployment is temporarily ahead of the API.
+  return item?.roundNumber ?? Math.max(1, total - index);
+}
+
 function operationTitle(operation: OperationResolution) {
   const primary = operation.elements.filter((item) => !["property", "logic"].includes(item.kind));
   const elements = (primary.length ? primary : operation.elements).map((item) => item.name || item.id).filter(Boolean);
@@ -259,6 +265,7 @@ export function BusinessProvenanceScene() {
   const [selectedConversation, setSelectedConversation] = useState<BusinessProvenanceConversation>();
   const [interactionKeyword, setInteractionKeyword] = useState("");
   const [interactions, setInteractions] = useState<BusinessProvenanceInteractionListItem[]>([]);
+  const [interactionTotal, setInteractionTotal] = useState(0);
   const [selectedInteraction, setSelectedInteraction] = useState<BusinessProvenanceInteractionListItem>();
   const [projection, setProjection] = useState<BusinessProvenanceInteraction>();
   const [interactionListLoading, setInteractionListLoading] = useState(false);
@@ -305,11 +312,11 @@ export function BusinessProvenanceScene() {
   useEffect(() => {
     if (!selectedConversation) return;
     let current = true;
-    setInteractions([]); setSelectedInteraction(undefined);
+    setInteractions([]); setInteractionTotal(0); setSelectedInteraction(undefined);
     setInteractionListLoading(true); setInteractionListError(false);
     setProjection(undefined); setDetailOperation(undefined); setKnowledgeSelection(undefined); setAnalysisResult(undefined); setAnalysisHistory([]); setAnalysisPanelOpen(false); setAnalysisError(undefined);
     void getBusinessProvenanceInteractions({ conversationId: selectedConversation.conversationId, page: 1, pageSize: 50, keyword: interactionKeyword })
-      .then((page) => { if (current) { setInteractions(page.entries); setSelectedInteraction(page.entries[0]); } })
+      .then((page) => { if (current) { setInteractions(page.entries); setInteractionTotal(page.total); setSelectedInteraction(page.entries[0]); } })
       .catch(() => { if (current) { setInteractionListError(true); message.error(bpText("errors.interactionsLoad")); } })
       .finally(() => { if (current) setInteractionListLoading(false); });
     return () => { current = false; };
@@ -446,14 +453,14 @@ export function BusinessProvenanceScene() {
         <div className={styles.conversationHeading}><h1>{conversationTitle(selectedConversation)}</h1><span>{selectedConversation.conversationId}</span><span>{bpText("interactionCount", { count: interactions.length || selectedConversation.interactionCount || 0 })}</span><span>{bpText("callCount", { count: projection?.operations.length ?? 0 })}</span><span>{selectedConversation.agentName || bpText("agentNotRecorded")}</span></div>
       </header>
       <aside className={styles.roundSidebar}>
-        <div className={styles.roundSidebarTitle}><div><h3>{bpText("rounds.title")}</h3><span>{interactionListLoading ? bpText("rounds.loading") : bpText("rounds.summary", { total: interactions.length, current: Math.max(1, interactions.findIndex((item) => item.interactionId === selectedInteraction?.interactionId) + 1) })}</span></div></div>
+        <div className={styles.roundSidebarTitle}><div><h3>{bpText("rounds.title")}</h3><span>{interactionListLoading ? bpText("rounds.loading") : bpText("rounds.summary", { total: interactionTotal, current: selectedInteraction ? roundNumber(selectedInteraction, interactions.findIndex((item) => item.interactionId === selectedInteraction.interactionId), interactionTotal) : 0 })}</span></div></div>
         <Input value={interactionKeyword} onChange={(event) => setInteractionKeyword(event.target.value)} prefix={<SearchOutlined />} placeholder={bpText("rounds.search")} />
-        <div className={styles.roundList}>{interactionListLoading ? <div className={styles.roundLoading}><Spin size="small" />{bpText("rounds.loading")}</div> : interactionListError ? <Alert type="error" showIcon message={bpText("errors.interactionsLoad")} /> : interactions.map((item, index) => <button key={item.interactionId} className={item.interactionId === selectedInteraction?.interactionId ? styles.roundSelected : ""} onClick={() => setSelectedInteraction(item)}><b>{bpText("roundLabel", { index: index + 1 })}</b><strong>{item.questionPreview || bpText("questionNotRecorded")}</strong><small>{formatClock(item.startedAt)} · {formatDuration(item.durationMs)} · {statusLabel(item.status)}</small></button>)}</div>
+        <div className={styles.roundList}>{interactionListLoading ? <div className={styles.roundLoading}><Spin size="small" />{bpText("rounds.loading")}</div> : interactionListError ? <Alert type="error" showIcon message={bpText("errors.interactionsLoad")} /> : interactions.map((item, index) => <button key={item.interactionId} className={item.interactionId === selectedInteraction?.interactionId ? styles.roundSelected : ""} onClick={() => setSelectedInteraction(item)}><b>{bpText("roundLabel", { index: roundNumber(item, index, interactionTotal) })}</b><strong>{item.questionPreview || bpText("questionNotRecorded")}</strong><small>{formatClock(item.startedAt)} · {formatDuration(item.durationMs)} · {statusLabel(item.status)}</small></button>)}</div>
       </aside>
       <section className={styles.analysisPane}>
         {interactionListLoading ? <div className={styles.workspaceEmpty}><Spin size="large" /><span>{bpText("rounds.loading")}</span></div> : interactionDetailLoading ? <div className={styles.workspaceEmpty}><Spin size="large" /><span>{bpText("rounds.loadingFacts")}</span></div> : interactionDetailError ? <Result status="error" title={bpText("errors.factsLoad")} extra={<Button type="primary" onClick={() => setInteractionReload((value) => value + 1)}>{t("bknTrace.businessProvenance.retry")}</Button>} /> : projection ? <>
           <section className={styles.interactionSummary}>
-            <header><span>{bpText("roundLabel", { index: Math.max(1, interactions.findIndex((item) => item.interactionId === selectedInteraction?.interactionId) + 1) })}</span><h2>{selectedInteraction?.questionPreview || bpText("roundQuestionNotRecorded")}</h2><small>{selectedConversation.agentName || bpText("agentNotRecorded")} · {formatTime(selectedInteraction?.startedAt)} · {formatDuration(selectedInteraction?.durationMs)} · {bpText("callCount", { count: projection.operations.length })} · {statusLabel(selectedInteraction?.status)}</small></header>
+            <header><span>{bpText("roundLabel", { index: roundNumber(selectedInteraction, interactions.findIndex((item) => item.interactionId === selectedInteraction?.interactionId), interactionTotal) })}</span><h2>{selectedInteraction?.questionPreview || bpText("roundQuestionNotRecorded")}</h2><small>{selectedConversation.agentName || bpText("agentNotRecorded")} · {formatTime(selectedInteraction?.startedAt)} · {formatDuration(selectedInteraction?.durationMs)} · {bpText("callCount", { count: projection.operations.length })} · {statusLabel(selectedInteraction?.status)}</small></header>
             <div className={styles.sourceTexts}><div><h4>{bpText("rounds.inputOriginal")}</h4><p>{selectedInteraction?.questionPreview || bpText("inputNotRecorded")}</p></div><div><h4>{bpText("rounds.outputOriginal")}</h4><p>{selectedInteraction?.resultPreview || bpText("resultNotRecorded")}</p></div></div>
             <footer><Button icon={<CopyOutlined />} disabled={analysisMarkdownLoading || !analysisMarkdown} onClick={() => void copyMarkdown()}>{bpText("actions.copyMarkdown")}</Button><Button icon={<DownloadOutlined />} disabled={analysisMarkdownLoading || !analysisMarkdown} onClick={() => void downloadMarkdown()}>{bpText("actions.downloadMarkdown")}</Button><Button type="primary" onClick={() => { setDetailOperation(undefined); setKnowledgeSelection(undefined); setAnalysisPanelOpen(true); }}>{bpText("actions.analyze")}</Button></footer>
           </section>
@@ -507,7 +514,7 @@ export function BusinessProvenanceScene() {
           </header>
           <p className={styles.agentIntro}>{bpText("agent.intro")}</p>
           <div className={styles.agentSource}>
-            <strong>{bpText("roundLabel", { index: Math.max(1, interactions.findIndex((item) => item.interactionId === selectedInteraction?.interactionId) + 1) })} · {selectedInteraction?.questionPreview || bpText("roundQuestionNotRecorded")}</strong>
+            <strong>{bpText("roundLabel", { index: roundNumber(selectedInteraction, interactions.findIndex((item) => item.interactionId === selectedInteraction?.interactionId), interactionTotal) })} · {selectedInteraction?.questionPreview || bpText("roundQuestionNotRecorded")}</strong>
             <small>{selectedInteraction?.interactionId}<br />{formatTime(selectedInteraction?.startedAt)} · {formatDuration(selectedInteraction?.durationMs)} · {bpText("callCount", { count: projection?.operations.length ?? 0 })}</small>
           </div>
           {analysisHistory.length ? <Select aria-label={bpText("agent.history")} value={analysisHistory.find((item) => item.result === analysisResult)?.analysisId ?? analysisHistory[0]?.analysisId} options={analysisHistory.map((item, index) => ({ value: item.analysisId, label: bpText("agent.historyItem", { index: analysisHistory.length - index, time: formatTime(item.startedAt), status: item.status === "completed" ? statusLabel("completed") : item.status === "failed" ? statusLabel("failed") : bpText("agent.analyzing") }) }))} onChange={(analysisId) => { const selected = analysisHistory.find((item) => item.analysisId === analysisId); setAnalysisResult(selected?.result); setAnalysisError(selected?.status === "failed" ? bpText("agent.failureWithReason", { reason: selected.failureMessage || bpText("agent.failureReasonMissing") }) : undefined); }} /> : null}

--- a/src/modules/bkn-trace/business-provenance/business-provenance.service.test.ts
+++ b/src/modules/bkn-trace/business-provenance/business-provenance.service.test.ts
@@ -68,13 +68,14 @@ describe("EE business provenance service", () => {
   });
 
   it("loads interaction rounds only for the selected conversation", async () => {
-    getMock.mockResolvedValue({ data: { entries: [{ interaction_id: "int-1", conversation_id: "conv-1" }], total: 1 } });
+    getMock.mockResolvedValue({ data: { entries: [{ interaction_id: "int-1", conversation_id: "conv-1", round_number: 3 }], total: 3 } });
     const { getBusinessProvenanceInteractions } = await import("./business-provenance.service");
-    await getBusinessProvenanceInteractions({ conversationId: "conv-1", page: 1, pageSize: 20 });
+    const page = await getBusinessProvenanceInteractions({ conversationId: "conv-1", page: 1, pageSize: 20 });
     expect(getMock).toHaveBeenCalledWith(
       "/agent-observability/v1/business-provenance/interactions",
       { headers: { "x-business-domain": "bd_demo" }, params: { conversation_id: "conv-1", page: 1, page_size: 20 } },
     );
+    expect(page.entries[0]).toMatchObject({ interactionId: "int-1", roundNumber: 3 });
   });
 
   it("streams the server-configured provenance Agent and returns its structured result", async () => {

--- a/src/modules/bkn-trace/business-provenance/business-provenance.service.ts
+++ b/src/modules/bkn-trace/business-provenance/business-provenance.service.ts
@@ -49,6 +49,8 @@ export type BusinessProvenanceConversation = {
 export type BusinessProvenanceInteractionListItem = {
   interactionId: string;
   conversationId?: string;
+  /** Chronological position within the conversation; the API list is newest first. */
+  roundNumber?: number;
   questionPreview?: string;
   resultPreview?: string;
   startedAt?: string;
@@ -133,7 +135,7 @@ export async function getBusinessProvenanceInteractions(
   query: BusinessProvenanceQuery,
 ): Promise<BusinessProvenancePage<BusinessProvenanceInteractionListItem>> {
   const response = await http.get<{ entries?: Array<{
-    interaction_id?: string; conversation_id?: string; question_preview?: string; result_preview?: string;
+    interaction_id?: string; conversation_id?: string; round_number?: number; question_preview?: string; result_preview?: string;
     started_at?: string; status?: string; duration_ms?: number;
   }>; total?: number; page?: number; page_size?: number }>(
     `${EE_PROVENANCE_PREFIX}/interactions`,
@@ -141,7 +143,7 @@ export async function getBusinessProvenanceInteractions(
   );
   return {
     entries: (response.data.entries ?? []).map((entry) => ({
-      interactionId: entry.interaction_id ?? "", conversationId: entry.conversation_id,
+      interactionId: entry.interaction_id ?? "", conversationId: entry.conversation_id, roundNumber: entry.round_number,
       questionPreview: entry.question_preview, resultPreview: entry.result_preview,
       startedAt: entry.started_at, status: entry.status, durationMs: entry.duration_ms,
     })),

--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -59,7 +59,7 @@ export const bknTraceEnUS = {
           exploreSchema: "Explore knowledge network schema", failedResult: "Call failed; error facts are recorded with this call.", findNetwork: "Find business knowledge network", queryElements: "Query {{elements}}", queryObject: "Query business object",
           resourceNotRecorded: "No resource binding was recorded in this interaction", resultNotRecorded: "Result not recorded.", rows: "Returned {{count}} rows.", runSql: "Run data query", sqlConditionBelow: "See full SQL below for conditions", zeroRows: "Returned 0 rows.",
         },
-        questionNotRecorded: "Question not recorded", resultNotRecorded: "Business result not recorded", roundLabel: "Interaction {{index}}", roundQuestionNotRecorded: "Question for this interaction not recorded",
+        questionNotRecorded: "Question not recorded", resultNotRecorded: "Business result not recorded", roundLabel: "Interaction {{index}}", roundNotRecorded: "Interaction number not recorded", roundQuestionNotRecorded: "Question for this interaction not recorded",
         rounds: { input: "Interaction input", inputOriginal: "Interaction input (original)", loading: "Loading interactions", loadingFacts: "Loading call facts", noOperations: "No call facts were recorded for this interaction", outputOriginal: "Interaction output (original)", search: "Search question or business object", select: "Select an interaction to inspect call facts", summary: "{{total}} interactions · current {{current}}", title: "Interactions" },
         status: { completed: "Completed", failed: "Failed", running: "In progress" }, timeNotRecorded: "Time not recorded", undetermined: "Undetermined", views: { knowledge: "Knowledge Network", timeline: "Timeline" },
       },

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -59,7 +59,7 @@ export const bknTraceZhCN = {
           exploreSchema: "探索知识网络结构", failedResult: "调用失败；错误事实已记录在本次调用中。", findNetwork: "查找业务知识网络", queryElements: "查询{{elements}}", queryObject: "查询业务对象",
           resourceNotRecorded: "本轮事实未记录资源绑定", resultNotRecorded: "结果未记录。", rows: "返回 {{count}} 条。", runSql: "执行数据查询", sqlConditionBelow: "SQL 条件见下方完整 SQL", zeroRows: "返回 0 条。",
         },
-        questionNotRecorded: "未记录问题", resultNotRecorded: "业务结果未记录", roundLabel: "第 {{index}} 轮", roundQuestionNotRecorded: "本轮问题未记录",
+        questionNotRecorded: "未记录问题", resultNotRecorded: "业务结果未记录", roundLabel: "第 {{index}} 轮", roundNotRecorded: "轮次未记录", roundQuestionNotRecorded: "本轮问题未记录",
         rounds: { input: "本轮输入", inputOriginal: "本轮输入（原文）", loading: "正在加载交互轮次", loadingFacts: "正在加载调用事实", noOperations: "本轮未记录调用事实", outputOriginal: "本轮输出（原文）", search: "搜索问题或业务对象", select: "选择交互轮次查看调用事实", summary: "共 {{total}} 轮 · 当前 {{current}} 轮", title: "交互轮次" },
         status: { completed: "已完成", failed: "失败", running: "进行中" }, timeNotRecorded: "时间未记录", undetermined: "未确定", views: { knowledge: "知识网络视图", timeline: "时间链视图" },
       },


### PR DESCRIPTION
Summary: Studio renders the chronological round number supplied by the API while retaining newest-first interaction order.\n\nVerification: focused Vitest service and scene regression tests passed. TypeScript build was clean for this change; the workspace has a pre-existing missing json-bigint dependency.