### PR TITLE
fix(system-admin): rename operator to function

### DIFF
--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -61,7 +61,7 @@ export const systemAdminEnUS = {
         knowledge_network: "Knowledge network",
         large_model: "Large model",
         mcp: "MCP",
-        operator: "Operator",
+        operator: "Function",
         resource: "Data resource",
         safe_admin: "bkn-safe management API",
         skill: "Skill",
@@ -112,7 +112,7 @@ export const systemAdminEnUS = {
     },
     objectGrants: {
       title: "Permission Management",
-      description: "On top of role permissions, configure allowed operations on a specific object (catalog / model / operator / toolbox, etc.) for a user or department.",
+      description: "On top of role permissions, configure allowed operations on a specific object (catalog / model / function / toolbox, etc.) for a user or department.",
       create: "New Permission Rule",
       authorize: "Configure Permissions",
       manage: "Manage",

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -61,7 +61,7 @@ export const systemAdminZhCN = {
         knowledge_network: "知识网络",
         large_model: "大模型",
         mcp: "MCP",
-        operator: "算子",
+        operator: "函数",
         resource: "数据资源",
         safe_admin: "bkn-safe 管理 API",
         skill: "技能",
@@ -112,7 +112,7 @@ export const systemAdminZhCN = {
     },
     objectGrants: {
       title: "权限管理",
-      description: "在角色权限之上，为用户或部门配置某个具体对象（数据目录 / 模型 / 算子 / 工具箱 等）的可用操作。",
+      description: "在角色权限之上，为用户或部门配置某个具体对象（数据目录 / 模型 / 函数 / 工具箱 等）的可用操作。",
       create: "新建权限配置",
       authorize: "配置权限",
       manage: "管理",

--- a/src/modules/system-admin/utils/resource-catalog.ts
+++ b/src/modules/system-admin/utils/resource-catalog.ts
@@ -74,7 +74,7 @@ const RESOURCE_FALLBACK_LABELS: Record<string, string> = {
   knowledge_network: "Knowledge network",
   large_model: "Large model",
   mcp: "MCP",
-  operator: "Operator",
+  operator: "Function",
   resource: "Data resource",
   safe_admin: "bkn-safe management API",
   skill: "Skill",


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Rename the `operator` authorization resource label to **Function / 函数** in System Administration.
- [x] Update Object Authorization descriptions to use the new Function terminology.
- [x] Preserve the internal `operator` resource key and existing authorization behavior.

---

## Why

- Related Issue: Closes openbkn-ai/bkn-foundry#1272
- Related Feature: Authorization terminology alignment
- Background: The product concept formerly shown as “Operator / 算子” has been renamed to “Function / 函数”. The authorization UI still exposed the legacy terminology.

---

## How

- Updated Chinese and English resource labels used by Role Management and Object Authorization.
- Updated the fallback resource label for the internal `operator` type.
- Updated Object Authorization descriptions in both locales.
- Breaking changes: None. API paths, resource IDs, persisted grants, and backend authorization semantics remain unchanged.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `git diff --check` passed.
- Frontend test suite was not run because `pnpm` is unavailable in the local environment.

---

## Risk & Rollback

- Potential risks: Display terminology changes only; users may need to recognize that existing `operator` grants are now presented as Function grants.
- Rollback plan: Revert commit `412cd06e`.

---

## Additional Notes

- Internal compatibility is intentionally retained:
  - Resource type remains `operator`
  - Existing role grants remain valid
  - Execution Factory API paths remain unchanged
- Commit: `412cd06e fix(system-admin): rename operator to function`