### PR TITLE
fix(i18n): localize built-in role descriptions

### DIFF
--- a/src/modules/system-admin/components/CatalogAuthorizeModal.tsx
+++ b/src/modules/system-admin/components/CatalogAuthorizeModal.tsx
@@ -14,6 +14,7 @@ import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { listRoles, setRolePermission } from "@/modules/system-admin/services/admin.service";
 import type { AdminRole } from "@/modules/system-admin/types/admin";
+import { roleDescription } from "@/modules/system-admin/utils/role-catalog";
 import {
   operationLabel,
   operationsForType,
@@ -161,7 +162,7 @@ export function CatalogAuthorizeModal({
           onChange={setRoleId}
           optionFilterProp="label"
           options={candidateRoles.map((role) => ({
-            label: `${role.name}${role.description ? ` · ${role.description}` : ""}`,
+            label: `${role.name}${roleDescription(role) ? ` · ${roleDescription(role)}` : ""}`,
             value: role.id,
           }))}
           placeholder={t("systemAdmin.authorize.rolePlaceholder")}

--- a/src/modules/system-admin/components/RoleDetailDrawer.tsx
+++ b/src/modules/system-admin/components/RoleDetailDrawer.tsx
@@ -10,6 +10,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { AdminRole } from "@/modules/system-admin/types/admin";
+import { roleDescription } from "@/modules/system-admin/utils/role-catalog";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import {
   operationLabel,
@@ -142,9 +143,9 @@ export function RoleDetailDrawer({
                 : ""}
             </div>
           ) : null}
-          {role.description ? (
+          {roleDescription(role) ? (
             <p className={styles.muted} style={{ margin: "10px 0 0" }}>
-              {role.description}
+              {roleDescription(role)}
             </p>
           ) : null}
         </section>
@@ -204,4 +205,3 @@ export function RoleDetailDrawer({
     </Drawer>
   );
 }
-

--- a/src/modules/system-admin/components/UserRolesDrawer.tsx
+++ b/src/modules/system-admin/components/UserRolesDrawer.tsx
@@ -21,6 +21,7 @@ import {
   isAssignableRole,
   isSuperAdminRole,
   isThreeAdminRole,
+  roleDescription,
   threeAdminConflictLabels,
 } from "@/modules/system-admin/utils/role-catalog";
 
@@ -39,7 +40,7 @@ function matchesRoleKeyword(role: AdminRole, keyword: string) {
   if (!keyword) {
     return true;
   }
-  const haystack = `${role.name} ${role.description ?? ""}`.toLowerCase();
+  const haystack = `${role.name} ${roleDescription(role)}`.toLowerCase();
   return haystack.includes(keyword);
 }
 
@@ -148,8 +149,8 @@ export function UserRolesDrawer({ onClose, onSaved, open, roles, user }: UserRol
       />
       <span className={drawerStyles.roleOptionContent}>
         <span className={drawerStyles.roleOptionName}>{role.name}</span>
-        {role.description ? (
-          <span className={drawerStyles.roleOptionDesc}>{role.description}</span>
+        {roleDescription(role) ? (
+          <span className={drawerStyles.roleOptionDesc}>{roleDescription(role)}</span>
         ) : null}
       </span>
     </label>
@@ -254,8 +255,8 @@ export function UserRolesDrawer({ onClose, onSaved, open, roles, user }: UserRol
                     {controlledRoles.map((role) => (
                       <span className={drawerStyles.controlledRoleItem} key={role.id}>
                         <span className={drawerStyles.roleOptionName}>{role.name}</span>
-                        {role.description ? (
-                          <span className={drawerStyles.roleOptionDesc}>{role.description}</span>
+                        {roleDescription(role) ? (
+                          <span className={drawerStyles.roleOptionDesc}>{roleDescription(role)}</span>
                         ) : null}
                       </span>
                     ))}

--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -78,6 +78,12 @@ export const systemAdminEnUS = {
         normal_user: "Normal user",
         security: "Security administrator",
         super_admin: "Super administrator",
+        adminDescription: "System administrator for operations, users, and departments.",
+        auditDescription: "Audit administrator for audit logs, permission review, and admin behavior supervision.",
+        network_builderDescription: "Business network builder for data, knowledge, models, and execution factory assets.",
+        normal_userDescription: "Regular user for viewing, querying, executing, and invoking module capabilities.",
+        securityDescription: "Security administrator for roles, authorization, and account security.",
+        super_adminDescription: "Built-in hidden and controlled role with full platform permissions.",
       },
     },
     grant: {

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -78,6 +78,12 @@ export const systemAdminZhCN = {
         normal_user: "普通用户",
         security: "安全管理员",
         super_admin: "超级管理员",
+        adminDescription: "负责运维、用户和部门管理的系统管理员。",
+        auditDescription: "负责审计日志、权限复核和管理员行为监督的审计管理员。",
+        network_builderDescription: "负责数据、知识、模型和执行工厂资产的业务网络构建者。",
+        normal_userDescription: "用于查看、查询、执行和调用模块能力的普通用户。",
+        securityDescription: "负责角色、授权和账号安全的安全管理员。",
+        super_adminDescription: "内置隐藏 / 受控角色，拥有平台全量权限。",
       },
     },
     grant: {

--- a/src/modules/system-admin/scenes/RoleManagementScene.tsx
+++ b/src/modules/system-admin/scenes/RoleManagementScene.tsx
@@ -76,7 +76,7 @@ import {
   WILDCARD,
 
 } from "@/modules/system-admin/utils/resource-catalog";
-import { isSuperAdminRole } from "@/modules/system-admin/utils/role-catalog";
+import { isSuperAdminRole, roleDescription } from "@/modules/system-admin/utils/role-catalog";
 
 
 
@@ -473,11 +473,11 @@ export function RoleManagementScene() {
 
             </span>
 
-            {role.description ? (
+            {roleDescription(role) ? (
 
-              <Tooltip title={role.description}>
+              <Tooltip title={roleDescription(role)}>
 
-                <span className={styles.singleLineText}>{role.description}</span>
+                <span className={styles.singleLineText}>{roleDescription(role)}</span>
 
               </Tooltip>
 

--- a/src/modules/system-admin/scenes/RoleManagementScene.tsx
+++ b/src/modules/system-admin/scenes/RoleManagementScene.tsx
@@ -76,7 +76,7 @@ import {
   WILDCARD,
 
 } from "@/modules/system-admin/utils/resource-catalog";
-import { isSuperAdminRole, roleDescription } from "@/modules/system-admin/utils/role-catalog";
+import { isSuperAdminRole, roleDescription, roleSearchText } from "@/modules/system-admin/utils/role-catalog";
 
 
 
@@ -331,7 +331,7 @@ export function RoleManagementScene() {
 
     return roles.filter((role) =>
 
-      `${role.name} ${role.description}`.toLowerCase().includes(query),
+      roleSearchText(role).toLowerCase().includes(query),
 
     );
 

--- a/src/modules/system-admin/utils/role-catalog.test.ts
+++ b/src/modules/system-admin/utils/role-catalog.test.ts
@@ -13,6 +13,7 @@ import {
   hasThreeAdminConflict,
   isAssignableRole,
   roleDescription,
+  roleSearchText,
   resolveBuiltinRoleKey,
   threeAdminConflictLabels,
 } from "@/modules/system-admin/utils/role-catalog";
@@ -28,9 +29,10 @@ describe("role-catalog", () => {
   });
 
   it("recognizes old system display names as default role aliases", () => {
-    expect(resolveBuiltinRoleKey({ name: "系统管理员" })).toBe("admin");
-    expect(resolveBuiltinRoleKey({ name: "安全管理员" })).toBe("security");
-    expect(resolveBuiltinRoleKey({ name: "审计管理员" })).toBe("audit");
+    expect(resolveBuiltinRoleKey({ name: "系统管理员", builtin: true })).toBe("admin");
+    expect(resolveBuiltinRoleKey({ name: "安全管理员", builtin: true })).toBe("security");
+    expect(resolveBuiltinRoleKey({ name: "审计管理员", builtin: true })).toBe("audit");
+    expect(resolveBuiltinRoleKey({ name: "系统管理员", builtin: false })).toBeNull();
   });
 
   it("keeps super admin out of normal role assignment", () => {
@@ -40,15 +42,19 @@ describe("role-catalog", () => {
 
   it("localizes built-in descriptions while preserving custom descriptions", async () => {
     await i18n.changeLanguage("en-US");
-    expect(roleDescription({ name: "super_admin", description: "中文后端描述" })).toBe(
+    expect(roleDescription({ name: "super_admin", description: "中文后端描述", builtin: true })).toBe(
       "Built-in hidden and controlled role with full platform permissions.",
     );
-    expect(roleDescription({ name: "custom_role", description: "用户自定义描述" })).toBe("用户自定义描述");
+    expect(roleDescription({ name: "系统管理员", description: "用户自定义描述", builtin: false })).toBe("用户自定义描述");
+    expect(roleSearchText({ name: "admin", description: "backend description", builtin: true })).toContain(
+      "operations",
+    );
 
     await i18n.changeLanguage("zh-CN");
-    expect(roleDescription({ name: "super_admin", description: "中文后端描述" })).toBe(
+    expect(roleDescription({ name: "super_admin", description: "中文后端描述", builtin: true })).toBe(
       "内置隐藏 / 受控角色，拥有平台全量权限。",
     );
+    expect(roleSearchText({ name: "admin", description: "backend description", builtin: true })).toContain("运维");
   });
 
   it("detects multiple three-admin roles on the same account", async () => {

--- a/src/modules/system-admin/utils/role-catalog.test.ts
+++ b/src/modules/system-admin/utils/role-catalog.test.ts
@@ -12,6 +12,7 @@ import {
   getRoleDutyCategory,
   hasThreeAdminConflict,
   isAssignableRole,
+  roleDescription,
   resolveBuiltinRoleKey,
   threeAdminConflictLabels,
 } from "@/modules/system-admin/utils/role-catalog";
@@ -35,6 +36,19 @@ describe("role-catalog", () => {
   it("keeps super admin out of normal role assignment", () => {
     expect(isAssignableRole({ name: "super_admin" })).toBe(false);
     expect(isAssignableRole({ name: "network_builder" })).toBe(true);
+  });
+
+  it("localizes built-in descriptions while preserving custom descriptions", async () => {
+    await i18n.changeLanguage("en-US");
+    expect(roleDescription({ name: "super_admin", description: "中文后端描述" })).toBe(
+      "Built-in hidden and controlled role with full platform permissions.",
+    );
+    expect(roleDescription({ name: "custom_role", description: "用户自定义描述" })).toBe("用户自定义描述");
+
+    await i18n.changeLanguage("zh-CN");
+    expect(roleDescription({ name: "super_admin", description: "中文后端描述" })).toBe(
+      "内置隐藏 / 受控角色，拥有平台全量权限。",
+    );
   });
 
   it("detects multiple three-admin roles on the same account", async () => {

--- a/src/modules/system-admin/utils/role-catalog.test.ts
+++ b/src/modules/system-admin/utils/role-catalog.test.ts
@@ -42,6 +42,7 @@ describe("role-catalog", () => {
 
   it("localizes built-in descriptions while preserving custom descriptions", async () => {
     await i18n.changeLanguage("en-US");
+    expect(i18n.exists("systemAdmin.roleCatalog.builtin.adminDescription", { lng: "en-US" })).toBe(true);
     expect(roleDescription({ name: "super_admin", description: "中文后端描述", builtin: true })).toBe(
       "Built-in hidden and controlled role with full platform permissions.",
     );

--- a/src/modules/system-admin/utils/role-catalog.ts
+++ b/src/modules/system-admin/utils/role-catalog.ts
@@ -23,6 +23,9 @@ type RoleMeta = {
   label: string;
 };
 
+type RoleIdentity = Pick<AdminRole, "name"> & Partial<Pick<AdminRole, "builtin">>;
+type RoleClassification = RoleIdentity & Pick<AdminRole, "source">;
+
 const BUILTIN_ROLE_FALLBACK_DESCRIPTIONS: Record<BuiltinRoleKey, string> = {
   admin: "System administrator for operations, users, and departments.",
   audit: "Audit administrator for audit logs, permission review, and admin behavior supervision.",
@@ -71,19 +74,23 @@ export function builtinRoleDescription(key: BuiltinRoleKey): string {
   });
 }
 
-export function resolveBuiltinRoleKey(role: Pick<AdminRole, "name">): BuiltinRoleKey | null {
+export function resolveBuiltinRoleKey(role: RoleIdentity): BuiltinRoleKey | null {
   if (role.name in BUILTIN_ROLE_META) {
     return role.name as BuiltinRoleKey;
   }
-  return ROLE_NAME_ALIASES[role.name] ?? null;
+  return role.builtin ? (ROLE_NAME_ALIASES[role.name] ?? null) : null;
 }
 
-export function roleDescription(role: Pick<AdminRole, "name" | "description">): string {
+export function roleDescription(role: RoleIdentity & Pick<AdminRole, "description">): string {
   const builtinKey = resolveBuiltinRoleKey(role);
   return builtinKey ? builtinRoleDescription(builtinKey) : role.description;
 }
 
-export function getRoleDutyCategory(role: Pick<AdminRole, "name" | "source">): RoleDutyCategory {
+export function roleSearchText(role: RoleIdentity & Pick<AdminRole, "description">): string {
+  return `${role.name} ${roleDescription(role)}`;
+}
+
+export function getRoleDutyCategory(role: RoleClassification): RoleDutyCategory {
   const builtinKey = resolveBuiltinRoleKey(role);
   if (builtinKey) {
     return BUILTIN_ROLE_META[builtinKey].category;
@@ -91,23 +98,23 @@ export function getRoleDutyCategory(role: Pick<AdminRole, "name" | "source">): R
   return "custom";
 }
 
-export function isSuperAdminRole(role: Pick<AdminRole, "name">): boolean {
+export function isSuperAdminRole(role: RoleIdentity): boolean {
   return resolveBuiltinRoleKey(role) === "super_admin";
 }
 
-export function isThreeAdminRole(role: Pick<AdminRole, "name" | "source">): boolean {
+export function isThreeAdminRole(role: RoleClassification): boolean {
   return getRoleDutyCategory(role) === "three-admin";
 }
 
-export function isAssignableRole(role: Pick<AdminRole, "name">): boolean {
+export function isAssignableRole(role: RoleIdentity): boolean {
   return !isSuperAdminRole(role);
 }
 
-export function hasThreeAdminConflict(roles: Pick<AdminRole, "name" | "source">[]): boolean {
+export function hasThreeAdminConflict(roles: RoleClassification[]): boolean {
   return roles.filter(isThreeAdminRole).length > 1;
 }
 
-export function threeAdminConflictLabels(roles: Pick<AdminRole, "name" | "source">[]): string[] {
+export function threeAdminConflictLabels(roles: RoleClassification[]): string[] {
   return roles
     .filter(isThreeAdminRole)
     .map((role) => {

--- a/src/modules/system-admin/utils/role-catalog.ts
+++ b/src/modules/system-admin/utils/role-catalog.ts
@@ -23,6 +23,15 @@ type RoleMeta = {
   label: string;
 };
 
+const BUILTIN_ROLE_FALLBACK_DESCRIPTIONS: Record<BuiltinRoleKey, string> = {
+  admin: "System administrator for operations, users, and departments.",
+  audit: "Audit administrator for audit logs, permission review, and admin behavior supervision.",
+  network_builder: "Business network builder for data, knowledge, models, and execution factory assets.",
+  normal_user: "Regular user for viewing, querying, executing, and invoking module capabilities.",
+  security: "Security administrator for roles, authorization, and account security.",
+  super_admin: "Built-in hidden and controlled role with full platform permissions.",
+};
+
 const BUILTIN_ROLE_FALLBACK_LABELS: Record<BuiltinRoleKey, string> = {
   admin: "System administrator",
   audit: "Audit administrator",
@@ -56,11 +65,22 @@ export function builtinRoleLabel(key: BuiltinRoleKey): string {
   });
 }
 
+export function builtinRoleDescription(key: BuiltinRoleKey): string {
+  return i18n.t(`systemAdmin.roleCatalog.builtin.${key}Description`, {
+    defaultValue: BUILTIN_ROLE_FALLBACK_DESCRIPTIONS[key],
+  });
+}
+
 export function resolveBuiltinRoleKey(role: Pick<AdminRole, "name">): BuiltinRoleKey | null {
   if (role.name in BUILTIN_ROLE_META) {
     return role.name as BuiltinRoleKey;
   }
   return ROLE_NAME_ALIASES[role.name] ?? null;
+}
+
+export function roleDescription(role: Pick<AdminRole, "name" | "description">): string {
+  const builtinKey = resolveBuiltinRoleKey(role);
+  return builtinKey ? builtinRoleDescription(builtinKey) : role.description;
 }
 
 export function getRoleDutyCategory(role: Pick<AdminRole, "name" | "source">): RoleDutyCategory {


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] System administration / i18n
- [ ] Feature/module 2
- [ ] Docs/doc 1

修复英文模式下内置角色描述仍显示中文的问题。

- 增加内置角色描述的中英文资源。
- 内置角色根据当前 locale 显示对应描述。
- 自定义角色继续显示后端返回的原始描述。
- 更新用户角色配置抽屉、角色详情、角色管理列表和授权角色选择器。

---

## Why

- Related Issue: [Issue #448](https://github.com/openbkn-ai/bkn-studio/issues/448)
- Related Feature: N/A
- Background: 英文模式下，`super_admin` 等内置角色的描述直接使用后端中文字段，导致界面中英文混用。

---

## How

- Key implementation points:
  - 在 `role-catalog` 中新增内置角色描述映射。
  - 在英文和中文 locale 中补充 6 个内置角色的描述资源。
  - 通过统一的 `roleDescription()` 方法处理内置角色与自定义角色。
  - 增加内置角色描述的中英文及自定义角色回归测试。
- Breaking changes (API, config, database, etc.):
  - 无。
  - 不修改角色 ID、权限、成员绑定、受控状态或后端授权逻辑。

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `git diff --check` 已通过。
- 已新增聚焦回归测试，覆盖：
  - 英文模式下 `super_admin` 显示英文描述。
  - 中文模式下 `super_admin` 显示中文描述。
  - 自定义角色继续显示后端原始描述。
- 当前环境未安装 `pnpm`，因此未能执行 Vitest、ESLint、TypeScript 和完整构建检查。

---

## Risk & Rollback

- Potential risks:
  - 低风险，仅影响内置角色描述的前端展示。
  - 自定义角色描述逻辑保持不变。
- Rollback plan:
  - 回退 commit `92123406`。
  - 或执行 `git revert 92123406`。

---

## Additional Notes

- Helm Chart 未修改。
- Commit: `92123406 fix(i18n): localize built-in role descriptions`
- Closes #448