### PR TITLE
fix(i18n): persist login-selected locale

### DIFF
--- a/src/framework/runtime/bootstrap.test.tsx
+++ b/src/framework/runtime/bootstrap.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LOCALE_COOKIE_NAME,
+  LOCALE_STORAGE_KEY,
+} from "@/framework/i18n/locale";
+import { startStandaloneApp } from "@/framework/runtime/bootstrap";
+
+vi.mock("react-dom/client", () => ({
+  createRoot: vi.fn(() => ({
+    render: vi.fn(),
+    unmount: vi.fn(),
+  })),
+}));
+
+vi.mock("@/app/App", () => ({
+  App: () => null,
+}));
+
+vi.mock("@/app/locales/i18n", () => ({
+  default: {
+    changeLanguage: vi.fn(),
+    on: vi.fn(),
+    use: vi.fn(() => ({
+      init: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock("@/framework/auth/token-store", () => ({
+  subscribeAuthBroadcast: vi.fn(() => () => undefined),
+}));
+
+describe("standalone bootstrap locale persistence", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+    window.localStorage.clear();
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
+    delete window.__BKN_STUDIO_RUNTIME__;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    window.localStorage.clear();
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
+    delete window.__BKN_STUDIO_RUNTIME__;
+  });
+
+  it("persists the login-page cookie locale over an older Studio preference", () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, "en-US");
+    document.cookie = `${LOCALE_COOKIE_NAME}=zh-CN; Path=/`;
+
+    startStandaloneApp();
+
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("zh-CN");
+  });
+
+  it("does not persist locale for hosted runtime mode", () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, "en-US");
+    document.cookie = `${LOCALE_COOKIE_NAME}=zh-CN; Path=/`;
+    window.__BKN_STUDIO_RUNTIME__ = { mode: "hosted" };
+
+    startStandaloneApp();
+
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("en-US");
+  });
+});

--- a/src/framework/runtime/bootstrap.tsx
+++ b/src/framework/runtime/bootstrap.tsx
@@ -11,7 +11,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "@/app/App";
 import i18n from "@/app/locales/i18n";
 import { subscribeAuthBroadcast } from "@/framework/auth/token-store";
-import { preserveDocumentLanguage } from "@/framework/i18n/locale";
+import { persistLocale, preserveDocumentLanguage } from "@/framework/i18n/locale";
 import {
   createRuntimeConfig,
   readWindowRuntimeInput,
@@ -42,6 +42,13 @@ export function mountApp(container: Element, runtimeInput: RuntimeInput = {}) {
   ensureAuthBroadcastListener();
   const runtimeConfig = createRuntimeConfig(runtimeInput);
   setRuntimeConfig(runtimeConfig);
+  if (runtimeConfig.mode === "standalone") {
+    // Standalone Studio shares the auth locale cookie with bkn-safe. Persist
+    // the resolved startup locale back into Studio's own preference store so a
+    // login-page switch wins over an older in-app language selection after the
+    // OAuth callback lands back in the SPA.
+    persistLocale(runtimeConfig.locale);
+  }
 
   const existingRoot = roots.get(container);
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Persist the resolved standalone startup locale back to Studio local storage.
- [x] Add regression coverage for login-page locale cookies overriding an older Studio preference.
- [x] Preserve hosted runtime behavior by avoiding local preference writes in hosted mode.

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#994
- Related PR: openbkn-ai/bkn-studio#465
- Background: after signing in with English, signing out, switching the bkn-safe login page to Chinese, and signing in again, Studio could still render in English because the previous in-app locale preference remained in localStorage.

---

## How

- Key implementation points:
  - Standalone bootstrap resolves the locale using the existing priority chain.
  - The resolved standalone locale is persisted via `persistLocale`, synchronizing the shared `openbkn_locale` cookie and Studio `bkn-studio:locale` localStorage value.
  - Hosted runtime mode is excluded so embedded deployments keep host-controlled locale behavior.
- Breaking changes (API, config, database, etc.): none.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; no integration suite for this startup preference sync.
- [ ] Verified in test environment — pending rebuilt image deployment.

Test notes:

- `pnpm exec vitest --run src/framework/runtime/bootstrap.test.tsx src/framework/i18n/locale.test.ts src/framework/runtime/config.test.ts`
- `pnpm exec eslint src/framework/runtime/bootstrap.tsx src/framework/runtime/bootstrap.test.tsx --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vitest --run --maxWorkers=1 --minWorkers=1`
- `pnpm exec vite build`
- `pnpm audit --prod` exited successfully with the existing ignored high vulnerability.

---

## Risk & Rollback

- Potential risks: standalone startup now refreshes the locale preference cookie/localStorage from the resolved locale; hosted mode is intentionally unchanged.
- Rollback plan: revert this PR to restore the previous startup persistence behavior.

---

## Additional Notes

- This is a follow-up fix after PR #465 was merged, so it is opened as a separate PR from a clean branch based on current `main`.
