### PR TITLE
fix(model-resources): gate statistics by large model view

### DIFF
--- a/src/framework/auth/permission-map.test.ts
+++ b/src/framework/auth/permission-map.test.ts
@@ -238,7 +238,7 @@ describe("折叠通配契约", () => {
     expect(isStudioPermissionGranted("execution-factory-lab:sandbox-runtime:view", globalWildcard, false)).toBe(false);
   });
 
-  it("模型资源权限映射到 bkn-safe 的 large_model/small_model 操作", () => {
+  it("大模型查看权限开放模型统计，小模型查看不开放", () => {
     const grants = flattenSafeGrants([
       {
         operations: ["display", "create", "modify"],
@@ -254,6 +254,11 @@ describe("折叠通配契约", () => {
     expect(isStudioPermissionGranted("model-resources:model:delete", grants, false)).toBe(false);
     expect(isStudioPermissionGranted("model-resources:statistics:view", grants, false)).toBe(true);
     expect(isStudioPermissionGranted("model-resources:quota:edit", grants, false)).toBe(true);
+
+    const smallModelDisplay = flattenSafeGrants([
+      { operations: ["display"], resource: { id: "*", type: "small_model" } },
+    ]);
+    expect(isStudioPermissionGranted("model-resources:statistics:view", smallModelDisplay, false)).toBe(false);
   });
 });
 

--- a/src/framework/auth/permission-map.ts
+++ b/src/framework/auth/permission-map.ts
@@ -93,7 +93,7 @@ const MODEL_RESOURCE_PERMISSIONS: Record<string, string[]> = {
   "model-resources:model:delete": ["large_model:delete", "small_model:delete"],
   "model-resources:quota:view": ["large_model:display", "small_model:display"],
   "model-resources:quota:edit": ["large_model:modify", "small_model:modify"],
-  "model-resources:statistics:view": ["large_model:display", "small_model:display"],
+  "model-resources:statistics:view": ["large_model:display"],
 };
 
 /**

--- a/src/modules/model-resources/navigation.tsx
+++ b/src/modules/model-resources/navigation.tsx
@@ -31,11 +31,7 @@ export const modelResourcesNavigation: ConsoleNavContribution = {
       labelKey: "shell.items.modelStatistics",
       icon: <BarChartOutlined />,
       path: "/model-resources/statistics",
-      permission: [
-        "model-resources:large-model:view",
-        "model-resources:small-model:view",
-      ],
-      permissionMode: "any",
+      permission: "model-resources:statistics:view",
     },
   ],
 };

--- a/src/modules/model-resources/routes.tsx
+++ b/src/modules/model-resources/routes.tsx
@@ -79,11 +79,7 @@ export const modelResourcesRoutes: RouteObject[] = [
       },
     },
     element: withRouteLoading(
-      [
-        "model-resources:large-model:view",
-        "model-resources:small-model:view",
-        "model-resources:statistics:view",
-      ],
+      "model-resources:statistics:view",
       <ModelStatisticsPage />,
     ),
   },


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Restrict the Model Statistics entry and route to `model-resources:statistics:view`.
- [x] Map `model-resources:statistics:view` exclusively to `large_model:display`.
- [x] Add regression coverage confirming small-model display permission does not grant access to Model Statistics.

---

## Why

- Related Issue: N/A
- Related Feature: Model Statistics permission alignment
- Background: Model Statistics reports large-model usage. Previously, either large-model or small-model display permission exposed the entry and route. The expected behavior is that only users with large-model display permission can view this page.

---

## How

- Updated the Studio permission map so `model-resources:statistics:view` requires `large_model:display`.
- Updated navigation and route guards to use the dedicated statistics permission.
- Added a regression test for the small-model-only permission case.
- Breaking changes: No API, configuration, or database changes. Users with only `small_model:display` will no longer see or access Model Statistics.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Static diff check passed: `git diff --check`
- Local Vitest/ESLint/TypeScript checks were not run because `pnpm` is unavailable in the environment.

---

## Risk & Rollback

- Potential risks: Users previously relying on small-model display permission to access Model Statistics will receive a 403 and the menu item will be hidden.
- Rollback plan: Revert commit `d606a652` or restore `small_model:display` in the Model Statistics permission mapping.

---

## Additional Notes

- The backend Model Statistics endpoint already checks `large_model:display`; this change aligns Studio navigation and route access with the existing backend authorization behavior.
- Commit: `d606a652 fix(model-resources): gate statistics by large model view`