### PR TITLE
fix(knowledge-network): align permission and MCP follow-ups

### DIFF
--- a/src/modules/data-catalog/permissions.ts
+++ b/src/modules/data-catalog/permissions.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/** Permissions that allow the caller to read resource index/build state. */
+export const dataCatalogResourceStatusPermissions = [
+  "resource:view_detail",
+  "catalog:task_manage",
+] as const;

--- a/src/modules/knowledge-network/hooks/useExperienceNetwork.test.tsx
+++ b/src/modules/knowledge-network/hooks/useExperienceNetwork.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+
+import { useExperienceNetwork } from "./useExperienceNetwork";
+
+const { getKnowledgeNetwork } = vi.hoisted(() => ({
+  getKnowledgeNetwork: vi.fn<() => Promise<KnowledgeNetworkRecord | null>>(),
+}));
+
+vi.mock("@/modules/knowledge-network/services/knowledge-network.service", () => ({
+  getKnowledgeNetwork,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useExperienceNetwork", () => {
+  it("reuses the identity supplied by the workspace without another detail request", () => {
+    const identity = { id: "network-1", name: "Orders", slug: "orders_kn" };
+
+    const { result } = renderHook(() => useExperienceNetwork("network-1", identity));
+
+    expect(result.current).toEqual(identity);
+    expect(getKnowledgeNetwork).not.toHaveBeenCalled();
+  });
+
+  it("loads the identity for standalone consumers", async () => {
+    getKnowledgeNetwork.mockResolvedValue({
+      id: "network-1",
+      identifier: "orders_kn",
+      name: "Orders",
+    } as KnowledgeNetworkRecord);
+
+    const { result } = renderHook(() => useExperienceNetwork("network-1"));
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        id: "network-1",
+        name: "Orders",
+        slug: "orders_kn",
+      });
+    });
+    expect(getKnowledgeNetwork).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse a stale workspace identity after the route id changes", () => {
+    const { result } = renderHook(() =>
+      useExperienceNetwork("network-2", {
+        id: "network-1",
+        name: "Orders",
+        slug: "orders_kn",
+      }),
+    );
+
+    expect(result.current).toBeNull();
+    expect(getKnowledgeNetwork).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/knowledge-network/hooks/useExperienceNetwork.ts
+++ b/src/modules/knowledge-network/hooks/useExperienceNetwork.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { useEffect, useState } from "react";
+
+import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
+
+export type ExperienceNetworkIdentity = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+/**
+ * Resolves the network identity needed by Context Loader.
+ *
+ * A workspace passes its already loaded identity (including `null` while loading), so the
+ * embedded experience does not issue a second knowledge-network detail request. Standalone
+ * consumers omit the value and keep the self-loading behavior.
+ */
+export function useExperienceNetwork(
+  networkId: string,
+  providedNetwork?: ExperienceNetworkIdentity | null,
+) {
+  const [resolvedNetwork, setResolvedNetwork] =
+    useState<ExperienceNetworkIdentity | null>(providedNetwork ?? null);
+
+  useEffect(() => {
+    if (providedNetwork !== undefined) {
+      setResolvedNetwork(
+        providedNetwork?.id === networkId ? providedNetwork : null,
+      );
+      return undefined;
+    }
+
+    if (!networkId) {
+      setResolvedNetwork(null);
+      return undefined;
+    }
+
+    setResolvedNetwork(null);
+    let cancelled = false;
+    void getKnowledgeNetwork(networkId)
+      .then((record) => {
+        if (!cancelled) {
+          setResolvedNetwork(
+            record
+              ? { id: record.id, name: record.name, slug: record.identifier }
+              : null,
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResolvedNetwork(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [networkId, providedNetwork]);
+
+  return resolvedNetwork;
+}

--- a/src/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify.test.tsx
+++ b/src/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify.test.tsx
@@ -61,12 +61,22 @@ describe("useKnowledgeNetworkModifyAccess", () => {
 
     const { result } = renderHook(() => useKnowledgeNetworkModifyAccess("kn-1"));
 
-    expect(result.current).toEqual({ canModify: false, isLoading: true });
+    expect(result.current).toEqual({
+      canModify: false,
+      error: null,
+      isForbidden: false,
+      isLoading: true,
+    });
 
     resolveDetail(createRecord(["view_detail", "modify", "delete"]));
 
     await waitFor(() => {
-      expect(result.current).toEqual({ canModify: true, isLoading: false });
+      expect(result.current).toEqual({
+        canModify: true,
+        error: null,
+        isForbidden: false,
+        isLoading: false,
+      });
     });
   });
 
@@ -80,6 +90,46 @@ describe("useKnowledgeNetworkModifyAccess", () => {
     await waitFor(() => {
       expect(result.current).toEqual({
         access: { delete: false, modify: true },
+        error: null,
+        isForbidden: false,
+        isLoading: false,
+      });
+    });
+  });
+
+  it("treats a confirmed 403 as denied without reporting a service failure", async () => {
+    getKnowledgeNetwork.mockRejectedValue(
+      Object.assign(new Error("forbidden"), { response: { status: 403 } }),
+    );
+
+    const { result } = renderHook(() =>
+      useKnowledgeNetworkOperationAccessState("kn-1", ["modify"]),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        access: { modify: false },
+        error: null,
+        isForbidden: true,
+        isLoading: false,
+      });
+    });
+  });
+
+  it("reports a non-permission failure instead of silently treating it as denial", async () => {
+    getKnowledgeNetwork.mockRejectedValue(
+      Object.assign(new Error("backend unavailable"), { response: { status: 503 } }),
+    );
+
+    const { result } = renderHook(() =>
+      useKnowledgeNetworkOperationAccessState("kn-1", ["modify"]),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        access: { modify: false },
+        error: "backend unavailable",
+        isForbidden: false,
         isLoading: false,
       });
     });

--- a/src/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify.ts
+++ b/src/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify.ts
@@ -7,13 +7,17 @@
 
 import { useEffect, useState } from "react";
 
+import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { getRequestErrorStatus } from "@/modules/knowledge-network/services/shared/runtime";
 import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 
 type OperationAccess = Record<string, boolean>;
 
 type OperationAccessState = {
   access: OperationAccess;
+  error: string | null;
+  isForbidden: boolean;
   isLoading: boolean;
 };
 
@@ -31,6 +35,8 @@ export function useKnowledgeNetworkOperationAccessState(
   const operationsKey = operations.join("\u0000");
   const requestKey = `${networkId}\u0000${operationsKey}`;
   const [resolvedRequestKey, setResolvedRequestKey] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isForbidden, setIsForbidden] = useState(false);
   const isLoading = Boolean(networkId) && resolvedRequestKey !== requestKey;
 
   useEffect(() => {
@@ -39,6 +45,8 @@ export function useKnowledgeNetworkOperationAccessState(
       operationsKey.length > 0 ? operationsKey.split("\u0000") : [];
 
     setAccess(createOperationAccess(requestedOperations, false));
+    setError(null);
+    setIsForbidden(false);
 
     if (!networkId) {
       setResolvedRequestKey(requestKey);
@@ -58,12 +66,17 @@ export function useKnowledgeNetworkOperationAccessState(
               ]),
             ),
           );
+          setError(null);
+          setIsForbidden(false);
           setResolvedRequestKey(requestKey);
         }
       })
-      .catch(() => {
+      .catch((nextError: unknown) => {
         if (!cancelled) {
           setAccess(createOperationAccess(requestedOperations, false));
+          const forbidden = getRequestErrorStatus(nextError) === 403;
+          setError(forbidden ? null : extractRequestErrorMessage(nextError));
+          setIsForbidden(forbidden);
           setResolvedRequestKey(requestKey);
         }
       });
@@ -73,7 +86,7 @@ export function useKnowledgeNetworkOperationAccessState(
     };
   }, [networkId, operationsKey, requestKey]);
 
-  return { access, isLoading };
+  return { access, error, isForbidden, isLoading };
 }
 
 export function useKnowledgeNetworkOperationAccess(
@@ -92,6 +105,12 @@ export function useKnowledgeNetworkCanModify(networkId: string) {
 }
 
 export function useKnowledgeNetworkModifyAccess(networkId: string) {
-  const { access, isLoading } = useKnowledgeNetworkOperationAccessState(networkId, ["modify"]);
-  return { canModify: access.modify ?? false, isLoading };
+  const { access, error, isForbidden, isLoading } =
+    useKnowledgeNetworkOperationAccessState(networkId, ["modify"]);
+  return {
+    canModify: access.modify ?? false,
+    error,
+    isForbidden,
+    isLoading,
+  };
 }

--- a/src/modules/knowledge-network/hooks/useResourceIndexStates.ts
+++ b/src/modules/knowledge-network/hooks/useResourceIndexStates.ts
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
 import { hasPermissions } from "@/framework/permission/has-permissions";
+import { dataCatalogResourceStatusPermissions } from "@/modules/data-catalog/permissions";
 import { getCatalogResources } from "@/modules/data-catalog/services/resource.service";
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 
@@ -18,7 +19,7 @@ export function useResourceIndexStates(resourceIds: Array<string | undefined>) {
   const canLoadResourceIndexStates = hasPermissions({
     currentPermissions: runtimeConfig.currentUser.permissions,
     mode: "any",
-    requiredPermissions: ["resource:view_detail", "catalog:task_manage"],
+    requiredPermissions: [...dataCatalogResourceStatusPermissions],
   });
   const boundResourceIds = useMemo(
     () =>

--- a/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.test.tsx
+++ b/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.test.tsx
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -123,5 +123,23 @@ describe("KnowledgeNetworkModifyRouteGate", () => {
 
     expect(await screen.findByText("backend unavailable")).toBeTruthy();
     expect(screen.queryByText("overview page")).toBeNull();
+  });
+
+  it("retries a temporary request failure", async () => {
+    mockedGetKnowledgeNetwork
+      .mockRejectedValueOnce(
+        Object.assign(new Error("backend unavailable"), {
+          response: { status: 503 },
+        }),
+      )
+      .mockResolvedValueOnce(createRecord(["modify"]));
+
+    renderGate();
+
+    expect(await screen.findByText("backend unavailable")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(await screen.findByText("modify form")).toBeTruthy();
+    expect(mockedGetKnowledgeNetwork).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.tsx
+++ b/src/modules/knowledge-network/routes/KnowledgeNetworkModifyRouteGate.tsx
@@ -5,8 +5,9 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { Alert, Spin } from "antd";
+import { Alert, Button, Spin } from "antd";
 import { type ReactNode, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Navigate, useParams } from "react-router-dom";
 
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
@@ -21,9 +22,11 @@ type KnowledgeNetworkModifyRouteGateProps = {
 export function KnowledgeNetworkModifyRouteGate({
   children,
 }: KnowledgeNetworkModifyRouteGateProps) {
+  const { t } = useTranslation();
   const { networkId = "" } = useParams<{ networkId: string }>();
   const [allowed, setAllowed] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -50,10 +53,21 @@ export function KnowledgeNetworkModifyRouteGate({
     return () => {
       cancelled = true;
     };
-  }, [networkId]);
+  }, [networkId, reloadToken]);
 
   if (error) {
-    return <Alert message={error} showIcon type="error" />;
+    return (
+      <Alert
+        action={
+          <Button onClick={() => setReloadToken((value) => value + 1)} size="small">
+            {t("common.retry")}
+          </Button>
+        }
+        message={error}
+        showIcon
+        type="error"
+      />
+    );
   }
 
   if (allowed === null) {

--- a/src/modules/knowledge-network/scenes/ActionTypeExecutionScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeExecutionScene.tsx
@@ -89,7 +89,11 @@ export function ActionTypeExecutionScene() {
   const [executeModalOpen, setExecuteModalOpen] = useState(false);
   const [taskRefreshToken, setTaskRefreshToken] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const { access: operationAccess, isLoading: isPermissionLoading } =
+  const {
+    access: operationAccess,
+    error: permissionError,
+    isLoading: isPermissionLoading,
+  } =
     useKnowledgeNetworkOperationAccessState(
       networkId,
       ACTION_TYPE_EXECUTION_OPERATIONS,
@@ -426,53 +430,56 @@ export function ActionTypeExecutionScene() {
       ) : error ? (
         <Alert message={error} showIcon type="error" />
       ) : (
-        <div className={detailStyles.detailLayout}>
-          <aside className={detailStyles.sideNav}>
-            <button
-              className={
-                activeTab === "run" ? detailStyles.sideNavItemActive : detailStyles.sideNavItem
-              }
-              onClick={() => setActiveTab("run")}
-              type="button"
-            >
-              <PlayCircleOutlined />
-              <span>{t("knowledgeNetwork.actionTypeExecutionRun")}</span>
-            </button>
-            <button
-              className={
-                activeTab === "config" ? detailStyles.sideNavItemActive : detailStyles.sideNavItem
-              }
-              onClick={() => setActiveTab("config")}
-              type="button"
-            >
-              <SettingOutlined />
-              <span>{t("knowledgeNetwork.actionTypeExecutionConfig")}</span>
-            </button>
-            <button
-              className={
-                activeTab === "tasks" ? detailStyles.sideNavItemActive : detailStyles.sideNavItem
-              }
-              onClick={() => setActiveTab("tasks")}
-              type="button"
-            >
-              <UnorderedListOutlined />
-              <span>{t("knowledgeNetwork.actionTypeDetailTaskManagement")}</span>
-            </button>
-          </aside>
+        <>
+          {permissionError ? <Alert message={permissionError} showIcon type="error" /> : null}
+          <div className={detailStyles.detailLayout}>
+            <aside className={detailStyles.sideNav}>
+              <button
+                className={
+                  activeTab === "run" ? detailStyles.sideNavItemActive : detailStyles.sideNavItem
+                }
+                onClick={() => setActiveTab("run")}
+                type="button"
+              >
+                <PlayCircleOutlined />
+                <span>{t("knowledgeNetwork.actionTypeExecutionRun")}</span>
+              </button>
+              <button
+                className={
+                  activeTab === "config" ? detailStyles.sideNavItemActive : detailStyles.sideNavItem
+                }
+                onClick={() => setActiveTab("config")}
+                type="button"
+              >
+                <SettingOutlined />
+                <span>{t("knowledgeNetwork.actionTypeExecutionConfig")}</span>
+              </button>
+              <button
+                className={
+                  activeTab === "tasks" ? detailStyles.sideNavItemActive : detailStyles.sideNavItem
+                }
+                onClick={() => setActiveTab("tasks")}
+                type="button"
+              >
+                <UnorderedListOutlined />
+                <span>{t("knowledgeNetwork.actionTypeDetailTaskManagement")}</span>
+              </button>
+            </aside>
 
-          <div className={detailStyles.contentPanel}>
-            {activeTab === "run" ? renderRunPanel() : null}
-            {activeTab === "config" ? renderConfigPanel() : null}
-            {activeTab === "tasks" && detail ? (
-              <ActionTypeTaskManagementPanel
-                actionTypeId={actionTypeId}
-                canManage={canTaskManage}
-                networkId={networkId}
-                refreshToken={taskRefreshToken}
-              />
-            ) : null}
+            <div className={detailStyles.contentPanel}>
+              {activeTab === "run" ? renderRunPanel() : null}
+              {activeTab === "config" ? renderConfigPanel() : null}
+              {activeTab === "tasks" && detail ? (
+                <ActionTypeTaskManagementPanel
+                  actionTypeId={actionTypeId}
+                  canManage={canTaskManage}
+                  networkId={networkId}
+                  refreshToken={taskRefreshToken}
+                />
+              ) : null}
+            </div>
           </div>
-        </div>
+        </>
       )}
       {detail ? (
         <ActionTypeExecuteModal

--- a/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.tsx
@@ -125,9 +125,8 @@ export function ConceptGroupDetailScene() {
   const [addObjectTypesOpen, setAddObjectTypesOpen] = useState(false);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const { access: operationAccess } = useKnowledgeNetworkOperationAccessState(networkId, [
-    "modify",
-  ]);
+  const { access: operationAccess, error: permissionError } =
+    useKnowledgeNetworkOperationAccessState(networkId, ["modify"]);
   const canModify = operationAccess.modify;
 
   const listPath = `/knowledge-network/workspace/${networkId}/concept-groups`;
@@ -412,6 +411,7 @@ export function ConceptGroupDetailScene() {
         title={detail.name}
       >
         <div className={styles.page}>
+          {permissionError ? <Alert message={permissionError} showIcon type="error" /> : null}
           <section className={styles.summaryCard}>
             <div className={styles.summaryHead}>
               <span

--- a/src/modules/knowledge-network/scenes/ExperienceScene.tsx
+++ b/src/modules/knowledge-network/scenes/ExperienceScene.tsx
@@ -29,7 +29,10 @@ import {
   parsePrecisionSafeJSON,
 } from "@/framework/request/precision-safe-json";
 import { buildApiKeyPagePath, consumeApiKeyHandoff } from "@/modules/api-keys/utils/api-key-handoff";
-import { getKnowledgeNetwork } from "@/modules/knowledge-network/services/knowledge-network.service";
+import {
+  useExperienceNetwork,
+  type ExperienceNetworkIdentity,
+} from "@/modules/knowledge-network/hooks/useExperienceNetwork";
 import {
   CONTEXT_LOADER_OPS,
   MCP_PATH,
@@ -182,6 +185,7 @@ type ExperienceSceneProps = {
   embedded?: boolean;
   initialMode?: ContextLoaderMode;
   lockMode?: boolean;
+  network?: ExperienceNetworkIdentity | null;
   showMcpConnect?: boolean;
 };
 
@@ -189,6 +193,7 @@ export function ExperienceScene({
   embedded = false,
   initialMode = "agent",
   lockMode = false,
+  network: providedNetwork,
   showMcpConnect = false,
 }: ExperienceSceneProps) {
   const navigate = useNavigate();
@@ -216,7 +221,7 @@ export function ExperienceScene({
     [message, t],
   );
 
-  const [network, setNetwork] = useState<{ name: string; slug: string } | null>(null);
+  const network = useExperienceNetwork(id, providedNetwork);
   const [mode, setMode] = useState<ContextLoaderMode>(initialMode);
   const showModeTabs = !lockMode;
   const showEnvSettings = mode !== "agent" && !lockMode;
@@ -305,25 +310,6 @@ export function ExperienceScene({
     },
     [invalidateFill, invalidateRequest],
   );
-
-  useEffect(() => {
-    if (!id) {
-      setNetwork(null);
-      return;
-    }
-
-    let cancelled = false;
-    getKnowledgeNetwork(id)
-      .then((record) => {
-        if (!cancelled && record) {
-          setNetwork({ name: record.name, slug: record.identifier });
-        }
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [id]);
 
   const knId = network?.slug ?? "kn_legal";
   const currentKnIdRef = useRef(knId);

--- a/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
+++ b/src/modules/knowledge-network/scenes/KnowledgeNetworkWorkspaceScene.tsx
@@ -98,6 +98,13 @@ export function KnowledgeNetworkWorkspaceScene({
     detail,
     "task_manage",
   );
+  const experienceNetwork = useMemo(
+    () =>
+      detail
+        ? { id: detail.id, name: detail.name, slug: detail.identifier }
+        : null,
+    [detail],
+  );
 
   const navigationItems: WorkspaceNavItem[] = useMemo(() => {
     const items: WorkspaceNavItem[] = [
@@ -224,7 +231,14 @@ export function KnowledgeNetworkWorkspaceScene({
     ) {
       const initialMode = section === "experience-mcp" ? "mcp" : "agent";
 
-      return <ExperienceScene embedded initialMode={initialMode} lockMode />;
+      return (
+        <ExperienceScene
+          embedded
+          initialMode={initialMode}
+          lockMode
+          network={experienceNetwork}
+        />
+      );
     }
 
     return (

--- a/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
@@ -14,6 +14,7 @@ import { useLocation, useNavigate, useParams, useSearchParams } from "react-rout
 
 import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
 import { hasPermissions } from "@/framework/permission/has-permissions";
+import { dataCatalogResourceStatusPermissions } from "@/modules/data-catalog/permissions";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { getCatalogResources } from "@/modules/data-catalog/services/resource.service";
@@ -225,7 +226,7 @@ export function ObjectTypeDetailScene() {
   const canLoadResourceIndexStates = hasPermissions({
     currentPermissions: runtimeConfig.currentUser.permissions,
     mode: "any",
-    requiredPermissions: ["resource:view_detail", "catalog:task_manage"],
+    requiredPermissions: [...dataCatalogResourceStatusPermissions],
   });
 
   const listPath = `/knowledge-network/workspace/${networkId}/object-types`;

--- a/src/modules/knowledge-network/services/context-loader.request.test.ts
+++ b/src/modules/knowledge-network/services/context-loader.request.test.ts
@@ -15,7 +15,6 @@ import {
   fetchObjectInstances,
   fetchMcpObjectTypes,
   fetchKnDetail,
-  fetchKnDetailRestLegacy,
   listMcpTools,
   sendRequest,
   type ContextLoaderOp,
@@ -211,6 +210,7 @@ describe("sendRequest", () => {
 
 describe("fetchKnDetail", () => {
   it("uses the MCP get_kn_detail tool with managed context", async () => {
+    const controller = new AbortController();
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response("{}", { status: 200, headers: { "Mcp-Session-Id": "session-1" } }))
@@ -232,7 +232,7 @@ describe("fetchKnDetail", () => {
         ),
       );
 
-    await fetchKnDetail({ base: "https://platform.example.com", token: "", knId: "kn-demo" }, undefined, undefined, {
+    await fetchKnDetail({ base: "https://platform.example.com", token: "", knId: "kn-demo" }, undefined, controller.signal, {
       nextContext: () => bknContext,
     });
 
@@ -248,22 +248,15 @@ describe("fetchKnDetail", () => {
         },
       },
     });
+    fetchSpy.mock.calls.forEach(([, init]) => {
+      expect(init?.signal).toBe(controller.signal);
+    });
   });
 });
 
-describe("legacy context-loader REST requests", () => {
-  it("uses the current UI locale", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ id: "kn-demo", object_types: [], concept_groups: [], relation_types: [] }), { status: 200 }),
-    );
-
-    await fetchKnDetailRestLegacy({ base: "https://platform.example.com", token: "", knId: "kn-demo" });
-
-    expect(fetchSpy.mock.calls[0]?.[1]?.headers).toMatchObject({ "Accept-Language": "en-US" });
-  });
-
+describe("context-loader REST requests", () => {
   it("preserves unsafe integers in object-instance preview rows", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         '{"datas":[{"order_id":110101199001152345,"signed":-9223372036854775808,"unsigned":18446744073709551615}]}',
         { status: 200 },
@@ -279,6 +272,9 @@ describe("legacy context-loader REST requests", () => {
         unsigned: "18446744073709551615",
       },
     ]);
+    expect(fetchSpy.mock.calls[0]?.[1]?.headers).toMatchObject({
+      "Accept-Language": "en-US",
+    });
   });
 });
 

--- a/src/modules/knowledge-network/services/context-loader.service.ts
+++ b/src/modules/knowledge-network/services/context-loader.service.ts
@@ -39,7 +39,11 @@ export type ContextLoaderOp = {
 
 export const REST_PREFIX = "/api/agent-retrieval/v1";
 
-/** MCP endpoint; the gateway route is /api/agent-retrieval/v1/mcp, not root /mcp. */
+/**
+ * Canonical MCP endpoint. Agent Retrieval mounts the outer Gin route at `/mcp/*path`, so the
+ * root Streamable HTTP endpoint is the slash-terminated `/mcp/`; omitting the slash does not
+ * enter that wildcard handler consistently and can redirect or reject a POST handshake.
+ */
 export const MCP_PATH = "/api/agent-retrieval/v1/mcp/";
 
 function languageHeaders(): Record<"Accept-Language", string> {
@@ -1050,7 +1054,11 @@ export type McpToolCallResult = {
 };
 
 export type McpSession = {
-  callTool(name: string, args: Record<string, unknown>): Promise<McpToolCallResult>;
+  callTool(
+    name: string,
+    args: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<McpToolCallResult>;
 };
 
 /**
@@ -1075,10 +1083,11 @@ export function createMcpSession(env: ContextLoaderEnv, auth?: McpAuth): McpSess
   let sessionId: string | null = null;
   let rpcId = 1;
 
-  async function initialize(): Promise<void> {
+  async function initialize(signal?: AbortSignal): Promise<void> {
     const initResp = await fetch(url, {
       method: "POST",
       headers: baseHeaders(),
+      signal,
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: rpcId++,
@@ -1091,40 +1100,52 @@ export function createMcpSession(env: ContextLoaderEnv, auth?: McpAuth): McpSess
       throw new Error((await initResp.text()) || `MCP initialize failed (${initResp.status})`);
     }
     if (sessionId) {
-      await fetch(url, {
-        method: "POST",
-        headers: { ...baseHeaders(), "Mcp-Session-Id": sessionId },
-        body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
-      }).catch(() => undefined);
+      try {
+        await fetch(url, {
+          method: "POST",
+          headers: { ...baseHeaders(), "Mcp-Session-Id": sessionId },
+          signal,
+          body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+        });
+      } catch (error) {
+        if (signal?.aborted) {
+          throw error;
+        }
+      }
     }
   }
 
-  function callOnce(name: string, args: Record<string, unknown>): Promise<Response> {
+  function callOnce(
+    name: string,
+    args: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<Response> {
     const headers = sessionId ? { ...baseHeaders(), "Mcp-Session-Id": sessionId } : baseHeaders();
     return fetch(url, {
       method: "POST",
       headers,
+      signal,
       body: JSON.stringify({ jsonrpc: "2.0", id: rpcId++, method: "tools/call", params: { name, arguments: args } }),
     });
   }
 
   return {
-    async callTool(name, args) {
+    async callTool(name, args, signal) {
       const start = performance.now();
-      if (!sessionId) await initialize();
-      let response = await callOnce(name, args);
+      if (!sessionId) await initialize(signal);
+      let response = await callOnce(name, args, signal);
       if (response.status === 401 && auth?.refresh) {
         // Token expired; refresh, reconnect, and retry.
         await auth.refresh().catch(() => null);
         sessionId = null;
-        await initialize();
-        response = await callOnce(name, args);
+        await initialize(signal);
+        response = await callOnce(name, args, signal);
       }
       if (response.status === 400 || response.status === 404) {
         // Session expired; reconnect once and retry.
         sessionId = null;
-        await initialize();
-        response = await callOnce(name, args);
+        await initialize(signal);
+        response = await callOnce(name, args, signal);
       }
       const text = await response.text();
       const parsed = parseMcpEnvelope(text);
@@ -1286,6 +1307,7 @@ export async function fetchKnDetail(
       { kn_id: env.knId, response_format: "json" },
       scope?.nextContext(),
     ),
+    signal,
   );
 
   if (signal?.aborted) {
@@ -1311,36 +1333,6 @@ export async function fetchKnDetail(
   }
 
   throw new Error("get_kn_detail did not return knowledge network detail");
-}
-
-export async function fetchKnDetailRestLegacy(
-  env: ContextLoaderEnv,
-  auth?: McpAuth,
-  signal?: AbortSignal,
-  scope?: BknCallScope,
-): Promise<KnDetail> {
-  const base = env.base.replace(/\/+$/, "");
-  const params = new URLSearchParams({ response_format: "json" });
-  const response = await restPost(
-    env,
-    auth,
-    `${base}${REST_PREFIX}/kn/get_kn_detail?${params.toString()}`,
-    withBknContext({ kn_id: env.knId }, scope?.nextContext()),
-    signal,
-  );
-  const text = await response.text();
-  if (!response.ok) {
-    throw new Error(text || `Failed to fetch knowledge network detail (${response.status})`);
-  }
-  const data = parsePrecisionSafeJSON(text) as Partial<KnDetail> & Record<string, unknown>;
-  return {
-    id: data.id ?? env.knId,
-    name: data.name,
-    comment: typeof data.comment === "string" ? data.comment : undefined,
-    object_types: Array.isArray(data.object_types) ? data.object_types : [],
-    concept_groups: Array.isArray(data.concept_groups) ? data.concept_groups : [],
-    relation_types: parseRelationTypes(data.relation_types ?? data.relations),
-  };
 }
 
 /** Fetches object-type details through MCP so metric tools can choose real metric_id values. */

--- a/src/modules/knowledge-network/services/mcp-client-config.ts
+++ b/src/modules/knowledge-network/services/mcp-client-config.ts
@@ -14,6 +14,7 @@ export interface McpClientConfigOptions {
   allowInsecureTls?: boolean;
 }
 
+/** Keep client examples on Agent Retrieval's slash-terminated `/mcp/*path` root route. */
 export function withMcpTrailingSlash(mcpUrl: string): string {
   return mcpUrl.endsWith("/") ? mcpUrl : `${mcpUrl}/`;
 }


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Distinguish confirmed permission denials from temporary knowledge-network access failures and surface retryable errors.
- [x] Reuse the workspace network identity in the embedded Experience console to avoid a duplicate detail request.
- [x] Centralize data-catalog resource-status permissions, remove the unused legacy detail REST path, and forward AbortSignal through MCP session requests.
- [x] Document the slash-terminated MCP endpoint required by the Agent Retrieval route.

---

## Why

- Related Issue: Closes #359
- Related Feature: Knowledge-network authorization alignment
- Background: Follow up the non-blocking review findings from PR #358 without changing backend authorization semantics.

---

## How

- Key implementation points:
  - Operation access state now reports non-403 failures separately from confirmed 403 denials; affected detail pages show the failure instead of silently hiding controls.
  - The modify route gate offers a retry action after a transient request failure.
  - Workspace-owned detail data is supplied to ExperienceScene, while standalone consumers retain their own lookup.
  - MCP session initialization, initialized notification, and tools/call receive the caller AbortSignal.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; this is a frontend-only cleanup)
- [ ] Verified in test environment (not run locally)

Test notes:

- node scripts/check-license-headers.mjs
- ESLint type-aware full-project check with zero warnings
- Vitest full suite: 244 files, 1,320 tests, maxWorkers=2
- TypeScript project build
- Vite production build
- pnpm audit --prod (one existing ignored high-severity advisory; command succeeded)

---

## Risk & Rollback

- Potential risks: A failed permission lookup now remains visible as an error state rather than a silently hidden control; MCP cancellation now interrupts all session handshake requests.
- Rollback plan: Revert commit a0d7a4af to restore the prior frontend-only behavior.

---

## Additional Notes

- The obsolete /tasks/create follow-up was not changed because PR #366 already removed that route and task surface.
- Vite reports existing chunk-size guidance but completes successfully.