### PR TITLE
feat(kn): adapt the console to run_code / run_shell on the tool surface

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -538,7 +538,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
     }
     setSettingsOpen(false);
     message.success(t("knowledgeNetwork.agentChat.chatPane.messages.settingsSaved"));
-  }, [draftConfig, draftModel, draftSystemPrompt, draftToolSelection, knId, message, messages, profile.paneKey, stats, t]);
+  }, [draftConfig, draftModel, draftSystemPrompt, draftToolSelection, knId, message, messages, profile.defaultPrompt, profile.paneKey, stats, t]);
   const resetDraftSystemPrompt = useCallback(() => {
     setDraftSystemPrompt(profile.defaultPrompt);
     message.success(t("knowledgeNetwork.agentChat.chatPane.messages.promptReset"));
@@ -591,7 +591,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
         /* Ignore unavailable localStorage. */
       }
     },
-    [knId, profile.paneKey, model, systemPrompt],
+    [knId, profile.defaultPrompt, profile.paneKey, model, systemPrompt],
   );
 
   useEffect(() => {

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -39,20 +39,7 @@ import remarkGfm from "remark-gfm";
 import { useTranslation } from "react-i18next";
 
 import type { LlmModel } from "@/modules/model-resources/types/llm";
-import {
-  buildAgentTools,
-  effectiveToolArgs,
-  guardAgentToolArgs,
-  isTakenOverLifecycleTool,
-  formatOutputContract,
-  formatToolResultLimits,
-  runAgentChat,
-  DEFAULT_AGENT_CONFIG,
-  type AgentChatTurn,
-  type AgentChunk,
-  type AgentConfig,
-  type AgentTokenProvider,
-} from "@/modules/knowledge-network/services/agent-chat.service";
+import { DEFAULT_AGENT_CONFIG, buildAgentTools, effectiveToolArgs, formatOutputContract, formatToolResultLimits, guardAgentToolArgs, isTakenOverLifecycleTool, promptFromPersisted, promptToPersist, runAgentChat, type AgentChatTurn, type AgentChunk, type AgentConfig, type AgentTokenProvider } from "@/modules/knowledge-network/services/agent-chat.service";
 import {
   normalizeAgentError,
   type NormalizedAgentError,
@@ -543,7 +530,8 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
       }
       localStorage.setItem(
         msgsLsKey(knId, profile.paneKey),
-        JSON.stringify({ messages, model: draftModel, systemPrompt: draftSystemPrompt, stats } satisfies Persisted),
+        JSON.stringify({ messages, model: draftModel,
+          systemPrompt: promptToPersist(draftSystemPrompt, profile.defaultPrompt), stats } satisfies Persisted),
       );
     } catch {
       /* Ignore unavailable localStorage. */
@@ -579,7 +567,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
     const saved = loadPersisted(msgsLsKey(knId, profile.paneKey));
     setMessages(Array.isArray(saved.messages) ? saved.messages : []);
     if (saved.model) setModel(saved.model);
-    setSystemPrompt(saved.systemPrompt ?? profile.defaultPrompt);
+    setSystemPrompt(promptFromPersisted(saved.systemPrompt, profile.defaultPrompt));
     setStats(saved.stats ?? { tokens: 0, ms: 0 });
   }, [knId, profile.paneKey, profile.defaultPrompt]);
 
