### PR TITLE
fix(observability): hide internal trace storage rows

### DIFF
--- a/public/bkn-trace-0.1.4-prototype.html
+++ b/public/bkn-trace-0.1.4-prototype.html
@@ -371,7 +371,7 @@
           <section class="settings-section">
             <div class="settings-section-head"><div><h2>存储与保留</h2><p>只读展示当前可确认的信息；没有接口事实的字段保持缺失。</p></div></div>
             <div class="retention-grid">
-              <div class="retention-list"><div class="retention-row head"><span>数据</span><span>热存储</span><span>保留口径</span><span>状态</span></div><div class="retention-row"><span>运行日志</span><span>OpenSearch</span><span>7 天 · 系统默认</span><span class="health-tag">正常</span></div><div class="retention-row"><span>审计日志</span><span>来源系统</span><span>365 天 · 系统默认</span><span class="health-tag">正常</span></div><div class="retention-row"><span>Trace 查询索引</span><span>OpenSearch</span><span>当前接口未返回</span><span class="health-tag pending">待补充</span></div><div class="retention-row"><span>Interaction 调用事实</span><span>MariaDB</span><span>当前接口未返回</span><span class="health-tag pending">待补充</span></div></div>
+              <div class="retention-list"><div class="retention-row head"><span>数据</span><span>热存储</span><span>保留口径</span><span>状态</span></div><div class="retention-row"><span>运行日志</span><span>OpenSearch</span><span>7 天 · 系统默认</span><span class="health-tag">正常</span></div><div class="retention-row"><span>审计日志</span><span>来源系统</span><span>365 天 · 系统默认</span><span class="health-tag">正常</span></div></div>
               <aside class="storage-card"><header><h3>归档存储</h3><span class="health-tag pending">状态未知</span></header><p>0.1.3 当前没有返回预配置对象存储及连接状态，原型不构造 Bucket 或连接成功信息。</p><dl><dt>目标名称</dt><dd>当前接口未返回</dd><dt>存储类型</dt><dd>预配置对象存储</dd><dt>最近检查</dt><dd>当前接口未返回</dd></dl></aside>
             </div>
           </section>

--- a/public/bkn-trace-0.1.4-prototype.test.mjs
+++ b/public/bkn-trace-0.1.4-prototype.test.mjs
@@ -134,3 +134,11 @@ test("可观测性设置按可落地的五段信息架构展示", () => {
   assert.doesNotMatch(html, /采样率/);
   assert.doesNotMatch(html, /只归档不清理/);
 });
+
+test("存储与保留不暴露无管理动作的内部 Trace 存储", () => {
+  assert.match(html, />运行日志</);
+  assert.match(html, />审计日志</);
+  assert.doesNotMatch(html, />Trace 查询索引</);
+  assert.doesNotMatch(html, />Interaction 调用事实</);
+  assert.match(html, /已结束交互轮次/);
+});

