### PR TITLE
fix(observability): backport audit filter simplification to 0.1.4

### DIFF
--- a/docs/plans/2026-08-22-audit-filter-layout-design.md
+++ b/docs/plans/2026-08-22-audit-filter-layout-design.md
@@ -1,0 +1,36 @@
+# Audit Filter Layout Design
+
+## Status
+
+Implemented.
+
+## Goal
+
+Make the audit-log filters compact and reliable: a single row containing time range, resource or business module, result status, and an operator value that accepts either a name or an ID.
+
+## Scope
+
+- Remove the ambiguous free-text `q` search and free-text action filter from the audit-log page.
+- Keep only structured filters and send them through the observability log API.
+- Interpret the new `actor` query as an exact actor ID or a case-insensitive match against the persisted actor-name snapshot.
+- Preserve `actor_id` for existing exact-ID links and API callers.
+
+## Alternatives considered
+
+1. Resolve an entered actor name to an ID in the UI. Rejected: it fails for deleted users and historical names, and couples audit search to the user directory.
+2. Expand generic `q` over all audit fields. Rejected: its broad, unclear semantics caused the reported defect.
+3. Add an explicit actor query contract and retain only structured filters. Chosen: the displayed controls have stable, testable semantics.
+
+## Data flow
+
+The Studio page sends `actor=<name-or-id>` alongside the selected time range, module/resource, and outcome. The observability handler parses that value into `LogQuery.ActorQuery`. The service applies the actor predicate only after receiving source records, matching `ActorID` exactly or `ActorNameSnapshot` case-insensitively. This preserves source authorization and avoids requiring upstream adapters to support name search.
+
+## Compatibility and risk
+
+`actor_id` remains exact-match compatible. Removing `q` and the free-text action control is intentional UI/API-call simplification; no persisted data, permissions, or schema migrations are involved. On narrow screens the row may wrap naturally, while standard desktop widths remain one row.
+
+## Verification
+
+- Studio request tests prove that the page omits `q` and passes the four retained filter categories.
+- Backend tests prove actor-name and actor-ID matches, including filtering after source retrieval.
+- Existing focused Studio and Go service tests remain green.

--- a/docs/plans/2026-08-22-audit-filter-layout.md
+++ b/docs/plans/2026-08-22-audit-filter-layout.md
@@ -1,0 +1,68 @@
+# Audit Filter Layout Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace ambiguous audit-log text searches with one compact row of reliable structured filters, including name-or-ID operator search.
+
+**Architecture:** Studio owns the compact filter state and serializes only explicit query parameters. The observability service owns the compatible `actor` predicate, applying it after source records are retrieved so adapters do not need to support a name-search API.
+
+**Tech Stack:** React, TypeScript, Ant Design, Vitest; Go, `net/http`, Go unit tests.
+
+---
+
+### Task 1: Prove the Studio request contract
+
+**Files:**
+- Modify: `src/modules/bkn-trace/services/observability.service.test.ts`
+- Modify: `src/modules/bkn-trace/services/observability.service.ts`
+
+**Step 1:** Add a failing request test showing that `actor` is serialized and `q` is absent from an audit-filter request.
+
+**Step 2:** Run the focused Vitest file and verify the new assertion fails.
+
+**Step 3:** Add the `actorQuery` request property and serialize it as `actor`.
+
+**Step 4:** Re-run the focused test and verify it passes.
+
+### Task 2: Prove the backend operator predicate
+
+**Files:**
+- Modify: `bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go`
+- Modify: `bkn-trace/agent-observability/src/domain/service/logsvc/service.go`
+- Modify: `bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/log.go`
+- Modify: `bkn-trace/agent-observability/src/driveradapter/api/httphandler/log_handler.go`
+- Modify: `bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client.go`
+
+**Step 1:** Add failing tests for exact actor ID and case-insensitive actor-name matching.
+
+**Step 2:** Run the focused Go tests and verify the actor-name case fails.
+
+**Step 3:** Project the actor-name snapshot, parse `actor`, and add the post-retrieval predicate.
+
+**Step 4:** Re-run the focused Go tests and verify them green.
+
+### Task 3: Simplify the Studio filters
+
+**Files:**
+- Modify: `src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx`
+- Modify: `src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx`
+- Modify: `src/modules/bkn-trace/scenes/ObservabilityWorkspace.module.css`
+
+**Step 1:** Add a failing scene test for the retained one-row filter controls and absence of the generic search control.
+
+**Step 2:** Run the focused scene test and verify it fails.
+
+**Step 3:** Replace generic search/category/service controls with time range, module/resource, outcome, and direct operator input; serialize only those filters.
+
+**Step 4:** Re-run the focused scene test and verify it passes.
+
+### Task 4: Verify and submit
+
+**Files:**
+- Modify: `docs/plans/2026-08-22-audit-filter-layout-design.md`
+
+**Step 1:** Run the focused Studio and Go tests, then the required repository quality checks.
+
+**Step 2:** Mark the design implemented and commit Studio and Foundry changes separately.
+
+**Step 3:** Push both branches, open linked PRs with complete templates, request review, and post progress on #504.

