### PR TITLE
fix(knowledge-network): backport lifecycle contract to 0.1.4

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
@@ -471,6 +471,7 @@ export function AgentChat({
   const summaryLifecycle = useMemo(
     () =>
       createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
+        agentName: "bkn-agent-smart-qa-summary",
         conversationStore: memoryConversationStore(),
       }),
     [env.base, knId, tokenProvider],

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
@@ -132,6 +132,18 @@ beforeEach(async () => {
 afterEach(cleanup);
 
 describe("ChatPane 受管生命周期接线", () => {
+  it("以稳定的智能问答场景名创建受管会话", () => {
+    stubLifecycle();
+
+    renderPane();
+
+    expect(createBknLifecycle).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ agentName: "bkn-agent-smart-qa" }),
+    );
+  });
+
   it("一轮问答开一轮交互，把它交给工具循环，并以答复正文终结", async () => {
     const { beginTurn, finish, session } = stubLifecycle();
     runAgentChat.mockImplementation(({ onChunk }) => {

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -91,6 +91,12 @@ const FALLBACK_SUGGESTION_KEYS = [
 
 export type PaneKey = "solo" | "base" | "kn";
 
+const AGENT_NAME_BY_PANE: Record<PaneKey, string> = {
+  solo: "bkn-agent-smart-qa",
+  base: "bkn-agent-base-data-chat",
+  kn: "bkn-agent-knowledge-network-chat",
+};
+
 /** Pane profile controlling defaults, context injection, tool selection, and storage keys. */
 export type PaneProfile = {
   paneKey: PaneKey;
@@ -701,6 +707,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
   const lifecycle = useMemo(
     () =>
       createBknLifecycle(lifecycleEnv(env.base, knId), tokenProvider, {
+        agentName: AGENT_NAME_BY_PANE[profile.paneKey],
         conversationStore: localConversationStore(
           conversationLsKey(knId, profile.paneKey),
           legacyConversationLsKey(knId, profile.paneKey),

--- a/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
+++ b/src/modules/knowledge-network/scenes/DataBrowserPanel.tsx
@@ -301,7 +301,11 @@ export function DataBrowserPanel({
    * require bkn_context or Context Loader rejects them. This is not a chat, so one session lasts for this mount.
    */
   const lifecycle = useMemo(
-    () => createBknLifecycle(lifecycleEnv(env.base, env.knId), auth, { conversationStore: memoryConversationStore() }),
+    () =>
+      createBknLifecycle(lifecycleEnv(env.base, env.knId), auth, {
+        agentName: "bkn-agent-data-browser",
+        conversationStore: memoryConversationStore(),
+      }),
     [env.base, env.knId, auth],
   );
 

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -58,10 +58,12 @@ import {
   type McpToolDef,
 } from "@/modules/knowledge-network/services/context-loader.service";
 import {
+  LIFECYCLE_TOOL_NAMES,
   createBknLifecycle,
   lifecycleEnv,
   memoryConversationStore,
   withManagedTurn,
+  type BknTurn,
 } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
 import { AgentChat } from "@/modules/knowledge-network/components/agent-chat/AgentChat";
 import type { AgentTokenProvider } from "@/modules/knowledge-network/services/agent-chat.service";
@@ -349,7 +351,11 @@ export function ExperienceScene({
    * Fill Test Data action is one interaction. Memory store resets on refresh.
    */
   const lifecycle = useMemo(
-    () => createBknLifecycle(lifecycleEnv(base, knId), tokenProvider, { conversationStore: memoryConversationStore() }),
+    () =>
+      createBknLifecycle(lifecycleEnv(base, knId), tokenProvider, {
+        agentName: "bkn-agent-mcp-debug",
+        conversationStore: memoryConversationStore(),
+      }),
     [base, knId, tokenProvider],
   );
 
@@ -507,26 +513,19 @@ export function ExperienceScene({
       const freshToken =
         authMode === "apikey" ? appKey.trim() : runtimeConfig.auth.tokenManager.getAccessToken() ?? env.token;
       const freshEnv = { ...env, token: freshToken };
-      // tokenProvider refreshes once after 401. One click equals one managed interaction.
-      const result = await withManagedTurn(
-        lifecycle,
-        t("knowledgeNetwork.contextLoaderPanel.experience.debugTurn", { id: op.id }),
-        async (turn) => {
-          const sent = await sendRequest(
-            freshEnv,
-            op,
-            mode,
-            queryVals,
-            bodyText,
-            tokenProvider,
-            controller.signal,
-            turn?.nextContext(),
+      const send = (turn: BknTurn | null = null) =>
+        sendRequest(freshEnv, op, mode, queryVals, bodyText, tokenProvider, controller.signal, turn?.nextContext());
+      // Lifecycle tools are entered directly by the debugger. Wrapping them would
+      // recursively create a turn and inject a bkn_context that their schema rejects.
+      const result = LIFECYCLE_TOOL_NAMES.has(op.id)
+        ? await send()
+        : await withManagedTurn(
+            lifecycle,
+            t("knowledgeNetwork.contextLoaderPanel.experience.debugTurn", { id: op.id }),
+            send,
+            // Even if the business call returns 500, this interaction completed from the caller side.
+            (sent) => `HTTP ${sent.status} · ${sent.sizeBytes}B`,
           );
-          return sent;
-        },
-        // Even if the business call returns 500, this interaction completed from the caller side.
-        (sent) => `HTTP ${sent.status} · ${sent.sizeBytes}B`,
-      );
       if (requestSequence !== requestSequenceRef.current) return;
       setResponse(result);
     } catch (error) {

--- a/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.service.ts
@@ -69,7 +69,11 @@ export type ConversationStore = {
   clear(): void;
 };
 
-export type BknLifecycleOptions = { conversationStore: ConversationStore };
+export type BknLifecycleOptions = {
+  conversationStore: ConversationStore;
+  /** Stable caller label required by the managed lifecycle contract. */
+  agentName?: string;
+};
 
 export function lifecycleEnv(base: string, knId: string): ContextLoaderEnv {
   return { base, token: "", knId };
@@ -229,7 +233,7 @@ export function createBknLifecycle(
 }
 
 export function createBknLifecycleOn(session: McpSession, options: BknLifecycleOptions): BknLifecycle {
-  const { conversationStore } = options;
+  const { conversationStore, agentName = "bkn-studio" } = options;
   let conversationId = conversationStore.read();
   // Whether the previous turn lacked lifecycle support; report only, not a short circuit.
   let notSupported = false;
@@ -259,7 +263,11 @@ export function createBknLifecycleOn(session: McpSession, options: BknLifecycleO
         // Do not short-circuit on notSupported. Lifecycle support is deployment
         // state and may appear after backend upgrades or restarts while the page is open.
         const startInteraction = (currentConversationId: string | null) => {
-          const args: Record<string, unknown> = { question };
+          const args: Record<string, unknown> = {
+            agent_name: agentName,
+            question,
+            conversation_mode: currentConversationId ? "continue" : "new",
+          };
           if (currentConversationId) args.conversation_id = currentConversationId;
           return callLifecycleTool(session, "bkn_start_interaction", args);
         };

--- a/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
+++ b/src/modules/knowledge-network/services/bkn-lifecycle.test.ts
@@ -65,10 +65,13 @@ describe("createBknLifecycle", () => {
     await first?.complete("first answer");
     const second = await lifecycle.beginTurn("second question");
 
-    expect(calls[0]).toEqual({ name: "bkn_start_interaction", args: { question: "first question" } });
+    expect(calls[0]).toEqual({
+      name: "bkn_start_interaction",
+      args: { agent_name: "bkn-studio", question: "first question", conversation_mode: "new" },
+    });
     expect(calls[2]).toEqual({
       name: "bkn_start_interaction",
-      args: { question: "second question", conversation_id: "conv_1" },
+      args: { agent_name: "bkn-studio", question: "second question", conversation_mode: "continue", conversation_id: "conv_1" },
     });
     expect(second?.conversationId).toBe(first?.conversationId);
   });
@@ -82,7 +85,7 @@ describe("createBknLifecycle", () => {
     await turn?.complete("answer");
 
     expect(calls).toEqual([
-      { name: "bkn_start_interaction", args: { question: "question" } },
+      { name: "bkn_start_interaction", args: { agent_name: "bkn-studio", question: "question", conversation_mode: "new" } },
       { name: "bkn_finish_interaction", args: { interaction_id: "int_1", outcome: "completed", answer: "answer" } },
     ]);
   });
@@ -186,8 +189,8 @@ describe("createBknLifecycle", () => {
 
     await expect(lifecycle.beginTurn("question")).resolves.toMatchObject({ conversationId: "conv_2", interactionId: "int_2" });
     expect(calls).toEqual([
-      { name: "bkn_start_interaction", args: { question: "question", conversation_id: "stale_conv" } },
-      { name: "bkn_start_interaction", args: { question: "question" } },
+      { name: "bkn_start_interaction", args: { agent_name: "bkn-studio", question: "question", conversation_mode: "continue", conversation_id: "stale_conv" } },
+      { name: "bkn_start_interaction", args: { agent_name: "bkn-studio", question: "question", conversation_mode: "new" } },
     ]);
     expect(store.clear).toHaveBeenCalledOnce();
     expect(store.write).toHaveBeenCalledWith("conv_2");
@@ -233,13 +236,13 @@ describe("createBknLifecycle", () => {
 
     await expect(lifecycle.beginTurn("question")).resolves.toMatchObject({ conversationId: "conv_live", interactionId: "int_9" });
     expect(calls).toEqual([
-      { name: "bkn_start_interaction", args: { question: "question", conversation_id: "conv_live" } },
+      { name: "bkn_start_interaction", args: { agent_name: "bkn-studio", question: "question", conversation_mode: "continue", conversation_id: "conv_live" } },
       {
         name: "bkn_finish_interaction",
         // Use cancelled rather than completed because that round did not answer fully and must not appear normal in Trace.
         args: { interaction_id: "int_stuck", outcome: "cancelled", reason: "reclaimed by client: previous turn did not finish" },
       },
-      { name: "bkn_start_interaction", args: { question: "question", conversation_id: "conv_live" } },
+      { name: "bkn_start_interaction", args: { agent_name: "bkn-studio", question: "question", conversation_mode: "continue", conversation_id: "conv_live" } },
     ]);
     // The session remains, so the user's conversation history stays connected in Trace.
     expect(store.clear).not.toHaveBeenCalled();
@@ -336,7 +339,7 @@ describe("createBknLifecycle", () => {
       "bkn_finish_interaction",
       "bkn_start_interaction",
     ]);
-    expect(calls.at(-1)?.args).toEqual({ question: "question" });
+    expect(calls.at(-1)?.args).toEqual({ agent_name: "bkn-studio", question: "question", conversation_mode: "new" });
     expect(store.clear).toHaveBeenCalledOnce();
   });
 

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -18,9 +18,17 @@ import {
   fetchKnDetailRestLegacy,
   listMcpTools,
   sendRequest,
+  type ContextLoaderOp,
 } from "@/modules/knowledge-network/services/context-loader.service";
 
 const searchSchema = CONTEXT_LOADER_OPS.find((operation) => operation.id === "search_schema")!;
+const startInteraction: ContextLoaderOp = {
+  id: "bkn_start_interaction",
+  summary: "Start an interaction",
+  path: "/api/agent-retrieval/v1/kn/bkn_start_interaction",
+  query: [],
+  body: {},
+};
 
 const bknContext = {
   conversation_id: "conv_1",
@@ -312,6 +320,21 @@ describe("fetchMcpObjectTypes", () => {
 });
 
 describe("buildCurl", () => {
+  it("does not inject managed context or expose the bearer token for lifecycle tools", () => {
+    const curl = buildCurl(
+      { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" },
+      startInteraction,
+      "mcp",
+      {},
+      '{"agent_name":"bkn-studio","conversation_mode":"new","question":"订单查询"}',
+      bknContext,
+    );
+
+    expect(curl).not.toContain("bkn_context");
+    expect(curl).not.toContain("token-1");
+    expect(curl).toContain("Authorization: Bearer <redacted>");
+  });
+
   it("includes the managed context so the copied command is the one that was sent", () => {
     const curl = buildCurl(
       { base: "https://platform.example.com", token: "token-1", knId: "kn-demo" },

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -622,6 +622,18 @@ function withBknContext(
   return { ...payload, bkn_context: bknContext };
 }
 
+function isLifecycleTool(op: ContextLoaderOp): boolean {
+  return op.id === "bkn_start_interaction" || op.id === "bkn_finish_interaction";
+}
+
+function withOperationContext(
+  op: ContextLoaderOp,
+  payload: Record<string, unknown>,
+  bknContext: BknContext | undefined,
+): Record<string, unknown> {
+  return isLifecycleTool(op) ? payload : withBknContext(payload, bknContext);
+}
+
 /**
  * Whether the payload already carries a context worth keeping.
  *
@@ -665,6 +677,7 @@ function strictBodyObject(bodyText: string): Record<string, unknown> {
  * response_format selector because MCP has no query string.
  */
 function mcpCallArgs(
+  op: ContextLoaderOp,
   bodyText: string,
   queryValues: Record<string, string>,
   bknContext?: BknContext,
@@ -674,7 +687,12 @@ function mcpCallArgs(
   if (responseFormat && !("response_format" in args)) {
     args.response_format = responseFormat;
   }
-  return withBknContext(args, bknContext);
+  return withOperationContext(op, args, bknContext);
+}
+
+function displayAuthHeaders(env: ContextLoaderEnv): Record<string, string> {
+  const headers = authHeaders(env);
+  return headers.Authorization ? { ...headers, Authorization: "Bearer <redacted>" } : headers;
 }
 
 export function buildCurl(
@@ -687,8 +705,8 @@ export function buildCurl(
 ): string {
   if (mode === "mcp") {
     const url = mcpBase(env);
-    const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream", ...languageHeaders(), ...authHeaders(env) };
-    const args = mcpCallArgs(bodyText, queryValues, bknContext);
+    const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream", ...languageHeaders(), ...displayAuthHeaders(env) };
+    const args = mcpCallArgs(op, bodyText, queryValues, bknContext);
     const payload = { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: op.id, arguments: args } };
     let curl = `curl -X POST '${url}'`;
     Object.entries(headers).forEach(([key, value]) => {
@@ -698,7 +716,7 @@ export function buildCurl(
     return curl;
   }
   const url = buildRestUrl(env, op, queryValues);
-  const headers = { "Content-Type": "application/json", ...languageHeaders(), ...authHeaders(env) };
+  const headers = { "Content-Type": "application/json", ...languageHeaders(), ...displayAuthHeaders(env) };
   let curl = `curl -X POST '${url}'`;
   Object.entries(headers).forEach(([key, value]) => {
     curl += ` \\\n  -H '${key}: ${value}'`;
@@ -708,7 +726,7 @@ export function buildCurl(
     // If the body is being edited and is not valid JSON yet, preserve user text.
     let body: string;
     try {
-      body = JSON.stringify(withBknContext(strictBodyObject(bodyText), bknContext));
+      body = JSON.stringify(withOperationContext(op, strictBodyObject(bodyText), bknContext));
     } catch {
       body = (bodyText || "{}").replace(/\n\s*/g, "");
     }
@@ -789,7 +807,7 @@ export async function sendRequest(
           jsonrpc: "2.0",
           id: 2,
           method: "tools/call",
-          params: { name: op.id, arguments: mcpCallArgs(bodyText, queryValues, bknContext) },
+          params: { name: op.id, arguments: mcpCallArgs(op, bodyText, queryValues, bknContext) },
         }),
       });
       const text = await response.text();
@@ -806,7 +824,7 @@ export async function sendRequest(
     const headers = { "Content-Type": "application/json", ...languageHeaders(), ...bearer };
     const init: RequestInit = { method: "POST", headers, signal };
     if (op.body !== null) {
-      init.body = JSON.stringify(withBknContext(strictBodyObject(bodyText), bknContext));
+      init.body = JSON.stringify(withOperationContext(op, strictBodyObject(bodyText), bknContext));
     }
     const response = await fetch(url, init);
     const text = await response.text();


### PR DESCRIPTION
## Summary
- backport the merged Studio lifecycle contract fix from #511 to `release/0.1.4`
- retain fixed scenario agent labels, correct new/continue conversation handling, context boundary, and debug token redaction

## Validation
- targeted Vitest: 43 passed
- `tsc -b --pretty false`
- targeted ESLint
- `git diff --check`

Cherry-picked from `cdb831d5e1971870cc86f74e7208a05de529e466` (#511).