### PR TITLE
Fix login locale cookie precedence

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,7 +13,10 @@ import { AppProviders } from "@/app/providers/AppProviders";
 import { createAppRouter } from "@/app/router/create-router";
 import { AuthGate } from "@/framework/auth/AuthGate";
 import { EntitlementProvider } from "@/framework/entitlement/EntitlementProvider";
-import { persistLocale } from "@/framework/i18n/locale";
+import {
+  persistLocale,
+  resolveAuthenticatedStandaloneLocale,
+} from "@/framework/i18n/locale";
 import { setRuntimeConfig } from "@/framework/runtime/config";
 import type { RuntimeConfig, RuntimeUser, SupportedLocale } from "@/framework/runtime/types";
 
@@ -29,7 +32,12 @@ export function App({ runtimeConfig }: AppProps) {
   // permissions), and update global runtimeConfig read by HTTP interceptors and other consumers.
   const handleCurrentUser = useCallback((currentUser: RuntimeUser) => {
     setConfig((previous) => {
-      const next = { ...previous, currentUser };
+      const locale = resolveAuthenticatedStandaloneLocale(previous.locale, previous.mode);
+      if (locale !== previous.locale) {
+        persistLocale(locale);
+        void i18n.changeLanguage(locale);
+      }
+      const next = { ...previous, currentUser, locale };
       setRuntimeConfig(next);
       return next;
     });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -32,7 +32,11 @@ export function App({ runtimeConfig }: AppProps) {
   // permissions), and update global runtimeConfig read by HTTP interceptors and other consumers.
   const handleCurrentUser = useCallback((currentUser: RuntimeUser) => {
     setConfig((previous) => {
-      const locale = resolveAuthenticatedStandaloneLocale(previous.locale, previous.mode);
+      const locale = resolveAuthenticatedStandaloneLocale(
+        previous.locale,
+        previous.mode,
+        previous.router.basename,
+      );
       if (locale !== previous.locale) {
         persistLocale(locale);
         void i18n.changeLanguage(locale);

--- a/src/framework/i18n/locale.test.ts
+++ b/src/framework/i18n/locale.test.ts
@@ -17,6 +17,7 @@ import {
   readLocaleCookie,
   readLocaleCookieValue,
   readPersistedLocale,
+  resolveAuthenticatedStandaloneLocale,
   resolveSupportedLocale,
   syncDocumentLanguage,
 } from "@/framework/i18n/locale";
@@ -74,6 +75,19 @@ describe("locale resolution", () => {
         persistedLocale: "zh-CN",
       }),
     ).toBe("en-US");
+  });
+
+  it("re-syncs the login-page locale after a standalone login returns to an already mounted app", () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, "zh-CN");
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/`;
+
+    expect(resolveAuthenticatedStandaloneLocale("zh-CN", "standalone")).toBe("en-US");
+  });
+
+  it("keeps hosted runtime locale isolated from the standalone login-page cookie", () => {
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/`;
+
+    expect(resolveAuthenticatedStandaloneLocale("zh-CN", "hosted")).toBe("zh-CN");
   });
 
   it("uses the last repeated login locale cookie value", () => {

--- a/src/framework/i18n/locale.test.ts
+++ b/src/framework/i18n/locale.test.ts
@@ -31,6 +31,7 @@ describe("locale resolution", () => {
     window.localStorage.removeItem(LOCALE_STORAGE_KEY);
     document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
     document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/studio; Max-Age=0`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/studio/; Max-Age=0`;
     window.history.replaceState(null, "", initialLocation);
     if (initialDocumentLanguage === null) {
       document.documentElement.removeAttribute("lang");
@@ -77,11 +78,14 @@ describe("locale resolution", () => {
     ).toBe("en-US");
   });
 
-  it("re-syncs the login-page locale after a standalone login returns to an already mounted app", () => {
-    window.localStorage.setItem(LOCALE_STORAGE_KEY, "zh-CN");
-    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/`;
+  it("re-syncs the root login-page locale after a standalone login returns to an already mounted app", () => {
+    window.history.replaceState(null, "", "/studio/callback");
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, "en-US");
+    document.cookie = `${LOCALE_COOKIE_NAME}=zh-CN; Path=/`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/studio/`;
 
-    expect(resolveAuthenticatedStandaloneLocale("zh-CN", "standalone")).toBe("en-US");
+    expect(resolveAuthenticatedStandaloneLocale("en-US", "standalone", "/studio/")).toBe("zh-CN");
+    expect(readLocaleCookie()).toBe("zh-CN");
   });
 
   it("keeps hosted runtime locale isolated from the standalone login-page cookie", () => {
@@ -130,6 +134,30 @@ describe("locale resolution", () => {
     document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
 
     expect(readLocaleCookie()).toBeNull();
+  });
+
+  it("clears trailing-slash legacy path-scoped cookies while keeping the root login locale cookie", () => {
+    window.history.replaceState(null, "", "/studio/callback");
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/studio/`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=zh-CN; Path=/`;
+
+    clearLegacyLocaleCookies("/studio/");
+
+    expect(readLocaleCookie()).toBe("zh-CN");
+  });
+
+  it("emits both normalized and trailing-slash legacy cookie deletions", () => {
+    const cookieSetter = vi.spyOn(Document.prototype, "cookie", "set");
+
+    clearLegacyLocaleCookies("studio/");
+
+    const writes = cookieSetter.mock.calls.map(([value]) => value);
+    expect(writes.some((value) => value.includes(`${LOCALE_COOKIE_NAME}=; Path=/studio;`))).toBe(
+      true,
+    );
+    expect(writes.some((value) => value.includes(`${LOCALE_COOKIE_NAME}=; Path=/studio/;`))).toBe(
+      true,
+    );
   });
 
   it("does not delete the root locale cookie when legacy paths normalize to root", () => {

--- a/src/framework/i18n/locale.test.ts
+++ b/src/framework/i18n/locale.test.ts
@@ -5,9 +5,10 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  clearLegacyLocaleCookies,
   LOCALE_COOKIE_NAME,
   LOCALE_STORAGE_KEY,
   normalizeSupportedLocale,
@@ -21,11 +22,15 @@ import {
 } from "@/framework/i18n/locale";
 
 const initialDocumentLanguage = document.documentElement.getAttribute("lang");
+const initialLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
 
 describe("locale resolution", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     window.localStorage.removeItem(LOCALE_STORAGE_KEY);
     document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/studio; Max-Age=0`;
+    window.history.replaceState(null, "", initialLocation);
     if (initialDocumentLanguage === null) {
       document.documentElement.removeAttribute("lang");
     } else {
@@ -87,6 +92,39 @@ describe("locale resolution", () => {
         browserLanguages: ["zh-CN"],
       }),
     ).toBe("en-US");
+  });
+
+  it("does not clear legacy path-scoped cookies when persisting an in-app locale change", () => {
+    const cookieSetter = vi.spyOn(Document.prototype, "cookie", "set");
+
+    persistLocale("en-US");
+
+    expect(cookieSetter).toHaveBeenCalledTimes(1);
+    expect(cookieSetter.mock.calls[0]?.[0]).toContain(`${LOCALE_COOKIE_NAME}=en-US; Path=/;`);
+    expect(cookieSetter.mock.calls.some(([value]) => value.includes("Max-Age=0"))).toBe(false);
+  });
+
+  it("clears normalized legacy path-scoped cookies while keeping the root login locale cookie", () => {
+    window.history.replaceState(null, "", "/studio/callback");
+    document.cookie = `${LOCALE_COOKIE_NAME}=zh-CN; Path=/studio`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/`;
+
+    clearLegacyLocaleCookies("studio/");
+
+    expect(readLocaleCookie()).toBe("en-US");
+
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
+
+    expect(readLocaleCookie()).toBeNull();
+  });
+
+  it("does not delete the root locale cookie when legacy paths normalize to root", () => {
+    window.history.replaceState(null, "", "/studio");
+    const cookieSetter = vi.spyOn(Document.prototype, "cookie", "set");
+
+    clearLegacyLocaleCookies("/");
+
+    expect(cookieSetter).not.toHaveBeenCalled();
   });
 
   it("ignores an unsupported shared login locale cookie", () => {

--- a/src/framework/i18n/locale.test.ts
+++ b/src/framework/i18n/locale.test.ts
@@ -14,6 +14,7 @@ import {
   persistLocale,
   preserveDocumentLanguage,
   readLocaleCookie,
+  readLocaleCookieValue,
   readPersistedLocale,
   resolveSupportedLocale,
   syncDocumentLanguage,
@@ -67,6 +68,12 @@ describe("locale resolution", () => {
         browserLanguages: ["zh-CN"],
         persistedLocale: "zh-CN",
       }),
+    ).toBe("en-US");
+  });
+
+  it("uses the last repeated login locale cookie value", () => {
+    expect(
+      readLocaleCookieValue(`${LOCALE_COOKIE_NAME}=zh-CN; other=value; ${LOCALE_COOKIE_NAME}=en-US`),
     ).toBe("en-US");
   });
 

--- a/src/framework/i18n/locale.ts
+++ b/src/framework/i18n/locale.ts
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import type { SupportedLocale } from "@/framework/runtime/types";
+import type { RuntimeConfig, SupportedLocale } from "@/framework/runtime/types";
 
 export const SUPPORTED_LOCALES = ["zh-CN", "en-US"] as const satisfies readonly SupportedLocale[];
 
@@ -69,6 +69,19 @@ export function resolveSupportedLocale({
     deploymentDefaultLocale ??
     FALLBACK_LOCALE
   );
+}
+
+export function resolveAuthenticatedStandaloneLocale(
+  currentLocale: SupportedLocale,
+  mode: RuntimeConfig["mode"],
+): SupportedLocale {
+  if (mode !== "standalone") {
+    return currentLocale;
+  }
+
+  return resolveSupportedLocale({
+    deploymentDefaultLocale: currentLocale,
+  });
 }
 
 export function readPersistedLocale(): string | null {

--- a/src/framework/i18n/locale.ts
+++ b/src/framework/i18n/locale.ts
@@ -74,10 +74,13 @@ export function resolveSupportedLocale({
 export function resolveAuthenticatedStandaloneLocale(
   currentLocale: SupportedLocale,
   mode: RuntimeConfig["mode"],
+  basename = "/studio",
 ): SupportedLocale {
   if (mode !== "standalone") {
     return currentLocale;
   }
+
+  clearLegacyLocaleCookies(basename);
 
   return resolveSupportedLocale({
     deploymentDefaultLocale: currentLocale,
@@ -208,6 +211,7 @@ function addLegacyLocaleCookiePath(paths: Set<string>, path: string | null | und
   const normalizedPath = normalizeCookiePath(path);
   if (normalizedPath && normalizedPath !== "/") {
     paths.add(normalizedPath);
+    paths.add(`${normalizedPath}/`);
   }
 }
 

--- a/src/framework/i18n/locale.ts
+++ b/src/framework/i18n/locale.ts
@@ -84,19 +84,41 @@ export function readLocaleCookie(): string | null {
     return null;
   }
 
-  for (const item of document.cookie.split(";")) {
+  return readLocaleCookieValue(document.cookie);
+}
+
+export function readLocaleCookieValue(cookieHeader: string): string | null {
+  let matchedValue: string | null = null;
+
+  for (const item of cookieHeader.split(";")) {
     const [rawName, ...rawValue] = item.trim().split("=");
     if (rawName !== LOCALE_COOKIE_NAME) {
       continue;
     }
     const value = rawValue.join("=");
     try {
-      return decodeURIComponent(value);
+      matchedValue = decodeURIComponent(value);
     } catch {
-      return value;
+      matchedValue = value;
     }
   }
-  return null;
+
+  return matchedValue;
+}
+
+export function clearLegacyLocaleCookies(basename = "/studio") {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return;
+  }
+
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  const legacyPaths = new Set<string>();
+  addLegacyLocaleCookiePath(legacyPaths, basename);
+  addLegacyLocaleCookiePath(legacyPaths, defaultCookiePath(window.location.pathname));
+
+  for (const path of legacyPaths) {
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=${path}; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax${secure}`;
+  }
 }
 
 export function persistLocale(locale: SupportedLocale) {
@@ -104,6 +126,7 @@ export function persistLocale(locale: SupportedLocale) {
     return;
   }
 
+  clearLegacyLocaleCookies();
   window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
   const secure = window.location.protocol === "https:" ? "; Secure" : "";
   document.cookie = `${LOCALE_COOKIE_NAME}=${encodeURIComponent(locale)}; Path=/; Max-Age=${LOCALE_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
@@ -167,4 +190,33 @@ function readBrowserLanguages(): string[] {
     return [];
   }
   return navigator.languages?.length ? [...navigator.languages] : [navigator.language];
+}
+
+function addLegacyLocaleCookiePath(paths: Set<string>, path: string | null | undefined) {
+  const normalizedPath = normalizeCookiePath(path);
+  if (normalizedPath && normalizedPath !== "/") {
+    paths.add(normalizedPath);
+  }
+}
+
+function normalizeCookiePath(path: string | null | undefined) {
+  const trimmed = path?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const withoutTrailingSlash = withLeadingSlash.replace(/\/+$/, "");
+  return withoutTrailingSlash || "/";
+}
+
+function defaultCookiePath(pathname: string) {
+  if (!pathname.startsWith("/") || pathname === "/") {
+    return "/";
+  }
+
+  const rightmostSlash = pathname.lastIndexOf("/");
+  if (rightmostSlash <= 0) {
+    return "/";
+  }
+  return pathname.slice(0, rightmostSlash);
 }

--- a/src/framework/i18n/locale.ts
+++ b/src/framework/i18n/locale.ts
@@ -126,7 +126,6 @@ export function persistLocale(locale: SupportedLocale) {
     return;
   }
 
-  clearLegacyLocaleCookies();
   window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
   const secure = window.location.protocol === "https:" ? "; Secure" : "";
   document.cookie = `${LOCALE_COOKIE_NAME}=${encodeURIComponent(locale)}; Path=/; Max-Age=${LOCALE_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secure}`;

--- a/src/framework/runtime/bootstrap.test.tsx
+++ b/src/framework/runtime/bootstrap.test.tsx
@@ -62,6 +62,15 @@ describe("standalone bootstrap locale persistence", () => {
     expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("zh-CN");
   });
 
+  it("persists an English login-page cookie over an older Chinese Studio preference", () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, "zh-CN");
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/`;
+
+    startStandaloneApp();
+
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("en-US");
+  });
+
   it("does not persist locale for hosted runtime mode", () => {
     window.localStorage.setItem(LOCALE_STORAGE_KEY, "en-US");
     document.cookie = `${LOCALE_COOKIE_NAME}=zh-CN; Path=/`;

--- a/src/framework/runtime/bootstrap.test.tsx
+++ b/src/framework/runtime/bootstrap.test.tsx
@@ -39,10 +39,14 @@ vi.mock("@/framework/auth/token-store", () => ({
 }));
 
 describe("standalone bootstrap locale persistence", () => {
+  const initialLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
   beforeEach(() => {
     document.body.innerHTML = '<div id="root"></div>';
     window.localStorage.clear();
     document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/studio; Max-Age=0`;
+    window.history.replaceState(null, "", initialLocation);
     delete window.__BKN_STUDIO_RUNTIME__;
   });
 
@@ -50,6 +54,8 @@ describe("standalone bootstrap locale persistence", () => {
     document.body.innerHTML = "";
     window.localStorage.clear();
     document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/studio; Max-Age=0`;
+    window.history.replaceState(null, "", initialLocation);
     delete window.__BKN_STUDIO_RUNTIME__;
   });
 
@@ -69,6 +75,22 @@ describe("standalone bootstrap locale persistence", () => {
     startStandaloneApp();
 
     expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("en-US");
+  });
+
+  it("clears stale scoped login locale cookies before resolving the standalone locale", () => {
+    window.history.replaceState(null, "", "/studio/callback");
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, "zh-CN");
+    document.cookie = `${LOCALE_COOKIE_NAME}=zh-CN; Path=/studio`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=en-US; Path=/`;
+    window.__BKN_STUDIO_RUNTIME__ = { router: { basename: "/studio" } };
+
+    startStandaloneApp();
+
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("en-US");
+
+    document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0`;
+
+    expect(document.cookie).not.toContain(`${LOCALE_COOKIE_NAME}=`);
   });
 
   it("does not persist locale for hosted runtime mode", () => {

--- a/src/framework/runtime/bootstrap.tsx
+++ b/src/framework/runtime/bootstrap.tsx
@@ -11,7 +11,11 @@ import { createRoot } from "react-dom/client";
 import { App } from "@/app/App";
 import i18n from "@/app/locales/i18n";
 import { subscribeAuthBroadcast } from "@/framework/auth/token-store";
-import { persistLocale, preserveDocumentLanguage } from "@/framework/i18n/locale";
+import {
+  clearLegacyLocaleCookies,
+  persistLocale,
+  preserveDocumentLanguage,
+} from "@/framework/i18n/locale";
 import {
   createRuntimeConfig,
   readWindowRuntimeInput,
@@ -40,6 +44,10 @@ function ensureAuthBroadcastListener() {
 
 export function mountApp(container: Element, runtimeInput: RuntimeInput = {}) {
   ensureAuthBroadcastListener();
+  const runtimeMode = runtimeInput.mode ?? "standalone";
+  if (runtimeMode === "standalone") {
+    clearLegacyLocaleCookies(runtimeInput.router?.basename);
+  }
   const runtimeConfig = createRuntimeConfig(runtimeInput);
   setRuntimeConfig(runtimeConfig);
   if (runtimeConfig.mode === "standalone") {


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Fix standalone locale startup to remove legacy path-scoped login locale cookies before resolving the runtime locale.
- [x] Read the last repeated \openbkn_locale\ cookie value so the latest root-scoped login-page selection wins over stale scoped values.
- [x] Add focused regression tests for both Chinese-over-English and English-over-Chinese login locale selection flows.

---

## Why

- Related Issue: Closes #994
- Related Feature: Login page internationalization
- Background: After switching the product UI to Chinese, signing out, selecting English on the login page, and signing in again, Studio could remain Chinese because stale path-scoped locale cookies could override the new login-page locale preference.

---

## How

- Key implementation points:
  - Clear legacy \openbkn_locale\ cookies scoped to the Studio basename/current default cookie path before standalone locale resolution.
  - Keep the canonical shared locale cookie on \Path=/\ through the existing \persistLocale\ flow.
  - Parse repeated locale cookies defensively by returning the last matching value.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — Not applicable; change is isolated to frontend locale resolution.
- [ ] Verified in test environment — Pending deployment to 118.196.95.132 after image build.

Test notes:

- \pnpm exec vitest --run src/framework/i18n/locale.test.ts src/framework/runtime/bootstrap.test.tsx- \pnpm exec eslint src/framework/i18n/locale.ts src/framework/i18n/locale.test.ts src/framework/runtime/bootstrap.tsx src/framework/runtime/bootstrap.test.tsx --config eslint.config.typechecked.js --max-warnings 0- \pnpm exec tsc -b --pretty false- \git diff --check
---

## Risk & Rollback

- Potential risks: Low. The change only affects locale preference cookie compatibility in standalone mode. Hosted mode remains unchanged.
- Rollback plan: Revert this PR or redeploy the previous bkn-studio image.

---

## Additional Notes

- The fix is intended to cover the reverse scenario reported during environment validation: product UI set to Chinese, sign out, select English on the login page, then sign in and see English in Studio.
