### PR TITLE
fix(observability): backport provenance 404 toast suppression

### DIFF
--- a/src/framework/request/http.test.ts
+++ b/src/framework/request/http.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AxiosAdapter } from "axios";
 
-import { http } from "@/framework/request/http";
+import { http, setRequestErrorHandler } from "@/framework/request/http";
 import { createRuntimeConfig, setRuntimeConfig } from "@/framework/runtime/config";
 
 const adapter = vi.fn<AxiosAdapter>((config) => Promise.resolve({
@@ -26,6 +26,7 @@ describe("http request headers", () => {
   });
 
   afterEach(() => {
+    setRequestErrorHandler(null);
     setRuntimeConfig(createRuntimeConfig());
   });
 
@@ -54,5 +55,33 @@ describe("http request headers", () => {
 
     expect(adapter.mock.calls[0]?.[0].headers?.get("Accept-Language")).toBe("en-US");
     expect(adapter.mock.calls[1]?.[0].headers?.get("Accept-Language")).toBe("zh-CN");
+  });
+
+  it("does not notify globally when an expected request error opts out", async () => {
+    const notify = vi.fn();
+    setRequestErrorHandler(notify);
+    const missingRoute: AxiosAdapter = (config) => Promise.reject(Object.assign(
+      new Error("Request failed with status code 404"),
+      { config, isAxiosError: true, response: { status: 404 } },
+    ));
+
+    await expect(http.get("/enterprise-only", { adapter: missingRoute, skipErrorToast: true }))
+      .rejects.toThrow("Request failed with status code 404");
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("notifies globally when a request error does not opt out", async () => {
+    const notify = vi.fn();
+    setRequestErrorHandler(notify);
+    const missingRoute: AxiosAdapter = (config) => Promise.reject(Object.assign(
+      new Error("Request failed with status code 404"),
+      { config, isAxiosError: true, response: { status: 404 } },
+    ));
+
+    await expect(http.get("/enterprise-only", { adapter: missingRoute }))
+      .rejects.toThrow("Request failed with status code 404");
+
+    expect(notify).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/bkn-trace/business-provenance/business-provenance.service.test.ts
+++ b/src/modules/bkn-trace/business-provenance/business-provenance.service.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/framework/runtime/config", () => ({
 describe("EE business provenance service", () => {
   beforeEach(() => { getMock.mockReset(); postMock.mockReset(); });
 
-  it("reads the EE conversation list rather than the removed community endpoint", async () => {
+  it("silences the expected missing-EE-route response while reading the conversation list", async () => {
     getMock.mockResolvedValue({ data: { entries: [{ conversation_id: "conv-1" }], total: 1 } });
     const { getBusinessProvenanceConversations } = await import("./business-provenance.service");
 
@@ -30,7 +30,11 @@ describe("EE business provenance service", () => {
 
     expect(getMock).toHaveBeenCalledWith(
       "/agent-observability/v1/business-provenance/conversations",
-      { headers: { "x-business-domain": "bd_demo" }, params: { page: 2, page_size: 20, keyword: "采购" } },
+      {
+        headers: { "x-business-domain": "bd_demo" },
+        params: { page: 2, page_size: 20, keyword: "采购" },
+        skipErrorToast: true,
+      },
     );
     expect(page.entries[0]?.conversationId).toBe("conv-1");
   });

--- a/src/modules/bkn-trace/business-provenance/business-provenance.service.ts
+++ b/src/modules/bkn-trace/business-provenance/business-provenance.service.ts
@@ -118,7 +118,7 @@ export async function getBusinessProvenanceConversations(
 ): Promise<BusinessProvenancePage<BusinessProvenanceConversation>> {
   const response = await http.get<{ entries?: BackendConversation[]; total?: number; page?: number; page_size?: number }>(
     `${EE_PROVENANCE_PREFIX}/conversations`,
-    { headers: provenanceHeaders(), params: provenanceParams(query) },
+    { headers: provenanceHeaders(), params: provenanceParams(query), skipErrorToast: true },
   );
   return {
     entries: (response.data.entries ?? []).map((entry) => ({


### PR DESCRIPTION
## Backport of #507

Suppress the global 404 toast when the community image correctly reports that the Enterprise business-provenance route is unavailable. The page still renders the existing upgrade-image state.

## Verification
- Already up to date
Done in 190ms using pnpm v11.5.1

 RUN  v3.2.6 /Users/leecky/openbkn/bkn-studio/.worktrees/backport-0.1.4-provenance-404

stdout | src/modules/bkn-trace/business-provenance/business-provenance.service.test.ts > EE business provenance service > silences the expected missing-EE-route response while reading the conversation list
🌐 i18next is made possible by our own product, Locize — consider powering your project with managed localization (AI, CDN, integrations): https://locize.com 💙

stdout | src/framework/request/http.test.ts
🌐 i18next is made possible by our own product, Locize — consider powering your project with managed localization (AI, CDN, integrations): https://locize.com 💙

 ✓ src/modules/bkn-trace/business-provenance/business-provenance.service.test.ts (6 tests) 391ms
   ✓ EE business provenance service > silences the expected missing-EE-route response while reading the conversation list  384ms
 ✓ src/framework/request/http.test.ts (4 tests) 12ms

 Test Files  2 passed (2)
      Tests  10 passed (10)
   Start at  08:45:10
   Duration  1.35s (transform 428ms, setup 213ms, collect 584ms, tests 404ms, environment 823ms, prepare 114ms) — 10 passed
- Already up to date
Done in 191ms using pnpm v11.5.1