### PR TITLE
fix(execution-factory): honor object-level authorization

### DIFF
--- a/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.test.tsx
+++ b/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.test.tsx
@@ -23,10 +23,11 @@ vi.mock("@/framework/permission/PermissionGate", () => ({
   PermissionGate: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-function buildItem(status: string): ExecutionUnitCardItem {
+function buildItem(status: string, operations?: string[]): ExecutionUnitCardItem {
   return {
     id: "box-1",
     name: "Demo Toolbox",
+    operations,
     status,
   };
 }
@@ -100,5 +101,36 @@ describe("ExecutionUnitCardMenu lifecycle actions", () => {
     fireEvent.click(within(screen.getByRole("menu")).getByText("executionFactory.publish"));
 
     expect(onAction).toHaveBeenCalledWith("publish", expect.objectContaining({ status: "unpublish" }));
+  });
+
+  it("only exposes configuration when the row has authorize", () => {
+    const onAction = vi.fn();
+    const { unmount } = render(
+      <ExecutionUnitCardMenu
+        activeTab="toolbox"
+        item={buildItem("published")}
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "executionFactory.cardMenu.more" }));
+    expect(within(screen.getByRole("menu")).queryByText("systemAdmin.objectGrants.authorize")).toBeNull();
+
+    unmount();
+    render(
+      <ExecutionUnitCardMenu
+        activeTab="toolbox"
+        item={buildItem("published", ["authorize"])}
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "executionFactory.cardMenu.more" }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("systemAdmin.objectGrants.authorize"));
+
+    expect(onAction).toHaveBeenCalledWith(
+      "authorize",
+      expect.objectContaining({ operations: ["authorize"] }),
+    );
   });
 });

--- a/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx
+++ b/src/modules/execution-factory/components/execution-unit/ExecutionUnitCardMenu.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { PermissionGate } from "@/framework/permission/PermissionGate";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { getExecutionUnitLifecycleActions } from "@/modules/execution-factory/utils/execution-unit-lifecycle";
+import { hasExecutionUnitRecordOperation } from "@/modules/execution-factory/utils/record-operations";
 
 import type { ExecutionUnitCardItem, ExecutionUnitTab } from "./types";
 
@@ -227,14 +228,16 @@ export function ExecutionUnitCardMenu({
     );
   }
 
