### PR TITLE
fix(system-admin): edit role grant operations

### DIFF
--- a/src/modules/system-admin/components/ResourceGrantEditor.test.ts
+++ b/src/modules/system-admin/components/ResourceGrantEditor.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  addOperationToGrant,
+  removeOperationFromGrant,
+} from "@/modules/system-admin/utils/resource-grant-operations";
+import type { ResourceGrant } from "@/modules/system-admin/types/admin";
+
+const catalogGrant: ResourceGrant = {
+  resource: { type: "catalog", id: "*" },
+  operations: ["view_detail", "query"],
+};
+
+describe("ResourceGrantEditor operation changes", () => {
+  it("adds an operation to the existing resource grant without replacing other operations", () => {
+    expect(addOperationToGrant([catalogGrant], catalogGrant, "create")).toEqual([
+      { ...catalogGrant, operations: ["view_detail", "query", "create"] },
+    ]);
+  });
+
+  it("removes only the selected operation", () => {
+    expect(removeOperationFromGrant([catalogGrant], catalogGrant, "query")).toEqual([
+      { ...catalogGrant, operations: ["view_detail"] },
+    ]);
+  });
+
+  it("removes the entire grant after its last operation is removed", () => {
+    const singleOperationGrant = { ...catalogGrant, operations: ["query"] };
+
+    expect(removeOperationFromGrant([singleOperationGrant], singleOperationGrant, "query")).toEqual([]);
+  });
+});

--- a/src/modules/system-admin/components/ResourceGrantEditor.tsx
+++ b/src/modules/system-admin/components/ResourceGrantEditor.tsx
@@ -6,12 +6,16 @@
  */
 
 import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
-import { Checkbox, Empty, Input, Select, Tag } from "antd";
+import { Checkbox, Empty, Input, Select, Tag, Tooltip } from "antd";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { AppButton } from "@/framework/ui/common/AppButton";
 import type { ResourceGrant, ResourceRef } from "@/modules/system-admin/types/admin";
