### PR TITLE
fix(observability): prevent audit logs horizontal overflow

### DIFF
--- a/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
@@ -6,7 +6,7 @@
  */
 
 import { ReloadOutlined, SearchOutlined } from "@ant-design/icons";
-import { Alert, Button, DatePicker, Input, Select, Space, Spin, Table, Tag, Typography } from "antd";
+import { Alert, Button, DatePicker, Input, Select, Space, Spin, Table, Tag, Tooltip, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import dayjs, { type Dayjs } from "dayjs";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -115,35 +115,35 @@ export function ObservabilityLogsScene({ mode = "logs" }: ObservabilityLogsScene
   }, [associatedScope, load, t]);
 
   const columns = useMemo<ColumnsType<LogRecord>>(() => [
-    { dataIndex: "eventTime", key: "time", title: t("bknTrace.logs.columns.time"), width: 150, render: formatTime },
+    { dataIndex: "eventTime", key: "time", title: t("bknTrace.logs.columns.time"), width: "12%", render: formatTime },
     {
-      dataIndex: "businessModule", key: "businessModule", title: t("bknTrace.logs.columns.module"), width: 145,
+      dataIndex: "businessModule", key: "businessModule", title: t("bknTrace.logs.columns.module"), width: "12%",
       render: (value: string) => <Tag>{moduleLabel(value, t)}</Tag>,
     },
     {
-      dataIndex: "action", key: "action", title: t("bknTrace.logs.columns.action"), width: 190,
+      dataIndex: "action", key: "action", title: t("bknTrace.logs.columns.action"), width: "14%",
       render: (_value: string, record) => <ClampedText value={presentLogAction(record, t)} />,
     },
     {
-      dataIndex: "target", key: "target", title: t("bknTrace.logs.columns.target"), width: 230,
+      dataIndex: "target", key: "target", title: t("bknTrace.logs.columns.target"), width: "20%",
       render: (_target: LogRecord["target"], record) => {
         const value = presentLogTarget(record, t);
         return <ClampedText secondary={value.secondary} value={value.primary} />;
       },
     },
     {
-      dataIndex: "actor", key: "actor", title: t("bknTrace.logs.columns.actor"), width: 180,
+      dataIndex: "actor", key: "actor", title: t("bknTrace.logs.columns.actor"), width: "18%",
       render: (_actor: LogRecord["actor"], record) => {
         const value = presentLogActor(record, t, userDirectory);
         return <ClampedText secondary={value.secondary} value={value.primary} />;
       },
     },
     {
-      dataIndex: "outcome", key: "outcome", title: t("bknTrace.logs.columns.outcome"), width: 105,
+      dataIndex: "outcome", key: "outcome", title: t("bknTrace.logs.columns.outcome"), width: "9%",
       render: (value: AuditOutcome) => <Tag color={outcomeColor(value)}>{t(`bknTrace.logs.outcomes.${value}`)}</Tag>,
     },
     {
-      dataIndex: "sourceId", key: "source", title: t("bknTrace.logs.columns.source"), width: 145,
+      dataIndex: "sourceId", key: "source", title: t("bknTrace.logs.columns.source"), width: "15%",
       render: (value: string, record) => <ClampedText secondary={record.sourceChannel} value={value} />,
     },
   ], [t, userDirectory]);
