### PR TITLE
fix(model-resources): gate default model selection

### DIFF
--- a/src/modules/data-connect/components/DiscoverScheduleFormModal.test.tsx
+++ b/src/modules/data-connect/components/DiscoverScheduleFormModal.test.tsx
@@ -112,7 +112,7 @@ describe("DiscoverScheduleFormModal", () => {
 
     await waitFor(() => {
       expect(screen.getAllByText("dataConnect.discoverTimeRangeInvalid")).toHaveLength(2);
-    });
+    }, { timeout: 3_000 });
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/src/modules/model-resources/components/models/LargeModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/LargeModelListPanel.tsx
@@ -77,6 +77,7 @@ export function LargeModelListPanel() {
   const [monitorOpen, setMonitorOpen] = useState(false);
   const [authorizeRecord, setAuthorizeRecord] = useState<LlmModel | null>(null);
   const [canCreate, setCanCreate] = useState(false);
+  const [canSetDefaultOnCreate, setCanSetDefaultOnCreate] = useState(false);
   const userPermissions = runtimeConfig.currentUser.permissions;
   // `is_admin` is held by all three administrator roles, not only the resource-wildcard
   // super administrator. Resource operations must therefore come from effective grants.
@@ -140,6 +141,7 @@ export function LargeModelListPanel() {
   useEffect(() => {
     void getLlmRolePermissions().then((operations) => {
       setCanCreate(operations.includes("create"));
+      setCanSetDefaultOnCreate(operations.includes("modify"));
     });
   }, []);
 
@@ -644,6 +646,7 @@ export function LargeModelListPanel() {
       />
 
       <LlmModelFormModal
+        canSetDefault={canSetDefaultOnCreate}
         mode={formMode}
         onClose={(refresh) => {
           setFormOpen(false);

--- a/src/modules/model-resources/components/models/ModelModals.tsx
+++ b/src/modules/model-resources/components/models/ModelModals.tsx
@@ -30,6 +30,7 @@ import { getLlmModelTypeLabel } from "@/modules/model-resources/utils/llm-labels
 import modalStyles from "./LlmModelFormModal.module.css";
 
 type LlmModelFormModalProps = {
+  canSetDefault?: boolean;
   mode: "create" | "edit" | "view";
   onClose: (refresh?: boolean) => void;
   open: boolean;
@@ -38,6 +39,7 @@ type LlmModelFormModalProps = {
 };
 
 export function LlmModelFormModal({
+  canSetDefault = false,
   mode,
   onClose,
   open,
@@ -308,12 +310,12 @@ export function LlmModelFormModal({
             </div>
           </>
         ) : null}
-        {modalMode === "create" ? (
+        {modalMode === "create" && canSetDefault ? (
           <Form.Item
             label={
               <span>
                 {t("modelResources.models.modal.defaultModel")}
-                <Tooltip title={t("modelResources.models.modal.defaultModelHint")}>
+                <Tooltip title={t("modelResources.models.modal.llmDefaultModelHint")}>
                   <QuestionCircleOutlined style={{ color: "rgba(0, 0, 0, 0.45)", marginLeft: 6 }} />
                 </Tooltip>
               </span>

--- a/src/modules/model-resources/components/models/ModelModals.tsx
+++ b/src/modules/model-resources/components/models/ModelModals.tsx
@@ -5,7 +5,8 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Drawer, Form, Input, InputNumber, Modal, Select, Spin, Switch } from "antd";
+import { QuestionCircleOutlined } from "@ant-design/icons";
+import { Drawer, Form, Input, InputNumber, Modal, Select, Spin, Switch, Tooltip } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -88,6 +89,7 @@ export function LlmModelFormModal({
       modelType: "llm",
       auth: "empty",
       quota: false,
+      default: false,
     });
   }, [form, mode, open, record]);
 
@@ -305,6 +307,22 @@ export function LlmModelFormModal({
                 : t("modelResources.models.modal.quotaTitleDescribe2Edit")}
             </div>
           </>
+        ) : null}
+        {modalMode === "create" ? (
+          <Form.Item
+            label={
+              <span>
+                {t("modelResources.models.modal.defaultModel")}
+                <Tooltip title={t("modelResources.models.modal.defaultModelHint")}>
+                  <QuestionCircleOutlined style={{ color: "rgba(0, 0, 0, 0.45)", marginLeft: 6 }} />
+                </Tooltip>
+              </span>
+            }
+            name="default"
+            valuePropName="checked"
+          >
+            <Switch />
+          </Form.Item>
         ) : null}
       </Form>
       {isView ? (

--- a/src/modules/model-resources/components/models/SmallModelFormModal.tsx
+++ b/src/modules/model-resources/components/models/SmallModelFormModal.tsx
@@ -29,13 +29,20 @@ import {
 import { AdaptationCodeEditor } from "./AdaptationCodeEditor";
 
 type SmallModelFormModalProps = {
+  canSetDefault?: boolean;
   mode: "create" | "edit" | "view";
   onClose: (refresh?: boolean) => void;
   open: boolean;
   record: SmallModel | null;
 };
 
-export function SmallModelFormModal({ mode, onClose, open, record }: SmallModelFormModalProps) {
+export function SmallModelFormModal({
+  canSetDefault = false,
+  mode,
+  onClose,
+  open,
+  record,
+}: SmallModelFormModalProps) {
   const { t } = useTranslation();
   const { message } = useAppServices();
   const [form] = Form.useForm<SmallModelFormValues>();
@@ -311,12 +318,12 @@ export function SmallModelFormModal({ mode, onClose, open, record }: SmallModelF
             </Form.Item>
           </>
         ) : null}
-        {modalMode === "create" ? (
+        {modalMode === "create" && canSetDefault ? (
           <Form.Item
             label={
               <span>
                 {t("modelResources.models.modal.defaultModel")}
-                <Tooltip title={t("modelResources.models.modal.defaultModelHint")}>
+                <Tooltip title={t("modelResources.models.modal.smallDefaultModelHint")}>
                   <QuestionCircleOutlined style={{ color: "rgba(0, 0, 0, 0.45)", marginLeft: 6 }} />
                 </Tooltip>
               </span>

--- a/src/modules/model-resources/components/models/SmallModelFormModal.tsx
+++ b/src/modules/model-resources/components/models/SmallModelFormModal.tsx
@@ -5,7 +5,8 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Form, Input, InputNumber, Modal, Select, Switch } from "antd";
+import { QuestionCircleOutlined } from "@ant-design/icons";
+import { Form, Input, InputNumber, Modal, Select, Switch, Tooltip } from "antd";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -82,6 +83,7 @@ export function SmallModelFormModal({ mode, onClose, open, record }: SmallModelF
       auth: "empty",
       adapter: false,
       batchSize: 32,
+      default: false,
     });
   }, [form, mode, open, record]);
 
@@ -308,6 +310,22 @@ export function SmallModelFormModal({ mode, onClose, open, record }: SmallModelF
               <InputNumber controls={false} min={1} style={{ width: "100%" }} />
             </Form.Item>
           </>
+        ) : null}
+        {modalMode === "create" ? (
+          <Form.Item
+            label={
+              <span>
+                {t("modelResources.models.modal.defaultModel")}
+                <Tooltip title={t("modelResources.models.modal.defaultModelHint")}>
+                  <QuestionCircleOutlined style={{ color: "rgba(0, 0, 0, 0.45)", marginLeft: 6 }} />
+                </Tooltip>
+              </span>
+            }
+            name="default"
+            valuePropName="checked"
+          >
+            <Switch />
+          </Form.Item>
         ) : null}
       </Form>
       {isView ? (

--- a/src/modules/model-resources/components/models/SmallModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/SmallModelListPanel.tsx
@@ -64,6 +64,7 @@ export function SmallModelListPanel() {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>([]);
   const [canCreate, setCanCreate] = useState(false);
+  const [canSetDefaultOnCreate, setCanSetDefaultOnCreate] = useState(false);
   const [activeRecord, setActiveRecord] = useState<SmallModel | null>(null);
   const [formMode, setFormMode] = useState<"create" | "edit" | "view">("create");
   const [formOpen, setFormOpen] = useState(false);
@@ -104,6 +105,7 @@ export function SmallModelListPanel() {
   useEffect(() => {
     void getSmallModelRolePermissions().then((operations) => {
       setCanCreate(operations.includes("create"));
+      setCanSetDefaultOnCreate(operations.includes("modify"));
     });
   }, []);
 
@@ -496,6 +498,7 @@ export function SmallModelListPanel() {
       />
 
       <SmallModelFormModal
+        canSetDefault={canSetDefaultOnCreate}
         mode={formMode}
         onClose={(refresh) => {
           setFormOpen(false);

--- a/src/modules/model-resources/locales/en-US.ts
+++ b/src/modules/model-resources/locales/en-US.ts
@@ -118,6 +118,8 @@ export const modelResourcesEnUS = {
           "- After disabling this feature, no quota configuration is required and all users can use the model without limits.",
         quotaTitleDescribe2Edit:
           "- After disabling this feature, all users can use the model without limits. Existing usage records are kept, but previous quota rules are cleared.",
+        defaultModel: "Set as default model",
+        defaultModelHint: "If this category has no default model, the new model is selected automatically.",
         enterPlaceholder: "Enter value",
         selectPlaceholder: "Select",
         apiModelPlaceholder: "Enter value (case sensitive)",

--- a/src/modules/model-resources/locales/en-US.ts
+++ b/src/modules/model-resources/locales/en-US.ts
@@ -119,7 +119,8 @@ export const modelResourcesEnUS = {
         quotaTitleDescribe2Edit:
           "- After disabling this feature, all users can use the model without limits. Existing usage records are kept, but previous quota rules are cleared.",
         defaultModel: "Set as default model",
-        defaultModelHint: "If this category has no default model, the new model is selected automatically.",
+        llmDefaultModelHint: "The first LLM is selected automatically; enabling this replaces the current default LLM.",
+        smallDefaultModelHint: "The first model of this type is selected automatically; enabling this replaces the current default of the same type.",
         enterPlaceholder: "Enter value",
         selectPlaceholder: "Select",
         apiModelPlaceholder: "Enter value (case sensitive)",

--- a/src/modules/model-resources/locales/zh-CN.ts
+++ b/src/modules/model-resources/locales/zh-CN.ts
@@ -117,7 +117,8 @@ export const modelResourcesZhCN = {
         quotaTitleDescribe2Edit:
           "- 关闭功能后，无需配置使用额度，所有用户均可无限制使用，且系统会自动保留用户之前用掉的额度记录，但会把之前设置的“额度规则”清零。",
         defaultModel: "设为默认模型",
-        defaultModelHint: "当前类别尚未设置默认模型时，系统会自动将新模型设为默认。",
+        llmDefaultModelHint: "未设置默认大模型时会自动设为默认；开启后将替换当前默认大模型。",
+        smallDefaultModelHint: "当前类型未设置默认模型时会自动设为默认；开启后将替换同类型默认模型。",
         enterPlaceholder: "请输入",
         selectPlaceholder: "请选择",
         apiModelPlaceholder: "请输入（填写字段时，请注意区分大小写字母）",

--- a/src/modules/model-resources/locales/zh-CN.ts
+++ b/src/modules/model-resources/locales/zh-CN.ts
@@ -116,6 +116,8 @@ export const modelResourcesZhCN = {
         quotaTitleDescribe2: "- 关闭功能后，无需配置使用额度，所有用户均可无限制使用。",
         quotaTitleDescribe2Edit:
           "- 关闭功能后，无需配置使用额度，所有用户均可无限制使用，且系统会自动保留用户之前用掉的额度记录，但会把之前设置的“额度规则”清零。",
+        defaultModel: "设为默认模型",
+        defaultModelHint: "当前类别尚未设置默认模型时，系统会自动将新模型设为默认。",
         enterPlaceholder: "请输入",
         selectPlaceholder: "请选择",
         apiModelPlaceholder: "请输入（填写字段时，请注意区分大小写字母）",

--- a/src/modules/model-resources/services/llm.service.ts
+++ b/src/modules/model-resources/services/llm.service.ts
@@ -305,7 +305,7 @@ export async function getLlmItemPermissions(
 
 export async function getLlmRolePermissions(): Promise<string[]> {
   if (useMock) {
-    return ["create"];
+    return ["create", "modify"];
   }
 
   try {

--- a/src/modules/model-resources/services/llm.service.ts
+++ b/src/modules/model-resources/services/llm.service.ts
@@ -107,7 +107,7 @@ function mapLlmModel(item: BackendLlmModel): LlmModel {
   };
 }
 
-function mapSavePayload(payload: LlmSavePayload) {
+function mapSavePayload(payload: LlmSavePayload, includeDefault = false) {
   const body: Record<string, unknown> = {
     model_name: payload.modelName,
     model_series: payload.modelSeries,
@@ -133,6 +133,10 @@ function mapSavePayload(payload: LlmSavePayload) {
 
   if (payload.change) {
     body.change = true;
+  }
+
+  if (includeDefault) {
+    body.default = payload.default ?? false;
   }
 
   return body;
@@ -205,6 +209,12 @@ export async function listLlmModels(query: LlmListQuery): Promise<LlmListResult>
 
 export async function createLlmModel(payload: LlmSavePayload) {
   if (useMock) {
+    const shouldSetDefault = payload.default || !mockLlmModels.some((item) => item.default);
+    if (shouldSetDefault) {
+      mockLlmModels.forEach((item) => {
+        item.default = false;
+      });
+    }
     mockLlmModels.unshift({
       modelId: `llm-${mockLlmModels.length + 1}`,
       modelName: payload.modelName,
@@ -213,6 +223,7 @@ export async function createLlmModel(payload: LlmSavePayload) {
       maxModelLen: payload.maxModelLen,
       modelParameters: payload.modelParameters,
       quota: payload.quota,
+      default: shouldSetDefault,
       createBy: "admin",
       createTime: new Date().toISOString().slice(0, 19).replace("T", " "),
       updateBy: "admin",
@@ -224,7 +235,7 @@ export async function createLlmModel(payload: LlmSavePayload) {
 
   const response = await http.post<BackendStatusResponse>(
     `${API_PREFIX}/llm/add`,
-    mapSavePayload(payload),
+    mapSavePayload(payload, true),
   );
 
   return response.data;

--- a/src/modules/model-resources/services/small-model.service.ts
+++ b/src/modules/model-resources/services/small-model.service.ts
@@ -96,7 +96,7 @@ function mapSmallModel(item: BackendSmallModel): SmallModel {
   };
 }
 
-function mapSavePayload(payload: SmallModelSavePayload) {
+function mapSavePayload(payload: SmallModelSavePayload, includeDefault = false) {
   const body: Record<string, unknown> = {
     model_name: payload.modelName,
     model_type: payload.modelType,
@@ -135,6 +135,10 @@ function mapSavePayload(payload: SmallModelSavePayload) {
 
   if (payload.change) {
     body.change = true;
+  }
+
+  if (includeDefault) {
+    body.default = payload.default ?? false;
   }
 
   return body;
@@ -208,6 +212,15 @@ export async function listSmallModels(
 
 export async function createSmallModel(payload: SmallModelSavePayload) {
   if (useMock) {
+    const shouldSetDefault =
+      payload.default || !mockSmallModels.some((item) => item.modelType === payload.modelType && item.default);
+    if (shouldSetDefault) {
+      mockSmallModels.forEach((item) => {
+        if (item.modelType === payload.modelType) {
+          item.default = false;
+        }
+      });
+    }
     mockSmallModels.unshift({
       modelId: `sm-${mockSmallModels.length + 1}`,
       modelName: payload.modelName,
@@ -224,13 +237,14 @@ export async function createSmallModel(payload: SmallModelSavePayload) {
       updateBy: "admin",
       updateTime: new Date().toISOString().slice(0, 19).replace("T", " "),
       operations: ["modify", "delete", "authorize"],
+      default: shouldSetDefault,
     });
     return { status: "ok" };
   }
 
   const response = await http.post<BackendStatusResponse>(
     `${API_PREFIX}/small-model/add`,
-    mapSavePayload(payload),
+    mapSavePayload(payload, true),
   );
 
   return response.data;

--- a/src/modules/model-resources/services/small-model.service.ts
+++ b/src/modules/model-resources/services/small-model.service.ts
@@ -371,7 +371,7 @@ export async function setDefaultSmallModel(modelId: string, asDefault = true) {
 
 export async function getSmallModelRolePermissions(): Promise<string[]> {
   if (useMock) {
-    return ["create"];
+    return ["create", "modify"];
   }
 
   try {

--- a/src/modules/model-resources/types/llm.ts
+++ b/src/modules/model-resources/types/llm.ts
@@ -65,6 +65,7 @@ export type LlmSavePayload = {
   maxModelLen: number;
   modelParameters?: number;
   quota?: boolean;
+  default?: boolean;
   modelConfig: LlmModelConfig;
   change?: boolean;
 };

--- a/src/modules/model-resources/types/small-model.ts
+++ b/src/modules/model-resources/types/small-model.ts
@@ -57,6 +57,7 @@ export type SmallModelSavePayload = {
   batchSize?: number;
   maxTokens?: number;
   maxDocuments?: number;
+  default?: boolean;
   modelConfig?: SmallModelConfig;
   change?: boolean;
 };

--- a/src/modules/model-resources/utils/model-form.test.ts
+++ b/src/modules/model-resources/utils/model-form.test.ts
@@ -7,7 +7,12 @@
 
 import { describe, expect, it } from "vitest";
 
-import { buildLlmSavePayload, type LlmFormValues } from "@/modules/model-resources/utils/model-form";
+import {
+  buildLlmSavePayload,
+  buildSmallModelSavePayload,
+  type LlmFormValues,
+  type SmallModelFormValues,
+} from "@/modules/model-resources/utils/model-form";
 
 const baseValues: LlmFormValues = {
   modelName: " Qwen ",
@@ -29,5 +34,28 @@ describe("buildLlmSavePayload", () => {
     expect(buildLlmSavePayload({ ...baseValues, modelParameters: null }).modelParameters).toBeUndefined();
     expect(buildLlmSavePayload({ ...baseValues, modelParameters: 0 }).modelParameters).toBeUndefined();
     expect(buildLlmSavePayload({ ...baseValues, modelParameters: 1.5 }).modelParameters).toBeUndefined();
+  });
+
+  it("keeps the requested default selection for model creation", () => {
+    expect(buildLlmSavePayload({ ...baseValues, default: true }).default).toBe(true);
+  });
+});
+
+describe("buildSmallModelSavePayload", () => {
+  const values: SmallModelFormValues = {
+    modelName: " Qwen embedding ",
+    modelType: "embedding",
+    adapter: false,
+    apiModel: " qwen3-embedding ",
+    apiUrl: " https://example.com ",
+    auth: "empty",
+    batchSize: 32,
+    maxTokens: 512,
+    embeddingDim: 1024,
+    default: true,
+  };
+
+  it("keeps the requested default selection for small-model creation", () => {
+    expect(buildSmallModelSavePayload(values).default).toBe(true);
   });
 });

--- a/src/modules/model-resources/utils/model-form.ts
+++ b/src/modules/model-resources/utils/model-form.ts
@@ -20,6 +20,7 @@ export type LlmFormValues = {
   maxModelLen: number;
   modelParameters?: number | null;
   quota?: boolean;
+  default?: boolean;
 };
 
 export type SmallModelFormValues = {
@@ -35,6 +36,7 @@ export type SmallModelFormValues = {
   batchSize?: number;
   maxTokens?: number;
   maxDocuments?: number;
+  default?: boolean;
 };
 
 export function llmModelToFormValues(record: LlmModel): LlmFormValues {
@@ -52,6 +54,7 @@ export function llmModelToFormValues(record: LlmModel): LlmFormValues {
     maxModelLen: record.maxModelLen ?? 0,
     modelParameters: record.modelParameters,
     quota: record.quota,
+    default: record.default,
   };
 }
 
@@ -88,6 +91,7 @@ export function buildLlmSavePayload(
     maxModelLen: values.maxModelLen,
     modelParameters,
     quota: values.quota,
+    default: values.default,
     modelConfig,
     change: !source || apiKeyChanged,
   };
@@ -109,6 +113,7 @@ export function smallModelToFormValues(record: SmallModel): SmallModelFormValues
     batchSize: record.batchSize,
     maxTokens: record.maxTokens,
     maxDocuments: record.maxDocuments,
+    default: record.default,
   };
 }
 
@@ -129,6 +134,7 @@ export function buildSmallModelSavePayload(
       batchSize: values.batchSize,
       maxTokens: values.maxTokens,
       maxDocuments: values.maxDocuments,
+      default: values.default,
       change: !source || apiKeyChanged,
     };
   }
@@ -142,6 +148,7 @@ export function buildSmallModelSavePayload(
     batchSize: values.batchSize,
     maxTokens: values.maxTokens,
     maxDocuments: values.maxDocuments,
+    default: values.default,
     modelConfig: {
       apiModel: values.apiModel?.trim() ?? "",
       apiUrl: values.apiUrl?.trim() ?? "",


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Show the Set as default model switch only to users with type-wide modify permission.
- [x] Keep the first-model automatic-default behavior while explaining replacement behavior in model-specific tooltips.
- [x] Keep mock permissions aligned so the switch remains available in the local mock administrator experience.
- [ ] Documentation update (not applicable).

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#1091
- Related Feature: Default model selection on model creation
- Background: The UI must not offer an explicit default replacement to users that the API will reject.

---

## How

- Key implementation points: Creation panels retrieve the wildcard model-type operations and pass the modify decision to their form modal. The switch is hidden without modify permission.
- Breaking changes (API, config, database, etc.): None. The related API returns 403 if an unauthorized client still sends default=true.

---

## Testing

- [ ] Unit tests passed locally (focused suites passed; the full-suite terminal session did not retain its final exit summary).
- [ ] Integration tests passed locally (not run).
- [ ] Verified in test environment (not run).

Test notes:

- Focused model-form and authorization suites: 13 tests passed.
- License-header check and ESLint completed successfully.
- Full Vitest suite, TypeScript build, and production Vite build were executed serially with two Vitest workers.
- Production dependency audit reported one ignored existing high-severity advisory.

---

## Risk & Rollback

- Potential risks: The permission gate depends on the matching Model Manager API change.
- Rollback plan: Revert commit f821256.

---

## Additional Notes

- The corresponding API PR is openbkn-ai/bkn-foundry#1094.
