### PR TITLE
fix(studio): align frontend image version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bkn-studio",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE",
   "packageManager": "pnpm@11.5.1",


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Feature/module 1
- [ ] Feature/module 2
- [ ] Docs/doc 1

将 bkn-studio 前端镜像版本从 `0.1.4` 修正为 `0.1.5`。

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background: 当前前端镜像版本为 `0.1.5`，但 `package.json` 中的版本仍为 `0.1.4`，需要保持一致。

---

## How

- Key implementation points:
  - 更新 `package.json` 中的 `version` 为 `0.1.5`。
- Breaking changes (API, config, database, etc.):
  - 无。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- 已通过 Node.js package 版本校验。
- 本次仅修改版本字段，未执行完整前端测试。

---

## Risk & Rollback

- Potential risks:
  - 低风险，仅影响前端镜像版本解析。
- Rollback plan:
  - 回退提交 `45f993bd` 即可恢复原版本。

---

## Additional Notes

- Helm Chart 按要求未修改。
- 原有未跟踪文件未纳入本次提交。