### PR TITLE
fix(data-catalog): refresh resource metadata on tab entry

### DIFF
--- a/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.test.tsx
@@ -127,18 +127,15 @@ describe("IndexConfigFormPanel", () => {
         type: "string",
       }],
     };
-    getCatalogResourceMock
-      .mockResolvedValueOnce(configuredResource)
-      .mockResolvedValueOnce(semanticResource);
+    getCatalogResourceMock.mockResolvedValue(semanticResource);
     updateCatalogResourceMock.mockResolvedValue(semanticResource);
 
     render(
       <MemoryRouter>
-        <IndexConfigFormPanel active resource={configuredResource} />
+        <IndexConfigFormPanel active resource={semanticResource} />
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(getCatalogResourceMock).toHaveBeenCalledTimes(1));
     await screen.findByText("title");
     fireEvent.click(screen.getByRole("button", { name: "dataCatalog.build.saveIndexConfig" }));
 

--- a/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
+++ b/src/modules/data-catalog/components/IndexConfigFormPanel.tsx
@@ -265,12 +265,7 @@ export function IndexConfigFormPanel({
       let preferredModel = "";
       setSchemaLoading(true);
       try {
-        const detail = await getCatalogResource(resource.id);
-        if (detail) {
-          preferredModel = hydrateFromResource(detail) || "";
-        } else if (resource.schema.length > 0) {
-          preferredModel = hydrateFromResource(resource) || "";
-        }
+        preferredModel = hydrateFromResource(resource) || "";
       } finally {
         setSchemaLoading(false);
       }

--- a/src/modules/data-catalog/components/ResourceDetailPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceDetailPanel.test.tsx
@@ -61,14 +61,12 @@ describe("ResourceDetailPanel", () => {
     }));
   });
 
