### PR TITLE
fix(i18n): sync native datetime picker language

### DIFF
--- a/src/app/locales/i18n.test.ts
+++ b/src/app/locales/i18n.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import i18n from "@/app/locales/i18n";
+
+describe("document language synchronization", () => {
+  afterEach(async () => {
+    await i18n.changeLanguage("zh-CN");
+  });
+
+  it("keeps the document language aligned when the UI locale changes", async () => {
+    await i18n.changeLanguage("en-US");
+
+    expect(document.documentElement.lang).toBe("en-US");
+
+    await i18n.changeLanguage("zh-CN");
+
+    expect(document.documentElement.lang).toBe("zh-CN");
+  });
+});

--- a/src/app/locales/i18n.ts
+++ b/src/app/locales/i18n.ts
@@ -10,6 +10,7 @@ import { initReactI18next } from "react-i18next";
 
 import { enUS } from "@/app/locales/resources/en-US";
 import { zhCN } from "@/app/locales/resources/zh-CN";
+import { normalizeSupportedLocale, syncDocumentLanguage } from "@/framework/i18n/locale";
 
 void i18n.use(initReactI18next).init({
   lng: "zh-CN",
@@ -27,5 +28,11 @@ void i18n.use(initReactI18next).init({
   },
 });
 
-export default i18n;
+i18n.on("languageChanged", (language) => {
+  const locale = normalizeSupportedLocale(language);
+  if (locale) {
+    syncDocumentLanguage(locale);
+  }
+});
 
+export default i18n;

--- a/src/framework/i18n/locale.test.ts
+++ b/src/framework/i18n/locale.test.ts
@@ -91,4 +91,15 @@ describe("locale resolution", () => {
 
     expect(document.documentElement.lang).toBe("fr-FR");
   });
+
+  it("keeps a host language changed while Studio is mounted", () => {
+    document.documentElement.lang = "fr-FR";
+    const release = preserveDocumentLanguage();
+
+    syncDocumentLanguage("en-US");
+    document.documentElement.lang = "de-DE";
+    release();
+
+    expect(document.documentElement.lang).toBe("de-DE");
+  });
 });

--- a/src/framework/i18n/locale.test.ts
+++ b/src/framework/i18n/locale.test.ts
@@ -11,13 +11,22 @@ import {
   LOCALE_STORAGE_KEY,
   normalizeSupportedLocale,
   persistLocale,
+  preserveDocumentLanguage,
   readPersistedLocale,
   resolveSupportedLocale,
+  syncDocumentLanguage,
 } from "@/framework/i18n/locale";
+
+const initialDocumentLanguage = document.documentElement.getAttribute("lang");
 
 describe("locale resolution", () => {
   afterEach(() => {
     window.localStorage.removeItem(LOCALE_STORAGE_KEY);
+    if (initialDocumentLanguage === null) {
+      document.documentElement.removeAttribute("lang");
+      return;
+    }
+    document.documentElement.lang = initialDocumentLanguage;
   });
 
   it("normalizes supported locale aliases", () => {
@@ -66,5 +75,20 @@ describe("locale resolution", () => {
         runtimeLocale: "fr-FR",
       }),
     ).toBe("zh-CN");
+  });
+
+  it("restores the host document language after the last mounted app unmounts", () => {
+    document.documentElement.lang = "fr-FR";
+    const releaseFirst = preserveDocumentLanguage();
+    const releaseSecond = preserveDocumentLanguage();
+
+    syncDocumentLanguage("en-US");
+    releaseFirst();
+
+    expect(document.documentElement.lang).toBe("en-US");
+
+    releaseSecond();
+
+    expect(document.documentElement.lang).toBe("fr-FR");
   });
 });

--- a/src/framework/i18n/locale.ts
+++ b/src/framework/i18n/locale.ts
@@ -76,6 +76,14 @@ export function persistLocale(locale: SupportedLocale) {
   window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
 }
 