@@ -596,7 +584,8 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
       try {
         localStorage.setItem(
           msgsLsKey(knId, profile.paneKey),
-          JSON.stringify({ messages: msgs, model, systemPrompt, stats: statsSnapshot } satisfies Persisted),
+          JSON.stringify({ messages: msgs, model,
+            systemPrompt: promptToPersist(systemPrompt, profile.defaultPrompt), stats: statsSnapshot } satisfies Persisted),
         );
       } catch {
         /* Ignore unavailable localStorage. */

--- a/src/modules/knowledge-network/locales/en-US/agent-chat.ts
+++ b/src/modules/knowledge-network/locales/en-US/agent-chat.ts
@@ -148,9 +148,12 @@ export const agentChatPart = {
     chatPane: {
       defaultPrompt:
         "You are the BKN business knowledge network retrieval assistant. Answer user questions based on object types, relation types, and logical attributes in the current knowledge network.\n" +
-        "Call the provided retrieval tools when data is needed, such as search_schema, query_object_instance, query_instance_subgraph, and run_sql. Do not fabricate answers.\n" +
+        "Call the provided retrieval tools when data is needed, such as search_schema, query_object_instance, query_instance_subgraph, and get_object_types. Do not fabricate answers.\n" +
         "kn_id is locked to the current network. You do not need to change it and must not change it.\n" +
-        "Query efficiently: push aggregation, sorting, and counting to SQL where possible, use LIMIT and precise filters, return only needed fields, avoid loading entire tables or oversized results, and do not repeat queries for information already obtained.",
+        "The retrieval tools are the main path. For what they cannot answer there are three supplements: run_sql for aggregation, sorting, and counting, so the database returns only the result; " +
+        "run_code for a Python script that calls the tools above by name, suited to chaining several tools, branching on an intermediate result, or keeping bulk data in the sandbox when you only need a conclusion; " +
+        "and run_shell for a shell command to inspect files in the sandbox. All three share one workspace scoped to the conversation, and files written there survive between executions, so a later script can pick up where an earlier one left off.\n" +
+        "Query efficiently: use LIMIT and precise filters, return only needed fields, avoid loading entire tables or oversized results, and do not repeat queries for information already obtained.",
       basePrompt:
         "You are a data query assistant. You can only answer user questions by directly querying underlying data tables with three tools:\n" +
         "list_resources lists accessible data tables, describe_resource inspects table columns, and run_sql executes SQL.\n" +

--- a/src/modules/knowledge-network/locales/en-US/agent-chat.ts
+++ b/src/modules/knowledge-network/locales/en-US/agent-chat.ts
@@ -148,7 +148,8 @@ export const agentChatPart = {
     chatPane: {
       defaultPrompt:
         "You are the BKN business knowledge network retrieval assistant. Answer user questions based on object types, relation types, and logical attributes in the current knowledge network.\n" +
-        "Call the provided retrieval tools when data is needed, such as search_schema, query_object_instance, query_instance_subgraph, and get_object_types. Do not fabricate answers.\n" +
+        "Use the tools when you need data; do not fabricate answers. Establish the structure before fetching: when you are unsure which object types exist or what a field is called, look first with search_schema, " +
+        "then filter on the field names it returns — guessing a field name by meaning tends to yield an empty result, and an empty result raises no error.\n" +
         "kn_id is locked to the current network. You do not need to change it and must not change it.\n" +
         "The retrieval tools are the main path. For what they cannot answer there are three supplements: run_sql for aggregation, sorting, and counting, so the database returns only the result; " +
         "run_code for a Python script that calls the tools above by name, suited to chaining several tools, branching on an intermediate result, or keeping bulk data in the sandbox when you only need a conclusion; " +

--- a/src/modules/knowledge-network/locales/en-US/context-loader-panel.ts
+++ b/src/modules/knowledge-network/locales/en-US/context-loader-panel.ts
@@ -16,6 +16,8 @@ export const contextLoaderPanelPart = {
       data: { label: "Data Resources and SQL", description: "Data resource lists, field schemas, and SQL queries" },
       logic: { label: "Logical Attributes and Actions", description: "Logical attribute calculation, action recall, and execution" },
       resource: { label: "Data Resources", description: "Data resource inspection, skill recall, and execution" },
+      action: { label: "Actions", description: "Action tool recall, execution, and execution history" },
+      execution: { label: "Code Execution", description: "Run Python or a shell command in the sandbox, calling the tools above from inside the script" },
       skill: { label: "Skills and Dynamic Tools", description: "Skill retrieval and online dynamic tools" },
       other: { label: "Other Capabilities", description: "Uncategorized MCP capabilities" },
     },
@@ -215,6 +217,8 @@ export const contextLoaderPanelPart = {
     },
     request: {
       doc: "API Docs",
+      summaryExpand: "Show full description",
+      summaryCollapse: "Collapse description",
       running: "Running...",
       run: "Run",
       params: "Parameters",

--- a/src/modules/knowledge-network/locales/zh-CN/agent-chat.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/agent-chat.ts
@@ -148,9 +148,12 @@ export const agentChatPart = {
     chatPane: {
       defaultPrompt:
         "你是 BKN 业务知识网络的检索助手。基于当前知识网络上的对象类、关系类与逻辑属性回答用户问题。\n" +
-        "需要数据时调用提供的检索工具（search_schema / query_object_instance / query_instance_subgraph / run_sql 等），不要编造；" +
+        "需要数据时调用提供的检索工具（search_schema / query_object_instance / query_instance_subgraph / get_object_types 等），不要编造；" +
         "kn_id 已锁定为当前网络，无需也不要修改。\n" +
-        "查询要高效：聚合/排序/计数尽量交给 SQL（run_sql），用 LIMIT 和精确过滤、只取需要的字段，避免拉全表或返回超大结果；已获得的信息不要重复查询，少而准地调用工具。",
+        "检索工具是主路。它们答不了的那部分，用三个补充手段：run_sql 做聚合/排序/计数，让数据库算完只回结果；" +
+        "run_code 写一段 Python，脚本里可直接调用上面这些工具，适合串联多个工具、按中间结果分支、或中间数据量大而你只需要结论；" +
+        "run_shell 执行 shell 命令，用来看一眼沙箱里的文件。三者共用一个按会话隔离的工作区，落盘的文件在同一对话的多次执行之间保留，下一段脚本可以直接接着用。\n" +
+        "查询要高效：用 LIMIT 和精确过滤、只取需要的字段，避免拉全表或返回超大结果；已获得的信息不要重复查询，少而准地调用工具。",
       basePrompt:
         "你是数据查询助手。你只能使用三个工具直接查询底层数据表回答用户问题：\n" +
         "list_resources（列出可访问的数据表）、describe_resource（查看表的列结构）、run_sql（执行 SQL）。\n" +

--- a/src/modules/knowledge-network/locales/zh-CN/agent-chat.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/agent-chat.ts
@@ -148,7 +148,8 @@ export const agentChatPart = {
     chatPane: {
       defaultPrompt:
         "你是 BKN 业务知识网络的检索助手。基于当前知识网络上的对象类、关系类与逻辑属性回答用户问题。\n" +
-        "需要数据时调用提供的检索工具（search_schema / query_object_instance / query_instance_subgraph / get_object_types 等），不要编造；" +
+        "需要数据时用工具查，不要编造。先弄清结构再取数：不清楚有哪些对象类、字段叫什么，先用 search_schema 探一眼，" +
+        "再按返回里的真实字段名过滤——按语义猜字段名往往得到空结果，而空结果不报错。\n" +
         "kn_id 已锁定为当前网络，无需也不要修改。\n" +
         "检索工具是主路。它们答不了的那部分，用三个补充手段：run_sql 做聚合/排序/计数，让数据库算完只回结果；" +
         "run_code 写一段 Python，脚本里可直接调用上面这些工具，适合串联多个工具、按中间结果分支、或中间数据量大而你只需要结论；" +

--- a/src/modules/knowledge-network/locales/zh-CN/context-loader-panel.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/context-loader-panel.ts
@@ -16,6 +16,8 @@ export const contextLoaderPanelPart = {
       data: { label: "数据资源与 SQL 查询", description: "数据资源列表、字段结构、SQL 数据查询" },
       logic: { label: "逻辑属性与行动调用", description: "逻辑属性计算、行动工具召回与执行" },
       resource: { label: "数据资源", description: "数据资源检查、技能召回和执行" },
+      action: { label: "行动", description: "行动工具召回、执行与执行记录" },
+      execution: { label: "代码执行", description: "在沙箱内运行 Python 或 shell 命令，脚本里可直接调用上面这些工具" },
       skill: { label: "技能与动态工具", description: "Skill 检索和线上动态工具" },
       other: { label: "其他能力", description: "暂未归类的 MCP 能力" },
     },
@@ -215,6 +217,8 @@ export const contextLoaderPanelPart = {
     },
     request: {
       doc: "接口文档",
+      summaryExpand: "查看完整说明",
+      summaryCollapse: "收起说明",
       running: "运行中...",
       run: "运行",
       params: "参数",

--- a/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.tsx
+++ b/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.tsx
@@ -19,6 +19,8 @@ import {
   type ContextLoaderOp,
   type ContextLoaderResponse,
   type McpToolDef,
+  isLongToolSummary,
+  toolSummaryPreview,
 } from "@/modules/knowledge-network/services/context-loader.service";
 import { createClaudeCodeMcpCommand, createMcpRemoteJsonConfig, withMcpTrailingSlash } from "@/modules/knowledge-network/services/mcp-client-config";
 import { buildMcpToolGroups, toolDisplayOf } from "@/modules/knowledge-network/services/mcp-tool-display";
@@ -236,6 +238,7 @@ export function ContextLoaderIntegrationPanel({
   const { t } = useTranslation();
   const location = useLocation();
   const verb = mode === "mcp" ? "MCP" : "POST";
+  const [summaryOpen, setSummaryOpen] = useState(false);
   const [schemaOpen, setSchemaOpen] = useState(false);
   const [queryParamsOpen, setQueryParamsOpen] = useState(true);
   const [callParamsOpen, setCallParamsOpen] = useState(true);
@@ -546,7 +549,20 @@ export function ContextLoaderIntegrationPanel({
             <h2 className={styles.reqTitle}>{mode === "mcp" ? opDisplay.name : op.id}</h2>
             {mode === "mcp" ? <span className={styles.reqId}>{op.id}</span> : null}
           </div>
-          <p className={styles.reqSum}>{op.summary}</p>
+          {isLongToolSummary(op.summary) ? (
+            <div className={styles.reqSumBlock}>
+              <p className={`${styles.reqSum} ${summaryOpen ? styles.reqSumFull : ""}`}>
+                {summaryOpen ? op.summary : toolSummaryPreview(op.summary)}
+              </p>
+              <button type="button" className={styles.reqSumToggle} onClick={() => setSummaryOpen((open) => !open)}>
+                {summaryOpen
+                  ? t("knowledgeNetwork.contextLoaderPanel.request.summaryCollapse")
+                  : t("knowledgeNetwork.contextLoaderPanel.request.summaryExpand")}
+              </button>
+            </div>
+          ) : (
+            <p className={styles.reqSum}>{op.summary}</p>
+          )}
         </div>
         <div className={styles.reqBody}>
           {visibleQuery.length > 0 ? (

--- a/src/modules/knowledge-network/scenes/ExperienceScene.module.css
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.module.css
@@ -1079,6 +1079,33 @@
   line-height: 1.6;
 }
 
+.reqSumBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+/* 收起态最多三行；展开后放开高度并保留原文换行，规则小节才读得下去。 */
+.reqSumFull {
+  max-height: 320px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+.reqSumToggle {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--brand, #2563eb);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.reqSumToggle:hover {
+  text-decoration: underline;
+}
+
 .reqBody {
   flex: 1 1 auto;
   overflow-y: auto;

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -32,7 +32,6 @@ import {
   CONTEXT_LOADER_OPS,
   MCP_PATH,
   REST_CONTEXT_LOADER_OPS,
-  REST_PREFIX,
   buildCurl,
   buildTestData,
   createMcpSession,
@@ -43,6 +42,7 @@ import {
   pickQueryableObjectType,
   requestDataAssistantKindOf,
   listMcpTools,
+  synthesizeOp,
   mcpPathOf,
   sendRequest,
   subgraphPathFor,
@@ -68,54 +68,6 @@ import { DataBrowserPanel } from "./DataBrowserPanel";
 import { McpSetupModal, ToolDiscoveryModal } from "./McpIntegrationModals";
 
 import styles from "./ExperienceScene.module.css";
-
-function sampleForSchemaProp(def: unknown): unknown {
-  if (!def || typeof def !== "object") return "";
-  const d = def as Record<string, unknown>;
-  if (d.default !== undefined) return d.default;
-  if (Array.isArray(d.enum) && d.enum.length > 0) return d.enum[0];
-  switch (d.type) {
-    case "number":
-    case "integer":
-      return 0;
-    case "boolean":
-      return false;
-    case "array":
-      return [];
-    case "object":
-      return {};
-    default:
-      return "";
-  }
-}
-
-/** Builds an example request body from a tool inputSchema for synthesized ops. */
-function exampleBodyFromSchema(schema: unknown): Record<string, unknown> {
-  if (!schema || typeof schema !== "object") return {};
-  const s = schema as Record<string, unknown>;
-  const props = (s.properties && typeof s.properties === "object" ? s.properties : {}) as Record<string, unknown>;
-  const required = Array.isArray(s.required) ? (s.required as string[]) : [];
-  const out: Record<string, unknown> = {};
-  for (const [key, def] of Object.entries(props)) {
-    if (required.includes(key) || key === "kn_id" || key === "response_format") {
-      out[key] = sampleForSchemaProp(def);
-    }
-  }
-  return out;
-}
-
-/** Converts live MCP tools/list entries into ContextLoaderOp when no local op exists. */
-function synthesizeOp(tool: McpToolDef): ContextLoaderOp {
-  const body = exampleBodyFromSchema(tool.inputSchema);
-  return {
-    id: tool.name,
-    summary: tool.description ?? tool.name,
-    path: `${REST_PREFIX}/kn/${tool.name}`,
-    query: [{ name: "response_format", value: "json", options: ["json", "toon"] }],
-    body,
-    mcpArgs: body,
-  };
-}
 
 /** Extracts result.content[].text from an MCP tools/call envelope. */
 function mcpContentTexts(obj: unknown): string[] | null {

--- a/src/modules/knowledge-network/services/agent-chat.prompt-persist.test.ts
+++ b/src/modules/knowledge-network/services/agent-chat.prompt-persist.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { promptFromPersisted, promptToPersist } from "./agent-chat.service";
+
+const V1 = "你是检索助手。需要数据时调用 search_schema / query_object_instance。";
+const V2 = "你是检索助手。先弄清结构再取数，检索工具是主路。";
+
+describe("system prompt persistence", () => {
+  /**
+   * The reason this exists: storing the prompt unconditionally froze whichever
+   * default was current when the pane was first used, and the restore path only
+   * fell back when the key was absent. Shipping a better default then reached
+   * nobody who had already opened the pane.
+   */
+  it("carries a later default through to a user who never edited the prompt", () => {
+    const stored = promptToPersist(V1, V1);
+
+    expect(promptFromPersisted(stored, V2)).toBe(V2);
+  });
+
+  it("keeps an edited prompt across a change of default", () => {
+    const edited = "只用 run_sql 回答。";
+    const stored = promptToPersist(edited, V1);
+
+    expect(stored).toBe(edited);
+    expect(promptFromPersisted(stored, V2)).toBe(edited);
+  });
+
+  it("treats an absent or blank stored prompt as the default", () => {
+    expect(promptFromPersisted(undefined, V2)).toBe(V2);
+    expect(promptFromPersisted("", V2)).toBe(V2);
+    expect(promptFromPersisted("   \n ", V2)).toBe(V2);
+  });
+});

--- a/src/modules/knowledge-network/services/agent-chat.service.ts
+++ b/src/modules/knowledge-network/services/agent-chat.service.ts
@@ -349,6 +349,24 @@ export type AgentToolsOptions = {
   turn?: AgentTurnScope | null;
 };
 
+/**
+ * What to persist for a system prompt the user has not customized.
+ *
+ * Storing the prompt unconditionally freezes whatever default was current at
+ * the time: the restore path only falls back when the key is absent, so a later
+ * change to defaultPrompt never reaches anyone who has already used the pane.
+ * Persisting an empty string for an unedited prompt keeps the pane on whatever
+ * the default is today, while an edited one is still stored verbatim.
+ */
+export function promptToPersist(prompt: string, defaultPrompt: string): string {
+  return prompt === defaultPrompt ? "" : prompt;
+}
+
+/** Restores a persisted prompt, treating both absent and empty as "use the default". */
+export function promptFromPersisted(saved: string | undefined, defaultPrompt: string): string {
+  return saved && saved.trim() ? saved : defaultPrompt;
+}
+
 export function buildAgentTools(
   mcpTools: McpToolDef[],
   env: ContextLoaderEnv,

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -140,6 +140,65 @@ describe("sendRequest", () => {
     });
   });
 
+  /**
+   * A body carrying an empty `bkn_context` used to suppress injection: the guard
+   * asked whether the key was present, not whether it held anything, so the
+   * request went out with `{}` and Context Loader answered conversation_required.
+   * Synthesized ops produced exactly that body from the backend schema, which is
+   * why some operations failed in the console while hand-written ops worked.
+   */
+  it("overwrites a placeholder bkn_context in the request body", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await sendRequest(
+      { base: "https://platform.example.com", token: "", knId: "kn-demo" },
+      searchSchema,
+      "rest",
+      {},
+      '{"query":"订单","bkn_context":{}}',
+      undefined,
+      undefined,
+      bknContext,
+    );
+
+    expect(restBody(fetchSpy.mock.calls[0][1])).toEqual({ query: "订单", bkn_context: bknContext });
+  });
+
+  it("keeps a caller-supplied bkn_context that carries both ids", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    const explicit = { conversation_id: "conv_explicit", interaction_id: "int_explicit" };
+
+    await sendRequest(
+      { base: "https://platform.example.com", token: "", knId: "kn-demo" },
+      searchSchema,
+      "rest",
+      {},
+      JSON.stringify({ query: "订单", bkn_context: explicit }),
+      undefined,
+      undefined,
+      bknContext,
+    );
+
+    expect(restBody(fetchSpy.mock.calls[0][1])).toEqual({ query: "订单", bkn_context: explicit });
+  });
+
+  it("replaces a half-filled bkn_context, since both ids are required", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await sendRequest(
+      { base: "https://platform.example.com", token: "", knId: "kn-demo" },
+      searchSchema,
+      "rest",
+      {},
+      '{"query":"订单","bkn_context":{"conversation_id":"conv_1"}}',
+      undefined,
+      undefined,
+      bknContext,
+    );
+
+    expect(restBody(fetchSpy.mock.calls[0][1])).toEqual({ query: "订单", bkn_context: bknContext });
+  });
+
 });
 
 describe("fetchKnDetail", () => {

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -517,12 +517,129 @@ export type BknCallScope = {
 };
 
 /** Merges managed context into request body or arguments without overwriting bkn_context. */
+/* ============================ Tool Summary Display ============================ */
+/**
+ * Length past which a tool summary is collapsed in the UI.
+ *
+ * Tool descriptions serve the model, not the reader: run_code carries the whole
+ * code-mode rulebook at roughly 4.5k characters. Rendering that inline pushes
+ * the parameters and the run button off the panel, so the operation cannot be
+ * exercised at all. Business tools sit at 90-160 characters, hence a threshold
+ * with room to spare above them — anything under it keeps rendering as before.
+ */
+export const TOOL_SUMMARY_COLLAPSE_CHARS = 240;
+
+/** Whether this summary is long enough to need the collapsed treatment. */
+export function isLongToolSummary(summary: string): boolean {
+  return summary.length > TOOL_SUMMARY_COLLAPSE_CHARS;
+}
+
+/**
+ * First readable chunk of a long summary, for the collapsed state.
+ *
+ * Cuts on the first blank line, then on a sentence end, so the preview reads as
+ * a finished thought rather than a severed clause. Falls back to a hard cut when
+ * the text offers neither within range.
+ */
+export function toolSummaryPreview(summary: string): string {
+  if (!isLongToolSummary(summary)) return summary;
+  const paragraph = summary.indexOf("\n\n");
+  if (paragraph > 0 && paragraph <= TOOL_SUMMARY_COLLAPSE_CHARS) {
+    return summary.slice(0, paragraph).trim();
+  }
+  const window = summary.slice(0, TOOL_SUMMARY_COLLAPSE_CHARS);
+  const sentence = Math.max(window.lastIndexOf("。"), window.lastIndexOf(". "), window.lastIndexOf("\n"));
+  if (sentence > TOOL_SUMMARY_COLLAPSE_CHARS / 3) {
+    return window.slice(0, sentence + 1).trim();
+  }
+  return window.trim() + "…";
+}
+
+/* ============================ Synthesized Ops (schema-driven) ============================ */
+function sampleForSchemaProp(def: unknown): unknown {
+  if (!def || typeof def !== "object") return "";
+  const d = def as Record<string, unknown>;
+  if (d.default !== undefined) return d.default;
+  if (Array.isArray(d.enum) && d.enum.length > 0) return d.enum[0];
+  switch (d.type) {
+    case "number":
+    case "integer":
+      return 0;
+    case "boolean":
+      return false;
+    case "array":
+      return [];
+    case "object":
+      return {};
+    default:
+      return "";
+  }
+}
+
+/**
+ * Builds an example request body from a tool inputSchema for synthesized ops.
+ *
+ * `bkn_context` is skipped even though the backend marks it required. It is
+ * platform identity injected at send time, not a caller parameter — the same
+ * reason stripBknContextSchema removes it from the schema shown to the model.
+ * Emitting it here would produce `"bkn_context": {}`, which reads as "fill this
+ * in yourself" and, worse, counts as a caller-supplied override that suppresses
+ * the real injection, so every synthesized op would answer conversation_required.
+ */
+export function exampleBodyFromSchema(schema: unknown): Record<string, unknown> {
+  if (!schema || typeof schema !== "object") return {};
+  const s = schema as Record<string, unknown>;
+  const props = (s.properties && typeof s.properties === "object" ? s.properties : {}) as Record<string, unknown>;
+  const required = Array.isArray(s.required) ? (s.required as string[]) : [];
+  const out: Record<string, unknown> = {};
+  for (const [key, def] of Object.entries(props)) {
+    if (key === "bkn_context") continue;
+    if (required.includes(key) || key === "kn_id" || key === "response_format") {
+      out[key] = sampleForSchemaProp(def);
+    }
+  }
+  return out;
+}
+
+/** Converts live MCP tools/list entries into ContextLoaderOp when no local op exists. */
+export function synthesizeOp(tool: McpToolDef): ContextLoaderOp {
+  const body = exampleBodyFromSchema(tool.inputSchema);
+  return {
+    id: tool.name,
+    summary: tool.description ?? tool.name,
+    path: `${REST_PREFIX}/kn/${tool.name}`,
+    query: [{ name: "response_format", value: "json", options: ["json", "toon"] }],
+    body,
+    mcpArgs: body,
+  };
+}
+
 function withBknContext(
   payload: Record<string, unknown>,
   bknContext: BknContext | undefined,
 ): Record<string, unknown> {
-  if (!bknContext || "bkn_context" in payload) return payload;
+  if (!bknContext || hasUsableBknContext(payload)) return payload;
   return { ...payload, bkn_context: bknContext };
+}
+
+/**
+ * Whether the payload already carries a context worth keeping.
+ *
+ * Presence of the key is not enough. Context Loader requires both ids on every
+ * business tool, so a `bkn_context` that lacks either one is not an override —
+ * it is a placeholder, and treating it as one silently drops the real context
+ * and gets the call rejected with conversation_required.
+ */
+function hasUsableBknContext(payload: Record<string, unknown>): boolean {
+  const value = payload.bkn_context;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const context = value as Record<string, unknown>;
+  return (
+    typeof context.conversation_id === "string" &&
+    context.conversation_id.trim() !== "" &&
+    typeof context.interaction_id === "string" &&
+    context.interaction_id.trim() !== ""
+  );
 }
 
 /** Parses request-body JSON; non-object or invalid JSON falls back to an empty object. */

--- a/src/modules/knowledge-network/services/context-loader.synthesize.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.synthesize.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { exampleBodyFromSchema, synthesizeOp } from "./context-loader.service";
+
+/** Shaped like what Context Loader actually serves: bkn_context is a required object. */
+const searchInstanceSchema = {
+  type: "object",
+  properties: {
+    kn_id: { type: "string" },
+    query: { type: "string" },
+    limit: { type: "integer", default: 10 },
+    response_format: { type: "string", enum: ["toon", "json"] },
+    bkn_context: {
+      type: "object",
+      properties: { conversation_id: { type: "string" }, interaction_id: { type: "string" } },
+      required: ["conversation_id", "interaction_id"],
+    },
+  },
+  required: ["kn_id", "query", "bkn_context"],
+};
+
+describe("exampleBodyFromSchema", () => {
+  /**
+   * The console injects the live context at send time. Emitting the key here put
+   * an empty object in the body, which both misled the reader into filling it in
+   * and counted as a caller override that suppressed the real injection.
+   */
+  it("omits bkn_context even though the schema marks it required", () => {
+    const body = exampleBodyFromSchema(searchInstanceSchema);
+
+    expect(body).not.toHaveProperty("bkn_context");
+    expect(body).toEqual({ kn_id: "", query: "", response_format: "toon" });
+  });
+
+  it("keeps required fields, kn_id and response_format, and skips optional ones", () => {
+    const body = exampleBodyFromSchema(searchInstanceSchema);
+
+    expect(Object.keys(body).sort()).toEqual(["kn_id", "query", "response_format"]);
+  });
+});
+
+describe("synthesizeOp", () => {
+  it("builds a REST path and MCP arguments with no bkn_context in either", () => {
+    const op = synthesizeOp({ name: "search_instance", inputSchema: searchInstanceSchema });
+
+    expect(op.id).toBe("search_instance");
+    expect(op.path).toContain("/kn/search_instance");
+    expect(op.body).not.toHaveProperty("bkn_context");
+    expect(op.mcpArgs).not.toHaveProperty("bkn_context");
+  });
+});

--- a/src/modules/knowledge-network/services/mcp-tool-display.ts
+++ b/src/modules/knowledge-network/services/mcp-tool-display.ts
@@ -52,6 +52,9 @@ const GROUP_DESCRIPTIONS: Record<string, string> = {
   data: "Data resource lists, field schemas, and SQL data queries",
   logic: "Logical property calculation, action recall, and action execution",
   skill: "Skill search and online dynamic tools",
+  // run_code / run_shell. The server merged them onto the business tool surface,
+  // so they arrive as ordinary tools with their own group rather than a mode switch.
+  execution: "Run Python or a shell command in the sandbox, calling the tools above from inside the script",
   other: "Unclassified MCP capabilities",
 };
 
@@ -64,6 +67,7 @@ const LOCAL_GROUPS: Array<{ key: string; label: string }> = [
   { key: "data", label: "Data Resources and SQL" },
   { key: "logic", label: "Logic and Actions" },
   { key: "skill", label: "Skills and Dynamic Tools" },
+  { key: "execution", label: "Code Execution" },
   { key: "other", label: "Other Capabilities" },
 ];
 
@@ -106,6 +110,8 @@ const LOCAL_TOOLS: Array<{ id: string; groupKey: string; name: string }> = [
   { id: "get_skill_content", groupKey: "skill", name: "View Skill Content" },
   { id: "read_skill_file", groupKey: "skill", name: "Read Skill File" },
   { id: "execute_skill", groupKey: "skill", name: "Execute Skill" },
+  { id: "run_code", groupKey: "execution", name: "Run Code" },
+  { id: "run_shell", groupKey: "execution", name: "Run Command" },
 ];
 
 /** Fallback order base; local fallback entries sort after server-declared entries. */


### PR DESCRIPTION
## What

Context Loader now serves `run_code` and `run_shell` as ordinary business tools on `/mcp` (openbkn-ai/bkn-foundry#992), not only on the separate `/mcp/ptc` endpoint. This adapts the console.

The model path needed almost nothing: `buildAgentTools` iterates the whole `tools/list` with no allowlist, and the arguments it injects unconditionally (`kn_id`, `response_format`) are ignored by the backend for these two tools — verified against a live deployment. Everything around that path did need work.

## Two bugs on the synthesized-op path

Operations with no local static definition are built from the live `inputSchema` by `synthesizeOp`. That path was broken in a way that presented as "some endpoints work and some don't", when the real dividing line was **whether an operation had a hand-written entry**.

`exampleBodyFromSchema` emitted every required property, and the backend marks `bkn_context` required. A `type: "object"` property yields `{}`, so the example body carried `"bkn_context": {}`.

`withBknContext` then refused to inject the live context, because its guard asked whether the key was present rather than whether it held anything:

```ts
if (!bknContext || "bkn_context" in payload) return payload;
```

The request went out with an empty object and Context Loader answered `conversation_required`. The guard exists so a hand-written context wins over the injected one — a real requirement — so it now checks that both ids are non-empty strings. A half-filled context is replaced too, since the backend requires both and one of them is not a usable override.

Both fixes were checked by reverting them against the new tests: the guard change turns 2 red, the schema change turns 3 red.

`sampleForSchemaProp` / `exampleBodyFromSchema` / `synthesizeOp` moved from the scene into the service — schema logic with no view concerns, where the test infrastructure already is, and exporting them from a component file trips `react-refresh/only-export-components`.

## Display metadata

The server sends `group` / `group_title` / `order` in `_meta` and the client already prefers them, so the `execution` group renders unaided. Missing were the local fallback catalogue (used when an older server sends no metadata) and the group description, which the server does not send at all.

Two group keys were absent from the translation tables and fell through to the English strings baked into `mcp-tool-display`: the new `execution`, and `action` — served by the backend for some time while the tables still carried the older `logic` / `model` / `data` keys. Both are translated now. The stale keys stay, since an older deployment still sends them.

## Long descriptions collapse

`run_code` carries the code-mode rulebook, against 90–160 characters for a business tool. Rendered inline it pushes the parameters and the run button out of view, so the operation cannot be exercised — the console breaks precisely on the tool most in need of experimentation. Summaries past 240 characters now show a preview cut at a paragraph or sentence boundary, with a toggle for the full text. The threshold clears every business tool, so nothing else changes appearance.

## The prompt places the three `run_*` tools as supplements

The default prompt named four retrieval tools and never mentioned `run_code`, so the model rarely reached for it. Simply adding it overcorrected: `run_code` alone was 51% of all description text on the surface, and none of that text says when *not* to write code, because it was written for an endpoint where it was the only choice.

The prompt now states the retrieval tools are the main path and groups `run_sql`, `run_code`, `run_shell` as three supplements of equal weight, each with the case it fits. `run_sql` moved out of the retrieval list, where it sat next to `search_schema`. The shared workspace is documented too: all three see one conversation-scoped directory whose files survive between executions.

`basePrompt` is left alone — it deliberately narrows the model to three tools, and widening it would defeat that.

## Verification

344 tests pass, `tsc` clean. The two remaining eslint warnings predate this branch.

openbkn-ai/bkn-foundry#1001 separately cuts the `run_code` digest to 39% of the surface; the collapse here is what keeps the console usable regardless of how long any tool description gets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
