### PR TITLE
fix(navigation): position observability before models

### DIFF
--- a/docs/plans/2026-09-03-observability-menu-position-design.md
+++ b/docs/plans/2026-09-03-observability-menu-position-design.md
@@ -1,0 +1,22 @@
+# Observability Menu Position Design
+
+## Goal
+
+Place the Observability top-level menu after General Business Knowledge Network
+(which contains the data-resource entry) and before Model Resources.
+
+## Decision
+
+Use the existing contribution anchor mechanism. Change only
+`bknTraceNavigation.afterKey` from `model-resources` to
+`general-business-knowledge-network`.
+
+This keeps menu ownership unchanged, preserves all permissions and routes, and
+does not affect the System Management menu.
+
+## Verification
+
+Update the focused navigation test to assert the order:
+
+`general-business-knowledge-network` → `observability` → `model-resources` →
+`system-management`.

--- a/docs/plans/2026-09-03-observability-menu-position.md
+++ b/docs/plans/2026-09-03-observability-menu-position.md
@@ -1,0 +1,87 @@
+# Observability Menu Position Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move Observability below General Business Knowledge Network and above Model Resources.
+
+**Architecture:** `ConsoleNavContribution.afterKey` inserts a top-level module
+after a base navigation item. Updating the BKN Trace contribution's anchor is
+sufficient; a focused unit test protects the resulting top-level order.
+
+**Tech Stack:** TypeScript, React, Vitest.
+
+---
+
+### Task 1: Capture the required menu order
+
+**Files:**
+- Modify: `src/app/shell/console-navigation.test.ts`
+
+**Step 1: Write the failing test**
+
+Change the menu-order test to require:
+
+```ts
+expect(navigationKeys.indexOf("general-business-knowledge-network")).toBeLessThan(
+  navigationKeys.indexOf("observability"),
+);
+expect(navigationKeys.indexOf("observability")).toBeLessThan(
+  navigationKeys.indexOf("model-resources"),
+);
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/app/shell/console-navigation.test.ts`
+
+Expected: the current `afterKey: "model-resources"` places Observability after
+Model Resources, so the new assertion fails.
+
+### Task 2: Move the navigation contribution
+
+**Files:**
+- Modify: `src/modules/bkn-trace/navigation.tsx`
+- Test: `src/app/shell/console-navigation.test.ts`
+
+**Step 1: Write minimal implementation**
+
+Set the contribution anchor to:
+
+```ts
+afterKey: "general-business-knowledge-network",
+```
+
+**Step 2: Run test to verify it passes**
+
+Run: `pnpm vitest run src/app/shell/console-navigation.test.ts`
+
+Expected: all focused navigation tests pass.
+
+### Task 3: Verify and commit
+
+**Files:**
+- Modify: `docs/plans/2026-09-03-observability-menu-position-design.md`
+- Modify: `docs/plans/2026-09-03-observability-menu-position.md`
+- Modify: `src/app/shell/console-navigation.test.ts`
+- Modify: `src/modules/bkn-trace/navigation.tsx`
+
+**Step 1: Run targeted verification**
+
+Run:
+
+```bash
+pnpm vitest run src/app/shell/console-navigation.test.ts
+pnpm exec eslint src/app/shell/console-navigation.test.ts src/modules/bkn-trace/navigation.tsx --config eslint.config.typechecked.js --max-warnings 0
+pnpm exec tsc -b --pretty false
+pnpm exec vite build
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-09-03-observability-menu-position-design.md \
+  docs/plans/2026-09-03-observability-menu-position.md \
+  src/app/shell/console-navigation.test.ts \
+  src/modules/bkn-trace/navigation.tsx
+git commit -m "fix(navigation): position observability before models"
+```

--- a/src/app/shell/console-navigation.test.ts
+++ b/src/app/shell/console-navigation.test.ts
@@ -18,14 +18,14 @@ const systemGroup = (items: ReturnType<typeof filterNavByPermission>) =>
   items.find((item) => item.key === "system-management");
 
 describe("consoleNavigation — 主线菜单顺序", () => {
-  it("将可观测性置于模型管理之后、系统管理之前", () => {
+  it("将可观测性置于通用业务知识网络之后、模型管理之前", () => {
     const navigationKeys = keys(consoleNavigation);
 
-    expect(navigationKeys.indexOf("model-resources")).toBeLessThan(
+    expect(navigationKeys.indexOf("general-business-knowledge-network")).toBeLessThan(
       navigationKeys.indexOf("observability"),
     );
     expect(navigationKeys.indexOf("observability")).toBeLessThan(
-      navigationKeys.indexOf("system-management"),
+      navigationKeys.indexOf("model-resources"),
     );
   });
 });

--- a/src/modules/bkn-trace/navigation.tsx
+++ b/src/modules/bkn-trace/navigation.tsx
@@ -16,7 +16,7 @@ import type { ConsoleNavContribution } from "@/app/shell/navigation/types";
 import { CAPABILITIES } from "@/framework/entitlement/capabilities";
 
 export const bknTraceNavigation: ConsoleNavContribution = {
-  afterKey: "model-resources",
+  afterKey: "general-business-knowledge-network",
   items: [
     {
       key: "observability",


### PR DESCRIPTION
## What Changed

- [x] Moved the Observability top-level menu below General Business Knowledge Network, which contains the data-resource entries.
- [x] Added a regression assertion for the resulting menu order.
- [x] Added the approved design and implementation plan.

---

## Why

- Related Issue: Follow-up to [Issue #532](https://github.com/openbkn-ai/bkn-studio/issues/532).
- Related Feature: Console navigation ordering.
- Background: Observability should appear after knowledge-network/data-resource navigation and before Model Resources.

---

## How

- Changed `bknTraceNavigation.afterKey` from `model-resources` to `general-business-knowledge-network`.
- Kept all routes, permissions, menu ownership, and System Management placement unchanged.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Focused navigation tests passed locally (8/8).
- [x] Focused Observability workspace tests passed locally (27/27).
- [x] TypeScript build, full type-aware ESLint, and Vite production build passed locally.
- [ ] Full default Vitest run — blocked by cross-module failures under the local high-concurrency run; an affected Observability file passes in isolation.
- [ ] Production dependency audit — the configured npmmirror registry does not implement the audit endpoint.
- [ ] Verified in test environment — not applicable for a menu-order-only change.

Test notes:

- `node scripts/check-license-headers.mjs` passed.
- `pnpm vitest run src/app/shell/console-navigation.test.ts` passed (8 tests).
- `pnpm vitest run src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx` passed (27 tests).
- `pnpm exec tsc -b --pretty false`, full ESLint, and `pnpm exec vite build` passed.
- The full default Vitest run was stopped after unrelated cross-module failures; it is not represented as passing.

---

## Risk & Rollback

- Potential risks: Only the intended top-level navigation order changes.
- Rollback plan: Revert commit `6165e781`.

---

## Additional Notes

- No runtime API, permission, localization, or capability behavior changed.