### PR TITLE
test(data-connect): cover connection failure details

### DIFF
--- a/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
+++ b/src/modules/data-connect/scenes/DataConnectFormScene.test.tsx
@@ -25,12 +25,13 @@ const createDataConnectRecordMock = vi.hoisted(() => vi.fn());
 const getDataConnectRecordMock = vi.hoisted(() => vi.fn());
 const listDataConnectConnectorTypesMock = vi.hoisted(() => vi.fn());
 const testDataConnectConfigMock = vi.hoisted(() => vi.fn());
+const messageErrorMock = vi.hoisted(() => vi.fn());
 const messageSuccessMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/framework/context/use-app-services", () => ({
   useAppServices: () => ({
     message: {
-      error: vi.fn(),
+      error: messageErrorMock,
       success: messageSuccessMock,
       warning: vi.fn(),
     },
@@ -137,6 +138,7 @@ describe("DataConnectFormScene · connection preflight", () => {
     vi.useRealTimers();
     permissionState.values = new Set(["catalog:modify"]);
     entitlementState.snapshot = null;
+    messageErrorMock.mockReset();
     messageSuccessMock.mockReset();
     createDataConnectRecordMock.mockReset();
     createDataConnectRecordMock.mockResolvedValue(undefined);
@@ -218,6 +220,26 @@ describe("DataConnectFormScene · connection preflight", () => {
     expect(messageSuccessMock).toHaveBeenCalledWith(
       "dataConnect.testConnectionSuccess",
     );
+  });
+
+  it("shows backend connection details when the preflight fails", async () => {
+    permissionState.values.add("catalog:create");
+    testDataConnectConfigMock.mockRejectedValue(
+      new Error("dial tcp db.example.com:3306: i/o timeout"),
+    );
+    render(<DataConnectFormScene mode="edit" recordId="catalog-1" />);
+
+    await screen.findByDisplayValue("orders");
+    fireEvent.click(
+      screen.getByRole("button", { name: "common.testConnection" }),
+    );
+
+    await waitFor(() => {
+      expect(messageErrorMock).toHaveBeenCalledWith(
+        "dial tcp db.example.com:3306: i/o timeout",
+      );
+    });
+    expect(messageSuccessMock).not.toHaveBeenCalled();
   });
 
   it("normalizes SQL Server schemas and options in the connection test request", async () => {

--- a/src/modules/data-connect/services/data-connect.service.test.ts
+++ b/src/modules/data-connect/services/data-connect.service.test.ts
@@ -106,6 +106,23 @@ describe("data-connect.service · test connection", () => {
     );
   });
 
+  it("rejects a preflight business failure with the backend details", async () => {
+    testCatalogConnectionConfigMock.mockResolvedValue({
+      message: "dial tcp db.example.com:3306: i/o timeout",
+      success: false,
+    });
+    const { testDataConnectConfig } = await import(
+      "@/modules/data-connect/services/data-connect.service"
+    );
+
+    await expect(
+      testDataConnectConfig({
+        connectorConfig: { host: "db.example.com" },
+        connectorType: "mariadb",
+      }),
+    ).rejects.toThrow("dial tcp db.example.com:3306: i/o timeout");
+  });
+
   it("uses the localized fallback when the backend failure message is empty", async () => {
     testCatalogConnectionConfigMock.mockResolvedValue({
       message: "  ",


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Add service-level coverage that retains a failed connection test message.
- [x] Add form-level coverage that displays the backend diagnostic to the user.
- [ ] Production behavior change (not needed; the existing implementation already propagates and renders `message`).

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#971
- Related Feature: N/A
- Background: Vega now returns sanitized connection diagnostics, and Studio needs regression coverage for its existing detail-display path.

---

## How

- Key implementation points: assert that failed preflight `message` values are thrown by the service and displayed by the data-connect form.
- Breaking changes (API, config, database, etc.): No production code or API changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not required)
- [ ] Verified in test environment (not run)

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod`

---

## Risk & Rollback

- Potential risks: none at runtime; this PR changes tests only.
- Rollback plan: revert this test-only PR.

---

## Additional Notes

- Companion backend implementation: https://github.com/openbkn-ai/bkn-foundry/pull/987