+import {
+  addOperationToGrant,
+  removeOperationFromGrant,
+} from "@/modules/system-admin/utils/resource-grant-operations";
 import {
   operationLabel,
   operationsForType,
@@ -43,6 +47,7 @@ export function ResourceGrantEditor({
   const [draftId, setDraftId] = useState<string>(lockedResource?.id ?? WILDCARD);
   const [wholeType, setWholeType] = useState<boolean>(!lockedResource);
   const [draftOps, setDraftOps] = useState<string[]>([]);
+  const [addingGrantKey, setAddingGrantKey] = useState<string | null>(null);
 
   const ops = useMemo(() => operationsForType(draftType), [draftType]);
 
@@ -72,6 +77,15 @@ export function ResourceGrantEditor({
     onChange(value.filter((item) => item !== grant));
   };
 
+  const addOperation = (grant: ResourceGrant, operation: string) => {
+    onChange(addOperationToGrant(value, grant, operation));
+    setAddingGrantKey(null);
+  };
+
+  const removeOperation = (grant: ResourceGrant, operation: string) => {
+    onChange(removeOperationFromGrant(value, grant, operation));
+  };
+
   return (
     <div className={styles.grantEditor}>
       {value.length ? (
@@ -86,7 +100,15 @@ export function ResourceGrantEditor({
               </div>
               <div className={styles.chipRow}>
                 {grant.operations.map((op) => (
-                  <Tag className={styles.permChip} key={op}>
+                  <Tag
+                    closable={!disabled}
+                    className={styles.permChip}
+                    key={op}
+                    onClose={(event) => {
+                      event.preventDefault();
+                      removeOperation(grant, op);
+                    }}
+                  >
                     {grant.resource.id === WILDCARD || op === "*"
                       ? op === "*"
                         ? t("systemAdmin.grant.allOps")
@@ -94,6 +116,32 @@ export function ResourceGrantEditor({
                       : operationLabel(grant.resource.type, op)}
                   </Tag>
                 ))}
+                {!disabled && !grant.operations.includes("*") ? (
+                  addingGrantKey === `${grant.resource.type}:${grant.resource.id}:${index}` ? (
+                    <Select
+                      autoFocus
+                      onBlur={() => setAddingGrantKey(null)}
+                      onSelect={(operation: string) => addOperation(grant, operation)}
+                      options={operationsForType(grant.resource.type)
+                        .filter((operation) => !grant.operations.includes(operation.key))
+                        .map((operation) => ({ label: operation.label, value: operation.key }))}
+                      placeholder={t("systemAdmin.grant.operationsPlaceholder")}
+                      size="small"
+                      style={{ minWidth: 150 }}
+                    />
+                  ) : (
+                    <Tooltip title={t("systemAdmin.grant.addOperation")}>
+                      <AppButton
+                        icon={<PlusOutlined />}
+                        onClick={() => setAddingGrantKey(`${grant.resource.type}:${grant.resource.id}:${index}`)}
+                        size="small"
+                        type="link"
+                      >
+                        {t("systemAdmin.grant.addOperation")}
+                      </AppButton>
+                    </Tooltip>
+                  )
+                ) : null}
               </div>
               {!disabled ? (
                 <AppButton

--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -91,6 +91,7 @@ export const systemAdminEnUS = {
       allOps: "All operations",
       empty: "No grants yet",
       add: "Add grant",
+      addOperation: "Add operation",
       resourceIdPlaceholder: "Resource ID (a specific one)",
       operationsPlaceholder: "Pick operations",
     },

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -91,6 +91,7 @@ export const systemAdminZhCN = {
       allOps: "全部操作",
       empty: "暂无授权",
       add: "添加授权",
+      addOperation: "添加操作",
       resourceIdPlaceholder: "资源 ID（指定某一条）",
       operationsPlaceholder: "选择操作",
     },

--- a/src/modules/system-admin/utils/resource-grant-operations.ts
+++ b/src/modules/system-admin/utils/resource-grant-operations.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ResourceGrant, ResourceRef } from "@/modules/system-admin/types/admin";
+
+const sameResource = (a: ResourceRef, b: ResourceRef) => a.type === b.type && a.id === b.id;
+
+export function addOperationToGrant(
+  grants: ResourceGrant[],
+  target: ResourceGrant,
+  operation: string,
+): ResourceGrant[] {
+  return grants.map((grant) =>
+    sameResource(grant.resource, target.resource)
+      ? { ...grant, operations: Array.from(new Set([...grant.operations, operation])) }
+      : grant,
+  );
+}
+
+export function removeOperationFromGrant(
+  grants: ResourceGrant[],
+  target: ResourceGrant,
+  operation: string,
+): ResourceGrant[] {
+  const remainingOperations = target.operations.filter((item) => item !== operation);
+  if (remainingOperations.length === 0) {
+    return grants.filter((grant) => !sameResource(grant.resource, target.resource));
+  }
+
+  return grants.map((grant) =>
+    sameResource(grant.resource, target.resource)
+      ? { ...grant, operations: remainingOperations }
+      : grant,
+  );
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add inline operation editing for role resource grants.
- [x] Allow administrators to remove an individual operation from an existing grant.
- [x] Allow administrators to add an operation to an existing grant without recreating the grant.
- [x] Automatically remove a grant when its final operation is removed.
- [x] Add Chinese and English labels plus focused regression tests.

---

## Why

- Related Issue: N/A
- Related Feature: Role permission management
- Background:

  Role editing previously allowed only deletion of an entire resource grant. To remove or add one operation, administrators had to delete the full grant and recreate it, which was error-prone and inefficient.

---

## How

- Key implementation points:
  - Add closable operation tags for per-operation removal.
  - Add an inline “Add operation” selector for each existing resource grant.
  - Preserve all other operations when adding or removing one operation.
  - Remove the grant automatically when no operations remain.
  - Keep wildcard (`*`) grants as whole-grant semantics.

- Breaking changes (API, config, database, etc.):
  - None. The existing role permission attach/detach API contract is unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable for this frontend-only change.
- [ ] Verified in test environment — not performed.

Test notes:

- `ResourceGrantEditor.test.ts`: 3 tests passed.
- Relevant ESLint checks passed with zero warnings.
- `git diff --check` passed.
- Full test suite was not run to avoid overloading the development server.

---

## Risk & Rollback

- Potential risks:
  - Removing an operation immediately updates the local role permission draft; the backend update remains deferred until the role form is saved.
  - Removing the final operation revokes the complete resource grant on save.

- Rollback plan:
  - Revert commit `14a2fc01`.

---

## Additional Notes

- Branch: `fix/role-grant-operation-editing`
- No backend API, database schema, or runtime configuration changes.