### PR TITLE
fix(i18n): localize model statistics copy

### DIFF
--- a/src/modules/model-resources/locales/en-US.ts
+++ b/src/modules/model-resources/locales/en-US.ts
@@ -239,8 +239,8 @@ export const modelResourcesEnUS = {
         unit: "Unit",
       },
       metrics: {
-        usageCount: "Usage count",
-        times: "times",
+        usageCount: "Model calls",
+        times: "calls",
         errorRate: "Model error rate",
         avgResponseTime: "Average response time",
         tokenConsumption: "Token consumption",
@@ -255,7 +255,7 @@ export const modelResourcesEnUS = {
       charts: {
         inputTokens: "Input Tokens",
         outputTokens: "Output Tokens",
-        timeAndFirstToken: "Call time and first-token time",
+        timeAndFirstToken: "Model latency and time to first token",
         tokenRate: "Token rate",
         qps: "Model QPS",
       },

--- a/src/modules/model-resources/locales/statistics.test.ts
+++ b/src/modules/model-resources/locales/statistics.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { modelResourcesEnUS } from "@/modules/model-resources/locales/en-US";
+import { modelResourcesZhCN } from "@/modules/model-resources/locales/zh-CN";
+
+describe("model statistics locales", () => {
+  it("uses standard model-call terminology in English", () => {
+    const statistics = modelResourcesEnUS.modelResources.statistics;
+
+    expect(statistics.metrics.usageCount).toBe("Model calls");
+    expect(statistics.metrics.times).toBe("calls");
+    expect(statistics.charts.timeAndFirstToken).toBe("Model latency and time to first token");
+  });
+
+  it("localizes token chart legends in Chinese", () => {
+    const statistics = modelResourcesZhCN.modelResources.statistics;
+
+    expect(statistics.charts.inputTokens).toBe("输入 Tokens");
+    expect(statistics.charts.outputTokens).toBe("输出 Tokens");
+  });
+});

--- a/src/modules/model-resources/locales/zh-CN.ts
+++ b/src/modules/model-resources/locales/zh-CN.ts
@@ -249,8 +249,8 @@ export const modelResourcesZhCN = {
         secondsHint: "（单位：秒）",
       },
       charts: {
-        inputTokens: "Input Tokens",
-        outputTokens: "Output Tokens",
+        inputTokens: "输入 Tokens",
+        outputTokens: "输出 Tokens",
         timeAndFirstToken: "模型调用耗时与模型首Tokens耗时",
         tokenRate: "模型Token速率",
         qps: "模型 QPS",


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Model statistics localization
- [ ] Feature/module 2
- [ ] Docs/doc 1

Fix localized copy on the Model Statistics page.

- Replaced unnatural English model usage terms with standard terminology.
- Updated the latency chart title to use “time to first token”.
- Localized the Chinese token chart legends.
- Added regression coverage for the affected English and Chinese locale resources.

---

## Why

- Related Issue: Closes #446
- Related Feature: N/A
- Background: The Model Statistics page mixed unnatural English wording with unlocalized English chart legends in the Chinese locale.

---

## How

- Key implementation points:
  - Updated `usageCount` from `Usage count` to `Model calls`.
  - Updated the usage unit from `times` to `calls`.
  - Updated the latency chart title to `Model latency and time to first token`.
  - Updated Chinese token legend labels to `输入 Tokens` and `输出 Tokens`.
  - Added locale regression tests for the affected copy.
- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Added and ran `src/modules/model-resources/locales/statistics.test.ts`.
- Commit completed successfully through the repository Git hook.

---

## Risk & Rollback

- Potential risks:
  - Low risk. Changes are limited to frontend locale resources and regression tests.
- Rollback plan:
  - Revert commit `fe3ca580`.

---

## Additional Notes

- No API contracts, statistics calculations, chart data, or Helm Chart files were changed.
- Commit: `fe3ca580 fix(i18n): localize model statistics copy`
- PR created by an Agent; please apply the `by-agent` label.