### PR TITLE
fix(studio): hide license removal when no license is installed

### DIFF
--- a/src/modules/system-admin/scenes/LicenseManagementScene.test.tsx
+++ b/src/modules/system-admin/scenes/LicenseManagementScene.test.tsx
@@ -105,7 +105,9 @@ describe("LicenseManagementScene", () => {
 
       await waitFor(() => expect(getLicenseDetailMock).toHaveBeenCalledTimes(1));
 
-      expect(screen.getByRole("button", { name: removeButtonName }).disabled).toBe(false);
+      const removeButton = screen.getByRole("button", { name: removeButtonName });
+      expect(removeButton).toBeInstanceOf(HTMLButtonElement);
+      expect((removeButton as HTMLButtonElement).disabled).toBe(false);
     },
   );
 

--- a/src/modules/system-admin/scenes/LicenseManagementScene.test.tsx
+++ b/src/modules/system-admin/scenes/LicenseManagementScene.test.tsx
@@ -91,6 +91,7 @@ describe("LicenseManagementScene", () => {
       await waitFor(() => expect(getLicenseDetailMock).toHaveBeenCalledTimes(1));
 
       expect(screen.queryByRole("button", { name: removeButtonName })).toBeNull();
+      expect(screen.getByText(`systemAdmin.license.statusDesc.${state}`)).toBeTruthy();
       expect(deleteLicenseMock).not.toHaveBeenCalled();
       expect(modalConfirmMock).not.toHaveBeenCalled();
       expect(messageMock.success).not.toHaveBeenCalledWith("systemAdmin.license.toast.deleted");

--- a/src/modules/system-admin/scenes/LicenseManagementScene.test.tsx
+++ b/src/modules/system-admin/scenes/LicenseManagementScene.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LicenseDetail } from "@/modules/system-admin/types/license";
+
+const deleteLicenseMock = vi.hoisted(() => vi.fn());
+const getLicenseDetailMock = vi.hoisted(() => vi.fn());
+const getLicenseFingerprintMock = vi.hoisted(() => vi.fn());
+const messageMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn() }));
+const modalConfirmMock = vi.hoisted(() => vi.fn());
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ i18n: { language: "zh-CN" }, t: (key: string) => key }),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({
+    message: messageMock,
+    modal: { confirm: modalConfirmMock },
+  }),
+}));
+
+vi.mock("@/framework/entitlement/LicenseStateBanner", () => ({
+  LicenseStateBanner: () => null,
+}));
+
+vi.mock("@/framework/entitlement/use-entitlement", () => ({
+  useRefreshEntitlement: () => vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/framework/permission/PermissionGate", () => ({
+  PermissionGate: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/modules/system-admin/services/license.service", () => ({
+  activateLicense: vi.fn(),
+  deleteLicense: deleteLicenseMock,
+  getLicenseDetail: getLicenseDetailMock,
+  getLicenseFingerprint: getLicenseFingerprintMock,
+  importLicense: vi.fn(),
+  resolveLicenseRequestErrorCode: vi.fn(),
+}));
+
+import { LicenseManagementScene } from "./LicenseManagementScene";
+
+function licenseDetail(state: LicenseDetail["state"]): LicenseDetail {
+  return {
+    activated: false,
+    edition: "community",
+    features: [],
+    instanceFp: "fp_001",
+    limits: {},
+    state,
+  };
+}
+
+function renderScene(state: LicenseDetail["state"]) {
+  getLicenseDetailMock.mockResolvedValue(licenseDetail(state));
+  getLicenseFingerprintMock.mockResolvedValue("fp_001");
+
+  render(
+    <MemoryRouter>
+      <LicenseManagementScene />
+    </MemoryRouter>,
+  );
+}
+
+const removeButtonName = /systemAdmin\.license\.delete$/;
+
+describe("LicenseManagementScene", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deleteLicenseMock.mockResolvedValue(undefined);
+  });
+
+  it.each(["trial", "unlicensed"] as const)(
+    "does not expose removal for the no-license %s state",
+    async (state) => {
+      renderScene(state);
+
+      await waitFor(() => expect(getLicenseDetailMock).toHaveBeenCalledTimes(1));
+
+      expect(screen.queryByRole("button", { name: removeButtonName })).toBeNull();
+      expect(deleteLicenseMock).not.toHaveBeenCalled();
+      expect(modalConfirmMock).not.toHaveBeenCalled();
+      expect(messageMock.success).not.toHaveBeenCalledWith("systemAdmin.license.toast.deleted");
+    },
+  );
+
+  it.each(["valid", "grace", "fallback_community", "invalid"] as const)(
+    "keeps removal available for the installed-license %s state",
+    async (state) => {
+      renderScene(state);
+
+      await waitFor(() => expect(getLicenseDetailMock).toHaveBeenCalledTimes(1));
+
+      expect(screen.getByRole("button", { name: removeButtonName }).disabled).toBe(false);
+    },
+  );
+
+  it("removes an invalid installed license and reports success", async () => {
+    renderScene("invalid");
+
+    const removeButton = await screen.findByRole("button", {
+      name: removeButtonName,
+    });
+    fireEvent.click(removeButton);
+
+    expect(modalConfirmMock).toHaveBeenCalledTimes(1);
+    const [[{ onOk }]] = modalConfirmMock.mock.calls as [[{ onOk: () => Promise<void> }]];
+    await act(async () => {
+      await onOk();
+    });
+
+    expect(deleteLicenseMock).toHaveBeenCalledTimes(1);
+    expect(messageMock.success).toHaveBeenCalledWith("systemAdmin.license.toast.deleted");
+    await waitFor(() => expect(getLicenseDetailMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/modules/system-admin/scenes/LicenseManagementScene.tsx
+++ b/src/modules/system-admin/scenes/LicenseManagementScene.tsx
@@ -144,6 +144,9 @@ export function LicenseManagementScene() {
     if (detail.state === "fallback_community") {
       return t("systemAdmin.license.statusDesc.fallback_community");
     }
+    if (detail.state === "trial" || detail.state === "unlicensed") {
+      return t(`systemAdmin.license.statusDesc.${detail.state}`);
+    }
     if (detail.state === "invalid") {
       return t("systemAdmin.license.statusDesc.invalid");
     }

--- a/src/modules/system-admin/scenes/LicenseManagementScene.tsx
+++ b/src/modules/system-admin/scenes/LicenseManagementScene.tsx
@@ -43,6 +43,10 @@ const { TextArea } = Input;
 
 type ActionKind = "delete" | "import" | "online" | null;
 
+function canRemoveLicense(detail: LicenseDetail | null) {
+  return detail !== null && detail.state !== "trial" && detail.state !== "unlicensed";
+}
+
 function formatUnixSeconds(value: number | undefined, locale: string, permanentText: string) {
   if (value === undefined || value === null) {
     return "-";
@@ -330,17 +334,18 @@ export function LicenseManagementScene() {
           <AppButton icon={<ReloadOutlined />} loading={loading} onClick={() => void load()}>
             {t("common.refresh")}
           </AppButton>
-          <PermissionGate permissions={systemAdminPermissions.licenseManage}>
-            <AppButton
-              danger
-              disabled={!detail || detail.state === "invalid"}
-              icon={<DeleteOutlined />}
-              loading={action === "delete"}
-              onClick={handleDelete}
-            >
-              {t("systemAdmin.license.delete")}
-            </AppButton>
-          </PermissionGate>
+          {canRemoveLicense(detail) ? (
+            <PermissionGate permissions={systemAdminPermissions.licenseManage}>
+              <AppButton
+                danger
+                icon={<DeleteOutlined />}
+                loading={action === "delete"}
+                onClick={handleDelete}
+              >
+                {t("systemAdmin.license.delete")}
+              </AppButton>
+            </PermissionGate>
+          ) : null}
         </div>
       </div>
 

--- a/src/modules/system-admin/services/license.service.test.ts
+++ b/src/modules/system-admin/services/license.service.test.ts
@@ -46,6 +46,10 @@ describe("license.service", () => {
     });
   });
 
+  it("treats a missing backend state as unlicensed", () => {
+    expect(mapLicenseDetail({}).state).toBe("unlicensed");
+  });
+
   it("classifies import and activation errors", () => {
     expect(
       resolveLicenseRequestErrorCode(

--- a/src/modules/system-admin/services/license.service.ts
+++ b/src/modules/system-admin/services/license.service.ts
@@ -196,7 +196,7 @@ export async function deleteLicense() {
       features: [],
       instanceFp: mockInstanceFingerprint,
       limits: {},
-      state: "invalid",
+      state: "trial",
     };
     return wait(undefined);
   }

--- a/src/modules/system-admin/services/license.service.ts
+++ b/src/modules/system-admin/services/license.service.ts
@@ -91,7 +91,9 @@ export function mapLicenseDetail(item: BackendLicenseDetail): LicenseDetail {
     licId: item.lic_id,
     limits: item.limits ?? {},
     renewError: item.renew_error,
-    state: item.state ?? "invalid",
+    // A missing state is an incomplete response, not proof that a corrupt
+    // license is installed. Fail closed so the UI cannot issue a no-op delete.
+    state: item.state ?? "unlicensed",
   };
 }
 
@@ -192,7 +194,6 @@ export async function deleteLicense() {
     mockLicense = {
       activated: false,
       edition: "community",
-      error: "No license has been imported.",
       features: [],
       instanceFp: mockInstanceFingerprint,
       limits: {},


### PR DESCRIPTION
Hide the “Remove license” action for trial and unlicensed deployments, preventing no-op DELETE requests and misleading success notifications.

Keep removal available for valid, grace, fallback-community, and invalid licenses so installed or corrupted license records can still be cleared. Align the mock post-removal state with the backend’s trial state and add regression coverage for all license states.

# Pull Request

## What Changed

Brief description of changes:

- [x] Hide the “Remove license” action when the license state is `trial` or `unlicensed`.
- [x] Keep license removal available for `valid`, `grace`, `fallback_community`, and `invalid` states.
- [x] Add regression tests covering removal availability and success behavior across license states.
- [x] Align the frontend mock post-removal state with the backend’s `trial` state.

---

## Why

- Related Issue: N/A
- Related Feature: License management
- Background: A deployment without an installed license could trigger `DELETE /safe/v1/admin/license`, receive an idempotent `204 No Content`, and incorrectly display a successful removal notification.

---

## How

- Key implementation points:
  - Render the removal action only when the current state represents an installed license.
  - Treat `trial` and `unlicensed` as no-license states.
  - Preserve the `invalid` cleanup path for installed but corrupted licenses.
  - Keep the existing idempotent backend DELETE contract unchanged.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — Not applicable; this is a frontend state/UI change.
- [ ] Verified in test environment — Not performed.

Test notes:

- `pnpm exec vitest --run src/modules/system-admin/scenes/LicenseManagementScene.test.tsx src/modules/system-admin/services/license.service.test.ts`
- Verified that `trial` and `unlicensed` do not expose the removal action, do not invoke DELETE, and do not show the removal success notification.
- Verified that `valid`, `grace`, `fallback_community`, and `invalid` retain the removal action.
- Verified that an `invalid` installed license can still be removed successfully.

---

## Risk & Rollback

- Potential risks: The removal action is intentionally unavailable for no-license states; other installed-license states remain unchanged.
- Rollback plan: Revert the frontend state guard and regression test changes.

---

## Additional Notes

- The backend `DELETE /safe/v1/admin/license` response remains `204 No Content` for idempotency and compatibility with existing clients.