### PR TITLE
docs(eslint): translate rule descriptions to English

### DIFF
--- a/eslint.base.mjs
+++ b/eslint.base.mjs
@@ -53,25 +53,32 @@ export function createTypeScriptConfig({ typeChecked }) {
     ...reactPluginConfig,
     rules: {
       ...reactPluginConfig.rules,
-      // 禁止按证书的 features[] 做显隐判断。
+      // Never gate visibility based on a license's features[].
       //
-      // 授权按**档位**判(服务端 entitlement.AtLeast),证书里的 features[] 只发不
-      // 判——它是展示与审计核对用的原文。按它显隐等于把细粒度授权从后门放回来,
-      // 而且放在最没有强制力的一层:前端那行判断谁都能改,还会在「社区镜像 + 专业
-      // 证」这种真实部署下显示一个点进去必然 404 的入口(证书里有 key,镜像里没有
-      // 那段代码)。10.211.55.4 现在就是这种部署。
+      // Authorization is evaluated by **edition** (server-side
+      // entitlement.AtLeast). The license's features[] is transmitted but never
+      // evaluated: it is the original data for display and audit reconciliation.
+      // Using it for visibility gates reintroduces fine-grained authorization
+      // through a back door in the least enforceable layer: anyone can change a
+      // frontend condition, and it can expose an entry that inevitably returns
+      // 404 in a real "community image + professional license" deployment (the
+      // license contains a key while the image lacks the corresponding code).
+      // 10.211.55.4 is currently such a deployment.
       //
-      // 服务端已经在两处写死这条纪律(API 文档、Features() 的 doc comment),这是
-      // 第三处——也是唯一能自动拦住的一处。要按能力显隐,用 useCapability()。
-      // 见 bkn-docs docs/shared/licensing/ee-design.md §3.2。
+      // The server enforces this discipline in two places (the API documentation
+      // and the Features() doc comment). This is the third, and the only place
+      // that can enforce it automatically. Use useCapability() for
+      // capability-based visibility. See bkn-docs docs/shared/licensing/
+      // ee-design.md §3.2.
       //
-      // 只拦得住 `x.features.includes(...)` 这种形状;解构之后的裸 `features` 拦
-      // 不到。那一半由类型收口(useEntitlement 不透出 features)。
+      // This only catches shapes such as `x.features.includes(...)`; it cannot
+      // catch a destructured bare `features`. The type boundary covers that case:
+      // useEntitlement does not expose features.
       "no-restricted-syntax": [
         "error",
         {
           message:
-            "禁止按 license 的 features[] 判断显隐:授权按档位,features 只发不判。改用 useCapability() / CapabilityGate(framework/entitlement)。见 ee-design.md §3.2。",
+            "Do not gate visibility based on license features[]: authorization is edition-based, and features are transmitted but never evaluated. Use useCapability() / CapabilityGate (framework/entitlement). See ee-design.md §3.2.",
           selector:
             "CallExpression[callee.property.name=/^(includes|indexOf|some|find|filter)$/][callee.object.property.name='features']",
         },


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Translated the `no-restricted-syntax` design rationale in `eslint.base.mjs` into English.
- [x] Translated the rule diagnostic message into English.
- [x] Preserved the rule selector, severity, and all configuration behavior.

---

## Why

- Related Feature: Developer-facing ESLint configuration globalization
- Background: ESLint comments and diagnostics are consumed by developers and CI rather than runtime users. English provides a single, consistent language for global collaboration without adding runtime i18n complexity.

---

## How

- Key implementation points: Static comments and the `no-restricted-syntax` message are now English-only.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally — verified the exported rule retains its selector and starts with the English diagnostic.
- [ ] Integration tests passed locally — not applicable; this is a static ESLint configuration text change.
- [ ] Verified in test environment — not applicable.

Test notes:

- `pnpm exec eslint eslint.base.mjs --config eslint.config.js --max-warnings 0` passed.
- Confirmed no Chinese characters remain in `eslint.base.mjs`.
- `git diff --check` passed.

---

## Risk & Rollback

- Potential risks: Developers see English rather than Chinese in the lint diagnostic and source comments.
- Rollback plan: Revert this PR to restore the prior wording.

---

## Additional Notes

- No runtime i18n resources were added because the text is developer-facing configuration, not user-facing product copy.
