### PR TITLE
fix(observability): restrict settings to super admins

### DIFF
--- a/src/app/shell/console-navigation.test.ts
+++ b/src/app/shell/console-navigation.test.ts
@@ -109,4 +109,18 @@ describe("filterNavByPermission — 系统管理按功能独立授权", () => {
       "domain-knowledge-network-integration",
     ]);
   });
+
+  it("可观察性设置仅对超级管理员显示", () => {
+    const regular = filterNavByPermission(consoleNavigation, ["catalog:view_detail"]);
+    const superAdmin = filterNavByPermission(
+      consoleNavigation,
+      ["catalog:view_detail"],
+      ["super_admin"],
+    );
+    const observabilityChildren = (items: ReturnType<typeof filterNavByPermission>) =>
+      items.find((item) => item.key === "observability")?.children ?? [];
+
+    expect(keys(observabilityChildren(regular))).not.toContain("observability-settings");
+    expect(keys(observabilityChildren(superAdmin))).toContain("observability-settings");
+  });
 });

--- a/src/app/shell/console-navigation.test.ts
+++ b/src/app/shell/console-navigation.test.ts
@@ -115,7 +115,7 @@ describe("filterNavByPermission — 系统管理按功能独立授权", () => {
     const superAdmin = filterNavByPermission(
       consoleNavigation,
       ["catalog:view_detail"],
-      ["super_admin"],
+      true,
     );
     const observabilityChildren = (items: ReturnType<typeof filterNavByPermission>) =>
       items.find((item) => item.key === "observability")?.children ?? [];

--- a/src/app/shell/console-navigation.tsx
+++ b/src/app/shell/console-navigation.tsx
@@ -12,7 +12,6 @@ import type {
 } from "@/app/shell/navigation/types";
 import { capabilityState } from "@/framework/entitlement/capability-state";
 import type { EntitlementView } from "@/framework/entitlement/types";
-import { isSuperAdmin } from "@/framework/auth/super-admin";
 import { hasPermissions } from "@/framework/permission/has-permissions";
 import { bknTraceNavigation } from "@/modules/bkn-trace/navigation";
 import { capabilityMinEdition } from "@/modules/subscription/capability-catalog";
@@ -126,14 +125,14 @@ export function filterNavByCapability(
 export function filterNavByPermission(
   items: ConsoleNavItem[],
   permissions: string[],
-  roles: string[] = [],
+  isSuperAdmin = false,
 ): ConsoleNavItem[] {
   const visible: ConsoleNavItem[] = [];
   for (const item of items) {
     if (item.requiresBusinessPermission && !permissions.some(isBusinessPermission)) {
       continue;
     }
-    if (item.requiresSuperAdmin && !isSuperAdmin(roles)) {
+    if (item.requiresSuperAdmin && !isSuperAdmin) {
       continue;
     }
     if (
@@ -147,7 +146,7 @@ export function filterNavByPermission(
       continue;
     }
     if (item.children?.length) {
-      const children = filterNavByPermission(item.children, permissions, roles);
+      const children = filterNavByPermission(item.children, permissions, isSuperAdmin);
       if (children.length === 0 && !item.path) {
         continue;
       }

--- a/src/app/shell/console-navigation.tsx
+++ b/src/app/shell/console-navigation.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@/app/shell/navigation/types";
 import { capabilityState } from "@/framework/entitlement/capability-state";
 import type { EntitlementView } from "@/framework/entitlement/types";
+import { isSuperAdmin } from "@/framework/auth/super-admin";
 import { hasPermissions } from "@/framework/permission/has-permissions";
 import { bknTraceNavigation } from "@/modules/bkn-trace/navigation";
 import { capabilityMinEdition } from "@/modules/subscription/capability-catalog";
@@ -125,10 +126,14 @@ export function filterNavByCapability(
 export function filterNavByPermission(
   items: ConsoleNavItem[],
   permissions: string[],
+  roles: string[] = [],
 ): ConsoleNavItem[] {
   const visible: ConsoleNavItem[] = [];
   for (const item of items) {
     if (item.requiresBusinessPermission && !permissions.some(isBusinessPermission)) {
+      continue;
+    }
+    if (item.requiresSuperAdmin && !isSuperAdmin(roles)) {
       continue;
     }
     if (
@@ -142,7 +147,7 @@ export function filterNavByPermission(
       continue;
     }
     if (item.children?.length) {
-      const children = filterNavByPermission(item.children, permissions);
+      const children = filterNavByPermission(item.children, permissions, roles);
       if (children.length === 0 && !item.path) {
         continue;
       }

--- a/src/app/shell/navigation/types.ts
+++ b/src/app/shell/navigation/types.ts
@@ -62,6 +62,8 @@ export type ConsoleNavItem = {
    * declare `permission` instead.
    */
   requiresBusinessPermission?: boolean;
+  /** Hide an entry unless the account holds the controlled super_admin role. */
+  requiresSuperAdmin?: boolean;
 };
 
 export type ConsoleNavContribution = {

--- a/src/app/shell/navigation/use-console-navigation.ts
+++ b/src/app/shell/navigation/use-console-navigation.ts
@@ -42,10 +42,10 @@ export function useConsoleNavigation(): ConsoleNavItem[] {
             hideMarketCatalog: !isMarketCatalogEnabled(),
           }),
           runtimeConfig.currentUser.permissions,
-          runtimeConfig.currentUser.roles,
+          runtimeConfig.currentUser.isSuperAdmin,
         ),
         snapshot,
       ),
-    [features.catalog, runtimeConfig.currentUser.permissions, runtimeConfig.currentUser.roles, snapshot],
+    [features.catalog, runtimeConfig.currentUser.isSuperAdmin, runtimeConfig.currentUser.permissions, snapshot],
   );
 }

--- a/src/app/shell/navigation/use-console-navigation.ts
+++ b/src/app/shell/navigation/use-console-navigation.ts
@@ -42,9 +42,10 @@ export function useConsoleNavigation(): ConsoleNavItem[] {
             hideMarketCatalog: !isMarketCatalogEnabled(),
           }),
           runtimeConfig.currentUser.permissions,
+          runtimeConfig.currentUser.roles,
         ),
         snapshot,
       ),
-    [features.catalog, runtimeConfig.currentUser.permissions, snapshot],
+    [features.catalog, runtimeConfig.currentUser.permissions, runtimeConfig.currentUser.roles, snapshot],
   );
 }

--- a/src/app/theme/theme.test.ts
+++ b/src/app/theme/theme.test.ts
@@ -21,6 +21,7 @@ const runtimeConfig: RuntimeConfig = {
   currentUser: {
     id: null,
     isAdmin: false,
+    isSuperAdmin: false,
     name: null,
     permissions: [],
     roles: [],

--- a/src/framework/auth/current-user.test.ts
+++ b/src/framework/auth/current-user.test.ts
@@ -73,8 +73,39 @@ describe("fetchCurrentUser — 权限来源不可用时 fail-closed", () => {
     const user = await fetchCurrentUser();
 
     expect(user.isAdmin).toBe(true);
+    expect(user.isSuperAdmin).toBe(true);
     expect(user.permissions).toContain("admin-audit:view");
     expect(user.permissions).toContain("admin-license:view");
+  });
+
+  it("/me 失败但资源通配成功 → 仍识别为超级管理员", async () => {
+    mockGet.mockImplementation((url: string) =>
+      url === "/safe/v1/me"
+        ? Promise.reject(new Error("500"))
+        : meOk({
+            is_admin: true,
+            permissions: [{ operations: ["*"], resource: { id: "*", type: "*" } }],
+          }),
+    );
+
+    const fetchCurrentUser = await importFetchCurrentUser();
+    const user = await fetchCurrentUser();
+
+    expect(user.roles).toEqual([]);
+    expect(user.isSuperAdmin).toBe(true);
+  });
+
+  it("本地化超级管理员角色 → 识别为超级管理员", async () => {
+    mockGet.mockImplementation((url: string) =>
+      url === "/safe/v1/me"
+        ? meOk({ id: "root", roles: ["超级管理员"] })
+        : meOk({ is_admin: true, permissions: [] }),
+    );
+
+    const fetchCurrentUser = await importFetchCurrentUser();
+    const user = await fetchCurrentUser();
+
+    expect(user.isSuperAdmin).toBe(true);
   });
 
   // Backend CanAdmin checks safe_admin:console:manage, which all three administrator roles hold,
@@ -101,6 +132,7 @@ describe("fetchCurrentUser — 权限来源不可用时 fail-closed", () => {
     const user = await fetchCurrentUser();
 
     expect(user.isAdmin).toBe(true);
+    expect(user.isSuperAdmin).toBe(false);
     expect(user.permissions).toContain("admin-audit:view");
     expect(user.permissions).toContain("admin-authz:view");
     expect(user.permissions).toContain("admin-role:view");

--- a/src/framework/auth/current-user.ts
+++ b/src/framework/auth/current-user.ts
@@ -9,6 +9,7 @@ import {
   deriveStudioPermissions,
   flattenSafeGrants,
 } from "@/framework/auth/permission-map";
+import { isSuperAdmin } from "@/framework/auth/super-admin";
 import { http } from "@/framework/request/http";
 import { defaultDevPermissions } from "@/framework/runtime/module-manifests";
 import type { RuntimeUser } from "@/framework/runtime/types";
@@ -46,6 +47,7 @@ type MePermissionsResponse = {
 export const anonymousRuntimeUser: RuntimeUser = {
   id: null,
   isAdmin: false,
+  isSuperAdmin: false,
   name: null,
   permissions: [],
   roles: [],
@@ -92,12 +94,16 @@ export async function fetchCurrentUser(): Promise<RuntimeUser> {
   const isAdmin = Boolean(perm.is_admin);
   // A resource wildcard means super administrator and covers every operation on every resource type, so per-point derivation is unnecessary.
   const hasResourceWildcard = safeGrants.has("*:*");
+  const roles = me.roles ?? [];
 
   return {
     id: me.id ?? null,
     isAdmin,
+    // `/me` and `/me/permissions` fail independently. Preserve wildcard-derived
+    // super-admin access even when the identity request is temporarily unavailable.
+    isSuperAdmin: hasResourceWildcard || isSuperAdmin(roles),
     name: me.name || me.account || me.id || null,
-    roles: me.roles ?? [],
+    roles,
     permissions: hasResourceWildcard
       ? [...defaultDevPermissions]
       : deriveStudioPermissions(defaultDevPermissions, safeGrants, isAdmin),

--- a/src/framework/auth/super-admin.test.ts
+++ b/src/framework/auth/super-admin.test.ts
@@ -10,8 +10,8 @@ import { describe, expect, it } from "vitest";
 import { isSuperAdmin } from "@/framework/auth/super-admin";
 
 describe("isSuperAdmin", () => {
-  it.each([["super_admin"], ["超级管理员"]])("recognizes the controlled role %s", (role) => {
-    expect(isSuperAdmin(role)).toBe(true);
+  it.each([["super_admin"], ["\u8d85\u7ea7\u7ba1\u7406\u5458"]])("recognizes the controlled role %s", (role) => {
+    expect(isSuperAdmin([role])).toBe(true);
   });
 
   it("does not treat three-admin roles as super admin", () => {

--- a/src/framework/auth/super-admin.test.ts
+++ b/src/framework/auth/super-admin.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isSuperAdmin } from "@/framework/auth/super-admin";
+
+describe("isSuperAdmin", () => {
+  it.each([["super_admin"], ["超级管理员"]])("recognizes the controlled role %s", (role) => {
+    expect(isSuperAdmin(role)).toBe(true);
+  });
+
+  it("does not treat three-admin roles as super admin", () => {
+    expect(isSuperAdmin(["admin", "security", "audit"])).toBe(false);
+  });
+});

--- a/src/framework/auth/super-admin.ts
+++ b/src/framework/auth/super-admin.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+/** `is_admin` includes the three administrator roles; only this role is platform super admin. */
+export function isSuperAdmin(roles: readonly string[]): boolean {
+  return roles.includes("super_admin");
+}

--- a/src/framework/auth/super-admin.ts
+++ b/src/framework/auth/super-admin.ts
@@ -10,5 +10,5 @@
  * `is_admin` includes the three administrator roles and must not be used here.
  */
 export function isSuperAdmin(roles: readonly string[]): boolean {
-  return roles.some((role) => role === "super_admin" || role === "超级管理员");
+  return roles.some((role) => role === "super_admin" || role === "\u8d85\u7ea7\u7ba1\u7406\u5458");
 }

--- a/src/framework/auth/super-admin.ts
+++ b/src/framework/auth/super-admin.ts
@@ -5,7 +5,10 @@
  * Conditions. See LICENSE for the full text.
  */
 
-/** `is_admin` includes the three administrator roles; only this role is platform super admin. */
+/**
+ * `/me` may return either the stable role key or the legacy localized display name.
+ * `is_admin` includes the three administrator roles and must not be used here.
+ */
 export function isSuperAdmin(roles: readonly string[]): boolean {
-  return roles.includes("super_admin");
+  return roles.some((role) => role === "super_admin" || role === "超级管理员");
 }

--- a/src/framework/permission/RequireSuperAdmin.tsx
+++ b/src/framework/permission/RequireSuperAdmin.tsx
@@ -9,7 +9,6 @@ import type { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 
 import { DEFAULT_APP_ENTRY_PATH } from "@/app/router/app-paths";
-import { isSuperAdmin } from "@/framework/auth/super-admin";
 import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
 
 type RequireSuperAdminProps = {
@@ -20,5 +19,5 @@ type RequireSuperAdminProps = {
 export function RequireSuperAdmin({ children }: RequireSuperAdminProps) {
   const runtimeConfig = useRuntimeConfig();
 
-  return isSuperAdmin(runtimeConfig.currentUser.roles) ? <>{children}</> : <Navigate replace to={DEFAULT_APP_ENTRY_PATH} />;
+  return runtimeConfig.currentUser.isSuperAdmin ? <>{children}</> : <Navigate replace to={DEFAULT_APP_ENTRY_PATH} />;
 }

--- a/src/framework/permission/RequireSuperAdmin.tsx
+++ b/src/framework/permission/RequireSuperAdmin.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+
+import { DEFAULT_APP_ENTRY_PATH } from "@/app/router/app-paths";
+import { isSuperAdmin } from "@/framework/auth/super-admin";
+import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
+
+type RequireSuperAdminProps = {
+  children: ReactNode;
+};
+
+/** Route-level guard for functionality reserved for the controlled super_admin role. */
+export function RequireSuperAdmin({ children }: RequireSuperAdminProps) {
+  const runtimeConfig = useRuntimeConfig();
+
+  return isSuperAdmin(runtimeConfig.currentUser.roles) ? <>{children}</> : <Navigate replace to={DEFAULT_APP_ENTRY_PATH} />;
+}

--- a/src/framework/runtime/dev-profile.ts
+++ b/src/framework/runtime/dev-profile.ts
@@ -11,6 +11,7 @@ import { defaultDevPermissions } from "@/framework/runtime/module-manifests";
 export const defaultDevRuntimeUser: RuntimeUser = {
   id: "266c6a42-6131-4d62-8f39-853e7093701c",
   isAdmin: true,
+  isSuperAdmin: true,
   name: "Local Admin",
   permissions: defaultDevPermissions,
   roles: ["admin"],

--- a/src/framework/runtime/types.ts
+++ b/src/framework/runtime/types.ts
@@ -17,6 +17,8 @@ export type RuntimeUser = {
   id: string | null;
   /** `/me/permissions`.is_admin — super_admin without literal role `"admin"`. */
   isAdmin: boolean;
+  /** Derived from the `*:*` resource wildcard or the controlled super-admin role. */
+  isSuperAdmin: boolean;
   name: string | null;
   permissions: string[];
   roles: string[];

--- a/src/modules/bkn-trace/navigation.tsx
+++ b/src/modules/bkn-trace/navigation.tsx
@@ -52,6 +52,7 @@ export const bknTraceNavigation: ConsoleNavContribution = {
           labelKey: "shell.items.observabilitySettings",
           icon: <SettingOutlined />,
           path: "/observability/settings",
+          requiresSuperAdmin: true,
         },
       ],
     },

--- a/src/modules/bkn-trace/routes.tsx
+++ b/src/modules/bkn-trace/routes.tsx
@@ -11,6 +11,7 @@ import { Navigate, type RouteObject } from "react-router-dom";
 import { RouteLoading } from "@/app/router/RouteLoading";
 import { CAPABILITIES } from "@/framework/entitlement/capabilities";
 import { RequireEdition } from "@/framework/entitlement/RequireEdition";
+import { RequireSuperAdmin } from "@/framework/permission/RequireSuperAdmin";
 import type { AppRouteContribution } from "@/app/router/types";
 
 const BusinessProvenancePage = lazy(async () => {
@@ -67,7 +68,7 @@ export const bknTraceRoutes: RouteObject[] = [
   {
     path: "observability/settings",
     handle: { console: { descriptionKey: "bknTrace.settings.description", menuKey: "observability-settings", titleKey: "bknTrace.settings.title" } },
-    element: withRouteLoading(<ObservabilitySettingsPage />),
+    element: <RequireSuperAdmin>{withRouteLoading(<ObservabilitySettingsPage />)}</RequireSuperAdmin>,
   },
   {
     path: "system/bkn-trace",

--- a/src/modules/bkn-trace/scenes/ObservabilitySettingsScene.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilitySettingsScene.tsx
@@ -11,6 +11,8 @@ import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { isSuperAdmin } from "@/framework/auth/super-admin";
+import { useAppServices } from "@/framework/context/use-app-services";
 import styles from "@/modules/bkn-trace/scenes/ObservabilityWorkspace.module.css";
 import { BUSINESS_MODULES, createArchive, downloadArchive, getArchiveOverview, listArchiveJobs, listLogPolicies, listLogSources, retryArchiveCleanup, type ArchiveJob, type ArchiveKind, type ArchiveOverview, type BusinessModule, type LogPolicy, type LogSourceStatus } from "@/modules/bkn-trace/services/observability.service";
 import { getAccessProfile } from "@/modules/bkn-trace/services/trace.service";
@@ -21,6 +23,8 @@ type ModuleSourceRow = { module: BusinessModule; reason?: string; sourceIds: str
 
 export function ObservabilitySettingsScene() {
   const { t } = useTranslation();
+  const { runtimeConfig } = useAppServices();
+  const superAdmin = isSuperAdmin(runtimeConfig.currentUser.roles);
   const [sources, setSources] = useState<LogSourceStatus[]>([]);
   const [sourceLoadState, setSourceLoadState] = useState<SourceLoadState>("not_requested");
   const [policies, setPolicies] = useState<LogPolicy[]>([]);
@@ -32,6 +36,11 @@ export function ObservabilitySettingsScene() {
   const [error, setError] = useState<string>();
 
   useEffect(() => {
+    if (!superAdmin) {
+      setDenied(true);
+      setLoading(false);
+      return;
+    }
     let active = true;
     getAccessProfile().then(async (profile) => {
       if (!profile.globalLogSearch && !profile.logPolicyRead) {
@@ -64,7 +73,7 @@ export function ObservabilitySettingsScene() {
       if (active) { setError(t("bknTrace.errors.accessProfileFailed")); setLoading(false); }
     });
     return () => { active = false; };
-  }, [t]);
+  }, [superAdmin, t]);
 
   const moduleSources = useMemo<ModuleSourceRow[]>(() => BUSINESS_MODULES.map((module) => {
     if (sourceLoadState === "not_requested") return { module, reason: "source_not_requested", sourceIds: [], status: "unknown" };
@@ -111,7 +120,7 @@ export function ObservabilitySettingsScene() {
     { dataIndex: "status", key: "status", title: t("bknTrace.settings.columns.status"), render: (value: StorageRow["status"]) => <Tag color={value === "known" ? "green" : "default"}>{t(`bknTrace.settings.status.${value}`)}</Tag> },
   ];
 
-  if (loading) return <Spin />;
+  if (!superAdmin || loading) return superAdmin ? <Spin /> : <Alert message={t("bknTrace.errors.accessDenied")} showIcon type="warning" />;
   if (denied) return <Alert message={t("bknTrace.errors.accessDenied")} showIcon type="warning" />;
   return <div className={styles.workspace}>
     <header className={styles.header}><div><Typography.Title level={3}>{t("bknTrace.settings.title")}</Typography.Title><Typography.Text type="secondary">{t("bknTrace.settings.description")}</Typography.Text></div></header>

--- a/src/modules/bkn-trace/scenes/ObservabilitySettingsScene.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilitySettingsScene.tsx
@@ -11,7 +11,6 @@ import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { isSuperAdmin } from "@/framework/auth/super-admin";
 import { useAppServices } from "@/framework/context/use-app-services";
 import styles from "@/modules/bkn-trace/scenes/ObservabilityWorkspace.module.css";
 import { BUSINESS_MODULES, createArchive, downloadArchive, getArchiveOverview, listArchiveJobs, listLogPolicies, listLogSources, retryArchiveCleanup, type ArchiveJob, type ArchiveKind, type ArchiveOverview, type BusinessModule, type LogPolicy, type LogSourceStatus } from "@/modules/bkn-trace/services/observability.service";
@@ -24,7 +23,7 @@ type ModuleSourceRow = { module: BusinessModule; reason?: string; sourceIds: str
 export function ObservabilitySettingsScene() {
   const { t } = useTranslation();
   const { runtimeConfig } = useAppServices();
-  const superAdmin = isSuperAdmin(runtimeConfig.currentUser.roles);
+  const superAdmin = runtimeConfig.currentUser.isSuperAdmin;
   const [sources, setSources] = useState<LogSourceStatus[]>([]);
   const [sourceLoadState, setSourceLoadState] = useState<SourceLoadState>("not_requested");
   const [policies, setPolicies] = useState<LogPolicy[]>([]);

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -54,6 +54,10 @@ vi.mock("@/modules/execution-factory/utils/use-audit-user-directory", () => ({
   ]),
 }));
 
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({ runtimeConfig: { currentUser: { isSuperAdmin: true } } }),
+}));
+
 const profile = {
   accessScopeFingerprint: "sha256:test",
   allowedLogCategories: ["runtime.system" as const, "runtime.business" as const],

--- a/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
+++ b/src/modules/bkn-trace/scenes/ObservabilityWorkspaceScenes.test.tsx
@@ -32,6 +32,8 @@ const translate = (key: string, options?: Record<string, unknown>) => {
   return value.replace(/{{(\w+)}}/g, (_match, name: string) => typeof options?.[name] === "string" ? options[name] : "");
 };
 
+const mockCurrentUser = vi.hoisted(() => ({ isSuperAdmin: true }));
+
 vi.mock("react-i18next", async (importOriginal) => {
   const original = await importOriginal<typeof import("react-i18next")>();
   return { ...original, useTranslation: () => ({ t: translate }) };
@@ -55,7 +57,7 @@ vi.mock("@/modules/execution-factory/utils/use-audit-user-directory", () => ({
 }));
 
 vi.mock("@/framework/context/use-app-services", () => ({
-  useAppServices: () => ({ runtimeConfig: { currentUser: { isSuperAdmin: true } } }),
+  useAppServices: () => ({ runtimeConfig: { currentUser: mockCurrentUser } }),
 }));
 
 const profile = {
@@ -83,6 +85,7 @@ describe("observability workspace scenes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCurrentUser.isSuperAdmin = true;
     vi.mocked(createArchive).mockReset();
     vi.mocked(getArchiveOverview).mockReset();
     vi.mocked(listArchiveJobs).mockReset();
@@ -385,6 +388,17 @@ describe("observability workspace scenes", () => {
     expect(screen.getByText("bknTrace.settings.status.not_integrated")).not.toBeNull();
     expect(screen.getByText("7 bknTrace.settings.days")).not.toBeNull();
     expect(screen.getByText("bknTrace.settings.readOnlyNotice")).not.toBeNull();
+  });
+
+  it("非超级管理员访问设置页时拒绝访问且不请求数据", () => {
+    mockCurrentUser.isSuperAdmin = false;
+
+    render(<ObservabilitySettingsScene />);
+
+    expect(screen.getByText("bknTrace.errors.accessDenied")).not.toBeNull();
+    expect(getAccessProfile).not.toHaveBeenCalled();
+    expect(listLogSources).not.toHaveBeenCalled();
+    expect(listLogPolicies).not.toHaveBeenCalled();
   });
 
   it("设置页只展示可维护的日志保留项，不暴露内部 Trace 存储", async () => {


### PR DESCRIPTION
fix(observability): restrict settings to super admins


# Pull Request

## What Changed

Brief description of changes:

- [x] Restrict the Observability Settings navigation entry to the controlled `super_admin` role.
- [x] Add a route guard to prevent non-super-admin users from opening `/observability/settings` through a direct URL.
- [x] Add an in-page guard to prevent embedded use from loading settings data for non-super-admin users.
- [x] Add navigation regression coverage for regular users and super administrators.

---

## Why

- Related Issue: N/A
- Related Feature: Observability access control
- Background:

  Observability Settings exposes log-source status, retention-policy information, archive management, archive cleanup retries, and archive downloads. It was previously visible to any business user and had no dedicated route-level restriction. These operational capabilities should be reserved for the controlled super administrator role.

---

## How

- Key implementation points:
  - Add a shared `isSuperAdmin` helper based on the `super_admin` role.
  - Add `requiresSuperAdmin` support to console navigation filtering.
  - Mark the Observability Settings menu item as super-admin-only.
  - Add `RequireSuperAdmin` for route-level protection.
  - Add a page-level guard before requesting observability settings data.
  - Keep `isAdmin` out of this decision because it also applies to system, audit, and security administrators.

- Breaking changes (API, config, database, etc.):
  - None. This is a frontend access-control change; no API or schema changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable for this frontend-only change.
- [ ] Verified in test environment — not performed.

Test notes:

- `console-navigation.test.ts`: 9 tests passed.
- Relevant ESLint checks passed with zero warnings.
- `git diff --check` passed.

---

## Risk & Rollback

- Potential risks:
  - Non-super-admin users can no longer access the Observability Settings page from the UI or a direct frontend route.

- Rollback plan:
  - Revert commit `31853399`.

---

## Additional Notes

- Branch: `fix/observability-settings-super-admin`
- The backend should continue to enforce equivalent authorization for settings, archive, cleanup, and download APIs; this PR only adds frontend access control.