### PR TITLE
fix(bkn-studio): filter user audit logs by actor

### DIFF
--- a/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
@@ -81,6 +81,7 @@ export function ObservabilityLogsScene({ mode = "logs" }: ObservabilityLogsScene
         ...(nextFilters.businessModule ? { businessModule: nextFilters.businessModule } : {}),
         ...(nextFilters.actorId.trim() ? { actorQuery: nextFilters.actorId.trim() } : {}),
         ...(nextFilters.outcome ? { outcomes: [nextFilters.outcome] } : {}),
+        ...(associatedScope.actorId ? { actorId: associatedScope.actorId } : {}),
         ...(associatedScope.conversationId ? { conversationId: associatedScope.conversationId } : {}),
         ...(associatedScope.requestId ? { requestId: associatedScope.requestId } : {}),
         ...(associatedScope.targetId ? { targetId: associatedScope.targetId } : {}),
@@ -175,7 +176,7 @@ export function ObservabilityLogsScene({ mode = "logs" }: ObservabilityLogsScene
     return <Alert message={t("bknTrace.errors.accessDenied")} showIcon type="warning" />;
   }
 
-  const associated = associatedScope.conversationId || associatedScope.traceId || associatedScope.requestId || associatedScope.targetId;
+  const associated = associatedScope.actorId || associatedScope.conversationId || associatedScope.traceId || associatedScope.requestId || associatedScope.targetId;
   return (
     <div className={styles.workspace}>
       <header className={styles.header}>
@@ -250,7 +251,7 @@ function readInitialFilters(mode: "audit" | "logs"): Filters {
   const hasValidTimeRange = timeFrom.isValid() && timeTo.isValid() && !timeTo.isBefore(timeFrom);
   return {
     ...defaults,
-    actorId: parameters.get("actor_id") ?? "",
+    actorId: parameters.get("actor") ?? "",
     ...(BUSINESS_MODULES.includes(businessModule as BusinessModule) ? { businessModule: businessModule as BusinessModule } : {}),
     ...(AUDIT_OUTCOMES.includes(outcome as AuditOutcome) ? { outcome: outcome as AuditOutcome } : {}),
     query: parameters.get("q") ?? "",
@@ -258,12 +259,13 @@ function readInitialFilters(mode: "audit" | "logs"): Filters {
   };
 }
 
-type AssociatedLogScope = { conversationId: string; requestId: string; targetId: string; targetType: string; traceId: string };
+type AssociatedLogScope = { actorId: string; conversationId: string; requestId: string; targetId: string; targetType: string; traceId: string };
 
 function readAssociatedLogScope(): AssociatedLogScope {
   const parameters = new URLSearchParams(window.location.search);
   const target = readAuditLogDrilldown(parameters);
   return {
+    actorId: parameters.get("actor_id")?.trim() ?? "",
     conversationId: parameters.get("conversation_id") ?? "",
     requestId: parameters.get("request_id") ?? "",
     targetId: target.targetId,
@@ -279,9 +281,10 @@ function syncFiltersToUrl(filters: Filters, scope: AssociatedLogScope) {
   if (scope.targetId) parameters.set("target_id", scope.targetId);
   if (scope.targetType) parameters.set("target_type", scope.targetType);
   if (scope.traceId) parameters.set("trace_id", scope.traceId);
+  if (scope.actorId) parameters.set("actor_id", scope.actorId);
   if (filters.query.trim()) parameters.set("q", filters.query.trim());
   if (filters.businessModule) parameters.set("business_module", filters.businessModule);
-  if (filters.actorId.trim()) parameters.set("actor_id", filters.actorId.trim());
+  if (filters.actorId.trim()) parameters.set("actor", filters.actorId.trim());
   if (filters.outcome) parameters.set("outcome", filters.outcome);
   parameters.set("time_from", filters.timeRange[0].toISOString());
   parameters.set("time_to", filters.timeRange[1].toISOString());
@@ -295,6 +298,9 @@ function AssociatedScopeTag({ scope, t, userDirectory }: { scope: AssociatedLogS
   if (scope.targetId) {
     const displayType = scope.targetType === "user" ? "user" : "resource";
     return <Tag color="blue"><span>{t(`bknTrace.logs.associatedTarget.${displayType}`)}</span> <span>{userDirectory.get(scope.targetId) ?? scope.targetId}</span></Tag>;
+  }
+  if (scope.actorId) {
+    return <Tag color="blue"><span>{t("bknTrace.logs.associatedTarget.user")}</span> <span>{userDirectory.get(scope.actorId) ?? scope.actorId}</span></Tag>;
   }
   return <Tag color="blue">{scope.conversationId || scope.traceId || scope.requestId}</Tag>;
 }

--- a/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
@@ -36,6 +36,7 @@ const BUSINESS_MODULES: BusinessModule[] = [
 
 const AUDIT_OUTCOMES: AuditOutcome[] = ["success", "failure", "denied", "canceled", "unknown"];
 const SYSTEM_AUDIT_CATEGORIES: LogCategory[] = ["audit.admin"];
+const EXACT_ACTOR_MATCH = "exact";
 
 type ObservabilityLogsSceneProps = {
   mode?: "audit" | "logs";
@@ -249,9 +250,10 @@ function readInitialFilters(mode: "audit" | "logs"): Filters {
   const timeFrom = dayjs(parameters.get("time_from"));
   const timeTo = dayjs(parameters.get("time_to"));
   const hasValidTimeRange = timeFrom.isValid() && timeTo.isValid() && !timeTo.isBefore(timeFrom);
+  const exactActorMatch = parameters.get("actor_match") === EXACT_ACTOR_MATCH;
   return {
     ...defaults,
-    actorId: parameters.get("actor") ?? "",
+    actorId: parameters.get("actor") ?? (!exactActorMatch ? parameters.get("actor_id") : null) ?? "",
     ...(BUSINESS_MODULES.includes(businessModule as BusinessModule) ? { businessModule: businessModule as BusinessModule } : {}),
     ...(AUDIT_OUTCOMES.includes(outcome as AuditOutcome) ? { outcome: outcome as AuditOutcome } : {}),
     query: parameters.get("q") ?? "",
@@ -264,8 +266,9 @@ type AssociatedLogScope = { actorId: string; conversationId: string; requestId: 
 function readAssociatedLogScope(): AssociatedLogScope {
   const parameters = new URLSearchParams(window.location.search);
   const target = readAuditLogDrilldown(parameters);
+  const exactActorMatch = parameters.get("actor_match") === EXACT_ACTOR_MATCH;
   return {
-    actorId: parameters.get("actor_id")?.trim() ?? "",
+    actorId: exactActorMatch ? parameters.get("actor_id")?.trim() ?? "" : "",
     conversationId: parameters.get("conversation_id") ?? "",
     requestId: parameters.get("request_id") ?? "",
     targetId: target.targetId,
@@ -281,7 +284,10 @@ function syncFiltersToUrl(filters: Filters, scope: AssociatedLogScope) {
   if (scope.targetId) parameters.set("target_id", scope.targetId);
   if (scope.targetType) parameters.set("target_type", scope.targetType);
   if (scope.traceId) parameters.set("trace_id", scope.traceId);
-  if (scope.actorId) parameters.set("actor_id", scope.actorId);
+  if (scope.actorId) {
+    parameters.set("actor_id", scope.actorId);
+    parameters.set("actor_match", EXACT_ACTOR_MATCH);
+  }
   if (filters.query.trim()) parameters.set("q", filters.query.trim());
   if (filters.businessModule) parameters.set("business_module", filters.businessModule);
   if (filters.actorId.trim()) parameters.set("actor", filters.actorId.trim());

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -139,13 +139,13 @@ describe("observability workspace scenes", () => {
     }
   });
 
-  it("从用户管理审计下钻规范化目标并展示异常来源原因", async () => {
-    window.history.replaceState({}, "", "/system/audit?target_id=user-a&target_type=users&target_name=Administrator");
+  it("从用户管理审计下钻按操作者筛选并展示异常来源原因", async () => {
+    window.history.replaceState({}, "", "/system/audit?actor_id=user-a");
     render(<ObservabilityLogsScene mode="audit" />);
 
     await waitFor(() => expect(listLogs).toHaveBeenCalled());
     const [query] = vi.mocked(listLogs).mock.calls[0] ?? [];
-    expect(query).toMatchObject({ categories: ["audit.admin"], targetId: "user-a", targetType: "user" });
+    expect(query).toMatchObject({ actorId: "user-a", categories: ["audit.admin"] });
     expect(await screen.findByText("bknTrace.logs.associatedTarget.user")).not.toBeNull();
     expect(screen.getByText("Current Administrator")).not.toBeNull();
     expect(screen.getAllByText((_content, element) => element?.textContent?.includes("bknTrace.logs.sourceFailures.source_query_failed") ?? false)).not.toHaveLength(0);

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -140,7 +140,7 @@ describe("observability workspace scenes", () => {
   });
 
   it("从用户管理审计下钻按操作者筛选并展示异常来源原因", async () => {
-    window.history.replaceState({}, "", "/system/audit?actor_id=user-a");
+    window.history.replaceState({}, "", "/system/audit?actor_id=user-a&actor_match=exact");
     render(<ObservabilityLogsScene mode="audit" />);
 
     await waitFor(() => expect(listLogs).toHaveBeenCalled());
@@ -149,6 +149,25 @@ describe("observability workspace scenes", () => {
     expect(await screen.findByText("bknTrace.logs.associatedTarget.user")).not.toBeNull();
     expect(screen.getByText("Current Administrator")).not.toBeNull();
     expect(screen.getAllByText((_content, element) => element?.textContent?.includes("bknTrace.logs.sourceFailures.source_query_failed") ?? false)).not.toHaveLength(0);
+  });
+
+  it("将旧链接中的 actor_id 保持为自由文本操作者筛选", async () => {
+    window.history.replaceState({}, "", "/observability/logs?actor_id=%E5%BC%A0%E4%B8%89");
+    render(<ObservabilityLogsScene />);
+
+    await waitFor(() => expect(listLogs).toHaveBeenCalled());
+    const [query] = vi.mocked(listLogs).mock.calls[0] ?? [];
+    expect(query).toMatchObject({ actorQuery: "张三" });
+    expect(query).not.toHaveProperty("actorId");
+    expect(screen.getByDisplayValue("张三")).not.toBeNull();
+    expect(screen.queryByText("bknTrace.logs.associatedTarget.user")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "bknTrace.actions.reset" }));
+    await waitFor(() => expect(listLogs).toHaveBeenCalledTimes(2));
+    const [resetQuery] = vi.mocked(listLogs).mock.calls[1] ?? [];
+    expect(resetQuery).not.toHaveProperty("actorId");
+    expect(resetQuery).not.toHaveProperty("actorQuery");
+    expect(new URLSearchParams(window.location.search).has("actor_id")).toBe(false);
   });
 
   it("将可用来源标为正常并为未知失败原因提供本地化兜底", async () => {
@@ -241,7 +260,7 @@ describe("observability workspace scenes", () => {
 
     await waitFor(() => expect(listLogs).toHaveBeenCalledTimes(2));
     expect(screen.getByText("供应链分析助手 的业务会话")).not.toBeNull();
-    expect(document.querySelector(".ant-spin-spinning")).not.toBeNull();
+    await waitFor(() => expect(document.querySelector(".ant-spin-spinning")).not.toBeNull());
   });
 
   it("总数不可知时不显示为零条结果", async () => {

--- a/src/modules/system-admin/scenes/UserManagementScene.tsx
+++ b/src/modules/system-admin/scenes/UserManagementScene.tsx
@@ -429,7 +429,7 @@ export function UserManagementScene() {
             return;
           }
           if (key === "auditLogs") {
-            void navigate(buildAuditLogHref(user.id, "user"));
+            void navigate(buildAuditLogHref(user.id));
           }
         },
       };

--- a/src/modules/system-admin/utils/audit-log-url.test.ts
+++ b/src/modules/system-admin/utils/audit-log-url.test.ts
@@ -11,6 +11,6 @@ import { buildAuditLogHref } from "./audit-log-url";
 
 describe("buildAuditLogHref", () => {
   it("filters by the selected user as the audit actor without putting mutable display data in the URL", () => {
-    expect(buildAuditLogHref("user-a")).toBe("/system/audit?actor_id=user-a");
+    expect(buildAuditLogHref("user-a")).toBe("/system/audit?actor_id=user-a&actor_match=exact");
   });
 });

--- a/src/modules/system-admin/utils/audit-log-url.test.ts
+++ b/src/modules/system-admin/utils/audit-log-url.test.ts
@@ -10,9 +10,7 @@ import { describe, expect, it } from "vitest";
 import { buildAuditLogHref } from "./audit-log-url";
 
 describe("buildAuditLogHref", () => {
-  it("uses the canonical user target type without putting mutable display data in the URL", () => {
-    expect(buildAuditLogHref("user-a", "user")).toBe(
-      "/system/audit?target_id=user-a&target_type=user",
-    );
+  it("filters by the selected user as the audit actor without putting mutable display data in the URL", () => {
+    expect(buildAuditLogHref("user-a")).toBe("/system/audit?actor_id=user-a");
   });
 });

--- a/src/modules/system-admin/utils/audit-log-url.ts
+++ b/src/modules/system-admin/utils/audit-log-url.ts
@@ -7,6 +7,7 @@
 
 export const AUDIT_RESOURCE_PARAM = "target_type";
 export const AUDIT_ACTOR_PARAM = "actor_id";
+export const AUDIT_ACTOR_MATCH_PARAM = "actor_match";
 export const AUDIT_TARGET_PARAM = "target_id";
 export const AUDIT_FAILED_PARAM = "failed";
 export const AUDIT_FROM_PARAM = "from";
@@ -114,5 +115,6 @@ export function applyAuditLogFilters(
 export function buildAuditLogHref(actorId: string) {
   const params = new URLSearchParams();
   params.set(AUDIT_ACTOR_PARAM, actorId);
+  params.set(AUDIT_ACTOR_MATCH_PARAM, "exact");
   return `/system/audit?${params.toString()}`;
 }

--- a/src/modules/system-admin/utils/audit-log-url.ts
+++ b/src/modules/system-admin/utils/audit-log-url.ts
@@ -111,9 +111,8 @@ export function applyAuditLogFilters(
   return next;
 }
 
-export function buildAuditLogHref(targetId: string, resource = "user") {
+export function buildAuditLogHref(actorId: string) {
   const params = new URLSearchParams();
-  params.set(AUDIT_TARGET_PARAM, targetId);
-  params.set(AUDIT_RESOURCE_PARAM, resource);
+  params.set(AUDIT_ACTOR_PARAM, actorId);
   return `/system/audit?${params.toString()}`;
 }


### PR DESCRIPTION
Update the user management audit-log drilldown to query by actor_id instead of target_id/target_type.

This makes “View Operation Logs” return actions performed by the selected user and keeps target-based drilldowns available for other audit queries. Add regression coverage for the generated URL and actor filter mapping, while preserving loading feedback and unknown-count handling.

# Pull Request

## What Changed

Brief description of changes:

- [x] System admin user audit-log drilldown
- [x] Observability audit-filter mapping
- [x] Regression tests

---

## Why

- Related Issue: N/A
- Related Feature: System Management → User Management → View Operation Logs
- Background:

The user audit-log entry previously used `target_id` and `target_type=user`. This queried records where the selected user was the target, while the expected behavior is to show operations performed by that user. As a result, Administrator’s audit log could appear empty even when records existed.

---

## How

- Key implementation points:
  - Generate user audit-log URLs with `actor_id`.
  - Map associated `actor_id` links to the observability log query.
  - Keep target-based drilldown support for other audit scenarios.
  - Add regression coverage for URL generation and actor filtering.
  - Preserve loading feedback and unknown-count handling in the audit-log view.
- Breaking changes (API, config, database, etc.):

None. This change only updates frontend query construction.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `pnpm exec vitest --run src/modules/system-admin/utils/audit-log-url.test.ts src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx`
- `git diff --check`
- jsdom emitted existing `getComputedStyle()` warnings; tests completed successfully.

---

## Risk & Rollback

- Potential risks:
  - Existing bookmarked user audit URLs using `target_id` will retain their previous target-based behavior.
  - The result count still depends on the availability and coverage of authorized audit sources.
- Rollback plan:

Revert this frontend commit to restore the previous target-based user drilldown.

---

## Additional Notes

The corrected request format is:

`/api/observability/v1/logs?categories=audit.admin&actor_id=<user-id>&...`

For Administrator, the query returns the operations performed by:

`266c6a42-6131-4d62-8f39-853e7093701c`
