### PR TITLE
fix(knowledge-network): handle MCP transport security

### DIFF
--- a/src/framework/compat/clipboard.test.ts
+++ b/src/framework/compat/clipboard.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { writeTextToClipboard } from "./clipboard";
+
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+
+function setClipboard(value: { writeText: (text: string) => Promise<void> } | undefined) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value,
+  });
+}
+
+function setExecCommand(value: (command: string) => boolean) {
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value,
+  });
+}
+
+afterEach(() => {
+  if (clipboardDescriptor) {
+    Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
+
+  if (execCommandDescriptor) {
+    Object.defineProperty(document, "execCommand", execCommandDescriptor);
+  } else {
+    Reflect.deleteProperty(document, "execCommand");
+  }
+
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("writeTextToClipboard", () => {
+  it("uses the Clipboard API when it is available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const execCommand = vi.fn(() => true);
+    setClipboard({ writeText });
+    setExecCommand(execCommand);
+
+    await writeTextToClipboard("MCP config");
+
+    expect(writeText).toHaveBeenCalledWith("MCP config");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a selected textarea when the Clipboard API is unavailable on HTTP", async () => {
+    const execCommand = vi.fn(() => {
+      expect(document.querySelector("textarea")?.value).toBe("HTTP MCP config");
+      return true;
+    });
+    setClipboard(undefined);
+    setExecCommand(execCommand);
+
+    await writeTextToClipboard("HTTP MCP config");
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("uses the fallback when the Clipboard API rejects", async () => {
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error("NotAllowedError")) });
+    const execCommand = vi.fn(() => true);
+    setExecCommand(execCommand);
+
+    await writeTextToClipboard("fallback");
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+});

--- a/src/framework/compat/clipboard.ts
+++ b/src/framework/compat/clipboard.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+function writeTextWithSelectionFallback(text: string): void {
+  if (typeof document === "undefined" || typeof document.execCommand !== "function") {
+    throw new Error("Clipboard API is unavailable");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.inset = "0 auto auto -9999px";
+  textarea.style.opacity = "0";
+
+  const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const selection = document.getSelection();
+  const selectedRanges =
+    selection === null
+      ? []
+      : Array.from({ length: selection.rangeCount }, (_, index) => selection.getRangeAt(index));
+
+  document.body.appendChild(textarea);
+  textarea.focus({ preventScroll: true });
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+
+  try {
+    if (!document.execCommand("copy")) {
+      throw new Error("Copy command was rejected");
+    }
+  } finally {
+    textarea.remove();
+    selection?.removeAllRanges();
+    selectedRanges.forEach((range) => selection?.addRange(range));
+    activeElement?.focus();
+  }
+}
+
+export async function writeTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== "undefined" && typeof navigator.clipboard?.writeText === "function") {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // In a non-secure HTTP context the Clipboard API may exist but reject.
+    }
+  }
+
+  writeTextWithSelectionFallback(text);
+}

--- a/src/modules/knowledge-network/locales/en-US/context-loader-panel.ts
+++ b/src/modules/knowledge-network/locales/en-US/context-loader-panel.ts
@@ -182,6 +182,17 @@ export const contextLoaderPanelPart = {
       copiedCursor: "Cursor config copied",
       copiedGeneric: "mcp.json config copied",
     },
+    mcpSecurity: {
+      httpTitle: "HTTP connection detected",
+      httpDescription:
+        "The generated config includes --allow-http. Bearer keys are sent without transport encryption, so only use this on a trusted network.",
+      httpsTitle: "HTTPS certificate verification enabled",
+      httpsDescription: "The generated config verifies the server certificate by default.",
+      allowSelfSigned: "Allow a self-signed certificate",
+      insecureTitle: "Certificate verification disabled",
+      insecureDescription:
+        "Use only for a trusted self-signed certificate. The generated config adds NODE_TLS_REJECT_UNAUTHORIZED=0.",
+    },
     mcpSetup: {
       title: "Connect MCP (Claude Code / Cursor)",
       externalPrefix: "This guide is for ",

--- a/src/modules/knowledge-network/locales/zh-CN/context-loader-panel.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/context-loader-panel.ts
@@ -182,6 +182,16 @@ export const contextLoaderPanelPart = {
       copiedCursor: "Cursor 配置已复制",
       copiedGeneric: "mcp.json 配置已复制",
     },
+    mcpSecurity: {
+      httpTitle: "检测到 HTTP 连接",
+      httpDescription: "生成的配置会自动加入 --allow-http。Bearer Key 将以未加密方式传输，请仅在可信网络中使用。",
+      httpsTitle: "已启用 HTTPS 证书校验",
+      httpsDescription: "生成的配置默认校验服务端证书。",
+      allowSelfSigned: "允许使用自签名证书",
+      insecureTitle: "证书校验已关闭",
+      insecureDescription:
+        "仅用于可信的自签名证书。生成的配置会加入 NODE_TLS_REJECT_UNAUTHORIZED=0。",
+    },
     mcpSetup: {
       title: "接入 MCP（Claude Code / Cursor）",
       externalPrefix: "接入指南用于",

--- a/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.tsx
+++ b/src/modules/knowledge-network/scenes/ContextLoaderIntegrationPanel.tsx
@@ -22,10 +22,16 @@ import {
   isLongToolSummary,
   toolSummaryPreview,
 } from "@/modules/knowledge-network/services/context-loader.service";
-import { createClaudeCodeMcpCommand, createMcpRemoteJsonConfig, withMcpTrailingSlash } from "@/modules/knowledge-network/services/mcp-client-config";
+import {
+  createClaudeCodeMcpCommand,
+  createMcpRemoteJsonConfig,
+  getMcpConnectionProtocol,
+  withMcpTrailingSlash,
+} from "@/modules/knowledge-network/services/mcp-client-config";
 import { buildMcpToolGroups, toolDisplayOf } from "@/modules/knowledge-network/services/mcp-tool-display";
 
 import styles from "./ExperienceScene.module.css";
+import { McpConnectionSecurity } from "./McpConnectionSecurity";
 
 export type ResponseView = { kind: "json" | "toon"; text: string };
 
@@ -249,13 +255,16 @@ export function ContextLoaderIntegrationPanel({
   const [mcpConfigKeyDraft, setMcpConfigKeyDraft] = useState("");
   const [mcpConfigKeyError, setMcpConfigKeyError] = useState("");
   const [mcpConfigKeyModalOpen, setMcpConfigKeyModalOpen] = useState(false);
+  const [allowInsecureTls, setAllowInsecureTls] = useState(false);
   const filterText = filter.trim().toLowerCase();
   const appKeyPlaceholder = t("knowledgeNetwork.contextLoaderPanel.appKey.placeholder");
   const configAppKey = mcpConfigKey || appKeyPlaceholder;
   const mcpUrlWithSlash = withMcpTrailingSlash(mcpUrl);
+  const mcpProtocol = getMcpConnectionProtocol(mcpUrlWithSlash);
   const apiKeyPagePath = buildApiKeyPagePath(`${location.pathname}${location.search}`);
-  const mcpRemoteJsonConfig = createMcpRemoteJsonConfig(mcpUrlWithSlash, configAppKey);
-  const claudeCliConfig = createClaudeCodeMcpCommand(mcpUrlWithSlash, configAppKey);
+  const mcpClientOptions = { allowInsecureTls };
+  const mcpRemoteJsonConfig = createMcpRemoteJsonConfig(mcpUrlWithSlash, configAppKey, mcpClientOptions);
+  const claudeCliConfig = createClaudeCodeMcpCommand(mcpUrlWithSlash, configAppKey, mcpClientOptions);
   // Display names and groups come from tools/list metadata first, with local fallback for old servers.
   const toolMetaByName = useMemo(() => new Map((toolDefs ?? []).map((tool) => [tool.name, tool])), [toolDefs]);
   const displayOf = useCallback(
@@ -324,6 +333,10 @@ export function ContextLoaderIntegrationPanel({
   useEffect(() => {
     if (appKeyValue) setMcpConfigKey(appKeyValue);
   }, [appKeyValue]);
+
+  useEffect(() => {
+    if (mcpProtocol === "http") setAllowInsecureTls(false);
+  }, [mcpProtocol]);
 
   useEffect(() => {
     if (sending || response !== null || reqError !== null) {
@@ -432,6 +445,11 @@ export function ContextLoaderIntegrationPanel({
                   </button>
                 </div>
               </div>
+              <McpConnectionSecurity
+                protocol={mcpProtocol}
+                allowInsecureTls={allowInsecureTls}
+                onAllowInsecureTlsChange={setAllowInsecureTls}
+              />
               <div className={styles.mcpConfigBody}>
                 {mcpConfigTab === "claude" ? (
                   <>

--- a/src/modules/knowledge-network/scenes/ExperienceScene.module.css
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.module.css
@@ -365,6 +365,90 @@
   border-bottom: 1px solid var(--line);
 }
 
+.mcpSecurityStrip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-width: 0;
+  margin-bottom: 2px;
+  padding: 10px 12px;
+  border: 1px solid;
+  border-left-width: 3px;
+  border-radius: 4px;
+}
+
+.mcpSecuritySecure {
+  border-color: #bfdbca;
+  border-left-color: #238451;
+  background: #f4fbf7;
+}
+
+.mcpSecurityWarning {
+  border-color: #f1d59d;
+  border-left-color: #c87912;
+  background: #fffaf0;
+}
+
+.mcpSecurityStatus {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.mcpSecurityIcon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: #238451;
+  font-size: 16px;
+}
+
+.mcpSecurityWarning .mcpSecurityIcon {
+  color: #b86b0b;
+}
+
+.mcpSecurityProtocol {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  color: #287a50;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.mcpSecurityWarning .mcpSecurityProtocol {
+  color: #a96008;
+}
+
+.mcpSecurityCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.mcpSecurityCopy strong {
+  color: var(--txt);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.mcpSecurityCopy span {
+  color: var(--txt2);
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+
+.mcpSecurityCheckbox {
+  flex: 0 0 auto;
+  color: var(--txt2);
+  font-size: 12px;
+}
+
 .mcpConfigTabs {
   display: inline-flex;
   align-items: center;
@@ -372,6 +456,18 @@
   flex-wrap: wrap;
   gap: 4px;
   min-width: 0;
+}
+
+@media (max-width: 720px) {
+  .mcpSecurityStrip {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .mcpSecurityCheckbox {
+    padding-left: 25px;
+  }
 }
 
 .mcpConfigTab {

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { gatewayOrigin } from "@/framework/auth/oauth";
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
 import {
   formatPrecisionSafeJSON,
@@ -200,8 +201,7 @@ export function ExperienceScene({
 
   const copy = useCallback(
     (text: string, label?: string) => {
-      void navigator.clipboard
-        ?.writeText(text)
+      void writeTextToClipboard(text)
         .then(() =>
           message.success(
             label ?? t("knowledgeNetwork.contextLoaderPanel.experience.copied"),

--- a/src/modules/knowledge-network/scenes/McpConnectionSecurity.test.tsx
+++ b/src/modules/knowledge-network/scenes/McpConnectionSecurity.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { McpConnectionSecurity } from "./McpConnectionSecurity";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+describe("McpConnectionSecurity", () => {
+  it("shows a fixed warning without a TLS checkbox for HTTP", () => {
+    render(
+      <McpConnectionSecurity
+        protocol="http"
+        allowInsecureTls={false}
+        onAllowInsecureTlsChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("HTTP")).toBeTruthy();
+    expect(screen.getByText("knowledgeNetwork.contextLoaderPanel.mcpSecurity.httpTitle")).toBeTruthy();
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("lets HTTPS users explicitly allow a self-signed certificate", () => {
+    const onChange = vi.fn();
+    render(
+      <McpConnectionSecurity
+        protocol="https"
+        allowInsecureTls={false}
+        onAllowInsecureTlsChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/modules/knowledge-network/scenes/McpConnectionSecurity.tsx
+++ b/src/modules/knowledge-network/scenes/McpConnectionSecurity.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { SafetyCertificateOutlined, WarningOutlined } from "@ant-design/icons";
+import { Checkbox } from "antd";
+import { useTranslation } from "react-i18next";
+
+import type { McpConnectionProtocol } from "@/modules/knowledge-network/services/mcp-client-config";
+
+import styles from "./ExperienceScene.module.css";
+
+export function McpConnectionSecurity({
+  protocol,
+  allowInsecureTls,
+  onAllowInsecureTlsChange,
+}: {
+  protocol: McpConnectionProtocol;
+  allowInsecureTls: boolean;
+  onAllowInsecureTlsChange: (checked: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const isWarning = protocol === "http" || allowInsecureTls;
+  const titleKey =
+    protocol === "http"
+      ? "httpTitle"
+      : allowInsecureTls
+        ? "insecureTitle"
+        : "httpsTitle";
+  const descriptionKey =
+    protocol === "http"
+      ? "httpDescription"
+      : allowInsecureTls
+        ? "insecureDescription"
+        : "httpsDescription";
+
+  return (
+    <div
+      className={`${styles.mcpSecurityStrip} ${isWarning ? styles.mcpSecurityWarning : styles.mcpSecuritySecure}`}
+      aria-live="polite"
+    >
+      <div className={styles.mcpSecurityStatus}>
+        <span className={styles.mcpSecurityIcon} aria-hidden>
+          {isWarning ? <WarningOutlined /> : <SafetyCertificateOutlined />}
+        </span>
+        <span className={styles.mcpSecurityProtocol}>{protocol.toUpperCase()}</span>
+        <div className={styles.mcpSecurityCopy}>
+          <strong>{t(`knowledgeNetwork.contextLoaderPanel.mcpSecurity.${titleKey}`)}</strong>
+          <span>{t(`knowledgeNetwork.contextLoaderPanel.mcpSecurity.${descriptionKey}`)}</span>
+        </div>
+      </div>
+      {protocol === "https" ? (
+        <Checkbox
+          className={styles.mcpSecurityCheckbox}
+          checked={allowInsecureTls}
+          onChange={(event) => onAllowInsecureTlsChange(event.target.checked)}
+        >
+          {t("knowledgeNetwork.contextLoaderPanel.mcpSecurity.allowSelfSigned")}
+        </Checkbox>
+      ) : null}
+    </div>
+  );
+}

--- a/src/modules/knowledge-network/scenes/McpIntegrationModals.tsx
+++ b/src/modules/knowledge-network/scenes/McpIntegrationModals.tsx
@@ -7,13 +7,18 @@
 
 import { ApiOutlined, CopyOutlined } from "@ant-design/icons";
 import { Modal, Spin, Tabs } from "antd";
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { McpToolDef } from "@/modules/knowledge-network/services/context-loader.service";
-import { createClaudeCodeMcpCommand, createMcpRemoteJsonConfig } from "@/modules/knowledge-network/services/mcp-client-config";
+import {
+  createClaudeCodeMcpCommand,
+  createMcpRemoteJsonConfig,
+  getMcpConnectionProtocol,
+} from "@/modules/knowledge-network/services/mcp-client-config";
 
 import styles from "./ExperienceScene.module.css";
+import { McpConnectionSecurity } from "./McpConnectionSecurity";
 
 const JSON_TOKEN_RE = /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
 
@@ -88,9 +93,16 @@ export function McpSetupModal({
   copy: (text: string, label?: string) => void;
 }) {
   const { t } = useTranslation();
+  const [allowInsecureTls, setAllowInsecureTls] = useState(false);
   const tk = t("knowledgeNetwork.contextLoaderPanel.appKey.placeholder");
-  const jsonConfig = createMcpRemoteJsonConfig(mcpUrl, tk);
-  const claudeCli = createClaudeCodeMcpCommand(mcpUrl, tk);
+  const protocol = getMcpConnectionProtocol(mcpUrl);
+  const options = { allowInsecureTls };
+  const jsonConfig = createMcpRemoteJsonConfig(mcpUrl, tk, options);
+  const claudeCli = createClaudeCodeMcpCommand(mcpUrl, tk, options);
+
+  useEffect(() => {
+    if (protocol === "http") setAllowInsecureTls(false);
+  }, [protocol]);
 
   return (
     <Modal open={open} onCancel={onClose} footer={null} width={680} title={t("knowledgeNetwork.contextLoaderPanel.mcpSetup.title")}>
@@ -110,6 +122,11 @@ export function McpSetupModal({
         {t("knowledgeNetwork.contextLoaderPanel.mcpSetup.authDifferenceSuffix")}<code>Authorization: Bearer</code>
         {t("knowledgeNetwork.contextLoaderPanel.mcpSetup.authDifferenceEnd")}
       </p>
+      <McpConnectionSecurity
+        protocol={protocol}
+        allowInsecureTls={allowInsecureTls}
+        onAllowInsecureTlsChange={setAllowInsecureTls}
+      />
       <Tabs
         defaultActiveKey="claude"
         items={[

--- a/src/modules/knowledge-network/services/mcp-client-config.test.ts
+++ b/src/modules/knowledge-network/services/mcp-client-config.test.ts
@@ -7,23 +7,80 @@
 
 import { describe, expect, it } from "vitest";
 
-import { createClaudeCodeMcpCommand, createMcpRemoteJsonConfig } from "@/modules/knowledge-network/services/mcp-client-config";
+import {
+  createClaudeCodeMcpCommand,
+  createMcpRemoteJsonConfig,
+  getMcpConnectionProtocol,
+} from "@/modules/knowledge-network/services/mcp-client-config";
 
 describe("MCP client configuration", () => {
-  const mcpUrl = "https://platform.example.com/api/agent-retrieval/v1/mcp";
   const apiKey = "bak_test";
 
-  it("creates a Claude Code command that starts mcp-remote with TLS handling", () => {
+  it("adds --allow-http for an HTTP deployment without disabling TLS verification", () => {
+    const mcpUrl = "http://platform.example.com/api/agent-retrieval/v1/mcp";
+
     expect(createClaudeCodeMcpCommand(mcpUrl, apiKey)).toBe(`claude mcp add bkn-agent-retrieval \\
+  --scope user \\
+  -- npx -y mcp-remote http://platform.example.com/api/agent-retrieval/v1/mcp/ \\
+  --transport http-only \\
+  --allow-http \\
+  --header "Authorization: Bearer bak_test"`);
+    expect(JSON.parse(createMcpRemoteJsonConfig(mcpUrl, apiKey))).toEqual({
+      mcpServers: {
+        "bkn-agent-retrieval": {
+          command: "npx",
+          args: [
+            "-y",
+            "mcp-remote",
+            "http://platform.example.com/api/agent-retrieval/v1/mcp/",
+            "--transport",
+            "http-only",
+            "--allow-http",
+            "--header",
+            "Authorization: Bearer bak_test",
+          ],
+        },
+      },
+    });
+  });
+
+  it("keeps certificate verification enabled for an HTTPS deployment by default", () => {
+    const mcpUrl = "https://platform.example.com/api/agent-retrieval/v1/mcp";
+
+    expect(createClaudeCodeMcpCommand(mcpUrl, apiKey)).toBe(`claude mcp add bkn-agent-retrieval \\
+  --scope user \\
+  -- npx -y mcp-remote https://platform.example.com/api/agent-retrieval/v1/mcp/ \\
+  --transport http-only \\
+  --header "Authorization: Bearer bak_test"`);
+    expect(JSON.parse(createMcpRemoteJsonConfig(mcpUrl, apiKey))).toEqual({
+      mcpServers: {
+        "bkn-agent-retrieval": {
+          command: "npx",
+          args: [
+            "-y",
+            "mcp-remote",
+            "https://platform.example.com/api/agent-retrieval/v1/mcp/",
+            "--transport",
+            "http-only",
+            "--header",
+            "Authorization: Bearer bak_test",
+          ],
+        },
+      },
+    });
+  });
+
+  it("disables certificate verification only when explicitly allowed for HTTPS", () => {
+    const mcpUrl = "https://platform.example.com/api/agent-retrieval/v1/mcp";
+    const options = { allowInsecureTls: true };
+
+    expect(createClaudeCodeMcpCommand(mcpUrl, apiKey, options)).toBe(`claude mcp add bkn-agent-retrieval \\
   --scope user \\
   --env NODE_TLS_REJECT_UNAUTHORIZED=0 \\
   -- npx -y mcp-remote https://platform.example.com/api/agent-retrieval/v1/mcp/ \\
   --transport http-only \\
   --header "Authorization: Bearer bak_test"`);
-  });
-
-  it("creates the same mcp-remote server structure for project configuration", () => {
-    expect(JSON.parse(createMcpRemoteJsonConfig(mcpUrl, apiKey))).toEqual({
+    expect(JSON.parse(createMcpRemoteJsonConfig(mcpUrl, apiKey, options))).toEqual({
       mcpServers: {
         "bkn-agent-retrieval": {
           command: "npx",
@@ -42,5 +99,19 @@ describe("MCP client configuration", () => {
         },
       },
     });
+  });
+
+  it("ignores the self-signed certificate option for HTTP", () => {
+    const mcpUrl = "http://platform.example.com/api/agent-retrieval/v1/mcp";
+
+    expect(JSON.parse(createMcpRemoteJsonConfig(mcpUrl, apiKey, { allowInsecureTls: true }))).not.toHaveProperty(
+      "mcpServers.bkn-agent-retrieval.env",
+    );
+  });
+
+  it("detects supported protocols and rejects unsupported URLs", () => {
+    expect(getMcpConnectionProtocol("http://platform.example.com/mcp")).toBe("http");
+    expect(getMcpConnectionProtocol("https://platform.example.com/mcp")).toBe("https");
+    expect(() => getMcpConnectionProtocol("ftp://platform.example.com/mcp")).toThrow("Unsupported MCP URL protocol");
   });
 });

--- a/src/modules/knowledge-network/services/mcp-client-config.ts
+++ b/src/modules/knowledge-network/services/mcp-client-config.ts
@@ -8,33 +8,67 @@
 const MCP_SERVER_NAME = "bkn-agent-retrieval";
 const TLS_BYPASS_ENV = "NODE_TLS_REJECT_UNAUTHORIZED=0";
 
+export type McpConnectionProtocol = "http" | "https";
+
+export interface McpClientConfigOptions {
+  allowInsecureTls?: boolean;
+}
+
 export function withMcpTrailingSlash(mcpUrl: string): string {
   return mcpUrl.endsWith("/") ? mcpUrl : `${mcpUrl}/`;
 }
 
-function createMcpRemoteServer(mcpUrl: string, apiKey: string) {
-  return {
-    command: "npx",
-    args: [
-      "-y",
-      "mcp-remote",
-      withMcpTrailingSlash(mcpUrl),
-      "--transport",
-      "http-only",
-      "--header",
-      `Authorization: Bearer ${apiKey}`,
-    ],
-    env: {
-      NODE_TLS_REJECT_UNAUTHORIZED: "0",
-    },
-  };
+export function getMcpConnectionProtocol(mcpUrl: string): McpConnectionProtocol {
+  let protocol: string;
+
+  try {
+    protocol = new URL(mcpUrl).protocol;
+  } catch {
+    throw new Error("Invalid MCP URL");
+  }
+
+  if (protocol === "http:" || protocol === "https:") {
+    return protocol.slice(0, -1) as McpConnectionProtocol;
+  }
+
+  throw new Error(`Unsupported MCP URL protocol: ${protocol}`);
 }
 
-export function createMcpRemoteJsonConfig(mcpUrl: string, apiKey: string): string {
+function createMcpRemoteServer(mcpUrl: string, apiKey: string, options: McpClientConfigOptions) {
+  const protocol = getMcpConnectionProtocol(mcpUrl);
+  const args = ["-y", "mcp-remote", withMcpTrailingSlash(mcpUrl), "--transport", "http-only"];
+
+  if (protocol === "http") {
+    args.push("--allow-http");
+  }
+
+  args.push("--header", `Authorization: Bearer ${apiKey}`);
+
+  const server: {
+    command: string;
+    args: string[];
+    env?: { NODE_TLS_REJECT_UNAUTHORIZED: string };
+  } = {
+    command: "npx",
+    args,
+  };
+
+  if (protocol === "https" && options.allowInsecureTls) {
+    server.env = { NODE_TLS_REJECT_UNAUTHORIZED: "0" };
+  }
+
+  return server;
+}
+
+export function createMcpRemoteJsonConfig(
+  mcpUrl: string,
+  apiKey: string,
+  options: McpClientConfigOptions = {},
+): string {
   return JSON.stringify(
     {
       mcpServers: {
-        [MCP_SERVER_NAME]: createMcpRemoteServer(mcpUrl, apiKey),
+        [MCP_SERVER_NAME]: createMcpRemoteServer(mcpUrl, apiKey, options),
       },
     },
     null,
@@ -42,13 +76,28 @@ export function createMcpRemoteJsonConfig(mcpUrl: string, apiKey: string): strin
   );
 }
 
-export function createClaudeCodeMcpCommand(mcpUrl: string, apiKey: string): string {
-  return [
+export function createClaudeCodeMcpCommand(
+  mcpUrl: string,
+  apiKey: string,
+  options: McpClientConfigOptions = {},
+): string {
+  const protocol = getMcpConnectionProtocol(mcpUrl);
+  const lines = [
     `claude mcp add ${MCP_SERVER_NAME} \\`,
     "  --scope user \\",
-    `  --env ${TLS_BYPASS_ENV} \\`,
-    `  -- npx -y mcp-remote ${withMcpTrailingSlash(mcpUrl)} \\`,
-    "  --transport http-only \\",
-    `  --header "Authorization: Bearer ${apiKey}"`,
-  ].join("\n");
+  ];
+
+  if (protocol === "https" && options.allowInsecureTls) {
+    lines.push(`  --env ${TLS_BYPASS_ENV} \\`);
+  }
+
+  lines.push(`  -- npx -y mcp-remote ${withMcpTrailingSlash(mcpUrl)} \\`, "  --transport http-only \\");
+
+  if (protocol === "http") {
+    lines.push("  --allow-http \\");
+  }
+
+  lines.push(`  --header "Authorization: Bearer ${apiKey}"`);
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Generate protocol-aware MCP client configurations for HTTP and HTTPS.
- [x] Require explicit opt-in before disabling HTTPS certificate verification.
- [x] Add localized connection-security guidance and a clipboard compatibility fallback.
- [x] Add regression coverage for protocol handling, TLS opt-in, security UI, and copy fallback.

---

## Why

- Related Issue: Closes #434
- Related Feature: Knowledge Network MCP integration
- Background: HTTP MCP endpoints require --allow-http, while HTTPS endpoints should verify certificates by default. The async Clipboard API can also be unavailable or rejected in some managed browser environments.

---

## How

- Key implementation points:
  - Parse the MCP endpoint scheme before generating client configuration.
  - Keep the streamable HTTP transport argument for both schemes and add --allow-http only for HTTP endpoints.
  - Add NODE_TLS_REJECT_UNAUTHORIZED=0 only when users explicitly allow a self-signed HTTPS certificate.
  - Share the same behavior across Claude Code commands and JSON configurations used by Cursor and generic clients.
  - Prefer navigator.clipboard.writeText and fall back to selection-based copying only when the async API is unavailable or rejects.
  - Add matching Chinese and English security guidance.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- node scripts/check-license-headers.mjs
- pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
- pnpm run i18n:check (4 files, 27 tests)
- pnpm exec vitest --run --maxWorkers=2 (227 files, 1190 tests)
- pnpm exec tsc -b --pretty false
- pnpm exec vite build (3 GB Node heap limit, two build threads)
- pnpm audit --prod (exit 0; one ignored high-severity advisory reported by the repository policy)
- The production build reports existing dynamic-import and large-chunk warnings.

---

## Risk & Rollback

- Potential risks: Generated client arguments change for HTTP endpoints; the deprecated document.execCommand API is used only as a compatibility fallback; bearer tokens remain plaintext when users deliberately connect over HTTP.
- Rollback plan: Revert commit d2eb8d6.

---

## Additional Notes

- Use HTTP bearer tokens only on trusted private networks; HTTPS remains recommended.
- No backend, database, or dependency changes are included.