+export function syncDocumentLanguage(locale: SupportedLocale) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.lang = locale;
+}
+
 function firstSupportedLocale(locales: readonly string[]) {
   for (const locale of locales) {
     const normalized = normalizeSupportedLocale(locale);

--- a/src/framework/i18n/locale.ts
+++ b/src/framework/i18n/locale.ts
@@ -17,6 +17,9 @@ export const LOCALE_STORAGE_KEY = "bkn-studio:locale";
 
 const supportedLocaleSet = new Set<string>(SUPPORTED_LOCALES);
 
+let activeDocumentLanguageSyncs = 0;
+let restoreDocumentLanguage: (() => void) | undefined;
+
 export type LocaleResolutionInput = {
   browserLanguages?: readonly string[];
   deploymentDefaultLocale?: SupportedLocale;
@@ -82,6 +85,37 @@ export function syncDocumentLanguage(locale: SupportedLocale) {
   }
 
   document.documentElement.lang = locale;
+}
+
+export function preserveDocumentLanguage() {
+  if (typeof document === "undefined") {
+    return () => undefined;
+  }
+
+  if (activeDocumentLanguageSyncs === 0) {
+    const originalLanguage = document.documentElement.getAttribute("lang");
+    restoreDocumentLanguage = () => {
+      if (originalLanguage === null) {
+        document.documentElement.removeAttribute("lang");
+        return;
+      }
+      document.documentElement.lang = originalLanguage;
+    };
+  }
+  activeDocumentLanguageSyncs += 1;
+
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    activeDocumentLanguageSyncs -= 1;
+    if (activeDocumentLanguageSyncs === 0) {
+      restoreDocumentLanguage?.();
+      restoreDocumentLanguage = undefined;
+    }
+  };
 }
 
 function firstSupportedLocale(locales: readonly string[]) {

--- a/src/framework/i18n/locale.ts
+++ b/src/framework/i18n/locale.ts
@@ -19,6 +19,7 @@ const supportedLocaleSet = new Set<string>(SUPPORTED_LOCALES);
 
 let activeDocumentLanguageSyncs = 0;
 let restoreDocumentLanguage: (() => void) | undefined;
+let synchronizedDocumentLanguage: string | undefined;
 
 export type LocaleResolutionInput = {
   browserLanguages?: readonly string[];
@@ -85,6 +86,7 @@ export function syncDocumentLanguage(locale: SupportedLocale) {
   }
 
   document.documentElement.lang = locale;
+  synchronizedDocumentLanguage = locale;
 }
 
 export function preserveDocumentLanguage() {
@@ -112,8 +114,11 @@ export function preserveDocumentLanguage() {
     released = true;
     activeDocumentLanguageSyncs -= 1;
     if (activeDocumentLanguageSyncs === 0) {
-      restoreDocumentLanguage?.();
+      if (document.documentElement.lang === synchronizedDocumentLanguage) {
+        restoreDocumentLanguage?.();
+      }
       restoreDocumentLanguage = undefined;
+      synchronizedDocumentLanguage = undefined;
     }
   };
 }

--- a/src/framework/runtime/bootstrap.tsx
+++ b/src/framework/runtime/bootstrap.tsx
@@ -11,6 +11,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "@/app/App";
 import i18n from "@/app/locales/i18n";
 import { subscribeAuthBroadcast } from "@/framework/auth/token-store";
+import { preserveDocumentLanguage } from "@/framework/i18n/locale";
 import {
   createRuntimeConfig,
   readWindowRuntimeInput,
@@ -18,7 +19,12 @@ import {
 } from "@/framework/runtime/config";
 import type { RuntimeInput } from "@/framework/runtime/types";
 
-const roots = new WeakMap<Element, ReturnType<typeof createRoot>>();
+type MountedRoot = {
+  releaseDocumentLanguage: () => void;
+  root: ReturnType<typeof createRoot>;
+};
+
+const roots = new WeakMap<Element, MountedRoot>();
 
 let authBroadcastUnsub: (() => void) | undefined;
 
@@ -36,12 +42,12 @@ export function mountApp(container: Element, runtimeInput: RuntimeInput = {}) {
   ensureAuthBroadcastListener();
   const runtimeConfig = createRuntimeConfig(runtimeInput);
   setRuntimeConfig(runtimeConfig);
-  void i18n.changeLanguage(runtimeConfig.locale);
 
   const existingRoot = roots.get(container);
 
   if (existingRoot) {
-    existingRoot.render(
+    void i18n.changeLanguage(runtimeConfig.locale);
+    existingRoot.root.render(
       <StrictMode>
         <App runtimeConfig={runtimeConfig} />
       </StrictMode>,
@@ -49,8 +55,10 @@ export function mountApp(container: Element, runtimeInput: RuntimeInput = {}) {
     return;
   }
 
+  const releaseDocumentLanguage = preserveDocumentLanguage();
   const root = createRoot(container);
-  roots.set(container, root);
+  roots.set(container, { releaseDocumentLanguage, root });
+  void i18n.changeLanguage(runtimeConfig.locale);
   root.render(
     <StrictMode>
       <App runtimeConfig={runtimeConfig} />
@@ -59,13 +67,14 @@ export function mountApp(container: Element, runtimeInput: RuntimeInput = {}) {
 }
 
 export function unmountApp(container: Element) {
-  const root = roots.get(container);
+  const mountedRoot = roots.get(container);
 
-  if (!root) {
+  if (!mountedRoot) {
     return;
   }
 
-  root.unmount();
+  mountedRoot.root.unmount();
+  mountedRoot.releaseDocumentLanguage();
   roots.delete(container);
 }
 
@@ -85,4 +94,3 @@ export function startStandaloneApp() {
     mode: runtimeInput.mode ?? "standalone",
   });
 }
-

--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -332,7 +332,6 @@ export function CatalogDetailPanel({
       dataIndex: "columnCount",
       title: t("dataCatalog.resource.fieldCount"),
       width: 88,
-      sorter: (left, right) => (left.columnCount ?? 0) - (right.columnCount ?? 0),
       render: (value: number | null) =>
         value !== null && value > 0 ? (
           <span className={styles.monoText}>{value}</span>
@@ -344,7 +343,6 @@ export function CatalogDetailPanel({
       dataIndex: "rowCount",
       title: t("dataCatalog.resource.rowCount"),
       width: 112,
-      sorter: (left, right) => (left.rowCount ?? 0) - (right.rowCount ?? 0),
       render: (value: number) =>
         value > 0 ? <span className={styles.monoText}>{formatRowCount(value)}</span> : "—",
     },


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Synchronize `<html lang>` with the active i18n locale.
- [x] Preserve a host page’s original language and restore it once the final mounted Studio app unmounts.
- [x] Remove client-side sorting from resource field-count and row-count columns, which only affected the current server page.
- [x] Add regression coverage for Chinese/English synchronization and multi-mount host-language restoration.

---

## Why

- Related Issue: Closes #444
- Related Feature: N/A
- Background: Native `datetime-local` controls use the document language in supported browsers, while the app previously left `<html lang>` fixed at `zh-CN`. The resource-count columns also exposed misleading page-local sorting.

---

## How

- Key implementation points: Subscribe once to i18next `languageChanged`, normalize to a supported locale, and update `document.documentElement.lang`. Mount lifecycle ownership preserves the host’s original language until the last Studio root unmounts.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; no backend integration changed)
- [ ] Verified in test environment (not run locally)

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` (reports one ignored high-severity dependency finding)

---

## Risk & Rollback

- Potential risks: Native control presentation remains browser/OS-specific; the change only provides the correct document language hint.
- Rollback plan: Revert commits `a55ec24` and `53db65d`.

---

## Additional Notes

- Please manually verify Start Time and End Time native date-time pickers in Windows Edge after toggling English and Chinese.