@@ -224,10 +224,13 @@ export function ObservabilityLogsScene({ mode = "logs" }: ObservabilityLogsScene
 }
 
 function ClampedText({ secondary, value }: { secondary?: string; value: string }) {
-  return <div className={styles.clampedCell}>
-    <Typography.Paragraph ellipsis={{ rows: 2, tooltip: value }}>{value}</Typography.Paragraph>
-    {secondary && secondary !== value ? <Typography.Text className={styles.technicalId}>{secondary}</Typography.Text> : null}
-  </div>;
+  const fullText = secondary && secondary !== value ? `${value}\n${secondary}` : value;
+  return <Tooltip title={fullText}>
+    <span aria-label={fullText} className={styles.clampedCell}>
+      <span>{value}</span>
+      {secondary && secondary !== value ? <span className={styles.technicalId}> · {secondary}</span> : null}
+    </span>
+  </Tooltip>;
 }
 
 function defaultFilters(mode: "audit" | "logs"): Filters {

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspace.module.css
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspace.module.css
@@ -8,6 +8,7 @@
 .workspace {
 	background: #fff;
 	border: 1px solid #e2e7ef;
+	container-type: inline-size;
 	display: grid;
 	gap: 16px;
 	min-height: 100%;
@@ -74,19 +75,57 @@
 
 .auditTable {
   min-width: 0;
+  width: 100%;
+}
+
+.auditTable :global(.ant-table),
+.auditTable :global(.ant-table-container),
+.auditTable :global(.ant-table-content),
+.auditTable :global(table) {
+  max-width: 100%;
+  width: 100%;
 }
 
 .auditTable :global(.ant-table-cell) {
   overflow: hidden;
+  overflow-wrap: anywhere;
   vertical-align: top;
 }
 
 .clampedCell {
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  cursor: help;
+  display: -webkit-box;
   min-width: 0;
+  overflow: hidden;
+  overflow-wrap: anywhere;
 }
 
-.clampedCell :global(.ant-typography) {
-  margin: 0;
+.clampedCell .technicalId {
+  color: #8a97aa;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+@container (max-width: 960px) {
+  .filterRowPrimary,
+  .filterRowSecondary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@container (max-width: 640px) {
+  .filterRowPrimary,
+  .filterRowSecondary {
+    grid-template-columns: 1fr;
+  }
+
+  .resultSummary {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
 }
 
 .loadMore {

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -130,8 +130,10 @@ describe("observability workspace scenes", () => {
     expect(dayjs(query?.timeTo).diff(dayjs(query?.timeFrom), "day")).toBe(7);
     expect(await screen.findByText("bknTrace.logs.auditActions.startAgentConversation")).not.toBeNull();
     expect(screen.getByText("供应链分析助手 的业务会话")).not.toBeNull();
-    expect(screen.getByText("供应链管理员")).not.toBeNull();
-    expect(screen.getByText("通过 API Key")).not.toBeNull();
+    expect(screen.getByText("供应链分析助手 的业务会话").closest("[aria-label]")).not.toBeNull();
+    const actor = screen.getByText("供应链管理员").closest("[aria-label]");
+    expect(actor).not.toBeNull();
+    expect(actor?.getAttribute("aria-label")).toContain("通过 API Key");
     expect(screen.getByText("bknTrace.logs.partialWarning")).not.toBeNull();
     expect(screen.getByText("bknTrace.logs.modules.domain_knowledge_network")).not.toBeNull();
     for (const column of ["time", "module", "action", "target", "actor", "outcome", "source"]) {


### PR DESCRIPTION
## What Changed

- [x] Make the audit-log table use the available content width with proportional columns.
- [x] Clamp action, target, actor, and source text to two lines and show complete content on hover.
- [x] Add a regression assertion that preserves both primary and secondary audit text in the tooltip label.

---

## Why

- Related Issue: Closes #455
- Background: The source column on the log-search page could overflow beyond the page content area and be clipped.

---

## How

- Use percentage column widths totaling 100%, constrain the Ant Design table container, and enable safe word wrapping.
- Put primary and secondary values in one two-line clamped text block, with a Tooltip containing the full value.
- Add container-query breakpoints so filters reflow within the page container.
- Breaking changes: None.

---

## Testing

- [x] Focused log-search unit suite: 22 of 22 tests passed.
- [x] Full TypeScript lint passed.
- [x] Type check passed.
- [x] Production build passed.
- [x] Production dependency audit completed against npmjs.org; pnpm reports one ignored high advisory.

Test notes: The full Vitest run had 7 failures in unrelated trace-analysis, data-connect, and execution-factory tests, mostly timeouts. The focused log-search suite passes.

---

## Risk & Rollback

- Potential risks: Narrow viewports give individual table columns less width; long content is intentionally clamped to two lines.
- Rollback plan: Revert commit e75bea9.

---

## Additional Notes

- Opening this PR triggers the repository Claude Code Review workflow.