--- a/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityLogsScene.tsx
@@ -46,7 +46,6 @@ type Filters = {
   actorId: string;
   businessModule?: BusinessModule;
   outcome?: AuditOutcome;
-  query: string;
   timeRange: [Dayjs, Dayjs];
 };
 
@@ -78,7 +77,6 @@ export function ObservabilityLogsScene({ mode = "logs" }: ObservabilityLogsScene
         timeFrom: nextFilters.timeRange[0].toISOString(),
         timeTo: nextFilters.timeRange[1].toISOString(),
         ...(mode === "audit" ? { categories: SYSTEM_AUDIT_CATEGORIES } : {}),
-        ...(nextFilters.query.trim() ? { query: nextFilters.query.trim() } : {}),
         ...(nextFilters.businessModule ? { businessModule: nextFilters.businessModule } : {}),
         ...(nextFilters.actorId.trim() ? { actorQuery: nextFilters.actorId.trim() } : {}),
         ...(nextFilters.outcome ? { outcomes: [nextFilters.outcome] } : {}),
@@ -197,15 +195,11 @@ export function ObservabilityLogsScene({ mode = "logs" }: ObservabilityLogsScene
 
       {profile?.globalLogSearch ? (
         <div className={styles.filterPanel}>
-          <div className={styles.filterRowPrimary}>
-            <Input allowClear onChange={(event) => setFilters((value) => ({ ...value, query: event.target.value }))} onPressEnter={submit} placeholder={t("bknTrace.logs.searchPlaceholder")} prefix={<SearchOutlined />} value={filters.query} />
-            <DatePicker allowClear={false} onChange={(value) => { if (value) setFilters((current) => ({ ...current, timeRange: [value, current.timeRange[1]] })); }} placeholder={t("bknTrace.logs.startTime")} showTime value={filters.timeRange[0]} />
-            <DatePicker allowClear={false} onChange={(value) => { if (value) setFilters((current) => ({ ...current, timeRange: [current.timeRange[0], value] })); }} placeholder={t("bknTrace.logs.endTime")} showTime value={filters.timeRange[1]} />
+          <div className={styles.filterRow}>
+            <DatePicker.RangePicker allowClear={false} onChange={(value) => { const [start, end] = value ?? []; if (start && end) setFilters((current) => ({ ...current, timeRange: [start, end] })); }} placeholder={[t("bknTrace.logs.startTime"), t("bknTrace.logs.endTime")]} showTime value={filters.timeRange} />
             <Select allowClear onChange={(businessModule) => setFilters((value) => ({ ...value, businessModule }))} options={BUSINESS_MODULES.map((module) => ({ label: moduleLabel(module, t), value: module }))} placeholder={t("bknTrace.logs.modulePlaceholder")} value={filters.businessModule} />
-          </div>
-          <div className={styles.filterRowSecondary}>
-            <Input allowClear onChange={(event) => setFilters((value) => ({ ...value, actorId: event.target.value }))} onPressEnter={submit} placeholder={t("bknTrace.logs.actorPlaceholder")} value={filters.actorId} />
             <Select allowClear onChange={(outcome) => setFilters((value) => ({ ...value, outcome }))} options={AUDIT_OUTCOMES.map((outcome) => ({ label: t(`bknTrace.logs.outcomes.${outcome}`), value: outcome }))} placeholder={t("bknTrace.logs.outcomePlaceholder")} value={filters.outcome} />
+            <Input allowClear onChange={(event) => setFilters((value) => ({ ...value, actorId: event.target.value }))} onPressEnter={submit} placeholder={t("bknTrace.logs.actorPlaceholder")} value={filters.actorId} />
             <Space><Button icon={<SearchOutlined />} onClick={submit} type="primary">{t("bknTrace.actions.query")}</Button><Button onClick={reset}>{t("bknTrace.actions.reset")}</Button></Space>
           </div>
         </div>
@@ -242,7 +236,7 @@ function ClampedText({ secondary, value }: { secondary?: string; value: string }
 
 function defaultFilters(mode: "audit" | "logs"): Filters {
   const end = dayjs();
-  return { actorId: "", query: "", timeRange: [end.subtract(mode === "audit" ? 30 : 7, "day"), end] };
+  return { actorId: "", timeRange: [end.subtract(mode === "audit" ? 30 : 7, "day"), end] };
 }
 
 function readInitialFilters(mode: "audit" | "logs"): Filters {
@@ -259,7 +253,6 @@ function readInitialFilters(mode: "audit" | "logs"): Filters {
     actorId: parameters.get("actor") ?? (!exactActorMatch ? parameters.get("actor_id") : null) ?? "",
     ...(BUSINESS_MODULES.includes(businessModule as BusinessModule) ? { businessModule: businessModule as BusinessModule } : {}),
     ...(AUDIT_OUTCOMES.includes(outcome as AuditOutcome) ? { outcome: outcome as AuditOutcome } : {}),
-    query: parameters.get("q") ?? "",
     ...(hasValidTimeRange ? { timeRange: [timeFrom, timeTo] } : {}),
   };
 }
@@ -291,7 +284,6 @@ function syncFiltersToUrl(filters: Filters, scope: AssociatedLogScope) {
     parameters.set("actor_id", scope.actorId);
     parameters.set("actor_match", EXACT_ACTOR_MATCH);
   }
-  if (filters.query.trim()) parameters.set("q", filters.query.trim());
   if (filters.businessModule) parameters.set("business_module", filters.businessModule);
   if (filters.actorId.trim()) parameters.set("actor", filters.actorId.trim());
   if (filters.outcome) parameters.set("outcome", filters.outcome);

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspace.module.css
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspace.module.css
@@ -35,19 +35,14 @@
   padding: 14px;
 }
 
-.filterRowPrimary,
-.filterRowSecondary {
+.filterRow {
   align-items: center;
   display: grid;
   gap: 10px;
 }
 
-.filterRowPrimary {
-  grid-template-columns: minmax(260px, 1.4fr) minmax(180px, 0.8fr) minmax(180px, 0.8fr) minmax(190px, 0.8fr);
-}
-
-.filterRowSecondary {
-  grid-template-columns: minmax(220px, 1fr) minmax(220px, 1fr) minmax(180px, 0.8fr) auto;
+.filterRow {
+  grid-template-columns: minmax(280px, 1.2fr) minmax(180px, 0.7fr) minmax(160px, 0.6fr) minmax(180px, 0.7fr) auto;
 }
 
 .sourceStrip {
@@ -108,16 +103,14 @@
   font-size: 12px;
 }
 
-@container (max-width: 960px) {
-  .filterRowPrimary,
-  .filterRowSecondary {
+@container (max-width: 1080px) {
+  .filterRow {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @container (max-width: 640px) {
-  .filterRowPrimary,
-  .filterRowSecondary {
+  .filterRow {
     grid-template-columns: 1fr;
   }
 
@@ -254,8 +247,7 @@
 		padding: 16px;
 	}
 
-  .filterRowPrimary,
-  .filterRowSecondary {
+  .filterRow {
     grid-template-columns: 1fr;
   }
 

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -232,6 +232,18 @@ describe("observability workspace scenes", () => {
     expect(query?.timeTo).toBe("2026-08-03T00:00:00.000Z");
   });
 
+  it("忽略已废弃的 q 参数，仅保留结构化筛选", async () => {
+    window.history.replaceState({}, "", "/observability/logs?q=legacy-keyword&actor=%E5%BC%A0%E4%B8%89&outcome=failure");
+
+    render(<ObservabilityLogsScene />);
+
+    await waitFor(() => expect(listLogs).toHaveBeenCalled());
+    const [query] = vi.mocked(listLogs).mock.calls[0] ?? [];
+    expect(query).toMatchObject({ actorQuery: "张三", outcomes: ["failure"] });
+    expect(query).not.toHaveProperty("query");
+    expect(screen.queryByPlaceholderText("bknTrace.logs.searchPlaceholder")).toBeNull();
+  });
+
   it("系统管理日志入口复用统一工作台并保留对象下钻条件", async () => {
     window.history.replaceState({}, "", "/system/audit?target_type=user&target_id=user-a");
     render(<AuditLogPage />);


### PR DESCRIPTION
## What Changed

- [x] Backport #505: compact audit filters into one responsive row.
- [x] Remove the deprecated generic `q` filter while retaining time range, module, outcome, and name-or-ID actor filters.
- [x] Include implementation design and focused regression coverage.

## Why

- Backport of #505 for the `release/0.1.4` release line.

## How

- Cherry-picked the merged squash commit onto `release/0.1.4`; release already contains the required #495–#501 dependencies.
- Resolved the release-line divergence by applying the same final five-file patch against its current base.
- No API, configuration, or database migration changes.

## Testing

- [x] Focused Vitest: `ObservabilityWorkspaceScenes.test.tsx` (27 passed)
- [x] Type-aware ESLint for affected scene and test files
- [ ] Verified in test environment (pending CI/deployment)

## Risk & Rollback

- Risk: legacy `q` URL parameters are intentionally ignored.
- Rollback: revert this single backport commit.

## Additional Notes

- Source PR: #505