### PR TITLE
fix(data-catalog): let a data connection's owner authorize it from the connection page

### DIFF
--- a/src/modules/data-catalog/components/CatalogDetailPanel.test.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CatalogRecord } from "@/shared/catalog";
+
+const listCatalogResourcePageMock = vi.hoisted(() => vi.fn());
+const currentPermissions = vi.hoisted(() => ({ value: [] as string[] }));
+const drawerProps = vi.hoisted(() => ({ value: null as Record<string, unknown> | null }));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ i18n: { language: "zh-CN" }, t: (key: string) => key }),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({
+    message: { error: vi.fn(), success: vi.fn() },
+    modal: { confirm: vi.fn() },
+    runtimeConfig: { currentUser: { permissions: currentPermissions.value } },
+  }),
+}));
+
+vi.mock("@/framework/permission/PermissionGate", () => ({
+  PermissionGate: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/modules/data-catalog/services/resource.service", () => ({
+  listCatalogResourcePage: listCatalogResourcePageMock,
+}));
+
+vi.mock("@/modules/system-admin/components/ObjectAuthorizeDrawer", () => ({
+  ObjectAuthorizeDrawer: (props: Record<string, unknown>) => {
+    drawerProps.value = props;
+    return props.open ? <div data-testid="authorize-drawer" /> : null;
+  },
+}));
+
+import { CatalogDetailPanel } from "./CatalogDetailPanel";
+
+const catalog: CatalogRecord = {
+  category: "database",
+  connectorConfig: {},
+  connectorType: "mysql",
+  createTime: null,
+  creatorName: "test",
+  description: "",
+  enabled: true,
+  healthCheckResult: "",
+  healthStatus: "healthy",
+  id: "catalog-1",
+  internal: false,
+  lastCheckTime: null,
+  metadata: {},
+  mode: "",
+  name: "nb_test_conn",
+  operations: ["view_detail"],
+  status: "enabled",
+  tags: [],
+  type: "physical",
+  updateTime: null,
+  expectedUpdateTime: 0,
+  updaterName: "test",
+};
+
+function renderPanel(record: CatalogRecord) {
+  return render(
+    <MemoryRouter>
+      <CatalogDetailPanel
+        catalog={record}
+        onCreateResource={vi.fn()}
+        onOpenResource={vi.fn()}
+        tasks={[]}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("CatalogDetailPanel authorize entry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentPermissions.value = [];
+    drawerProps.value = null;
+    listCatalogResourcePageMock.mockResolvedValue({ items: [], total: 0 });
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+  });
+
+  // The bug: the button asked for admin-authz:grant, which no network_builder holds, so the person
+  // who created the data connection could not share it — while bkn-safe was already accepting the
+  // grant from them on /me/object-grants.
+  it("offers the drawer to the catalog owner, who holds no admin point", async () => {
+    renderPanel({ ...catalog, operations: ["view_detail", "authorize"] });
+    await act(async () => {});
+
+    fireEvent.click(screen.getByText("dataCatalog.catalog.authorize"));
+
+    expect(screen.getByTestId("authorize-drawer")).toBeTruthy();
+    expect(drawerProps.value?.objType).toBe("catalog");
+    expect(drawerProps.value?.objId).toBe("catalog-1");
+    // Tells the drawer to run in owner mode: /me endpoints, no `authorize` chip to pass on.
+    expect(drawerProps.value?.objectAuthorized).toBe(true);
+  });
+
+  it("keeps the entry for an administrator without the object operation", async () => {
+    currentPermissions.value = ["admin-authz:grant"];
+    renderPanel(catalog);
+    await act(async () => {});
+
+    expect(screen.getByText("dataCatalog.catalog.authorize")).toBeTruthy();
+    expect(drawerProps.value?.objectAuthorized).toBe(false);
+  });
+
+  it("hides the entry when the account holds neither", async () => {
+    renderPanel(catalog);
+    await act(async () => {});
+
+    expect(screen.queryByText("dataCatalog.catalog.authorize")).toBeNull();
+  });
+
+  // Built-in catalogs stay read-only in Studio, owner row or not.
+  it("hides the entry on an internal catalog", async () => {
+    currentPermissions.value = ["admin-authz:grant"];
+    renderPanel({ ...catalog, internal: true, operations: ["view_detail", "authorize"] });
+    await act(async () => {});
+
+    expect(screen.queryByText("dataCatalog.catalog.authorize")).toBeNull();
+  });
+});

