### PR TITLE
fix(data-connect): refresh connector group labels on locale change

### DIFF
--- a/src/modules/data-connect/components/DataConnectConfigForm.test.tsx
+++ b/src/modules/data-connect/components/DataConnectConfigForm.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { Form } from "antd";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "@/app/locales/i18n";
+import { DataConnectConfigForm } from "@/modules/data-connect/components/DataConnectConfigForm";
+import type { DataConnectConnectorType } from "@/modules/data-connect/types/data-connect";
+
+const mariaDbConnector: DataConnectConnectorType = {
+  category: "table",
+  description: "MariaDB connector",
+  enabled: true,
+  fieldConfig: {
+    databases: { encrypted: false, required: false, type: "array" },
+    host: { encrypted: false, required: true, type: "string" },
+    options: { encrypted: false, required: false, type: "object" },
+    password: { encrypted: true, required: true, type: "string" },
+    port: { encrypted: false, required: true, type: "integer" },
+    username: { encrypted: false, required: true, type: "string" },
+  },
+  mode: "local",
+  name: "MariaDB",
+  type: "mariadb",
+};
+
+function hasGroupTitle(title: string) {
+  return [...document.querySelectorAll("[class*='_groupTitle_']")].some(
+    (element) => element.textContent === title,
+  );
+}
+
+describe("DataConnectConfigForm", () => {
+  beforeEach(async () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      addEventListener: () => undefined,
+      addListener: () => undefined,
+      dispatchEvent: () => false,
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: () => undefined,
+      removeListener: () => undefined,
+    }));
+    await i18n.changeLanguage("zh-CN");
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage("zh-CN");
+  });
+
+  it("updates connector group titles when the active locale changes", async () => {
+    render(
+      <Form>
+        <DataConnectConfigForm selectedConnectorType={mariaDbConnector} />
+      </Form>,
+    );
+
+    expect(hasGroupTitle("连接参数")).toBe(true);
+    expect(hasGroupTitle("认证信息")).toBe(true);
+    expect(hasGroupTitle("高级设置")).toBe(true);
+    expect(screen.getByText("主机地址")).not.toBeNull();
+
+    await act(async () => {
+      await i18n.changeLanguage("en-US");
+    });
+
+    expect(hasGroupTitle("Connection parameters")).toBe(true);
+    expect(hasGroupTitle("Authentication")).toBe(true);
+    expect(hasGroupTitle("Advanced settings")).toBe(true);
+    expect(screen.getByText("Host")).not.toBeNull();
+    expect(hasGroupTitle("连接参数")).toBe(false);
+    expect(screen.queryByText("主机地址")).toBeNull();
+  });
+});

--- a/src/modules/data-connect/components/DataConnectConfigForm.tsx
+++ b/src/modules/data-connect/components/DataConnectConfigForm.tsx
@@ -8,7 +8,6 @@
 import { Form, Input, InputNumber, Select, Switch } from "antd";
 import type { Rule } from "antd/es/form";
 import type { ReactNode } from "react";
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -86,10 +85,7 @@ export function DataConnectConfigForm({
   );
   const connectorConfig = Form.useWatch<Record<string, unknown>>("connectorConfig");
 
-  const groupedFields = useMemo(
-    () => groupConnectorFields(selectedConnectorType),
-    [selectedConnectorType],
-  );
+  const groupedFields = groupConnectorFields(selectedConnectorType);
 
   const templateMeta = selectedConnectorType
     ? getConnectorTemplateMeta(selectedConnectorType)


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Refresh connector configuration group titles whenever the form rerenders after a locale change.
- [x] Add a MariaDB regression test for changing locale without unmounting the form.
- [ ] Docs/doc 1 (not applicable: no public contract or user-facing documentation change).

---

## Why

- Related Issue: Closes #487
- Related Feature: Not applicable.
- Background: Group titles were memoized by connector type only, so they kept the previous locale while field labels updated after a language switch.

---

## How

- Key implementation points: Remove the stale memoization and derive grouped connector fields during rendering from the active i18n resources.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: frontend-only rendering fix).
- [ ] Verified in test environment (not run).

Test notes:

- `pnpm exec vitest --run src/modules/data-connect/components/DataConnectConfigForm.test.tsx src/modules/data-connect/lib/connector-template.test.ts`
- `pnpm exec eslint src/modules/data-connect/components/DataConnectConfigForm.tsx src/modules/data-connect/components/DataConnectConfigForm.test.tsx --config eslint.config.typechecked.js --max-warnings 0`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`

---

## Risk & Rollback

- Potential risks: Group fields are now recalculated on ordinary form renders; the configuration field set is small and no behavior or API contract changes.
- Rollback plan: Revert commit `0ffcdf8`.

---

## Additional Notes

- Production build succeeds with pre-existing chunking warnings.
- Full CI remains required before merge.