### PR TITLE
feat(i18n): propagate locale through login

### DIFF
--- a/src/framework/auth/OAuthCallback.test.tsx
+++ b/src/framework/auth/OAuthCallback.test.tsx
@@ -25,7 +25,13 @@ vi.mock("@/framework/auth/oauth", () => oauth);
 
 vi.mock("react-i18next", async (importOriginal) => {
   const original = await importOriginal<typeof import("react-i18next")>();
-  return { ...original, useTranslation: () => ({ t: (key: string) => key }) };
+  return {
+    ...original,
+    useTranslation: () => ({
+      i18n: { language: "zh-CN", resolvedLanguage: "zh-CN" },
+      t: (key: string) => key,
+    }),
+  };
 });
 
 vi.mock("@/app/router/app-paths", () => ({
@@ -59,7 +65,7 @@ describe("OAuthCallback CSRF recovery wiring", () => {
 
     render(<OAuthCallback />);
 
-    expect(oauth.beginLogin).toHaveBeenCalledWith("/studio/knowledge-network");
+    expect(oauth.beginLogin).toHaveBeenCalledWith("/studio/knowledge-network", "zh-CN");
     expect(oauth.completeLogin).not.toHaveBeenCalled();
     expect(oauth.stashCallbackError).toHaveBeenCalledTimes(1);
   });

--- a/src/framework/auth/OAuthCallback.tsx
+++ b/src/framework/auth/OAuthCallback.tsx
@@ -25,7 +25,8 @@ import { AppButton } from "@/framework/ui/common/AppButton";
 import styles from "./SignInScreen.module.css";
 
 export function OAuthCallback() {
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
+  const loginLocale = i18n.resolvedLanguage ?? i18n.language;
   const [error, setError] = useState<string | null>(null);
   const startedRef = useRef(false);
 
@@ -51,7 +52,7 @@ export function OAuthCallback() {
 
     if (isCsrfConflictCallback() && consumeCsrfRetry()) {
       stashCallbackError();
-      beginLogin(getStoredReturnTo()).catch(fail);
+      beginLogin(getStoredReturnTo(), loginLocale).catch(fail);
       return;
     }
 
@@ -60,7 +61,7 @@ export function OAuthCallback() {
         window.location.replace(returnTo);
       })
       .catch(fail);
-  }, []);
+  }, [loginLocale]);
 
   return (
     <div className={styles.page}>

--- a/src/framework/auth/SignInScreen.test.tsx
+++ b/src/framework/auth/SignInScreen.test.tsx
@@ -33,7 +33,13 @@ vi.mock("@/framework/auth/oauth", () => oauth);
 
 vi.mock("react-i18next", async (importOriginal) => {
   const original = await importOriginal<typeof import("react-i18next")>();
-  return { ...original, useTranslation: () => ({ t: (key: string) => key }) };
+  return {
+    ...original,
+    useTranslation: () => ({
+      i18n: { language: "zh-CN", resolvedLanguage: "zh-CN" },
+      t: (key: string) => key,
+    }),
+  };
 });
 
 /** jsdom reports "visible" by default; override per test. */
@@ -56,6 +62,7 @@ describe("SignInScreen auto-redirect gating", () => {
     render(<SignInScreen onDevTokenSaved={vi.fn()} />);
 
     expect(oauth.beginLogin).toHaveBeenCalledTimes(1);
+    expect(oauth.beginLogin).toHaveBeenCalledWith(expect.any(String), "zh-CN");
   });
 
   // A background tab redirecting would rewrite the browser's single login CSRF

--- a/src/framework/auth/SignInScreen.tsx
+++ b/src/framework/auth/SignInScreen.tsx
@@ -25,7 +25,8 @@ type SignInScreenProps = {
 };
 
 export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
+  const loginLocale = i18n.resolvedLanguage ?? i18n.language;
   const startedRef = useRef(false);
   const [redirecting, setRedirecting] = useState(true);
   const [redirectError, setRedirectError] = useState<string | null>(null);
@@ -54,7 +55,7 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
       setRedirecting(true);
       const { hash, pathname, search } = window.location;
 
-      beginLogin(`${pathname}${search}${hash}`).catch((cause: unknown) => {
+      beginLogin(`${pathname}${search}${hash}`, loginLocale).catch((cause: unknown) => {
         setRedirectError(cause instanceof Error ? cause.message : String(cause));
         setRedirecting(false);
         startedRef.current = false;
@@ -80,7 +81,7 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
       document.removeEventListener("visibilitychange", retry);
       unsubscribe();
     };
-  }, [showDevTokenForm]);
+  }, [loginLocale, showDevTokenForm]);
 
   if (showDevTokenForm) {
     return <DevTokenSetupForm onSaved={onDevTokenSaved} />;
@@ -94,7 +95,7 @@ export function SignInScreen({ onDevTokenSaved }: SignInScreenProps) {
     setRedirectError(null);
     setDeferredToOtherTab(false);
     const { hash, pathname, search } = window.location;
-    void beginLogin(`${pathname}${search}${hash}`).catch((cause: unknown) => {
+    void beginLogin(`${pathname}${search}${hash}`, loginLocale).catch((cause: unknown) => {
       setRedirectError(cause instanceof Error ? cause.message : String(cause));
       setRedirecting(false);
       startedRef.current = false;

--- a/src/framework/auth/oauth.test.ts
+++ b/src/framework/auth/oauth.test.ts
@@ -9,7 +9,10 @@ import { webcrypto } from "node:crypto";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { LOCALE_COOKIE_NAME } from "@/framework/i18n/locale";
+
 import {
+  buildAuthorizationRequestURL,
   canAutoStartLogin,
   completeLogin,
   computeCodeChallenge,
@@ -50,6 +53,30 @@ describe("oauth", () => {
     await expect(
       computeCodeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"),
     ).resolves.toBe("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+  });
+
+  it("sends the normalized Studio locale through OIDC ui_locales", () => {
+    const authorizationURL = new URL(
+      buildAuthorizationRequestURL("challenge-1", "state-1", "en-GB"),
+      window.location.origin,
+    );
+
+    expect(authorizationURL.pathname).toBe("/oauth2/auth");
+    expect(authorizationURL.searchParams.get("client_id")).toBe("openbkn-studio");
+    expect(authorizationURL.searchParams.get("code_challenge")).toBe("challenge-1");
+    expect(authorizationURL.searchParams.get("state")).toBe("state-1");
+    expect(authorizationURL.searchParams.get("ui_locales")).toBe("en-US");
+  });
+
+  it("uses the shared login preference when no locale is passed explicitly", () => {
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/`;
+
+    const authorizationURL = new URL(
+      buildAuthorizationRequestURL("challenge-1", "state-1"),
+      window.location.origin,
+    );
+
+    expect(authorizationURL.searchParams.get("ui_locales")).toBe("en-US");
   });
 
   it("rejects the callback when the state does not match", async () => {

--- a/src/framework/auth/oauth.ts
+++ b/src/framework/auth/oauth.ts
@@ -7,6 +7,10 @@
 import CryptoJS from "crypto-js";
 import { getAppCallbackPath, getAppHomePath } from "@/app/router/app-paths";
 import { getDevRefreshToken } from "@/framework/auth/dev-auth";
+import {
+  normalizeSupportedLocale,
+  resolveSupportedLocale,
+} from "@/framework/i18n/locale";
 import { getRuntimeConfig } from "@/framework/runtime/config";
 import {
   clearStoredTokens,
@@ -293,7 +297,28 @@ export function getStoredReturnTo() {
   return window.sessionStorage.getItem(RETURN_TO_KEY) ?? undefined;
 }
 
-export async function beginLogin(returnTo?: string) {
+export function buildAuthorizationRequestURL(
+  codeChallenge: string,
+  state: string,
+  requestedLocale?: string | null,
+) {
+  const locale = normalizeSupportedLocale(requestedLocale) ?? resolveSupportedLocale();
+  const params = new URLSearchParams({
+    audience: OAUTH_AUDIENCE,
+    client_id: OAUTH_CLIENT_ID,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    redirect_uri: redirectUri(),
+    response_type: "code",
+    scope: OAUTH_SCOPE,
+    state,
+    ui_locales: locale,
+  });
+
+  return `${gatewayOrigin()}${AUTHORIZE_PATH}?${params.toString()}`;
+}
+
+export async function beginLogin(returnTo?: string, requestedLocale?: string | null) {
   const verifier = randomUrlSafeString();
   const state = randomUrlSafeString();
 
@@ -305,21 +330,16 @@ export async function beginLogin(returnTo?: string) {
     window.sessionStorage.removeItem(RETURN_TO_KEY);
   }
 
-  const params = new URLSearchParams({
-    audience: OAUTH_AUDIENCE,
-    client_id: OAUTH_CLIENT_ID,
-    code_challenge: await computeCodeChallenge(verifier),
-    code_challenge_method: "S256",
-    redirect_uri: redirectUri(),
-    response_type: "code",
-    scope: OAUTH_SCOPE,
+  const authorizationURL = buildAuthorizationRequestURL(
+    await computeCodeChallenge(verifier),
     state,
-  });
+    requestedLocale,
+  );
 
   // Claim the browser's login CSRF cookie before navigating; other tabs stop
   // auto-redirecting until this flow finishes or the lock ages out.
   writeFlowLock();
-  window.location.assign(`${gatewayOrigin()}${AUTHORIZE_PATH}?${params.toString()}`);
+  window.location.assign(authorizationURL);
 }
 
 async function requestToken(body: URLSearchParams): Promise<TokenResponse> {

--- a/src/framework/i18n/locale.test.ts
+++ b/src/framework/i18n/locale.test.ts
@@ -8,10 +8,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  LOCALE_COOKIE_NAME,
   LOCALE_STORAGE_KEY,
   normalizeSupportedLocale,
   persistLocale,
   preserveDocumentLanguage,
+  readLocaleCookie,
   readPersistedLocale,
   resolveSupportedLocale,
   syncDocumentLanguage,
@@ -22,11 +24,12 @@ const initialDocumentLanguage = document.documentElement.getAttribute("lang");
 describe("locale resolution", () => {
   afterEach(() => {
     window.localStorage.removeItem(LOCALE_STORAGE_KEY);
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
     if (initialDocumentLanguage === null) {
       document.documentElement.removeAttribute("lang");
-      return;
+    } else {
+      document.documentElement.lang = initialDocumentLanguage;
     }
-    document.documentElement.lang = initialDocumentLanguage;
   });
 
   it("normalizes supported locale aliases", () => {
@@ -56,15 +59,38 @@ describe("locale resolution", () => {
     ).toBe("zh-CN");
   });
 
+  it("uses the shared login locale cookie before Studio local storage", () => {
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/`;
+
+    expect(
+      resolveSupportedLocale({
+        browserLanguages: ["zh-CN"],
+        persistedLocale: "zh-CN",
+      }),
+    ).toBe("en-US");
+  });
+
   it("persists the selected locale for future app starts", () => {
     persistLocale("en-US");
 
     expect(readPersistedLocale()).toBe("en-US");
+    expect(readLocaleCookie()).toBe("en-US");
     expect(
       resolveSupportedLocale({
         browserLanguages: ["zh-CN"],
       }),
     ).toBe("en-US");
+  });
+
+  it("ignores an unsupported shared login locale cookie", () => {
+    document.cookie = `${LOCALE_COOKIE_NAME}=fr-FR; Path=/`;
+
+    expect(
+      resolveSupportedLocale({
+        browserLanguages: ["zh-CN"],
+        persistedLocale: null,
+      }),
+    ).toBe("zh-CN");
   });
 
   it("falls back to deployment default when no requested locale is supported", () => {

--- a/src/framework/i18n/locale.ts
+++ b/src/framework/i18n/locale.ts
@@ -15,6 +15,10 @@ export const DEPLOYMENT_DEFAULT_LOCALE: SupportedLocale = "zh-CN";
 
 export const LOCALE_STORAGE_KEY = "bkn-studio:locale";
 
+export const LOCALE_COOKIE_NAME = "openbkn_locale";
+
+const LOCALE_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
+
 const supportedLocaleSet = new Set<string>(SUPPORTED_LOCALES);
 
 let activeDocumentLanguageSyncs = 0;
@@ -23,6 +27,7 @@ let synchronizedDocumentLanguage: string | undefined;
 
 export type LocaleResolutionInput = {
   browserLanguages?: readonly string[];
+  cookieLocale?: string | null;
   deploymentDefaultLocale?: SupportedLocale;
   persistedLocale?: string | null;
   runtimeLocale?: string | null;
@@ -51,12 +56,14 @@ export function normalizeSupportedLocale(locale: string | null | undefined): Sup
 
 export function resolveSupportedLocale({
   browserLanguages = readBrowserLanguages(),
+  cookieLocale = readLocaleCookie(),
   deploymentDefaultLocale = DEPLOYMENT_DEFAULT_LOCALE,
   persistedLocale = readPersistedLocale(),
   runtimeLocale,
 }: LocaleResolutionInput = {}): SupportedLocale {
   return (
     normalizeSupportedLocale(runtimeLocale) ??
+    normalizeSupportedLocale(cookieLocale) ??
     normalizeSupportedLocale(persistedLocale) ??
     firstSupportedLocale(browserLanguages) ??
     deploymentDefaultLocale ??
@@ -72,12 +79,34 @@ export function readPersistedLocale(): string | null {
   return window.localStorage.getItem(LOCALE_STORAGE_KEY);
 }
 
+export function readLocaleCookie(): string | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  for (const item of document.cookie.split(";")) {
+    const [rawName, ...rawValue] = item.trim().split("=");
+    if (rawName !== LOCALE_COOKIE_NAME) {
+      continue;
+    }
+    const value = rawValue.join("=");
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+  return null;
+}
+
 export function persistLocale(locale: SupportedLocale) {
   if (typeof window === "undefined") {
     return;
   }
 
   window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  document.cookie = `${LOCALE_COOKIE_NAME}=${encodeURIComponent(locale)}; Path=/; Max-Age=${LOCALE_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
 }
 
 export function syncDocumentLanguage(locale: SupportedLocale) {


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Persist the selected Studio locale in the shared `openbkn_locale` cookie while retaining localStorage as a fallback.
- [x] Send the normalized locale through the standard OIDC `ui_locales` authorization parameter.
- [x] Cover the login entry points, OAuth URL generation, locale precedence, and persistence behavior with tests.

---

## Why

- Related Issue: [openbkn-ai/bkn-foundry#994](https://github.com/openbkn-ai/bkn-foundry/issues/994)
- Related Feature: Localized Studio and BKN Safe login flow
- Background: The Studio shell supports Chinese and English, but the server-rendered BKN Safe login flow previously could not inherit or return the selected locale.

---

## How

- Key implementation points: Resolve the active Studio locale at each login entry point, add it to the authorization request as `ui_locales`, and share explicit locale choices through a same-origin, one-year `SameSite=Lax` cookie.
- Breaking changes (API, config, database, etc.): None. The new OIDC parameter and cookie are optional and backward compatible.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; this change has no standalone integration-test target.
- [ ] Verified in test environment — pending validation of the final images.

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run` (208 files, 1,094 tests)
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` (one existing ignored high-severity advisory)

---

## Risk & Rollback

- Potential risks: A stale or malformed locale cookie could influence presentation. Values are normalized to the supported `zh-CN` / `en-US` allowlist before use.
- Rollback plan: Revert this commit; Studio will return to localStorage/browser-language resolution and omit `ui_locales`.

---

## Additional Notes

- Companion backend PR: [openbkn-ai/bkn-foundry#1045](https://github.com/openbkn-ai/bkn-foundry/pull/1045)
- This PR does not change authentication, token exchange, or authorization decisions.