--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -25,6 +25,7 @@ import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { TableSurface } from "@/framework/ui/common/TableSurface";
 import { dataCatalogCreationAvailable } from "@/modules/data-catalog/lib/creation-availability";
 import { formatRowCount } from "@/modules/data-catalog/lib/format";
+import { ObjectAuthorizeDrawer } from "@/modules/system-admin/components/ObjectAuthorizeDrawer";
 import { authzPoints } from "@/modules/system-admin/permissions";
 import { formatIndexStateLabel } from "@/modules/data-catalog/lib/format-index-state";
 import { resourceQueryBlockReason } from "@/modules/data-catalog/lib/resource-query-availability";
@@ -38,7 +39,7 @@ import type {
   CatalogResource,
   ResourceDiscoverStatus,
 } from "@/modules/data-catalog/types/data-catalog";
-import type { CatalogRecord } from "@/shared/catalog";
+import { hasCatalogOperation, type CatalogRecord } from "@/shared/catalog";
 
 import styles from "./CatalogDetailPanel.module.css";
 
@@ -141,6 +142,7 @@ export function CatalogDetailPanel({
   const [resourcesLoading, setResourcesLoading] = useState(false);
   const [resourceLoadError, setResourceLoadError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+  const [authorizeOpen, setAuthorizeOpen] = useState(false);
   const [nameColumnWidth, setNameColumnWidth] = useState(() => {
     try {
       const value = window.localStorage.getItem("data-catalog.resourceNameColumnWidth");
@@ -162,13 +164,15 @@ export function CatalogDetailPanel({
     resourceKeyword.trim().length > 0 ||
     categoryFilter.length > 0 ||
     (showIndexState && indexFilter.length > 0);
-  // Granting access to this catalog is the one action available on every catalog, built-in ones
-  // aside, so the bar shows whenever the catalog is a real one.
-  const canAuthorizeCatalog = !catalog.internal;
   const canAuthorizeGrants = hasPermissions({
     currentPermissions: runtimeConfig.currentUser.permissions,
     requiredPermissions: authzPoints.grant,
   });
+  // Two ways to earn the button, and they are different questions. `authorize` on THIS catalog is
+  // what its creator holds (vega writes it at create time); admin-authz:grant is the platform-wide
+  // point. Asking only the second one hid the button from every person who built a data connection.
+  const ownsCatalogAuthorize = hasCatalogOperation(catalog, "authorize");
+  const canAuthorizeCatalog = !catalog.internal && (ownsCatalogAuthorize || canAuthorizeGrants);
   const showOperationBar =
     resourceTotal > 0 ||
     hasResourceQuery ||
@@ -512,25 +516,16 @@ export function CatalogDetailPanel({
               </PermissionGate>
             ) : null}
             {/*
-              授权发生在系统管理的对象授权页,这里只是把当前目录带过去,省掉在几百个对象里
-              重新找一遍。看得见这颗按钮的前提是有 admin-authz:grant——那张页面本身要的点位,
-              而不是数据面的动词。
+              授权在抽屉里当场做完,走 /me/object-grants 自助面。原先这里跳系统管理的对象授权页,
+              那张页面打的是 /admin/object-grants,整组挂在 RequireAdmin 后面——建这个连接的人
+              够不到,而按钮本身又门控在 admin-authz:grant 上,于是"自己建的目录自己授不了"。
+              判定改成问这个目录自己的 operations:建目录时创建者就拿到了 authorize,
+              管理员则继续走平台点位。
             */}
             {canAuthorizeCatalog ? (
-              <PermissionGate permissions={authzPoints.grant}>
-                <AppButton
-                  icon={<KeyOutlined />}
-                  onClick={() => {
-                    void navigate(
-                      `/system/authorizations/new?object=${encodeURIComponent(`catalog::${catalog.id}`)}`,
-                      // Leaving the wizard should land back on this catalog, not in system management.
-                      { state: { objectGrantReturnTo: `${location.pathname}${location.search}` } },
-                    );
-                  }}
-                >
-                  {t("dataCatalog.catalog.authorize")}
-                </AppButton>
-              </PermissionGate>
+              <AppButton icon={<KeyOutlined />} onClick={() => setAuthorizeOpen(true)}>
+                {t("dataCatalog.catalog.authorize")}
+              </AppButton>
             ) : null}
           </div>
         </div>
@@ -661,6 +656,15 @@ export function CatalogDetailPanel({
           total={showIndexState && indexFilter ? displayResources.length : resourceTotal}
         />
       ) : null}
+
+      <ObjectAuthorizeDrawer
+        objectAuthorized={ownsCatalogAuthorize}
+        objId={catalog.id}
+        objName={catalog.name}
+        objType="catalog"
+        onClose={() => setAuthorizeOpen(false)}
+        open={authorizeOpen}
+      />
     </section>
   );
 }

--- a/src/shared/catalog/catalog-operations.ts
+++ b/src/shared/catalog/catalog-operations.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { CatalogRecord } from "@/shared/catalog/types";
+
+/**
+ * Whether the current account holds one bkn-safe operation on THIS catalog.
+ *
+ * Vega answers the per-object question the global permission set cannot: `catalog:*` in
+ * /me/permissions says nothing about which catalog, while `operations` on the record is the
+ * effective set for this instance — the object grant a creator receives included. Screens that gate
+ * on an object action must ask here, not at the permission points.
+ *
+ * `*` is honored because the super administrator's policy is a wildcard on both object and action.
+ */
+export function hasCatalogOperation(
+  catalog: Pick<CatalogRecord, "operations"> | null | undefined,
+  operation: string,
+) {
+  if (!catalog) {
+    return false;
+  }
+  return catalog.operations?.includes("*") || catalog.operations?.includes(operation) || false;
+}

--- a/src/shared/catalog/index.ts
+++ b/src/shared/catalog/index.ts
@@ -24,6 +24,8 @@ export type {
 
 export { catalogListAllQuery, catalogListPhysicalQuery } from "@/shared/catalog/catalog-queries";
 
+export { hasCatalogOperation } from "@/shared/catalog/catalog-operations";
+
 export {
   appendMockPhysicalCatalog,
   createLogicalCatalog,


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `data-catalog`: the 授权 button on a data connection is gated on the catalog's own `operations`, and opens `ObjectAuthorizeDrawer` instead of routing to the platform authorization page
- [x] `shared/catalog`: new `hasCatalogOperation` helper (mirrors `hasKnowledgeNetworkRecordOperation`)
- [x] Tests: `CatalogDetailPanel.test.tsx` pins the owner / administrator / neither / internal-catalog cases

---

## Why

- Related Issue: none filed — found while checking whether `network_builder` can share a data connection
- Background:

The button asked for `admin-authz:grant` and navigated to `/system/authorizations/new`, which posts to `/api/safe/v1/admin/object-grants` — a group mounted behind `RequireAdmin`. A `network_builder` who creates a data connection holds neither, so the person the feature exists for had no entry point, while bkn-safe was already accepting exactly that grant from them on `/me/object-grants`.

---

## How

- Key implementation points:
  - Gate on the object, not the permission points: vega writes `authorize` into the catalog's own `operations` at create time, so the record answers "may I share THIS catalog", which `catalog:*` in `/me/permissions` cannot. Administrators keep the entry through `admin-authz:grant`.
  - The button opens the same self-service drawer the knowledge network, execution factory and model panels use, so the write goes to `/me/object-grants` where an owner is accepted.
  - Resource rows are deliberately left on the administrator-only entry: after bkn-foundry #977 management sits on the owning catalog and no one but an administrator holds `authorize` on a table, so an owner-facing button there would always 403.
- Breaking changes (API, config, database, etc.): none. Administrators see the same button, now opening a drawer rather than a separate page.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable, no e2e covers this panel
- [x] Verified in test environment

Test notes:

```
node scripts/check-license-headers.mjs            exit 0
eslint --config eslint.config.typechecked.js      exit 0 (changed files; a whole-repo run is drowned by a stale .claude/worktrees checkout unrelated to this change)
vitest --run                                      232 files / 1236 tests passed
tsc -b --force                                    exit 0
vite build                                        exit 0
```

The four new cases fail on the pre-change component, which is the point of them.

Checked against a real `network_builder` account on the dev VM, with this build served from the studio pod:
- `GET /api/vega-backend/v1/catalogs` returns `authorize` in `operations` for the catalog that account created, and not for the ones the administrator created
- `POST /api/safe/v1/me/object-grants` on its own catalog → 204; on an administrator's catalog → 403

---

## Risk & Rollback

- Potential risks: the button now appears wherever the backend says the account may authorize the catalog. That set is the backend's to define — bkn-foundry #1150 narrowed it to creators plus explicit object grants — and this PR only stops hiding it.
- Rollback plan: revert the commit; the drawer and the helper are additive and nothing else imports them.

---

## Additional Notes

- Depends on bkn-foundry #1150 for the drawer's directory reads to answer an owner; that is already on main there.
