### PR TITLE
fix(i18n): replace native datetime inputs

### DIFF
--- a/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.test.tsx
+++ b/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.test.tsx
@@ -192,6 +192,15 @@ describe("TraceAnalysisScene", { timeout: 30_000 }, () => {
     expect(await screen.findByText("bknTrace.traceWorkspace.detailTitle")).not.toBeNull();
   });
 
+  it("uses Ant Design date pickers for trace time filters", async () => {
+    const { container } = render(<TraceAnalysisScene />);
+
+    await screen.findByRole("button", { name: "c2c97a9e8afd1259218a9d975ad63e91" });
+    expect(screen.getByLabelText("bknTrace.traceWorkspace.filters.from")).not.toBeNull();
+    expect(screen.getByLabelText("bknTrace.traceWorkspace.filters.to")).not.toBeNull();
+    expect(container.querySelectorAll('input[type="datetime-local"]')).toHaveLength(0);
+  });
+
   it("keeps the latest list response when an earlier page request finishes late", async () => {
     let resolvePageTwo!: (value: Awaited<ReturnType<typeof listTechnicalTraces>>) => void;
     const pageTwo = new Promise<Awaited<ReturnType<typeof listTechnicalTraces>>>((resolve) => { resolvePageTwo = resolve; });

--- a/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.tsx
+++ b/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.tsx
@@ -237,8 +237,8 @@ export function TraceAnalysisScene() {
           <Select allowClear options={["completed", "failed", "running", "unknown"].map((value) => ({ label: value, value }))} placeholder={t("bknTrace.traceWorkspace.filters.status")} />
         </Form.Item>
         <Form.Item name="errorKeyword"><Input allowClear placeholder={t("bknTrace.traceWorkspace.filters.error")} /></Form.Item>
-        <Form.Item name="from"><DatePicker aria-label={t("bknTrace.traceWorkspace.filters.from")} format="YYYY-MM-DD HH:mm" showTime={{ format: "HH:mm" }} /></Form.Item>
-        <Form.Item name="to"><DatePicker aria-label={t("bknTrace.traceWorkspace.filters.to")} format="YYYY-MM-DD HH:mm" showTime={{ format: "HH:mm" }} /></Form.Item>
+        <Form.Item name="from"><DatePicker aria-label={t("bknTrace.traceWorkspace.filters.from")} format="YYYY-MM-DD HH:mm" placeholder={t("bknTrace.traceWorkspace.filters.from")} showTime={{ format: "HH:mm", showSecond: false }} /></Form.Item>
+        <Form.Item name="to"><DatePicker aria-label={t("bknTrace.traceWorkspace.filters.to")} format="YYYY-MM-DD HH:mm" placeholder={t("bknTrace.traceWorkspace.filters.to")} showTime={{ format: "HH:mm", showSecond: false }} /></Form.Item>
         <Button htmlType="submit" icon={<SearchOutlined />} type="primary">{t("bknTrace.actions.query")}</Button>
       </Form>
 

--- a/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.tsx
+++ b/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.tsx
@@ -15,6 +15,7 @@ import {
 import {
   Alert,
   Button,
+  DatePicker,
   Descriptions,
   Empty,
   Form,
@@ -30,6 +31,7 @@ import {
   Typography,
 } from "antd";
 import type { ColumnsType } from "antd/es/table";
+import type { Dayjs } from "dayjs";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -53,7 +55,7 @@ const defaultPageSize = 20;
 
 export function TraceAnalysisScene() {
   const { t } = useTranslation();
-  const [form] = Form.useForm<TechnicalTraceQuery>();
+  const [form] = Form.useForm<TechnicalTraceFilterValues>();
   const [listState, setListState] = useState<{ query: TechnicalTraceQuery; page: number }>({
     query: { limit: defaultPageSize },
     page: 1,
@@ -211,7 +213,7 @@ export function TraceAnalysisScene() {
         <Button icon={<ReloadOutlined />} onClick={() => void loadList(query, page)}>{t("bknTrace.actions.refresh")}</Button>
       </header>
 
-      <Form<TechnicalTraceQuery>
+      <Form<TechnicalTraceFilterValues>
         className={styles.filters}
         form={form}
         initialValues={{}}
@@ -235,8 +237,8 @@ export function TraceAnalysisScene() {
           <Select allowClear options={["completed", "failed", "running", "unknown"].map((value) => ({ label: value, value }))} placeholder={t("bknTrace.traceWorkspace.filters.status")} />
         </Form.Item>
         <Form.Item name="errorKeyword"><Input allowClear placeholder={t("bknTrace.traceWorkspace.filters.error")} /></Form.Item>
-        <Form.Item name="from"><Input aria-label={t("bknTrace.traceWorkspace.filters.from")} type="datetime-local" /></Form.Item>
-        <Form.Item name="to"><Input aria-label={t("bknTrace.traceWorkspace.filters.to")} type="datetime-local" /></Form.Item>
+        <Form.Item name="from"><DatePicker aria-label={t("bknTrace.traceWorkspace.filters.from")} format="YYYY-MM-DD HH:mm" showTime={{ format: "HH:mm" }} /></Form.Item>
+        <Form.Item name="to"><DatePicker aria-label={t("bknTrace.traceWorkspace.filters.to")} format="YYYY-MM-DD HH:mm" showTime={{ format: "HH:mm" }} /></Form.Item>
         <Button htmlType="submit" icon={<SearchOutlined />} type="primary">{t("bknTrace.actions.query")}</Button>
       </Form>
 
@@ -519,10 +521,13 @@ function buildDiagnostics(detail: TechnicalTraceDetail) {
   return [...diagnostics];
 }
 
-function toIsoDateTime(value?: string) {
-  if (!value) return undefined;
-  const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : value;
+type TechnicalTraceFilterValues = Omit<TechnicalTraceQuery, "from" | "to"> & {
+  from?: Dayjs;
+  to?: Dayjs;
+};
+
+function toIsoDateTime(value?: Dayjs) {
+  return value?.isValid() ? value.toISOString() : undefined;
 }
 
 type ExecutionEvent =

--- a/src/modules/data-connect/components/DiscoverScheduleFormModal.test.tsx
+++ b/src/modules/data-connect/components/DiscoverScheduleFormModal.test.tsx
@@ -81,7 +81,7 @@ describe("DiscoverScheduleFormModal", () => {
 
     await waitFor(() => {
       expect(screen.getByText("dataConnect.discoverCronInvalid")).toBeTruthy();
-    });
+    }, { timeout: 3_000 });
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -114,5 +114,34 @@ describe("DiscoverScheduleFormModal", () => {
       expect(screen.getAllByText("dataConnect.discoverTimeRangeInvalid")).toHaveLength(2);
     });
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits selected times with minute precision", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <DiscoverScheduleFormModal
+        catalogs={[]}
+        defaultCatalogId="catalog-1"
+        mode="create"
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+        open
+        submitting={false}
+      />,
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText("dataConnect.discoverScheduleNamePlaceholder"),
+      { target: { value: "Minute precision" } },
+    );
+    fireEvent.change(screen.getByLabelText("dataConnect.discoverStartTime"), {
+      target: { value: "2026-08-20 10:00:59" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        startTime: Date.parse("2026-08-20T10:00:00"),
+      }));
+    });
   });
 });

--- a/src/modules/data-connect/components/DiscoverScheduleFormModal.test.tsx
+++ b/src/modules/data-connect/components/DiscoverScheduleFormModal.test.tsx
@@ -18,6 +18,30 @@ vi.mock("react-i18next", async (importOriginal) => {
   };
 });
 
+vi.mock("antd", async (importOriginal) => {
+  const original = await importOriginal<typeof import("antd")>();
+  const { default: dayjs } = await import("dayjs");
+
+  return {
+    ...original,
+    DatePicker: ({
+      id,
+      onChange,
+      value,
+    }: {
+      id?: string;
+      onChange?: (value: ReturnType<typeof dayjs> | null) => void;
+      value?: ReturnType<typeof dayjs>;
+    }) => (
+      <input
+        id={id}
+        onChange={(event) => onChange?.(event.target.value ? dayjs(event.target.value) : null)}
+        value={value?.format("YYYY-MM-DD HH:mm") ?? ""}
+      />
+    ),
+  };
+});
+
 describe("DiscoverScheduleFormModal", () => {
   beforeAll(() => {
     window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -78,11 +102,12 @@ describe("DiscoverScheduleFormModal", () => {
       screen.getByPlaceholderText("dataConnect.discoverScheduleNamePlaceholder"),
       { target: { value: "Invalid time range" } },
     );
-    const timeInputs = document.querySelectorAll<HTMLInputElement>(
-      'input[type="datetime-local"]',
-    );
-    fireEvent.change(timeInputs[0], { target: { value: "2026-08-20T10:00" } });
-    fireEvent.change(timeInputs[1], { target: { value: "2026-08-20T09:00" } });
+    const startTimeInput = screen.getByLabelText("dataConnect.discoverStartTime");
+    const endTimeInput = screen.getByLabelText("dataConnect.discoverEndTime");
+    fireEvent.change(startTimeInput, { target: { value: "2026-08-20 10:00" } });
+    fireEvent.blur(startTimeInput);
+    fireEvent.change(endTimeInput, { target: { value: "2026-08-20 09:00" } });
+    fireEvent.blur(endTimeInput);
     fireEvent.click(screen.getByRole("button", { name: "common.save" }));
 
     await waitFor(() => {

--- a/src/modules/data-connect/components/DiscoverScheduleFormModal.tsx
+++ b/src/modules/data-connect/components/DiscoverScheduleFormModal.tsx
@@ -5,8 +5,9 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Form, Input, Modal, Select, Switch } from "antd";
+import { DatePicker, Form, Input, Modal, Select, Switch } from "antd";
 import type { Rule } from "antd/es/form";
+import dayjs, { type Dayjs } from "dayjs";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -39,9 +40,9 @@ type DiscoverScheduleFormValues = {
   catalogId: string;
   cronExpr: string;
   enabled: boolean;
-  endTime?: string;
+  endTime?: Dayjs;
   name: string;
-  startTime?: string;
+  startTime?: Dayjs;
   strategy: DataConnectDiscoverStrategy;
 };
 
@@ -95,9 +96,9 @@ export function DiscoverScheduleFormModal({
       catalogId: initialValue?.catalogId ?? defaultCatalogId,
       cronExpr: initialValue?.cronExpr ?? "0 2 * * *",
       enabled: initialValue?.enabled ?? true,
-      endTime: formatDateTimeLocal(initialValue?.endTimeValue),
+      endTime: toDateTimeValue(initialValue?.endTimeValue),
       name: initialValue?.name ?? "",
-      startTime: formatDateTimeLocal(initialValue?.startTimeValue),
+      startTime: toDateTimeValue(initialValue?.startTimeValue),
       strategy: initialValue?.strategy ?? "full_sync",
     });
   }, [defaultCatalogId, form, initialValue, open]);
@@ -276,7 +277,11 @@ export function DiscoverScheduleFormModal({
               rules={[{ validator: validateTimeRange }]}
               span="half"
             >
-              <Input type="datetime-local" />
+              <DatePicker
+                format="YYYY-MM-DD HH:mm"
+                showTime={{ format: "HH:mm" }}
+                style={{ width: "100%" }}
+              />
             </InlineField>
             <InlineField
               label={t("dataConnect.discoverEndTime")}
@@ -284,7 +289,11 @@ export function DiscoverScheduleFormModal({
               rules={[{ validator: validateTimeRange }]}
               span="half"
             >
-              <Input type="datetime-local" />
+              <DatePicker
+                format="YYYY-MM-DD HH:mm"
+                showTime={{ format: "HH:mm" }}
+                style={{ width: "100%" }}
+              />
             </InlineField>
           </div>
         </div>
@@ -337,26 +346,18 @@ function InlineField({
   );
 }
 
-function formatDateTimeLocal(value?: number) {
+function toDateTimeValue(value?: number) {
   if (!value) {
     return undefined;
   }
 
-  const date = new Date(value);
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, "0");
-  const day = `${date.getDate()}`.padStart(2, "0");
-  const hours = `${date.getHours()}`.padStart(2, "0");
-  const minutes = `${date.getMinutes()}`.padStart(2, "0");
-
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
+  return dayjs(value).startOf("minute");
 }
 
 function parseDateTimeLocal(value: unknown) {
-  if (typeof value !== "string" || !value) {
+  if (!dayjs.isDayjs(value) || !value.isValid()) {
     return undefined;
   }
 
-  const timestamp = Date.parse(value);
-  return Number.isNaN(timestamp) ? undefined : timestamp;
+  return value.valueOf();
 }

--- a/src/modules/data-connect/components/DiscoverScheduleFormModal.tsx
+++ b/src/modules/data-connect/components/DiscoverScheduleFormModal.tsx
@@ -279,7 +279,7 @@ export function DiscoverScheduleFormModal({
             >
               <DatePicker
                 format="YYYY-MM-DD HH:mm"
-                showTime={{ format: "HH:mm" }}
+                showTime={{ format: "HH:mm", showSecond: false }}
                 style={{ width: "100%" }}
               />
             </InlineField>
@@ -291,7 +291,7 @@ export function DiscoverScheduleFormModal({
             >
               <DatePicker
                 format="YYYY-MM-DD HH:mm"
-                showTime={{ format: "HH:mm" }}
+                showTime={{ format: "HH:mm", showSecond: false }}
                 style={{ width: "100%" }}
               />
             </InlineField>
@@ -359,5 +359,5 @@ function parseDateTimeLocal(value: unknown) {
     return undefined;
   }
 
-  return value.valueOf();
+  return value.startOf("minute").valueOf();
 }

--- a/src/modules/data-connect/scenes/DataConnectDiscoverScene.test.tsx
+++ b/src/modules/data-connect/scenes/DataConnectDiscoverScene.test.tsx
@@ -134,7 +134,9 @@ vi.mock("@/modules/data-connect/components/DiscoverScheduleFormModal", () => ({
       catalogId: string;
       cronExpr: string;
       enabled: boolean;
+      endTime?: number;
       name: string;
+      startTime?: number;
       strategy: "full_sync";
     }) => Promise<void>;
     submitting: boolean;
@@ -147,7 +149,9 @@ vi.mock("@/modules/data-connect/components/DiscoverScheduleFormModal", () => ({
           catalogId: "catalog-1",
           cronExpr: "0 * * * *",
           enabled: true,
+          endTime: undefined,
           name: "nightly",
+          startTime: undefined,
           strategy: "full_sync",
         })}
         type="button"
@@ -181,12 +185,14 @@ const schedule = (expectedUpdateTime: number) => ({
   cronExpr: "0 * * * *",
   enabled: true,
   endTime: "-",
+  endTimeValue: Date.parse("2026-08-20T11:00:00"),
   expectedUpdateTime,
   id: "schedule-1",
   lastRun: "-",
   name: "nightly",
   nextRun: "-",
   startTime: "-",
+  startTimeValue: Date.parse("2026-08-20T10:00:00"),
   strategy: "full_sync" as const,
   updateTime: "-",
   updaterName: "-",
@@ -234,6 +240,27 @@ describe("DataConnectDiscoverScene", () => {
     await waitFor(() => expect(getScheduleMock).toHaveBeenCalledTimes(2));
 
     expect(screen.getByTestId("schedule-submitting").textContent).toBe("false");
+  });
+
+  it("sends cleared schedule times to the update service", async () => {
+    updateScheduleMock.mockResolvedValue(undefined);
+    render(<DataConnectDiscoverScene catalogId="catalog-1" />);
+
+    await openScheduleEditor();
+    fireEvent.click(screen.getByRole("button", { name: "submit schedule 100" }));
+
+    await waitFor(() => {
+      expect(updateScheduleMock).toHaveBeenCalledWith("schedule-1", {
+        catalogId: "catalog-1",
+        cronExpr: "0 * * * *",
+        enabled: true,
+        endTime: undefined,
+        expectedUpdateTime: 100,
+        name: "nightly",
+        startTime: undefined,
+        strategy: "full_sync",
+      });
+    });
   });
 
   it("clears the submitting state when a schedule modal closes during submission", async () => {

--- a/src/modules/data-connect/scenes/DataConnectDiscoverScene.tsx
+++ b/src/modules/data-connect/scenes/DataConnectDiscoverScene.tsx
@@ -577,16 +577,6 @@ export function DataConnectDiscoverScene({
           scheduleModalState?.mode === "edit" && editingSchedule
             ? editingSchedule.catalogId
             : payload.catalogId,
-        endTime:
-          payload.endTime ??
-          (scheduleModalState?.mode === "edit"
-            ? editingSchedule?.endTimeValue
-            : undefined),
-        startTime:
-          payload.startTime ??
-          (scheduleModalState?.mode === "edit"
-            ? editingSchedule?.startTimeValue
-            : undefined),
       };
 
       if (scheduleModalState?.mode === "edit" && scheduleModalState.scheduleId) {


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Replaced native `datetime-local` inputs in Discover Schedule with localized Ant Design date-time pickers.
- [x] Replaced native `datetime-local` inputs in Trace Analysis with localized Ant Design date-time pickers.
- [x] Added focused regression coverage for the form validation and Trace filters.

---

## Why

- Related Issue: Closes #468
- Related Feature: N/A
- Background: Native date-time picker popups are rendered by the browser/OS and can remain Chinese when the Studio UI is English.

---

## How

- Key implementation points: Form fields now use Ant Design `DatePicker` with minute-level `showTime`; schedule submission remains epoch milliseconds and Trace query submission remains ISO 8601.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; no service contract change)
- [ ] Verified in test environment (not run)

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` (one existing ignored high vulnerability)

---

## Risk & Rollback

- Potential risks: Date-time values are adapted at the form boundary; this preserves the existing local-time-to-timestamp and ISO query semantics.
- Rollback plan: Revert commit `de230db`.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: No new dependency or API change.