--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -187,7 +187,7 @@ export const bknTraceEnUS = {
 	  excludedOperationAuditSources: "{{count}} non-operation log source(s) are excluded from these business-module states and remain available in Trace.",
 	  sourceState: { partial_management_audit_coverage: "Some management operations are integrated; remaining operations are not yet audited.", source_health_check_failed: "Source health check failed. Verify service connectivity and the endpoint response.", source_not_configured: "Collection source is not configured.", source_not_requested: "The current account did not query source status.", source_query_failed: "Source status query failed.", source_timeout: "Source health check timed out." },
       status: { available: "Integrated", error: "Error", healthy: "Integrated", known: "Returned", not_integrated: "Not integrated", unavailable: "Unavailable", unconfigured: "Not integrated", unknown: "Not returned" },
-      storage: { archiveTarget: "Archive storage", archiveTargetUnavailable: "Object storage status API is not available", auditLogs: "Audit logs", defaultValue: "Current server value", interactionFacts: "Interaction call facts", interfaceMissing: "The 0.1.4 API does not return this item", runtimeLogs: "Runtime logs", traceIndex: "Trace query index" },
+      storage: { archiveTarget: "Archive storage", archiveTargetUnavailable: "Object storage status API is not available", auditLogs: "Audit logs", defaultValue: "Current server value", runtimeLogs: "Runtime logs" },
       storageRetention: "Storage and retention",
       title: "Observability Settings",
     },

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -187,7 +187,7 @@ export const bknTraceZhCN = {
 	  excludedOperationAuditSources: "{{count}} 个非操作日志来源不计入本页业务模块状态，由 Trace 负责查看。",
 	  sourceState: { partial_management_audit_coverage: "已接入部分管理操作；其余操作尚未纳入审计。", source_health_check_failed: "来源健康探测失败，请检查服务连通性和接口响应。", source_not_configured: "未配置采集来源。", source_not_requested: "当前账号未查询来源状态。", source_query_failed: "来源状态查询失败。", source_timeout: "来源探测超时。" },
       status: { available: "已接入", error: "异常", healthy: "已接入", known: "已返回", not_integrated: "未接入", unavailable: "不可用", unconfigured: "未接入", unknown: "接口未返回" },
-      storage: { archiveTarget: "归档存储", archiveTargetUnavailable: "对象存储状态接口尚未提供", auditLogs: "审计日志", defaultValue: "服务端当前返回值", interactionFacts: "Interaction 调用事实", interfaceMissing: "0.1.4 接口尚未返回该项", runtimeLogs: "运行日志", traceIndex: "Trace 查询索引" },
+      storage: { archiveTarget: "归档存储", archiveTargetUnavailable: "对象存储状态接口尚未提供", auditLogs: "审计日志", defaultValue: "服务端当前返回值", runtimeLogs: "运行日志" },
       storageRetention: "存储与保留",
       title: "可观测性设置",
     },

--- a/src/modules/bkn-trace/scenes/ObservabilitySettingsScene.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilitySettingsScene.tsx
@@ -101,8 +101,6 @@ export function ObservabilitySettingsScene() {
     return [
       { dataKind: t("bknTrace.settings.storage.runtimeLogs"), description: t("bknTrace.settings.storage.defaultValue"), key: "runtime", retention: retention("runtime.system"), status: retention("runtime.system") === undefined ? "unknown" : "known" },
       { dataKind: t("bknTrace.settings.storage.auditLogs"), description: t("bknTrace.settings.storage.defaultValue"), key: "audit", retention: retention("audit.admin"), status: retention("audit.admin") === undefined ? "unknown" : "known" },
-      { dataKind: t("bknTrace.settings.storage.traceIndex"), description: t("bknTrace.settings.storage.interfaceMissing"), key: "trace", status: "unknown" },
-      { dataKind: t("bknTrace.settings.storage.interactionFacts"), description: t("bknTrace.settings.storage.interfaceMissing"), key: "interaction", status: "unknown" },
     ];
   }, [policies, t]);
 

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -276,6 +276,15 @@ describe("observability workspace scenes", () => {
     expect(screen.getByText("bknTrace.settings.readOnlyNotice")).not.toBeNull();
   });
 
+  it("设置页只展示可维护的日志保留项，不暴露内部 Trace 存储", async () => {
+    render(<ObservabilitySettingsScene />);
+
+    expect(await screen.findByText("bknTrace.settings.storage.runtimeLogs")).not.toBeNull();
+    expect(screen.getByText("bknTrace.settings.storage.auditLogs")).not.toBeNull();
+    expect(screen.queryByText("bknTrace.settings.storage.traceIndex")).toBeNull();
+    expect(screen.queryByText("bknTrace.settings.storage.interactionFacts")).toBeNull();
+  });
+
   it("设置页将部分管理审计覆盖说明为可读状态", async () => {
     vi.mocked(listLogSources).mockResolvedValueOnce([{ coveredModules: ["data_resource_knowledge_network"], collectionMethod: "source_adapter", reason: "partial_management_audit_coverage", reliability: "best_effort", sourceId: "vega", status: "healthy" }]);
 


### PR DESCRIPTION
## Summary\n- Show only administratively actionable retention rows in Observability Settings.\n- Keep Trace query index and Interaction operation facts as internal capabilities used by Trace, Business Provenance, and archive packages.\n- Add prototype and scene regression coverage.\n\n## Validation\n- npm test -- --run public/bkn-trace-0.1.4-prototype.test.mjs src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx\n- npm run lint\n\nNote: full build is blocked locally by an existing missing json-bigint dependency in node_modules; dependency files were not changed.