### PR TITLE
feat(navigation): 调整可观测性整体菜单顺序

### DIFF
--- a/docs/plans/2026-08-29-observability-menu-order-design.md
+++ b/docs/plans/2026-08-29-observability-menu-order-design.md
@@ -1,0 +1,23 @@
+# 可观测性菜单排序设计
+
+> 对应 Issue：[openbkn-ai/bkn-studio #532](https://github.com/openbkn-ai/bkn-studio/issues/532)
+
+## 目标
+
+将主线左侧导航中的可观测性整体菜单置于模型管理之后、系统管理之前。
+
+## 方案
+
+顶级菜单由 `src/app/shell/console-navigation.tsx` 组装。基础菜单与顶级
+模块贡献分属两组，单纯调整贡献数组不能将可观测性插入二者之间。因此在
+`ConsoleNavContribution` 上增加可选的 `afterKey` 锚点；BKN Trace 以
+`model-resources` 为锚点，由组装器将它插入模型管理之后。
+
+不引入排序权重，也不改渲染层。路由、子菜单、权限过滤和菜单 key 都保持
+不变。
+
+## 验证
+
+在 `console-navigation.test.ts` 中增加顶级菜单相对顺序断言，确认模型管理、
+可观测性与系统管理依次出现。保留现有权限过滤测试，证明排序改动不会改变
+可观测性对普通用户的可见性。

--- a/docs/plans/2026-08-29-observability-menu-order.md
+++ b/docs/plans/2026-08-29-observability-menu-order.md
@@ -1,0 +1,71 @@
+# Observability Menu Order Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Place the Observability top-level navigation group directly after Model Management and before System Management.
+
+**Architecture:** Base navigation and top-level module contributions are assembled separately. Add a small `afterKey` contribution anchor so BKN Trace can be inserted after the base `model-resources` item; preserve its navigation object, routes, permissions, and children. A focused navigation-unit test records the required relative order.
+
+**Tech Stack:** React 19, TypeScript, Vitest, pnpm.
+
+---
+
+### Task 1: Define the menu-order contract
+
+**Files:**
+- Modify: `src/app/shell/console-navigation.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a test that maps `consoleNavigation` to keys and asserts the index order:
+
+```ts
+expect(keys.indexOf("model-resources")).toBeLessThan(keys.indexOf("observability"));
+expect(keys.indexOf("observability")).toBeLessThan(keys.indexOf("system-management"));
+```
+
+**Step 2: Run the focused test to verify it fails**
+
+Run: `pnpm vitest run src/app/shell/console-navigation.test.ts`
+
+Expected: FAIL because `observability` currently follows the system-management group.
+
+### Task 2: Anchor the existing navigation contribution
+
+**Files:**
+- Modify: `src/app/shell/console-navigation.tsx`
+- Modify: `src/app/shell/navigation/types.ts`
+- Modify: `src/modules/bkn-trace/navigation.tsx`
+- Test: `src/app/shell/console-navigation.test.ts`
+
+**Step 1: Write minimal implementation**
+
+Add `afterKey?: string` to `ConsoleNavContribution`. Make the navigation builder insert ungrouped contributions with `afterKey` immediately after the matching base item, then declare `afterKey: "model-resources"` on `bknTraceNavigation`. Do not change its routes, child entries, or permission behavior.
+
+**Step 2: Run the focused test to verify it passes**
+
+Run: `pnpm vitest run src/app/shell/console-navigation.test.ts`
+
+Expected: PASS, including existing permission-filter tests.
+
+### Task 3: Verify the affected frontend quality gates
+
+**Files:**
+- Verify: `src/app/shell/console-navigation.tsx`
+- Verify: `src/app/shell/console-navigation.test.ts`
+
+**Step 1: Run lint and type checks**
+
+Run: `pnpm exec eslint src/app/shell/console-navigation.tsx src/app/shell/console-navigation.test.ts --config eslint.config.typechecked.js --max-warnings 0 && pnpm exec tsc -b --pretty false`
+
+Expected: PASS with no warnings or type errors.
+
+**Step 2: Run the production build**
+
+Run: `pnpm exec vite build`
+
+Expected: PASS.
+
+**Step 3: Present the diff for review**
+
+Do not commit, push, or create a pull request until human review approval, per `AGENTS.md`.

--- a/src/app/shell/console-navigation.test.ts
+++ b/src/app/shell/console-navigation.test.ts
@@ -17,6 +17,19 @@ const keys = (items: { key: string }[]) => items.map((item) => item.key);
 const systemGroup = (items: ReturnType<typeof filterNavByPermission>) =>
   items.find((item) => item.key === "system-management");
 
+describe("consoleNavigation — 主线菜单顺序", () => {
+  it("将可观测性置于模型管理之后、系统管理之前", () => {
+    const navigationKeys = keys(consoleNavigation);
+
+    expect(navigationKeys.indexOf("model-resources")).toBeLessThan(
+      navigationKeys.indexOf("observability"),
+    );
+    expect(navigationKeys.indexOf("observability")).toBeLessThan(
+      navigationKeys.indexOf("system-management"),
+    );
+  });
+});
+
 describe("filterNavByPermission — 系统管理按功能独立授权", () => {
   it("仅持有系统管理权限的用户只显示首页和获授权的系统管理菜单", () => {
     const group = systemGroup(filterNavByPermission(consoleNavigation, []));

--- a/src/app/shell/console-navigation.tsx
+++ b/src/app/shell/console-navigation.tsx
@@ -30,8 +30,8 @@ const navigationContributions: ConsoleNavContribution[] = [
   dataCatalogNavigation,
   executionFactoryNavigation,
   modelResourcesNavigation,
-  executionFactoryLabNavigation,
   bknTraceNavigation,
+  executionFactoryLabNavigation,
 ];
 
 export type { ConsoleNavItem } from "@/app/shell/navigation/types";
@@ -176,35 +176,40 @@ function buildConsoleNavigation(
   baseItems: ConsoleNavItem[],
   contributions: ConsoleNavContribution[],
 ) {
-  const topLevelItems = contributions.flatMap((contribution) =>
-    contribution.parentKey ? [] : contribution.items,
-  );
+  const topLevelItems: ConsoleNavItem[] = [];
+  const anchoredItems = new Map<string, ConsoleNavItem[]>();
   const groupedItems = new Map<string, ConsoleNavItem[]>();
 
   for (const contribution of contributions) {
-    if (!contribution.parentKey) {
+    if (contribution.parentKey) {
+      groupedItems.set(contribution.parentKey, [
+        ...(groupedItems.get(contribution.parentKey) ?? []),
+        ...contribution.items,
+      ]);
       continue;
     }
 
-    groupedItems.set(contribution.parentKey, [
-      ...(groupedItems.get(contribution.parentKey) ?? []),
-      ...contribution.items,
-    ]);
+    if (contribution.afterKey) {
+      anchoredItems.set(contribution.afterKey, [
+        ...(anchoredItems.get(contribution.afterKey) ?? []),
+        ...contribution.items,
+      ]);
+      continue;
+    }
+
+    topLevelItems.push(...contribution.items);
   }
 
   return [
     ...topLevelItems,
-    ...baseItems.map((item) => {
+    ...baseItems.flatMap((item) => {
       const extraChildren = groupedItems.get(item.key) ?? [];
 
-      if (extraChildren.length === 0) {
-        return item;
-      }
+      const baseItem = extraChildren.length === 0
+        ? item
+        : { ...item, children: [...extraChildren, ...(item.children ?? [])] };
 
-      return {
-        ...item,
-        children: [...extraChildren, ...(item.children ?? [])],
-      };
+      return [baseItem, ...(anchoredItems.get(item.key) ?? [])];
     }),
   ];
 }

--- a/src/app/shell/navigation/types.ts
+++ b/src/app/shell/navigation/types.ts
@@ -65,6 +65,8 @@ export type ConsoleNavItem = {
 };
 
 export type ConsoleNavContribution = {
+  /** Insert this top-level contribution after the matching base navigation item. */
+  afterKey?: string;
   items: ConsoleNavItem[];
   parentKey?: string;
 };

--- a/src/modules/bkn-trace/navigation.tsx
+++ b/src/modules/bkn-trace/navigation.tsx
@@ -16,6 +16,7 @@ import type { ConsoleNavContribution } from "@/app/shell/navigation/types";
 import { CAPABILITIES } from "@/framework/entitlement/capabilities";
 
 export const bknTraceNavigation: ConsoleNavContribution = {
+  afterKey: "model-resources",
   items: [
     {
       key: "observability",


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] 为顶级导航贡献增加 `afterKey` 锚点，并让组装器在基础菜单锚点之后插入该贡献。
- [x] 将可观测性锚定在模型管理之后，系统管理之前。
- [x] 新增菜单相对顺序回归测试及设计/执行计划文档。

---

## Why

- Related Issue: Closes #532
- Related Feature: 主线菜单信息架构调整
- Background: 可观测性应紧邻模型管理，且位于系统管理之前；现有模块贡献只能整体位于基础菜单之前，无法满足该相对顺序。

---

## How

- Key implementation points: `ConsoleNavContribution.afterKey` 指定基础菜单锚点；BKN Trace 以 `model-resources` 为锚点。
- Breaking changes (API, config, database, etc.): 无。

---

## Testing

- [x] Unit tests passed locally — `pnpm vitest run src/app/shell/console-navigation.test.ts`（8/8）。
- [ ] Integration tests passed locally — 不适用：导航组装为前端纯单元逻辑。
- [ ] Verified in test environment — 未执行。

Test notes:

- `pnpm exec tsc -b --pretty false` 通过。
- `pnpm exec vite build` 通过；仅有既有动态导入/chunk 体积警告。
- 变更文件类型化 ESLint 通过。全仓类型化 ESLint 在隔离工作树中运行超过 10 分钟未取得终态，已停止。
- 全量 Vitest 未完成。
- `pnpm audit --prod` 无法执行：当前 npm 镜像未实现 audit API。

---

## Risk & Rollback

- Potential risks: 其他未来顶级贡献若声明不存在的锚点，会保持未插入；本 PR 仅使用已存在的 `model-resources`。
- Rollback plan: 回退本 PR 即恢复原菜单组装与排序。

---

## Additional Notes

- 未改动用户可见文案；`shell.items.observability` 的中英文翻译保持复用。
- 尚未执行测试环境手工验证。
