### PR TITLE
refactor(data-catalog): remove property extensions

### DIFF
--- a/src/modules/data-catalog/services/resource.service.ts
+++ b/src/modules/data-catalog/services/resource.service.ts
@@ -55,7 +55,6 @@ type BackendSchemaField = {
   attributes?: Record<string, unknown> | null;
   description?: string;
   display_name?: string;
-  extensions?: Record<string, string>;
   features?: BackendFieldFeature[] | null;
   name?: string;
   original_description?: string;
@@ -159,7 +158,6 @@ function mapSchemaFieldUpdateToBackend(field: ResourceSchemaField): BackendSchem
     ? { ...field.raw }
     : ({
         attributes: field.attributes,
-        extensions: field.extensions,
         name: field.name,
         original_description: field.originalDescription ?? "",
         original_name: field.originalName ?? "",
@@ -190,7 +188,6 @@ function mapSchemaField(field: BackendSchemaField): ResourceSchemaField {
     displayName:
       displayName && displayName !== name ? displayName : undefined,
     description: description || undefined,
-    extensions: field.extensions,
     features: features.length > 0 ? features : undefined,
     originalDescription: field.original_description,
     originalName: field.original_name,

--- a/src/modules/data-catalog/types/data-catalog.ts
+++ b/src/modules/data-catalog/types/data-catalog.ts
@@ -40,7 +40,6 @@ export type ResourceSchemaField = {
   displayName?: string;
   /** Field description (backend description). */
   description?: string;
-  extensions?: Record<string, string>;
   /** Field-level index features, such as full text and vectors. */
   features?: ResourceFieldFeature[];
   name: string;


### PR DESCRIPTION
## What Changed

- [x] Remove Property extensions from the data-catalog field model
- [x] Remove Property extensions from backend DTO mapping in both directions

---

## Why

- Related Issue: https://github.com/openbkn-ai/bkn-foundry/issues/266
- Related Feature: https://github.com/openbkn-ai/bkn-foundry/pull/1160
- Background: the Vega backend removes the unused Property extensions contract without compatibility handling.

---

## How

- Key implementation points:
  - Remove extensions from ResourceSchemaField
  - Stop reading and writing extensions in resource schema field mapping
- Breaking changes:
  - Studio no longer retains or submits Property extensions
  - No navigation, locale, route, manifest, or public scene contract changes

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- pnpm lint passed with 4 existing warnings and no errors
- pnpm test -- --run passed: 1238 tests
- pnpm build passed
- Repository CI still needs to run remotely

---

## Risk & Rollback

- Potential risks:
  - This PR requires the Vega backend contract in bkn-foundry PR 1160
- Rollback plan:
  - Revert this PR and deploy it with the previous Vega backend contract

---

## Additional Notes

- Merge after https://github.com/openbkn-ai/bkn-foundry/pull/1160.