### PR TITLE
fix(system-admin): lock the grant rows a delegate is not allowed to write (#518)

### DIFF
--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ObjectGrant } from "@/modules/system-admin/types/authz";
+
+const listObjectGrantsForObjectMock = vi.hoisted(() => vi.fn());
+const listUsersPageMock = vi.hoisted(() => vi.fn());
+// One stable object, as the real context provides: the drawer's loaders are memoized on `message`,
+// so a fresh literal per render would re-fire the load effect forever.
+const appServices = vi.hoisted(() => ({
+  message: { error: vi.fn(), success: vi.fn() },
+  modal: { confirm: vi.fn() },
+  runtimeConfig: { currentUser: { permissions: [] as string[] } },
+}));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ i18n: { language: "zh-CN" }, t: (key: string) => key }),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => appServices,
+}));
+
+vi.mock("@/modules/system-admin/services/authz.service", () => ({
+  listObjectGrantsForObject: listObjectGrantsForObjectMock,
+  revokeObjectGrantForObject: vi.fn(),
+  upsertObjectGrantForObject: vi.fn(),
+}));
+
+vi.mock("@/modules/system-admin/services/admin.service", () => ({
+  listUsersPage: listUsersPageMock,
+}));
+
+vi.mock("@/modules/system-admin/utils/audit-lookup-cache", () => ({
+  getCachedDepartments: vi.fn(() => Promise.resolve([])),
+  getCachedUserSync: vi.fn(() => undefined),
+  hydrateUserLookup: vi.fn(() => Promise.resolve(undefined)),
+  primeUserLookupCache: vi.fn(),
+}));
+
+import { ObjectAuthorizeDrawer } from "./ObjectAuthorizeDrawer";
+
+const PUBLIC_ACCESSOR_ID = "00000000-0000-0000-0000-000000000000";
+
+function grant(accessorId: string, operations: string[]): ObjectGrant {
+  return {
+    accessorId,
+    objId: "catalog-1",
+    objName: "nb_test_conn",
+    objType: "catalog",
+    operations,
+  };
+}
+
+function renderDrawer() {
+  return render(
+    <ObjectAuthorizeDrawer
+      objectAuthorized
+      objId="catalog-1"
+      objName="nb_test_conn"
+      objType="catalog"
+      onClose={vi.fn()}
+      open
+    />,
+  );
+}
+
+/** The lock icon marks a row the caller may not write; each card renders one at most. */
+function lockedCardCount() {
+  return document.querySelectorAll('[aria-label="lock"]').length;
+}
+
+describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appServices.runtimeConfig.currentUser.permissions = [];
+    listUsersPageMock.mockResolvedValue({ total: 0, users: [] });
+    listObjectGrantsForObjectMock.mockResolvedValue({
+      accounts: [],
+      grants: [
+        grant("u-owner", ["view_detail", "authorize"]),
+        grant(PUBLIC_ACCESSOR_ID, ["view_detail"]),
+        grant("u-mate", ["view_detail"]),
+      ],
+    });
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+  });
+
+  // bkn-safe's protectAuthorizeHolder refuses a non-administrator write against an `authorize`
+  // holder — the caller's own row included — and against the public-access row. Offering the
+  // controls anyway means a click that can only 403.
+  it("locks the authorize holder and the public row for an owner", async () => {
+    renderDrawer();
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(2);
+    // The ordinary grant stays editable: that is what the owner opened the drawer for.
+    expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(1);
+  });
+
+  it("leaves every row writable for a platform administrator", async () => {
+    appServices.runtimeConfig.currentUser.permissions = [
+      "admin-authz:grant",
+      "admin-authz:revoke",
+    ];
+    renderDrawer();
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(0);
+    expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(3);
+  });
+});

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
@@ -17,7 +17,7 @@ const listUsersPageMock = vi.hoisted(() => vi.fn());
 const appServices = vi.hoisted(() => ({
   message: { error: vi.fn(), success: vi.fn() },
   modal: { confirm: vi.fn() },
-  runtimeConfig: { currentUser: { permissions: [] as string[] } },
+  runtimeConfig: { currentUser: { id: "u-owner", permissions: [] as string[] } },
 }));
 
 vi.mock("react-i18next", async (importOriginal) => ({
@@ -81,6 +81,7 @@ function lockedCardCount() {
 describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    appServices.runtimeConfig.currentUser.id = "u-owner";
     appServices.runtimeConfig.currentUser.permissions = [];
     listUsersPageMock.mockResolvedValue({ total: 0, users: [] });
     listObjectGrantsForObjectMock.mockResolvedValue({
@@ -132,11 +133,38 @@ describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
   // so the rows stay removable — reading administrator status off the grant point alone took the
   // remove control away from them.
   it("leaves every row removable for a revoke-only administrator", async () => {
+    appServices.runtimeConfig.currentUser.id = "u-admin";
     appServices.runtimeConfig.currentUser.permissions = [
       "admin-authz:view",
       "admin-authz:revoke",
     ];
     renderDrawer({ objectAuthorized: false });
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(0);
+    expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(3);
+  });
+
+  // Restoring `authorize` is a grant, and a revoke-only administrator holds no grant point: dropping
+  // it from their own row would leave them outside the object with no control here to undo it. The
+  // rows they can put back stay open.
+  it("keeps a revoke-only administrator from dropping their own authorize", async () => {
+    appServices.runtimeConfig.currentUser.permissions = [
+      "admin-authz:view",
+      "admin-authz:revoke",
+    ];
+    renderDrawer();
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(1);
+    // Their own row is the locked one; the public row and the ordinary grant stay removable.
+    expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(2);
+  });
+
+  // The same caller holding the grant point can restore what they drop, so nothing is locked.
+  it("leaves the caller's own authorize row open once they hold the grant point", async () => {
+    appServices.runtimeConfig.currentUser.permissions = ["admin-authz:grant"];
+    renderDrawer();
     await act(async () => {});
 
     expect(lockedCardCount()).toBe(0);

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
@@ -60,10 +60,10 @@ function grant(accessorId: string, operations: string[]): ObjectGrant {
   };
 }
 
-function renderDrawer() {
+function renderDrawer({ objectAuthorized = true } = {}) {
   return render(
     <ObjectAuthorizeDrawer
-      objectAuthorized
+      objectAuthorized={objectAuthorized}
       objId="catalog-1"
       objName="nb_test_conn"
       objType="catalog"
@@ -121,6 +121,22 @@ describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
       "admin-authz:revoke",
     ];
     renderDrawer();
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(0);
+    expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(3);
+  });
+
+  // The two admin-authz points are configured separately, and the platform authorization page does
+  // not pass objectAuthorized. A role holding revoke alone is still an administrator to bkn-safe,
+  // so the rows stay removable — reading administrator status off the grant point alone took the
+  // remove control away from them.
+  it("leaves every row removable for a revoke-only administrator", async () => {
+    appServices.runtimeConfig.currentUser.permissions = [
+      "admin-authz:view",
+      "admin-authz:revoke",
+    ];
+    renderDrawer({ objectAuthorized: false });
     await act(async () => {});
 
     expect(lockedCardCount()).toBe(0);

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
@@ -98,6 +98,27 @@ function mergeObjectGrants(
   return [...others, ...objectGrants];
 }
 
+/** The subject bkn-safe writes when the execution factory publishes something to everyone. */
+const PUBLIC_ACCESSOR_ID = "00000000-0000-0000-0000-000000000000";
+
+/**
+ * Whether bkn-safe will refuse a non-administrator write against this row
+ * (its protectAuthorizeHolder guard), so the drawer can lock it rather than offer a control that
+ * always 403s.
+ *
+ * Two rows are off limits to a delegate, and both because the write erases: POST is
+ * replace-semantics and DELETE removes everything the accessor holds.
+ *
+ * - A row carrying `authorize` — the object's creator, or anyone an administrator trusted with
+ *   sharing. Letting a delegate rewrite it would let them take the object away from the person who
+ *   made it, and `authorize` is administrator-conferred, so nobody inside the drawer could put it
+ *   back. This covers the caller's OWN row: an owner cannot drop their own authorize either.
+ * - The public-access row, whose removal would un-publish the object platform-wide.
+ */
+function isDelegateProtected(grant: ObjectGrant) {
+  return grant.accessorId === PUBLIC_ACCESSOR_ID || grant.operations.includes("authorize");
+}
+
 export function ObjectAuthorizeDrawer({
   objectAuthorized = false,
   objId,
@@ -499,7 +520,9 @@ export function ObjectAuthorizeDrawer({
             ) : null}
             <div className={styles.authzList}>
               {grants.map((grant) => {
-                const locked = isProtected(grant.accessorId);
+                const builtinLocked = isProtected(grant.accessorId);
+                const delegateLocked = !isAdminGrantor && isDelegateProtected(grant);
+                const locked = builtinLocked || delegateLocked;
                 const grantee = resolveGrantee(grant.accessorId);
                 return (
                   <div className={styles.authzCard} key={grant.accessorId}>
@@ -517,7 +540,13 @@ export function ObjectAuthorizeDrawer({
                         </Tag>
                       </span>
                       {locked ? (
-                        <Tooltip title={t("systemAdmin.objectGrants.adminLocked")}>
+                        <Tooltip
+                          title={t(
+                            builtinLocked
+                              ? "systemAdmin.objectGrants.adminLocked"
+                              : "systemAdmin.objectGrants.delegateLocked",
+                          )}
+                        >
                           <span className={styles.subText}>
                             <LockOutlined />
                           </span>

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
@@ -147,13 +147,18 @@ export function ObjectAuthorizeDrawer({
     currentPermissions,
     requiredPermissions: authzPoints.grant,
   });
+  const isAdminRevoker = hasPermissions({
+    currentPermissions,
+    requiredPermissions: authzPoints.revoke,
+  });
+  // Either admin-authz point makes the caller a platform administrator, the party bkn-safe exempts
+  // from its per-row guard. The two points are held separately — a review role may carry `revoke`
+  // alone — so reading administrator status off `grant` would lock a revoke-only administrator out
+  // of rows the backend accepts from them. Which control they get is still decided per direction by
+  // canGrant/canRevoke below.
+  const isPlatformAuthzAdmin = isAdminGrantor || isAdminRevoker;
   const canGrant = objectAuthorized || isAdminGrantor;
-  const canRevoke =
-    objectAuthorized ||
-    hasPermissions({
-      currentPermissions,
-      requiredPermissions: authzPoints.revoke,
-    });
+  const canRevoke = objectAuthorized || isAdminRevoker;
   const canManageGrants = canGrant || canRevoke;
   const [grants, setGrants] = useState<ObjectGrant[]>([]);
   const [departments, setDepartments] = useState<AdminDepartment[]>([]);
@@ -521,7 +526,7 @@ export function ObjectAuthorizeDrawer({
             <div className={styles.authzList}>
               {grants.map((grant) => {
                 const builtinLocked = isProtected(grant.accessorId);
-                const delegateLocked = !isAdminGrantor && isDelegateProtected(grant);
+                const delegateLocked = !isPlatformAuthzAdmin && isDelegateProtected(grant);
                 const locked = builtinLocked || delegateLocked;
                 const grantee = resolveGrantee(grant.accessorId);
                 return (

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
@@ -157,6 +157,7 @@ export function ObjectAuthorizeDrawer({
   // of rows the backend accepts from them. Which control they get is still decided per direction by
   // canGrant/canRevoke below.
   const isPlatformAuthzAdmin = isAdminGrantor || isAdminRevoker;
+  const currentUserId = runtimeConfig.currentUser.id;
   const canGrant = objectAuthorized || isAdminGrantor;
   const canRevoke = objectAuthorized || isAdminRevoker;
   const canManageGrants = canGrant || canRevoke;
@@ -526,7 +527,19 @@ export function ObjectAuthorizeDrawer({
             <div className={styles.authzList}>
               {grants.map((grant) => {
                 const builtinLocked = isProtected(grant.accessorId);
-                const delegateLocked = !isPlatformAuthzAdmin && isDelegateProtected(grant);
+                // Both writes erase, and putting `authorize` back is a grant. A caller without
+                // `admin-authz:grant` who drops it from their own row leaves the drawer with no way
+                // back in: the chip that would restore it is the one their point does not cover, and
+                // objectAuthorized — the other route to canGrant — dies with the row. So their own
+                // row stays locked even where bkn-safe would take the write. (An `authorize` held
+                // through a department grant is the same trap, but membership is not resolved here.)
+                const selfAuthorizeLockout =
+                  !isAdminGrantor &&
+                  currentUserId !== null &&
+                  grant.accessorId === currentUserId &&
+                  grant.operations.includes("authorize");
+                const delegateLocked =
+                  isDelegateProtected(grant) && (!isPlatformAuthzAdmin || selfAuthorizeLockout);
                 const locked = builtinLocked || delegateLocked;
                 const grantee = resolveGrantee(grant.accessorId);
                 return (
@@ -549,7 +562,9 @@ export function ObjectAuthorizeDrawer({
                           title={t(
                             builtinLocked
                               ? "systemAdmin.objectGrants.adminLocked"
-                              : "systemAdmin.objectGrants.delegateLocked",
+                              : isPlatformAuthzAdmin
+                                ? "systemAdmin.objectGrants.selfAuthorizeLocked"
+                                : "systemAdmin.objectGrants.delegateLocked",
                           )}
                         >
                           <span className={styles.subText}>

--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -159,6 +159,7 @@ export const systemAdminEnUS = {
       removeGrantConfirm: "Remove the permission rule for \"{{name}}\"?",
       removeLastOpConfirm: "This subject will have no operations left and the permission rule will be removed. Continue?",
       adminLocked: "The administrator holds all permissions and cannot be adjusted or removed here.",
+      delegateLocked: "Only a platform administrator can adjust or remove this grant — including your own.",
       revokeTitle: "Revoke permissions",
       revokeConfirm: "Revoke \"{{name}}\"'s permissions on \"{{object}}\"?",
       stats: {

--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -160,6 +160,7 @@ export const systemAdminEnUS = {
       removeLastOpConfirm: "This subject will have no operations left and the permission rule will be removed. Continue?",
       adminLocked: "The administrator holds all permissions and cannot be adjusted or removed here.",
       delegateLocked: "Only a platform administrator can adjust or remove this grant — including your own.",
+      selfAuthorizeLocked: "This grant carries your own authorize permission. Your role cannot grant it back, so it stays locked here.",
       revokeTitle: "Revoke permissions",
       revokeConfirm: "Revoke \"{{name}}\"'s permissions on \"{{object}}\"?",
       stats: {

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -157,6 +157,7 @@ export const systemAdminZhCN = {
       removeGrantConfirm: "确定移除「{{name}}」的权限配置吗？",
       removeLastOpConfirm: "该权限主体将不再拥有任何操作，权限配置会被移除。是否继续？",
       adminLocked: "管理员拥有全部权限，不可在此调整或移除。",
+      delegateLocked: "这条权限配置只有平台管理员能调整或移除，你自己的那条也一样。",
       revokeTitle: "撤销权限",
       revokeConfirm: "确定撤销「{{name}}」对「{{object}}」的权限吗？",
       stats: {

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -158,6 +158,7 @@ export const systemAdminZhCN = {
       removeLastOpConfirm: "该权限主体将不再拥有任何操作，权限配置会被移除。是否继续？",
       adminLocked: "管理员拥有全部权限，不可在此调整或移除。",
       delegateLocked: "这条权限配置只有平台管理员能调整或移除，你自己的那条也一样。",
+      selfAuthorizeLocked: "这条带着你自己的授权权限。你的角色无法重新授予它，移除后装不回来，因此锁定。",
       revokeTitle: "撤销权限",
       revokeConfirm: "确定撤销「{{name}}」对「{{object}}」的权限吗？",
       stats: {


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `system-admin`: `ObjectAuthorizeDrawer` locks the rows a non-administrator may not write — any row carrying `authorize` (the caller's own included) and the public-access row
- [x] i18n: `systemAdmin.objectGrants.delegateLocked` in zh-CN and en-US
- [x] Tests: `ObjectAuthorizeDrawer.test.tsx` pins owner vs administrator

---

## Why

- Related Issue: backport of #518 (main) to release/0.1.4; follow-up to #517
- Background:

The drawer gated its write controls on the caller's global grant/revoke capability alone. bkn-safe decides per row as well (`protectAuthorizeHolder`) and refuses a non-administrator against two of them:

- a row carrying `authorize` — the object's creator, or anyone an administrator trusted with sharing. Both writes erase (POST replaces the operation set, DELETE drops the row), so a delegate rewriting it could take the object away from the person who made it, and `authorize` is administrator-conferred, so nobody inside the drawer could put it back. **The caller's own row is included** — an owner cannot drop their own `authorize`.
- the public-access row, whose removal would un-publish the object platform-wide.

Those controls were live and answered 403 on click. It stayed invisible while the drawer was an administrators-only surface; #516 opened it to data-connection owners, and the first row an owner sees there is their own.

---

## How

- Key implementation points: `isDelegateProtected(grant)` mirrors the backend guard; the existing `locked` path (already used for the built-in administrator's row) carries it, with its own tooltip so the two reasons stay distinguishable.
- Breaking changes (API, config, database, etc.): none. Administrators see exactly what they saw.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable
- [x] Verified in test environment

Test notes:

```
node scripts/check-license-headers.mjs   exit 0
node scripts/scan-hardcoded-zh.mjs       exit 0
npm run i18n:check                       exit 0
eslint --config eslint.config.typechecked.js   exit 0 (changed files)
vitest --run                             233 files / 1238 tests passed
tsc -b --force                           exit 0
vite build                               exit 0
```

The owner case fails on the pre-change component (0 locked rows instead of 2); the administrator case passes before and after, which is the point of keeping it.

Backend behaviour this mirrors, checked on the dev VM with a `network_builder` account against a catalog it created:

```
DELETE /api/safe/v1/me/object-grants  accessor = itself            → 403
POST   /api/safe/v1/me/object-grants  accessor = itself, fewer ops → 403
```

---

## Risk & Rollback

- Potential risks: a row that the backend would in fact accept is now locked in the UI. The condition is copied from the backend guard, and administrators — the only callers exempt from it — are excluded from the lock.
- Rollback plan: revert the commit; nothing else references `isDelegateProtected` or the new string.

---

## Additional Notes

- The lock reuses the icon and layout the built-in administrator's row already renders, so there is no new visual language.
