### PR TITLE
feat(knowledge-network): fold consecutive agent tool calls into one collapsed group

### DIFF
--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.module.css
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.module.css
@@ -814,6 +814,22 @@
   word-break: break-word;
 }
 
+/* Collapsed run of consecutive tool calls */
+.group {
+  margin: 4px 0 8px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--code);
+}
+.groupBody {
+  border-top: 1px solid var(--line);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 /* Tool invocation card */
 .calls {
   margin: 4px 0 8px;
@@ -871,6 +887,39 @@
 .dotRunning {
   background: #c9821a;
   box-shadow: 0 0 5px rgba(201, 130, 26, 0.6);
+  animation: breathe 1.4s ease-in-out infinite;
+}
+/* A closed group is the only progress signal while calls are in flight, so it breathes. */
+.callLive .callName,
+.callLive .callMeta {
+  animation: breatheText 1.8s ease-in-out infinite;
+}
+@keyframes breathe {
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.2);
+  }
+}
+@keyframes breatheText {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dotRunning,
+  .callLive .callName,
+  .callLive .callMeta {
+    animation: none;
+  }
 }
 .dotError {
   background: #d63a3a;

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.lifecycle.test.tsx
@@ -226,6 +226,10 @@ describe("ChatPane 受管生命周期接线", () => {
       await Promise.resolve();
     });
 
+    // Consecutive tool calls collapse into one closed group; expand it before the cards.
+    for (const group of screen.getAllByText(/已调用工具/)) {
+      fireEvent.click(group);
+    }
     // Tool cards are collapsed by default and render the request body only when expanded.
     for (const header of screen.getAllByText(/^(run_sql|bkn_[a-z_]+)$/)) {
       fireEvent.click(header);

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tool-grouping.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tool-grouping.test.tsx
@@ -191,6 +191,45 @@ describe("ChatPane 工具调用折叠", () => {
     expect(headerLabels()).toEqual(["思考过程", "已调用工具 3 次", "search_schema", "run_sql", "run_sql"]);
   });
 
+  it("第二次调用到达时，已展开的卡片不被收回去", async () => {
+    stubLifecycle();
+    let emit!: (chunk: Parameters<Parameters<AgentChatModule["runAgentChat"]>[0]["onChunk"]>[0]) => void;
+    let finishRun!: () => void;
+    runAgentChat.mockImplementation(
+      ({ onChunk }) =>
+        new Promise<void>((resolve) => {
+          emit = onChunk;
+          finishRun = resolve;
+        }),
+    );
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    // A run starts as a bare card; the user expands it to read the request.
+    act(() => {
+      emit({ type: "tool-call", id: "c1", name: "run_sql", args: { sql: "SELECT 1" } });
+    });
+    fireEvent.click(screen.getByText("run_sql"));
+    expect(document.querySelectorAll("pre").length).toBeGreaterThan(0);
+
+    // The second call swaps the bare card for the group. Expansion must survive that swap,
+    // otherwise the card the user is reading closes mid-stream.
+    act(() => {
+      emit({ type: "tool-call", id: "c2", name: "search_schema", args: {} });
+    });
+    expect(screen.getByText("已调用工具 2 次")).toBeTruthy();
+    expect([...document.querySelectorAll("pre")].some((node) => (node.textContent ?? "").includes("SELECT 1"))).toBe(true);
+
+    await act(async () => {
+      finishRun();
+      await Promise.resolve();
+    });
+  });
+
   it("单次调用不额外套一层分组", async () => {
     stubLifecycle();
     runAgentChat.mockImplementation(({ onChunk }) => {

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tool-grouping.test.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tool-grouping.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/**
+ * Transcript segmentation. A turn runs up to maxSteps steps, so tool calls and text
+ * interleave; the panel must keep that order, fold each run of consecutive calls into
+ * one closed group, and start a new group after text is emitted.
+ */
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "@/app/locales/i18n";
+import type { BknLifecycle, BknTurn } from "@/modules/knowledge-network/services/bkn-lifecycle.service";
+import type { McpToolDef } from "@/modules/knowledge-network/services/context-loader.service";
+import type { LlmModel } from "@/modules/model-resources/types/llm";
+
+import { ChatPane, DEFAULT_PROMPT, KN_EVIDENCE_HINT, type ChatPaneHandle, type PaneProfile } from "./ChatPane";
+
+type AgentChatModule = typeof import("@/modules/knowledge-network/services/agent-chat.service");
+type LifecycleModule = typeof import("@/modules/knowledge-network/services/bkn-lifecycle.service");
+
+const { buildAgentTools, runAgentChat, createBknLifecycle } = vi.hoisted(() => ({
+  buildAgentTools: vi.fn<AgentChatModule["buildAgentTools"]>(),
+  runAgentChat: vi.fn<AgentChatModule["runAgentChat"]>(),
+  createBknLifecycle: vi.fn<LifecycleModule["createBknLifecycle"]>(),
+}));
+
+vi.mock("@/modules/knowledge-network/services/agent-chat.service", async (importOriginal) => ({
+  ...(await importOriginal<AgentChatModule>()),
+  buildAgentTools,
+  runAgentChat,
+}));
+
+vi.mock("@/modules/knowledge-network/services/bkn-lifecycle.service", async (importOriginal) => ({
+  ...(await importOriginal<LifecycleModule>()),
+  createBknLifecycle,
+}));
+
+vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }));
+
+const profile: PaneProfile = {
+  paneKey: "solo",
+  defaultPrompt: DEFAULT_PROMPT,
+  injectKnContext: false,
+  defaultToolNames: null,
+  evidenceHint: KN_EVIDENCE_HINT,
+};
+
+const toolDefs: McpToolDef[] = [{ name: "run_sql" }, { name: "search_schema" }];
+const models = [{ modelName: "qwen-test", default: true }] as unknown as LlmModel[];
+
+function stubLifecycle() {
+  const turn: BknTurn = {
+    conversationId: "conv_1",
+    interactionId: "int_1",
+    nextContext: () => ({ conversation_id: "conv_1", interaction_id: "int_1" }),
+    complete: vi.fn<BknTurn["complete"]>().mockResolvedValue(undefined),
+    fail: vi.fn<BknTurn["fail"]>().mockResolvedValue(undefined),
+    cancel: vi.fn<BknTurn["cancel"]>().mockResolvedValue(undefined),
+    finish: vi.fn<BknTurn["finish"]>().mockResolvedValue(undefined),
+  };
+  createBknLifecycle.mockReturnValue({
+    session: { callTool: vi.fn() },
+    conversationId: () => "conv_1",
+    unsupported: () => false,
+    beginTurn: vi.fn<BknLifecycle["beginTurn"]>().mockResolvedValue(turn),
+    reset: vi.fn<BknLifecycle["reset"]>(),
+  });
+}
+
+function renderPane() {
+  const ref = createRef<ChatPaneHandle>();
+  render(
+    <ChatPane
+      ref={ref}
+      env={{ base: "https://platform.example.com", token: "token-1", knId: "kn-demo" }}
+      tokenProvider={{ getToken: () => "token-1", refresh: () => Promise.resolve("token-1") }}
+      profile={profile}
+      models={models}
+      modelsLoaded
+      knContext=""
+      knSummary={null}
+      suggestions={[]}
+      getTools={() => Promise.resolve(toolDefs)}
+      toolDefs={toolDefs}
+      pageScrollRef={createRef<HTMLDivElement>()}
+    />,
+  );
+  return ref;
+}
+
+/** Collapsed headers in document order, reduced to what identifies each block. */
+function headerLabels() {
+  return [...document.querySelectorAll("button")]
+    .map((node) => node.textContent ?? "")
+    .filter((text) => /思考过程|思考中|已调用工具|search_schema|run_sql/.test(text))
+    .map((text) => {
+      if (text.includes("思考")) return "思考过程";
+      const match = /已调用工具 \d+ 次|search_schema|run_sql/.exec(text);
+      return match?.[0] ?? text;
+    });
+}
+
+beforeEach(async () => {
+  await i18n.changeLanguage("zh-CN");
+  localStorage.clear();
+  vi.clearAllMocks();
+  buildAgentTools.mockReturnValue({});
+});
+
+afterEach(cleanup);
+
+describe("ChatPane 工具调用折叠", () => {
+  it("连续调用折叠成一组，出文字后重新开一组", async () => {
+    stubLifecycle();
+    runAgentChat.mockImplementation(({ onChunk }) => {
+      onChunk({ type: "tool-call", id: "c1", name: "search_schema", args: {} });
+      onChunk({ type: "tool-result", id: "c1", result: "ok" });
+      onChunk({ type: "tool-call", id: "c2", name: "run_sql", args: { sql: "SELECT 1" } });
+      onChunk({ type: "tool-result", id: "c2", result: "ok" });
+      onChunk({ type: "text", delta: "中间结论" });
+      onChunk({ type: "tool-call", id: "c3", name: "run_sql", args: { sql: "SELECT 2" } });
+      onChunk({ type: "tool-result", id: "c3", result: "ok" });
+      onChunk({ type: "tool-call", id: "c4", name: "run_sql", args: { sql: "SELECT 3" } });
+      onChunk({ type: "tool-result", id: "c4", result: "ok" });
+      onChunk({ type: "text", delta: "最终答复" });
+      onChunk({ type: "finish" });
+      return Promise.resolve();
+    });
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    const groups = screen.getAllByText("已调用工具 2 次");
+    expect(groups).toHaveLength(2);
+
+    // Groups stay closed, so no request or response body is rendered yet.
+    expect(document.querySelectorAll("pre")).toHaveLength(0);
+
+    // Order matters: the first run, then the text it produced, then the next run.
+    const text = document.body.textContent ?? "";
+    expect(text.indexOf("中间结论")).toBeGreaterThan(text.indexOf("已调用工具 2 次"));
+    expect(text.lastIndexOf("已调用工具 2 次")).toBeGreaterThan(text.indexOf("中间结论"));
+    expect(text.indexOf("最终答复")).toBeGreaterThan(text.lastIndexOf("已调用工具 2 次"));
+
+    // Expanding one group reveals only that run's cards.
+    fireEvent.click(groups[0]);
+    expect(screen.getByText("search_schema")).toBeTruthy();
+    expect(screen.getAllByText("run_sql")).toHaveLength(1);
+  });
+
+  it("调用之间的思考不打断分组，思考过程仍是顶部一块", async () => {
+    stubLifecycle();
+    runAgentChat.mockImplementation(({ onChunk }) => {
+      onChunk({ type: "reasoning", delta: "先看 schema" });
+      onChunk({ type: "tool-call", id: "c1", name: "search_schema", args: {} });
+      onChunk({ type: "tool-result", id: "c1", result: "ok" });
+      onChunk({ type: "reasoning", delta: "再跑 SQL" });
+      onChunk({ type: "tool-call", id: "c2", name: "run_sql", args: { sql: "SELECT 1" } });
+      onChunk({ type: "tool-result", id: "c2", result: "ok" });
+      onChunk({ type: "tool-call", id: "c3", name: "run_sql", args: { sql: "SELECT 2" } });
+      onChunk({ type: "tool-result", id: "c3", result: "ok" });
+      onChunk({ type: "text", delta: "答复" });
+      onChunk({ type: "finish" });
+      return Promise.resolve();
+    });
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    // Reasoning between calls neither shatters the run nor spawns a second trace box;
+    // per-step reasoning blocks made the trace jump around the transcript.
+    const group = screen.getByText("已调用工具 3 次");
+    expect(screen.getAllByText("思考过程")).toHaveLength(1);
+    expect(headerLabels()).toEqual(["思考过程", "已调用工具 3 次"]);
+
+    fireEvent.click(group);
+    expect(screen.getAllByText("思考过程")).toHaveLength(1);
+    expect(headerLabels()).toEqual(["思考过程", "已调用工具 3 次", "search_schema", "run_sql", "run_sql"]);
+  });
+
+  it("单次调用不额外套一层分组", async () => {
+    stubLifecycle();
+    runAgentChat.mockImplementation(({ onChunk }) => {
+      onChunk({ type: "tool-call", id: "c1", name: "run_sql", args: { sql: "SELECT 1" } });
+      onChunk({ type: "tool-result", id: "c1", result: "ok" });
+      onChunk({ type: "text", delta: "答复" });
+      onChunk({ type: "finish" });
+      return Promise.resolve();
+    });
+
+    const ref = renderPane();
+    await act(async () => {
+      ref.current?.send("问一句");
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText(/已调用工具/)).toBeNull();
+    expect(screen.getByText("run_sql")).toBeTruthy();
+  });
+});

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -339,7 +339,9 @@ function ReasoningBlock({ text, live }: { text: string; live: boolean }) {
     <div className={styles.reasoning}>
       <button type="button" className={`${styles.reasoningHead} ${live ? styles.reasoningLive : ""}`} onClick={() => setOpen((v) => !v)}>
         <span>
-          {live ? t("knowledgeNetwork.agentChat.reasoning.live") : t("knowledgeNetwork.agentChat.reasoning.done")}
+          {live
+            ? t("knowledgeNetwork.agentChat.chatPane.reasoning.live")
+            : t("knowledgeNetwork.agentChat.chatPane.reasoning.done")}
           {live ? (
             <span className={styles.thinkDots}>
               <i />

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -358,8 +358,17 @@ function ReasoningBlock({ text, live }: { text: string; live: boolean }) {
 }
 
 /** Collapsible tool-call card showing actual request parameters and response. */
-function ToolCallCard({ call, t }: { call: ToolCallView; t: ReturnType<typeof useTranslation>["t"] }) {
-  const [open, setOpen] = useState(false);
+function ToolCallCard({
+  call,
+  open,
+  onToggle,
+  t,
+}: {
+  call: ToolCallView;
+  open: boolean;
+  onToggle: () => void;
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
   const statusDot =
     call.status === "running" ? styles.dotRunning : call.status === "error" ? styles.dotError : styles.dotOk;
   const statusText =
@@ -378,7 +387,7 @@ function ToolCallCard({ call, t }: { call: ToolCallView; t: ReturnType<typeof us
       <button
         type="button"
         className={`${styles.callHead} ${call.status === "running" ? styles.callLive : ""}`}
-        onClick={() => setOpen((v) => !v)}
+        onClick={onToggle}
       >
         <span className={styles.verb}>MCP</span>
         <span className={styles.callName}>{call.name}</span>
@@ -411,14 +420,22 @@ function ToolCallCard({ call, t }: { call: ToolCallView; t: ReturnType<typeof us
 /**
  * One run of consecutive tool calls. A lone call stays a bare card; a run collapses
  * into a single closed group so the transcript reads as text, not as a wall of calls.
+ *
+ * Card expansion is held here, keyed by call id. A streaming run switches from the
+ * bare card to the group the moment its second call arrives, and that swaps the child
+ * structure, so state owned by the card itself would be thrown away mid-stream: the
+ * card a user just expanded to read the request would silently close. For the same
+ * reason the group opens by default when a card inside it is already expanded.
  */
 function ToolCallSegment({ calls, t }: { calls: ToolCallView[]; t: ReturnType<typeof useTranslation>["t"] }) {
-  const [open, setOpen] = useState(false);
+  const [openCalls, setOpenCalls] = useState<Record<string, boolean>>({});
+  const [groupOpen, setGroupOpen] = useState<boolean | null>(null);
+  const toggleCall = (id: string) => setOpenCalls((prev) => ({ ...prev, [id]: !prev[id] }));
   if (calls.length === 0) return null;
   if (calls.length === 1) {
     return (
       <div className={styles.calls}>
-        <ToolCallCard call={calls[0]} t={t} />
+        <ToolCallCard call={calls[0]} open={!!openCalls[calls[0].id]} onToggle={() => toggleCall(calls[0].id)} t={t} />
       </div>
     );
   }
@@ -430,12 +447,14 @@ function ToolCallSegment({ calls, t }: { calls: ToolCallView[]; t: ReturnType<ty
     : failed > 0
       ? t("knowledgeNetwork.agentChat.chatPane.toolGroup.failed", { count: failed })
       : `${calls.reduce((ms, call) => ms + (call.latencyMs ?? 0), 0)}ms`;
+  // Once the user has toggled the group, their choice wins over the expanded-card default.
+  const open = groupOpen ?? calls.some((call) => openCalls[call.id]);
   return (
     <div className={styles.group}>
       <button
         type="button"
         className={`${styles.callHead} ${running ? styles.callLive : ""}`}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setGroupOpen(!open)}
       >
         <span className={styles.verb}>MCP</span>
         <span className={styles.callName}>
@@ -448,7 +467,7 @@ function ToolCallSegment({ calls, t }: { calls: ToolCallView[]; t: ReturnType<ty
       {open ? (
         <div className={styles.groupBody}>
           {calls.map((call) => (
-            <ToolCallCard key={call.id} call={call} t={t} />
+            <ToolCallCard key={call.id} call={call} open={!!openCalls[call.id]} onToggle={() => toggleCall(call.id)} t={t} />
           ))}
         </div>
       ) : null}

--- a/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/ChatPane.tsx
@@ -155,11 +155,20 @@ type ToolCallView = {
   latencyMs?: number;
 };
 
+/**
+ * Ordered render segment. A turn interleaves tool calls and text across up to
+ * maxSteps steps; parts preserve that order so a run of consecutive calls can
+ * collapse into one group and text output starts the next run.
+ */
+type MessagePart = { kind: "text"; text: string } | { kind: "tools"; ids: string[] };
+
 type ChatMessage = {
   role: "user" | "assistant";
   content: string;
   reasoning?: string;
   toolCalls?: ToolCallView[];
+  /** Render order only; content and toolCalls stay flat for history, export, and snapshots. */
+  parts?: MessagePart[];
   /** Actual token count for this turn, available from usage at finish. */
   tokens?: number;
   /** Total elapsed time for this turn in ms. */
@@ -175,6 +184,30 @@ type ChatMessage = {
 type SessionStats = { tokens: number; ms: number };
 
 type Persisted = { messages: ChatMessage[]; model: string; systemPrompt: string; stats?: SessionStats };
+
+function appendTextPart(parts: MessagePart[] | undefined, delta: string): MessagePart[] {
+  const next = [...(parts ?? [])];
+  const last = next[next.length - 1];
+  if (last?.kind === "text") next[next.length - 1] = { kind: "text", text: last.text + delta };
+  else next.push({ kind: "text", text: delta });
+  return next;
+}
+
+function appendToolPart(parts: MessagePart[] | undefined, id: string): MessagePart[] {
+  const next = [...(parts ?? [])];
+  const last = next[next.length - 1];
+  if (last?.kind === "tools") next[next.length - 1] = { kind: "tools", ids: [...last.ids, id] };
+  else next.push({ kind: "tools", ids: [id] });
+  return next;
+}
+
+/** Messages persisted before parts existed: all calls first, then all text. */
+function legacyParts(m: ChatMessage): MessagePart[] {
+  const parts: MessagePart[] = [];
+  if (m.toolCalls?.length) parts.push({ kind: "tools", ids: m.toolCalls.map((tc) => tc.id) });
+  if (m.content) parts.push({ kind: "text", text: m.content });
+  return parts;
+}
 
 /** Rough token estimate for live streaming display; replaced by real usage at finish. */
 function estimateTokens(chars: number): number {
@@ -340,7 +373,11 @@ function ToolCallCard({ call, t }: { call: ToolCallView; t: ReturnType<typeof us
     : t("knowledgeNetwork.agentChat.chatPane.toolCall.request", { name: call.name });
   return (
     <div className={`${styles.call} ${open ? styles.callOpen : ""}`}>
-      <button type="button" className={styles.callHead} onClick={() => setOpen((v) => !v)}>
+      <button
+        type="button"
+        className={`${styles.callHead} ${call.status === "running" ? styles.callLive : ""}`}
+        onClick={() => setOpen((v) => !v)}
+      >
         <span className={styles.verb}>MCP</span>
         <span className={styles.callName}>{call.name}</span>
         <span className={`${styles.dot} ${statusDot}`} />
@@ -363,6 +400,54 @@ function ToolCallCard({ call, t }: { call: ToolCallView; t: ReturnType<typeof us
             </div>
             <pre className={styles.callPre}>{call.status === "error" ? call.error : call.result ?? "-"}</pre>
           </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One run of consecutive tool calls. A lone call stays a bare card; a run collapses
+ * into a single closed group so the transcript reads as text, not as a wall of calls.
+ */
+function ToolCallSegment({ calls, t }: { calls: ToolCallView[]; t: ReturnType<typeof useTranslation>["t"] }) {
+  const [open, setOpen] = useState(false);
+  if (calls.length === 0) return null;
+  if (calls.length === 1) {
+    return (
+      <div className={styles.calls}>
+        <ToolCallCard call={calls[0]} t={t} />
+      </div>
+    );
+  }
+  const running = calls.some((call) => call.status === "running");
+  const failed = calls.filter((call) => call.status === "error").length;
+  const statusDot = running ? styles.dotRunning : failed > 0 ? styles.dotError : styles.dotOk;
+  const meta = running
+    ? t("knowledgeNetwork.agentChat.chatPane.toolCall.running")
+    : failed > 0
+      ? t("knowledgeNetwork.agentChat.chatPane.toolGroup.failed", { count: failed })
+      : `${calls.reduce((ms, call) => ms + (call.latencyMs ?? 0), 0)}ms`;
+  return (
+    <div className={styles.group}>
+      <button
+        type="button"
+        className={`${styles.callHead} ${running ? styles.callLive : ""}`}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className={styles.verb}>MCP</span>
+        <span className={styles.callName}>
+          {t("knowledgeNetwork.agentChat.chatPane.toolGroup.summary", { count: calls.length })}
+        </span>
+        <span className={`${styles.dot} ${statusDot}`} />
+        <span className={styles.callMeta}>{meta}</span>
+        <span className={styles.chev}>{open ? <DownOutlined /> : <RightOutlined />}</span>
+      </button>
+      {open ? (
+        <div className={styles.groupBody}>
+          {calls.map((call) => (
+            <ToolCallCard key={call.id} call={call} t={t} />
+          ))}
         </div>
       ) : null}
     </div>
@@ -632,14 +717,17 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
     (chunk: AgentChunk) => {
       switch (chunk.type) {
         case "text":
-          updateAssistant((m) => ({ ...m, content: m.content + chunk.delta }));
+          updateAssistant((m) => ({ ...m, content: m.content + chunk.delta, parts: appendTextPart(m.parts, chunk.delta) }));
           break;
         case "reasoning":
+          // Reasoning stays one merged block above the turn. Splitting it per step made the
+          // trace jump around the transcript as each step reopened a new box.
           updateAssistant((m) => ({ ...m, reasoning: (m.reasoning ?? "") + chunk.delta }));
           break;
         case "tool-call":
           updateAssistant((m) => ({
             ...m,
+            parts: appendToolPart(m.parts, chunk.id),
             toolCalls: [
               ...(m.toolCalls ?? []),
               (() => {
@@ -767,7 +855,7 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
       setMessages(() => [
         ...kept,
         { role: "user", content: question },
-        { role: "assistant", content: "", toolCalls: [] },
+        { role: "assistant", content: "", toolCalls: [], parts: [] },
       ]);
 
       const controller = new AbortController();
@@ -1185,7 +1273,9 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
           <div className={styles.wrap}>
             {messages.map((m, i) => {
               const isLast = i === lastIdx;
-              const hasTools = !!m.toolCalls && m.toolCalls.length > 0;
+              // Assistant turns render by segment order; user turns are plain text.
+              const renderParts = m.role === "assistant" ? m.parts ?? legacyParts(m) : [];
+              const callById = new Map((m.toolCalls ?? []).map((tc) => [tc.id, tc]));
               return (
                 <div key={i} className={`${styles.msg} ${m.role === "user" ? styles.msgUser : styles.msgBot}`}>
                   <div className={styles.avatar}>
@@ -1198,21 +1288,27 @@ export const ChatPane = forwardRef<ChatPaneHandle, ChatPaneProps>(function ChatP
                         : t("knowledgeNetwork.agentChat.chatPane.message.agent")}
                     </div>
                     {m.reasoning ? <ReasoningBlock text={m.reasoning} live={busy && isLast && !m.content} /> : null}
-                    {hasTools ? (
-                      <div className={styles.calls}>
-                        {m.toolCalls!.map((tc) => (
-                          <ToolCallCard key={tc.id} call={tc} t={t} />
-                        ))}
-                      </div>
-                    ) : null}
-                    {m.content ? (
-                      // During streaming, MarkdownView reparses only the tail block.
-                      m.role === "assistant" ? (
-                        <MarkdownView text={m.content} streaming={busy && isLast} />
-                      ) : (
-                        <div className={styles.txt}>{m.content}</div>
+                    {m.role === "user" ? (
+                      <div className={styles.txt}>{m.content}</div>
+                    ) : (
+                      renderParts.map((part, pi) =>
+                        part.kind === "tools" ? (
+                          <ToolCallSegment
+                            key={pi}
+                            calls={part.ids.map((id) => callById.get(id)).filter((call): call is ToolCallView => !!call)}
+                            t={t}
+                          />
+                        ) : (
+                          // During streaming, MarkdownView reparses only the tail block.
+                          <MarkdownView
+                            key={pi}
+                            text={part.text}
+                            streaming={busy && isLast && pi === renderParts.length - 1}
+                          />
+                        ),
                       )
-                    ) : m.role === "assistant" && busy && isLast && !m.reasoning && !hasTools ? (
+                    )}
+                    {m.role === "assistant" && renderParts.length === 0 && busy && isLast && !m.reasoning ? (
                       <div className={styles.typing}>
                         <i />
                         <i />

--- a/src/modules/knowledge-network/locales/en-US/agent-chat.ts
+++ b/src/modules/knowledge-network/locales/en-US/agent-chat.ts
@@ -197,6 +197,14 @@ export const agentChatPart = {
         error: "Error",
         response: "Response",
       },
+      toolGroup: {
+        summary: "Called {{count}} tools",
+        summary_one: "Called {{count}} tool",
+        summary_other: "Called {{count}} tools",
+        failed: "{{count}} failed",
+        failed_one: "{{count}} failed",
+        failed_other: "{{count}} failed",
+      },
       error: {
         retry: "Retry Round",
         detail: "Details",

--- a/src/modules/knowledge-network/locales/zh-CN/agent-chat.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/agent-chat.ts
@@ -197,6 +197,14 @@ export const agentChatPart = {
         error: "错误",
         response: "响应",
       },
+      toolGroup: {
+        summary: "已调用工具 {{count}} 次",
+        summary_one: "已调用工具 {{count}} 次",
+        summary_other: "已调用工具 {{count}} 次",
+        failed: "{{count}} 个失败",
+        failed_one: "{{count}} 个失败",
+        failed_other: "{{count}} 个失败",
+      },
       error: {
         retry: "重试本轮",
         detail: "详情",


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Agent chat transcript: a run of consecutive tool calls now folds into one group, closed by default, headed by `已调用工具 N 次` + status + total latency. Text output ends the run, so the next call starts a new group.
- [x] Running calls breathe: the status dot pulses and the group header fades in and out, so a closed group still signals progress. Disabled under `prefers-reduced-motion`.
- [x] Reasoning block title wired to i18n (it was hardcoded English while `chatPane.reasoning.live/done` already existed).

---

## Why

- Background: a turn runs up to `maxSteps: 40` steps, so tool calls and answer text interleave. The panel rendered every call of a turn as its own card above all of the turn's text. Two problems: the answer was buried under a wall of cards, and the real order was lost — text emitted at step 1 was concatenated with the final answer.

---

## How

- Key implementation points:
  - Assistant messages carry `parts`, an ordered list of `{kind:"text"}` / `{kind:"tools", ids}` segments. Flat `content` and `toolCalls` are untouched, so model history, the comparison report, `getSnapshot`, and export keep working exactly as before.
  - `tool-result` / `tool-error` still update only the flat `toolCalls`; parts hold ids and the renderer resolves them, so there is no double write.
  - A single call renders as a bare card instead of gaining a second layer to click through.
  - Messages persisted before `parts` existed fall back to the previous layout (`legacyParts`).
  - Reasoning deliberately stays one merged block above the turn. Rendering it per step was tried and reverted: the trace jumped around the transcript as each step opened a new box.
- Breaking changes (API, config, database, etc.): none. `parts` is additive and persisted state from older builds still renders.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
- New `ChatPane.tool-grouping.test.tsx`: consecutive calls fold into one group and stay closed; order is preserved across `tools → text → tools`; expanding one group reveals only that run; a single call is not wrapped; reasoning between calls neither splits the group nor spawns a second trace box.
- `ChatPane.lifecycle.test.tsx` updated to expand the group before its cards.
- `tsc -b`, `eslint --config eslint.config.typechecked.js --max-warnings 0`, 383 tests across 69 files, and the hardcoded-zh scan all pass locally.

---

## Risk & Rollback

- Potential risks: UI only, scoped to the agent chat transcript. `parts` slightly increases the size of the persisted message list in localStorage (answer text is stored both in `content` and in its segment); small next to the tool results already persisted per call.
- Rollback plan: revert the commit. Persisted messages then fall back to the old rendering path.

---

## Additional Notes

- The collapsed group also fixes a pre-existing ordering bug: intermediate step text and the final answer used to be concatenated into one block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)