-  pushMenuAction(
-    menuItems,
-    "authorize",
-    t("systemAdmin.objectGrants.authorize"),
-    onAction,
-    "authorize",
-    item,
-  );
+  if (hasExecutionUnitRecordOperation(item, "authorize")) {
+    pushMenuAction(
+      menuItems,
+      "authorize",
+      t("systemAdmin.objectGrants.authorize"),
+      onAction,
+      "authorize",
+      item,
+    );
+  }
 
   pushMenuAction(menuItems, "delete", t("common.delete"), onAction, "delete", item, {
     danger: true,

--- a/src/modules/execution-factory/components/execution-unit/types.ts
+++ b/src/modules/execution-factory/components/execution-unit/types.ts
@@ -12,6 +12,8 @@ export type ExecutionUnitCardItem = {
   name: string;
   /** The All view mixes types on one screen, so cards cannot infer their type from activeTab. */
   unitType?: ExecutionUnitTab;
+  /** Per-instance operations projected by Foundry; absent operations fail closed in the UI. */
+  operations?: string[];
   description?: string;
   metadataType?: string;
   /** MCP connection mode (sse / stream), used by the badge in the card subtitle. */

--- a/src/modules/execution-factory/scenes/ExecutionUnitListOverlays.tsx
+++ b/src/modules/execution-factory/scenes/ExecutionUnitListOverlays.tsx
@@ -47,7 +47,7 @@ export type ExecutionUnitListOverlaysProps = {
   onConfigurePublishedPerm: () => void;
   onReloadInstalledResourceIds: (options?: { manual?: boolean }) => void;
   onReloadList: () => void;
-  publishedPermTarget: { id: string; name: string; type: string } | null;
+  publishedPermTarget: { id: string; name: string; type: string; objectAuthorized: boolean } | null;
   skillInstallTarget: {
     id: string;
     name: string;

--- a/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
+++ b/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
@@ -79,6 +79,7 @@ import {
 } from "@/modules/execution-factory/utils/capability-ux";
 import { supportsCategoryFilter } from "@/modules/execution-factory/utils/capability-parity";
 import { formatAuditUserDisplay } from "@/modules/execution-factory/utils/audit-user-display";
+import { hasExecutionUnitRecordOperation } from "@/modules/execution-factory/utils/record-operations";
 import { useAuditUserDirectory } from "@/modules/execution-factory/utils/use-audit-user-directory";
 import { ObjectAuthorizeDrawer } from "@/modules/system-admin/components/ObjectAuthorizeDrawer";
 
@@ -104,6 +105,13 @@ const TAB_STORAGE_KEY = "execution-factory.activeTab";
 /** API/function subview under toolboxes, restored from detail-page navigation just like activeTab. */
 const TOOLBOX_VIEW_STORAGE_KEY = "execution-factory.toolboxView";
 const DEFAULT_TABS: ExecutionUnitTab[] = ["operator", "toolbox", "mcp", "skill"];
+
+type ObjectAuthorizationTarget = {
+  id: string;
+  name: string;
+  type: string;
+  objectAuthorized: boolean;
+};
 
 type IdleTaskHandle = {
   cancel: () => void;
@@ -203,6 +211,7 @@ function mapAuditUser(userId: string | undefined, directory: Map<string, string>
 
 function mapOperator(item: OperatorRecord, directory: Map<string, string>): ExecutionUnitCardItem {
   return {
+    operations: item.operations,
     id: item.operatorId,
     name: item.name,
     description: item.description,
@@ -221,6 +230,7 @@ function mapOperator(item: OperatorRecord, directory: Map<string, string>): Exec
 
 function mapToolbox(item: ToolboxRecord, directory: Map<string, string>): ExecutionUnitCardItem {
   return {
+    operations: item.operations,
     id: item.boxId,
     name: item.name,
     description: item.description,
@@ -239,6 +249,7 @@ function mapToolbox(item: ToolboxRecord, directory: Map<string, string>): Execut
 
 function mapMcp(item: McpRecord, directory: Map<string, string>): ExecutionUnitCardItem {
   return {
+    operations: item.operations,
     id: item.mcpId,
     name: item.name,
     description: item.description,
@@ -255,6 +266,7 @@ function mapMcp(item: McpRecord, directory: Map<string, string>): ExecutionUnitC
 
 function mapSkill(item: SkillRecord, directory: Map<string, string>): ExecutionUnitCardItem {
   return {
+    operations: item.operations,
     id: item.skillId,
     name: item.name,
     description: item.description,
@@ -330,9 +342,7 @@ export function ExecutionUnitListScene({
   const [detailBoxId, setDetailBoxId] = useState<string | null>(null);
   const [detailMcpId, setDetailMcpId] = useState<string | null>(null);
   const [detailSkillId, setDetailSkillId] = useState<string | null>(null);
-  const [authorizeTarget, setAuthorizeTarget] = useState<{ id: string; name: string; type: string } | null>(
-    null,
-  );
+  const [authorizeTarget, setAuthorizeTarget] = useState<ObjectAuthorizationTarget | null>(null);
   const [installTarget, setInstallTarget] = useState<{
     id: string;
     name: string;
@@ -348,11 +358,7 @@ export function ExecutionUnitListScene({
   const [installedResourceIdsReady, setInstalledResourceIdsReady] = useState(!marketMode);
   const installedSyncAbortRef = useRef<AbortController | null>(null);
   const installedSyncManualRef = useRef(false);
-  const [publishedPermTarget, setPublishedPermTarget] = useState<{
-    id: string;
-    name: string;
-    type: string;
-  } | null>(null);
+  const [publishedPermTarget, setPublishedPermTarget] = useState<ObjectAuthorizationTarget | null>(null);
   const [editMcpId, setEditMcpId] = useState<string | null>(null);
   const [updateSkillPackageTarget, setUpdateSkillPackageTarget] = useState<{
     id: string;
@@ -948,11 +954,16 @@ export function ExecutionUnitListScene({
               await onConfirm();
               void message.success(t("common.success"));
               reloadList();
-              if (!marketMode && nextStatus === "published") {
+              if (
+                !marketMode &&
+                nextStatus === "published" &&
+                hasExecutionUnitRecordOperation(item, "authorize")
+              ) {
                 setPublishedPermTarget({
                   id: item.id,
                   name: item.name,
                   type: AUTHZ_TYPE_BY_TAB[activeTab],
+                  objectAuthorized: true,
                 });
               }
             } catch (error) {
@@ -984,7 +995,12 @@ export function ExecutionUnitListScene({
       };
 
       if (action === "authorize") {
-        setAuthorizeTarget({ id: item.id, name: item.name, type: AUTHZ_TYPE_BY_TAB[activeTab] });
+        setAuthorizeTarget({
+          id: item.id,
+          name: item.name,
+          type: AUTHZ_TYPE_BY_TAB[activeTab],
+          objectAuthorized: hasExecutionUnitRecordOperation(item, "authorize"),
+        });
         return;
       }
 
@@ -1612,6 +1628,7 @@ export function ExecutionUnitListScene({
           objId={authorizeTarget.id}
           objName={authorizeTarget.name}
           objType={authorizeTarget.type}
+          objectAuthorized={authorizeTarget.objectAuthorized}
           onClose={() => setAuthorizeTarget(null)}
           open={Boolean(authorizeTarget)}
         />

--- a/src/modules/execution-factory/services/execution-unit-operations.service.test.ts
+++ b/src/modules/execution-factory/services/execution-unit-operations.service.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock },
+}));
+
+describe("execution-unit list operation mapping", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    getMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("preserves object operations for every execution-unit list", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ name: "Operator", operator_id: "operator-1", operations: ["authorize"], version: "1" }],
+          total: 1,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [{ box_id: "toolbox-1", box_name: "Toolbox", operations: ["authorize"] }], total: 1 },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [{ mcp_id: "mcp-1", name: "MCP", operations: ["authorize"] }], total: 1 },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [{ skill_id: "skill-1", name: "Skill", operations: ["authorize"] }], total: 1 },
+      });
+
+    const [{ listOperators }, { listToolboxes }, { listMcps }, { listSkills }] = await Promise.all([
+      import("./operator.service"),
+      import("./toolbox.service"),
+      import("./mcp.service"),
+      import("./skill.service"),
+    ]);
+
+    const [operators, toolboxes, mcps, skills] = await Promise.all([
+      listOperators({ page: 1, pageSize: 20 }),
+      listToolboxes({ page: 1, pageSize: 20 }),
+      listMcps({ page: 1, pageSize: 20 }),
+      listSkills({ page: 1, pageSize: 20 }),
+    ]);
+
+    expect(operators.items[0]?.operations).toEqual(["authorize"]);
+    expect(toolboxes.items[0]?.operations).toEqual(["authorize"]);
+    expect(mcps.items[0]?.operations).toEqual(["authorize"]);
+    expect(skills.items[0]?.operations).toEqual(["authorize"]);
+  });
+});

--- a/src/modules/execution-factory/services/mcp.service.ts
+++ b/src/modules/execution-factory/services/mcp.service.ts
@@ -32,6 +32,7 @@ type BackendMcpInfo = {
   mcp_id: string | number;
   mode?: string;
   name: string;
+  operations?: string[];
   status?: string;
   tool_configs?: Array<{
     box_id?: string;
@@ -59,6 +60,7 @@ const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 
 let mockMcps: McpRecord[] = [
   {
+    operations: ["*"],
     mcpId: "mcp_sse_demo",
     name: "SSE Demo MCP",
     description: "Sample SSE MCP server for local development.",
@@ -72,6 +74,7 @@ let mockMcps: McpRecord[] = [
     isInternal: true,
   },
   {
+    operations: ["*"],
     mcpId: "mcp_custom_ops",
     name: "Custom Operations MCP",
     description: "User-defined MCP with imported toolbox tools.",
@@ -107,6 +110,7 @@ function mapMcpDetail(baseInfo: BackendMcpInfo): McpDetail {
 
 function mapMcp(item: BackendMcpInfo): McpRecord {
   return {
+    operations: item.operations,
     mcpId: String(item.mcp_id),
     name: item.name,
     description: item.description,

--- a/src/modules/execution-factory/services/operator.service.ts
+++ b/src/modules/execution-factory/services/operator.service.ts
@@ -65,6 +65,7 @@ type BackendOperatorDataInfo = {
   operator_execute_control?: BackendOperatorExecuteControl;
   operator_id: string;
   operator_info?: { category?: string; category_name?: string };
+  operations?: string[];
   release_time?: number;
   release_user?: string;
   status?: string;
@@ -100,6 +101,7 @@ const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 
 let mockOperators: OperatorRecord[] = [
   {
+    operations: ["*"],
     operatorId: "op_text_extract",
     name: "Text Extract",
     version: "1.0.0",
@@ -113,6 +115,7 @@ let mockOperators: OperatorRecord[] = [
     isInternal: false,
   },
   {
+    operations: ["*"],
     operatorId: "op_data_transform",
     name: "Data Transform",
     version: "0.2.1",
@@ -245,6 +248,7 @@ function buildOperatorMutationBody(
 
 function mapOperator(item: BackendOperatorDataInfo): OperatorRecord {
   return {
+    operations: item.operations,
     operatorId: item.operator_id,
     name: item.name ?? item.operator_id,
     version: item.version,

--- a/src/modules/execution-factory/services/skill.service.ts
+++ b/src/modules/execution-factory/services/skill.service.ts
@@ -37,6 +37,7 @@ type BackendSkillSummary = {
   create_user?: string;
   description?: string;
   name: string;
+  operations?: string[];
   skill_id: string;
   status?: string;
   update_time?: number;
@@ -127,6 +128,7 @@ let mockSkillHistory: SkillHistoryRecord[] = [
 
 let mockSkills: SkillRecord[] = [
   {
+    operations: ["*"],
     skillId: "skill_doc_qa",
     name: "Document QA Skill",
     description: "Answer questions over uploaded documents.",
@@ -138,6 +140,7 @@ let mockSkills: SkillRecord[] = [
     updateTime: Date.now() - 345_600_000,
   },
   {
+    operations: ["*"],
     skillId: "skill_summarize",
     name: "Summarize Skill",
     description: "Summarize long-form content into concise notes.",
@@ -165,6 +168,7 @@ function normalizeTimestamp(value?: number): number | undefined {
 
 function mapSkill(item: BackendSkillSummary): SkillRecord {
   return {
+    operations: item.operations,
     skillId: item.skill_id,
     name: item.name,
     description: item.description,

--- a/src/modules/execution-factory/services/toolbox.service.ts
+++ b/src/modules/execution-factory/services/toolbox.service.ts
@@ -36,6 +36,7 @@ type BackendToolboxInfo = {
   create_user?: string;
   is_internal?: boolean;
   metadata_type?: string;
+  operations?: string[];
   release_time?: number;
   release_user?: string;
   status?: string;
@@ -56,6 +57,7 @@ const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 
 let mockToolboxes: ToolboxRecord[] = [
   {
+    operations: ["*"],
     boxId: "tb_context_loader",
     name: "Context Loader Toolbox",
     description: "Built-in toolbox for context loader tools.",
@@ -74,6 +76,7 @@ let mockToolboxes: ToolboxRecord[] = [
     isInternal: true,
   },
   {
+    operations: ["*"],
     boxId: "tb_custom_ops",
     name: "Custom Operations",
     description: "User-defined HTTP tools for business workflows.",
@@ -109,6 +112,7 @@ function mapToolbox(item: BackendToolboxInfo): ToolboxRecord {
     : undefined;
 
   return {
+    operations: item.operations,
     boxId: item.box_id,
     name: item.box_name,
     description: item.box_desc,

--- a/src/modules/execution-factory/types/mcp.ts
+++ b/src/modules/execution-factory/types/mcp.ts
@@ -12,6 +12,7 @@ export type McpMode = "sse" | "stream";
 export type McpCreationType = "custom" | "tool_imported";
 
 export type McpRecord = {
+  operations?: string[];
   mcpId: string;
   name: string;
   description?: string;

--- a/src/modules/execution-factory/types/operator.ts
+++ b/src/modules/execution-factory/types/operator.ts
@@ -49,6 +49,7 @@ export type OperatorCategory =
   | "model_train";
 
 export type OperatorRecord = {
+  operations?: string[];
   operatorId: string;
   name: string;
   version: string;

--- a/src/modules/execution-factory/types/skill.ts
+++ b/src/modules/execution-factory/types/skill.ts
@@ -8,6 +8,7 @@
 export type SkillStatus = "unpublish" | "published" | "offline";
 
 export type SkillRecord = {
+  operations?: string[];
   skillId: string;
   name: string;
   description?: string;

--- a/src/modules/execution-factory/types/toolbox.ts
+++ b/src/modules/execution-factory/types/toolbox.ts
@@ -18,6 +18,7 @@ export type ToolboxToolRecord = {
 };
 
 export type ToolboxRecord = {
+  operations?: string[];
   boxId: string;
   name: string;
   description?: string;

--- a/src/modules/execution-factory/utils/record-operations.test.ts
+++ b/src/modules/execution-factory/utils/record-operations.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { hasExecutionUnitRecordOperation } from "./record-operations";
+
+describe("hasExecutionUnitRecordOperation", () => {
+  it("fails closed for missing operations and supports the wildcard operation", () => {
+    expect(hasExecutionUnitRecordOperation(undefined, "authorize")).toBe(false);
+    expect(hasExecutionUnitRecordOperation({}, "authorize")).toBe(false);
+    expect(hasExecutionUnitRecordOperation({ operations: ["view"] }, "authorize")).toBe(false);
+    expect(hasExecutionUnitRecordOperation({ operations: ["*"] }, "authorize")).toBe(true);
+  });
+});

--- a/src/modules/execution-factory/utils/record-operations.ts
+++ b/src/modules/execution-factory/utils/record-operations.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+type OperationRecord = {
+  operations?: string[];
+};
+
+/**
+ * Checks a permission projected for this exact execution-unit record. Missing operation data is
+ * deliberately denied so an older or failed backend response cannot reveal a write control.
+ */
+export function hasExecutionUnitRecordOperation(
+  record: OperationRecord | null | undefined,
+  operation: string,
+) {
+  return record?.operations?.includes("*") || record?.operations?.includes(operation) || false;
+}


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Preserve object-level operations returned by execution-unit list APIs.
- [x] Show the per-record Configure Permissions action only when the record includes authorize.
- [x] Pass object-level authorization context to the permissions drawer, including the post-publish prompt.

---

## Why

- Related Issue: Closes #554
- Related Feature: Execution Factory object-level authorization
- Background: List visibility alone must not grant the ability to manage an individual execution unit's permissions.

---

## How

- Key implementation points: Map API operations for operator, toolbox, MCP, and skill records; fail closed when authorization data is absent; cover the card menu and response mapping with regression tests.
- Breaking changes (API, config, database, etc.): None. The UI consumes the optional response field and safely hides the action when it is unavailable.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; this change is covered by unit and full frontend tests)
- [ ] Verified in test environment (not performed locally)

Test notes:

- Full Vitest: 249 files and 1333 tests passed.
- ESLint, TypeScript type check, and Vite production build passed.
- pnpm audit --prod could not obtain a result because the current network blocks the npm security-advisory POST endpoint; GitHub CI will run the same check.

---

## Risk & Rollback

- Potential risks: If a backend omits operations, the authorization entry is intentionally hidden.
- Rollback plan: Revert commit 7fb4bfbf.

---

## Additional Notes

- The authorization API contract is supplied by the corresponding Foundry change.