-  it("returns the resource fetched after returning to the detail tab to its parent", async () => {
+  it("renders the refreshed resource supplied by the workspace without another request", async () => {
     const latestResource = { ...resource, name: "Orders" };
-    const onResourceRefreshed = vi.fn();
-    getCatalogResourceMock.mockResolvedValue(latestResource);
 
     const { rerender } = render(
       <MemoryRouter>
-        <ResourceDetailPanel active={false} catalog={null} onResourceRefreshed={onResourceRefreshed} resource={resource} />
+        <ResourceDetailPanel active={false} catalog={null} resource={resource} />
       </MemoryRouter>,
     );
 
@@ -76,50 +74,12 @@ describe("ResourceDetailPanel", () => {
 
     rerender(
       <MemoryRouter>
-        <ResourceDetailPanel active catalog={null} onResourceRefreshed={onResourceRefreshed} resource={resource} />
+        <ResourceDetailPanel active catalog={null} resource={latestResource} />
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(onResourceRefreshed).toHaveBeenCalledWith(latestResource));
-    expect(getCatalogResourceMock).toHaveBeenCalledWith(resource.id);
-  });
-
-  it("ignores a detail refresh superseded by a parent resource update", async () => {
-    const parentResource = { ...resource, name: "Orders", expectedUpdateTime: 1 };
-    const onResourceRefreshed = vi.fn();
-    let resolveRequest: (value: CatalogResource | null) => void;
-    getCatalogResourceMock.mockImplementation(
-      () => new Promise<CatalogResource | null>((resolve) => {
-        resolveRequest = resolve;
-      }),
-    );
-
-    const { rerender } = render(
-      <MemoryRouter>
-        <ResourceDetailPanel active={false} catalog={null} onResourceRefreshed={onResourceRefreshed} resource={resource} />
-      </MemoryRouter>,
-    );
-
-    await act(async () => {});
-
-    rerender(
-      <MemoryRouter>
-        <ResourceDetailPanel active catalog={null} onResourceRefreshed={onResourceRefreshed} resource={resource} />
-      </MemoryRouter>,
-    );
-    await waitFor(() => expect(getCatalogResourceMock).toHaveBeenCalledTimes(1));
-
-    rerender(
-      <MemoryRouter>
-        <ResourceDetailPanel active catalog={null} onResourceRefreshed={onResourceRefreshed} resource={parentResource} />
-      </MemoryRouter>,
-    );
-    act(() => {
-      resolveRequest(resource);
-    });
-    await Promise.resolve();
-
-    expect(onResourceRefreshed).not.toHaveBeenCalled();
+    expect(await screen.findByText("Orders")).toBeTruthy();
+    expect(getCatalogResourceMock).not.toHaveBeenCalled();
   });
 
   it("refreshes the resource version after an update conflict", async () => {

--- a/src/modules/data-catalog/components/ResourceDetailPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceDetailPanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import { ExclamationCircleOutlined } from "@ant-design/icons";
-import { Input, Spin } from "antd";
+import { Input } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -53,11 +53,9 @@ export function ResourceDetailPanel({
   const [schemaPageSize, setSchemaPageSize] = useState(10);
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
   const [resource, setResource] = useState(resourceProp);
   const [descriptionDraft, setDescriptionDraft] = useState(resourceProp.description);
   const [schemaDraft, setSchemaDraft] = useState<ResourceSchemaField[]>(resourceProp.schema);
-  const wasActiveRef = useRef<boolean | null>(null);
   const resourceIdentityKey = `${resourceProp.id}:${resourceProp.expectedUpdateTime}`;
   const resourceIdentityRef = useRef(resourceIdentityKey);
   resourceIdentityRef.current = resourceIdentityKey;
@@ -81,39 +79,6 @@ export function ResourceDetailPanel({
       setSchemaDraft(resource.schema);
     }
   }, [active, resource]);
-
-  useEffect(() => {
-    const wasActive = wasActiveRef.current;
-    wasActiveRef.current = active;
-
-    if (!active || wasActive !== false) {
-      return;
-    }
-
-    let cancelled = false;
-    setRefreshing(true);
-    void getCatalogResource(resourceProp.id)
-      .then((latestResource) => {
-        if (!cancelled && latestResource) {
-          setResource(latestResource);
-          onResourceRefreshed?.(latestResource);
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          void message.error(extractRequestErrorMessage(error));
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setRefreshing(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [active, message, onResourceRefreshed, resourceProp]);
 
   useEffect(() => {
     setSchemaPage(1);
@@ -297,8 +262,7 @@ export function ResourceDetailPanel({
   ];
 
   return (
-    <Spin spinning={refreshing}>
-      <div className={styles.contentSurface}>
+    <div className={styles.contentSurface}>
       {!gate.ok && catalog ? (
         <div className={styles.calloutWarn}>
           <ExclamationCircleOutlined />
@@ -413,7 +377,6 @@ export function ResourceDetailPanel({
           />
         ) : null}
       </div>
-      </div>
-    </Spin>
+    </div>
   );
 }

--- a/src/modules/data-catalog/components/ResourceIndexPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceIndexPanel.tsx
@@ -37,7 +37,6 @@ import {
 import {
   buildTaskStatusLabelKey,
 } from "@/modules/data-catalog/services/build-task.service";
-import { getCatalogResource } from "@/modules/data-catalog/services/resource.service";
 import type { BuildTask, CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 import type { CatalogRecord } from "@/shared/catalog";
 
@@ -174,35 +173,16 @@ export function ResourceIndexPanel({
   const [taskPageSize, setTaskPageSize] = useState(10);
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
   const { pauseOrResume, remove, retry } = useBuildTaskActions(onRefresh);
-  const [detailResource, setDetailResource] = useState<CatalogResource>(resource);
   const autoPickedRef = useRef(false);
 
-  const reloadResource = () => {
-    void getCatalogResource(resource.id).then((detail) => {
-      if (detail) {
-        setDetailResource(detail);
-      }
-    });
-  };
-
   useEffect(() => {
-    setDetailResource(resource);
     autoPickedRef.current = false;
-    let cancelled = false;
-    void getCatalogResource(resource.id).then((detail) => {
-      if (!cancelled && detail) {
-        setDetailResource(detail);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [resource]);
+  }, [resource.id]);
 
   const sortedTasks = useMemo(() => sortTasks(tasks), [tasks]);
   const state = useMemo(() => indexStateOf(sortedTasks), [sortedTasks]);
   const gate = resourceGateOf(catalog);
-  const resourceBlockReason = resourceQueryBlockReason(detailResource);
+  const resourceBlockReason = resourceQueryBlockReason(resource);
   const buildActionsDisabled = !gate.ok || resourceBlockReason !== null;
   const readOnly = isResourceIndexReadOnly(catalog);
   const canManageBuildTasks = canManageResourceBuildTasks(resource, catalog);
@@ -363,11 +343,10 @@ export function ResourceIndexPanel({
           active={active && indexView === "config"}
           hideBuildControls={readOnly}
           onSaved={() => {
-            reloadResource();
             void onRefresh();
           }}
           readOnly={readOnly}
-          resource={detailResource}
+          resource={resource}
         />
       </div>
     </>
@@ -475,7 +454,7 @@ export function ResourceIndexPanel({
                 onStarted={() => {
                   void onRefresh();
                 }}
-                resource={detailResource}
+                resource={resource}
               />
             </PermissionGate>
           </div>

--- a/src/modules/data-catalog/scenes/ResourceWorkspaceScene.test.tsx
+++ b/src/modules/data-catalog/scenes/ResourceWorkspaceScene.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
+
+const getCatalogResourceMock = vi.hoisted(() => vi.fn());
+const getCatalogMock = vi.hoisted(() => vi.fn());
+const listBuildTasksMock = vi.hoisted(() => vi.fn());
+
+vi.mock("antd", () => ({
+  Alert: ({ message }: { message: React.ReactNode }) => <div>{message}</div>,
+  Spin: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  Tabs: ({ activeKey, items }: { activeKey: string; items: Array<{ children: React.ReactNode; key: string }> }) => (
+    <>{items.find((item) => item.key === activeKey)?.children}</>
+  ),
+}));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({ message: { error: vi.fn() }, modal: { confirm: vi.fn() } }),
+}));
+
+vi.mock("@/framework/ui/common/AppButton", () => ({
+  AppButton: ({ children }: { children?: React.ReactNode }) => <button type="button">{children}</button>,
+}));
+
+vi.mock("@/framework/ui/common/EmptyStatePanel", () => ({
+  EmptyStatePanel: () => <div />,
+}));
+
+vi.mock("@/framework/ui/common/SceneBackButton", () => ({
+  SceneBackButton: () => <button type="button" />,
+}));
+
+vi.mock("@/framework/entitlement/EditionBadge", () => ({ EditionBadge: () => null }));
+vi.mock("@/framework/entitlement/RequireEdition", () => ({
+  RequireEdition: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/modules/data-catalog/components/ResourceDetailPanel", () => ({
+  ResourceDetailPanel: ({ resource }: { resource: CatalogResource }) => (
+    <div data-testid="detail-schema-name">{resource.schema[0]?.displayName ?? "-"}</div>
+  ),
+}));
+vi.mock("@/modules/data-catalog/components/ResourceIndexPanel", () => ({ ResourceIndexPanel: () => <div /> }));
+vi.mock("@/modules/data-catalog/components/ResourcePreviewPanel", () => ({ ResourcePreviewPanel: () => <div /> }));
+vi.mock("@/modules/data-catalog/components/ResourceSemanticUnderstandingPanel", () => ({
+  ResourceSemanticUnderstandingPanel: () => <div data-testid="semantic-panel" />,
+}));
+
+vi.mock("@/modules/data-catalog/services/resource.service", () => ({
+  getCatalogResource: getCatalogResourceMock,
+}));
+vi.mock("@/modules/data-catalog/services/build-task.service", () => ({
+  listBuildTasks: listBuildTasksMock,
+}));
+vi.mock("@/modules/data-catalog/services/mock-db", () => ({
+  subscribeMockDb: () => () => {},
+}));
+vi.mock("@/shared/catalog", () => ({ getCatalog: getCatalogMock }));
+
+import { ResourceWorkspaceScene } from "./ResourceWorkspaceScene";
+
+const staleResource: CatalogResource = {
+  catalogId: "catalog-1",
+  category: "table",
+  columnCount: 1,
+  description: "",
+  id: "resource-1",
+  name: "orders",
+  rowCount: 1,
+  schema: [{ name: "order_id", type: "string" }],
+  sourceIdentifier: "orders",
+  updateTime: "2026-08-20T00:00:00Z",
+  expectedUpdateTime: 1,
+};
+
+describe("ResourceWorkspaceScene", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCatalogMock.mockResolvedValue({ id: "catalog-1", name: "Catalog" });
+    listBuildTasksMock.mockResolvedValue([]);
+  });
+
+  it("refreshes the resource once when entering detail after semantic understanding", async () => {
+    const semanticResource: CatalogResource = {
+      ...staleResource,
+      expectedUpdateTime: 2,
+      schema: [{ ...staleResource.schema[0], description: "Order identifier", displayName: "订单编号" }],
+    };
+    getCatalogResourceMock
+      .mockResolvedValueOnce(staleResource)
+      .mockResolvedValueOnce(semanticResource);
+
+    const props = {
+      indexView: "config" as const,
+      onIndexViewChange: vi.fn(),
+      onTabChange: vi.fn(),
+      resourceId: staleResource.id,
+      tab: "semantic-understanding" as const,
+    };
+    const { rerender } = render(<ResourceWorkspaceScene {...props} />);
+
+    await screen.findByTestId("semantic-panel");
+    rerender(<ResourceWorkspaceScene {...props} tab="detail" />);
+
+    await waitFor(() => expect(getCatalogResourceMock).toHaveBeenCalledTimes(2));
+    expect((await screen.findByTestId("detail-schema-name")).textContent).toBe("订单编号");
+  });
+});

--- a/src/modules/data-catalog/scenes/ResourceWorkspaceScene.test.tsx
+++ b/src/modules/data-catalog/scenes/ResourceWorkspaceScene.test.tsx
@@ -13,10 +13,11 @@ import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog"
 const getCatalogResourceMock = vi.hoisted(() => vi.fn());
 const getCatalogMock = vi.hoisted(() => vi.fn());
 const listBuildTasksMock = vi.hoisted(() => vi.fn());
+const subscribeMockDbMock = vi.hoisted(() => vi.fn());
 
 vi.mock("antd", () => ({
   Alert: ({ message }: { message: React.ReactNode }) => <div>{message}</div>,
-  Spin: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  Spin: ({ children }: { children?: React.ReactNode }) => <div data-testid="workspace-spin">{children}</div>,
   Tabs: ({ activeKey, items }: { activeKey: string; items: Array<{ children: React.ReactNode; key: string }> }) => (
     <>{items.find((item) => item.key === activeKey)?.children}</>
   ),
@@ -70,7 +71,7 @@ vi.mock("@/modules/data-catalog/services/build-task.service", () => ({
   listBuildTasks: listBuildTasksMock,
 }));
 vi.mock("@/modules/data-catalog/services/mock-db", () => ({
-  subscribeMockDb: () => () => {},
+  subscribeMockDb: subscribeMockDbMock,
 }));
 vi.mock("@/shared/catalog", () => ({ getCatalog: getCatalogMock }));
 
@@ -95,6 +96,46 @@ describe("ResourceWorkspaceScene", () => {
     vi.clearAllMocks();
     getCatalogMock.mockResolvedValue({ id: "catalog-1", name: "Catalog" });
     listBuildTasksMock.mockResolvedValue([]);
+    subscribeMockDbMock.mockImplementation(() => () => {});
+  });
+
+  it("finishes an in-flight workspace load after a tab refresh", async () => {
+    let onMockDbChange: (() => void) | undefined;
+    let resolveLoad: (resource: CatalogResource) => void;
+    const semanticResource: CatalogResource = {
+      ...staleResource,
+      expectedUpdateTime: 2,
+      schema: [{ ...staleResource.schema[0], displayName: "订单编号" }],
+    };
+    subscribeMockDbMock.mockImplementation((listener: () => void) => {
+      onMockDbChange = listener;
+      return () => {};
+    });
+    getCatalogResourceMock
+      .mockResolvedValueOnce(staleResource)
+      .mockImplementationOnce(() => new Promise<CatalogResource>((resolve) => {
+        resolveLoad = resolve;
+      }))
+      .mockResolvedValueOnce(semanticResource);
+
+    const props = {
+      indexView: "config" as const,
+      onIndexViewChange: vi.fn(),
+      onTabChange: vi.fn(),
+      resourceId: staleResource.id,
+      tab: "semantic-understanding" as const,
+    };
+    const { rerender } = render(<ResourceWorkspaceScene {...props} />);
+
+    await screen.findByTestId("semantic-panel");
+    onMockDbChange?.();
+    await screen.findByTestId("workspace-spin");
+    rerender(<ResourceWorkspaceScene {...props} tab="detail" />);
+    await waitFor(() => expect(getCatalogResourceMock).toHaveBeenCalledTimes(3));
+    resolveLoad!(staleResource);
+
+    expect((await screen.findByTestId("detail-schema-name")).textContent).toBe("订单编号");
+    expect(screen.queryByTestId("workspace-spin")).toBeNull();
   });
 
   it("refreshes the resource once when entering detail after semantic understanding", async () => {

--- a/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
+++ b/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
@@ -7,7 +7,7 @@
 
 import { DatabaseOutlined } from "@ant-design/icons";
 import { Alert, Spin, Tabs } from "antd";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
@@ -61,24 +61,29 @@ export function ResourceWorkspaceScene({
 }: ResourceWorkspaceSceneProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { modal } = useAppServices();
+  const { message, modal } = useAppServices();
   const [resource, setResource] = useState<CatalogResource | null>(null);
   const [catalog, setCatalog] = useState<CatalogRecord | null>(null);
   const [tasks, setTasks] = useState<BuildTask[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [detailEditing, setDetailEditing] = useState(false);
+  const previousTabRef = useRef(tab);
+  const resourceRequestIdRef = useRef(0);
 
   const loadAll = useCallback(async () => {
+    const requestId = ++resourceRequestIdRef.current;
     setLoadError(null);
     setLoading(true);
 
     try {
       const detail = await getCatalogResource(resourceId);
       if (!detail) {
-        setResource(null);
-        setCatalog(null);
-        setTasks([]);
+        if (resourceRequestIdRef.current === requestId) {
+          setResource(null);
+          setCatalog(null);
+          setTasks([]);
+        }
         return;
       }
 
@@ -87,22 +92,50 @@ export function ResourceWorkspaceScene({
         listBuildTasks({ resourceId }),
       ]);
 
-      setResource(detail);
-      setCatalog(catalogRecord);
-      setTasks(taskList);
+      if (resourceRequestIdRef.current === requestId) {
+        setResource(detail);
+        setCatalog(catalogRecord);
+        setTasks(taskList);
+      }
     } catch (error) {
-      setResource(null);
-      setCatalog(null);
-      setTasks([]);
-      setLoadError(extractRequestErrorMessage(error));
+      if (resourceRequestIdRef.current === requestId) {
+        setResource(null);
+        setCatalog(null);
+        setTasks([]);
+        setLoadError(extractRequestErrorMessage(error));
+      }
     } finally {
-      setLoading(false);
+      if (resourceRequestIdRef.current === requestId) {
+        setLoading(false);
+      }
     }
   }, [resourceId]);
 
   useEffect(() => {
     void loadAll();
   }, [loadAll]);
+
+  const refreshResource = useCallback(async () => {
+    const requestId = ++resourceRequestIdRef.current;
+    try {
+      const detail = await getCatalogResource(resourceId);
+      if (detail && resourceRequestIdRef.current === requestId) {
+        setResource(detail);
+      }
+    } catch (error) {
+      if (resourceRequestIdRef.current === requestId) {
+        void message.error(extractRequestErrorMessage(error));
+      }
+    }
+  }, [message, resourceId]);
+
+  useEffect(() => {
+    const previousTab = previousTabRef.current;
+    previousTabRef.current = tab;
+    if (previousTab !== tab && (tab === "detail" || tab === "index" || tab === "preview")) {
+      void refreshResource();
+    }
+  }, [refreshResource, tab]);
 
   useEffect(() => {
     return subscribeMockDb(() => {

--- a/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
+++ b/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
@@ -69,17 +69,22 @@ export function ResourceWorkspaceScene({
   const [loadError, setLoadError] = useState<string | null>(null);
   const [detailEditing, setDetailEditing] = useState(false);
   const previousTabRef = useRef(tab);
-  const resourceRequestIdRef = useRef(0);
+  const resourceVersionRef = useRef(0);
+  const loadRequestIdRef = useRef(0);
 
   const loadAll = useCallback(async () => {
-    const requestId = ++resourceRequestIdRef.current;
+    const resourceVersion = ++resourceVersionRef.current;
+    const loadRequestId = ++loadRequestIdRef.current;
     setLoadError(null);
     setLoading(true);
 
     try {
       const detail = await getCatalogResource(resourceId);
       if (!detail) {
-        if (resourceRequestIdRef.current === requestId) {
+        if (
+          resourceVersionRef.current === resourceVersion
+          && loadRequestIdRef.current === loadRequestId
+        ) {
           setResource(null);
           setCatalog(null);
           setTasks([]);
@@ -92,20 +97,25 @@ export function ResourceWorkspaceScene({
         listBuildTasks({ resourceId }),
       ]);
 
-      if (resourceRequestIdRef.current === requestId) {
+      if (resourceVersionRef.current === resourceVersion) {
         setResource(detail);
+      }
+      if (loadRequestIdRef.current === loadRequestId) {
         setCatalog(catalogRecord);
         setTasks(taskList);
       }
     } catch (error) {
-      if (resourceRequestIdRef.current === requestId) {
+      if (
+        resourceVersionRef.current === resourceVersion
+        && loadRequestIdRef.current === loadRequestId
+      ) {
         setResource(null);
+        setLoadError(extractRequestErrorMessage(error));
         setCatalog(null);
         setTasks([]);
-        setLoadError(extractRequestErrorMessage(error));
       }
     } finally {
-      if (resourceRequestIdRef.current === requestId) {
+      if (loadRequestIdRef.current === loadRequestId) {
         setLoading(false);
       }
     }
@@ -116,14 +126,14 @@ export function ResourceWorkspaceScene({
   }, [loadAll]);
 
   const refreshResource = useCallback(async () => {
-    const requestId = ++resourceRequestIdRef.current;
+    const resourceVersion = ++resourceVersionRef.current;
     try {
       const detail = await getCatalogResource(resourceId);
-      if (detail && resourceRequestIdRef.current === requestId) {
+      if (detail && resourceVersionRef.current === resourceVersion) {
         setResource(detail);
       }
     } catch (error) {
-      if (resourceRequestIdRef.current === requestId) {
+      if (resourceVersionRef.current === resourceVersion) {
         void message.error(extractRequestErrorMessage(error));
       }
     }


### PR DESCRIPTION
## What Changed

- [x] Centralize catalog-resource refreshes in the resource workspace when entering detail, preview, or index tabs.
- [x] Remove duplicate resource-detail requests from child panels and add a regression test for semantic-understanding metadata.
- [ ] Docs/doc 1 (not applicable)

---

## Why

- Related Issue: Closes #478
- Related Feature: Data catalog resource workspace
- Background: A semantic-understanding task could finish after an index-config refresh cached an older resource snapshot. The first entry to detail then skipped a necessary resource refresh, so business names and descriptions remained stale.

---

## How

- Key implementation points: The workspace owns refreshes and guards concurrent responses with a request sequence; detail, preview, and index consume the parent resource snapshot.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; no external service dependency)
- [ ] Verified in test environment (not run)

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm audit --prod` (one existing ignored high-severity finding; command succeeded)

---

## Risk & Rollback

- Potential risks: Each relevant tab entry adds one resource-detail request; stale responses are ignored.
- Rollback plan: Revert commit `36e03d4`.

---

## Additional Notes

- Regression test covers semantic understanding with an old schema followed by first entry to detail, asserting the refreshed business name is rendered.