### PR TITLE
fix(knowledge-network): improve dark canvas theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,17 @@
     <link rel="shortcut icon" href="%BASE_URL%favicon.ico?v=openbkn-20260710" />
     <script>
       (() => {
+        let preference = "system";
+        try {
+          const storedPreference = window.localStorage.getItem("openbkn-theme-preference");
+          if (storedPreference === "dark" || storedPreference === "light") {
+            preference = storedPreference;
+          }
+        } catch {
+          // Fall back to the operating-system preference when storage is unavailable.
+        }
         const isDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches;
-        const theme = isDark ? "dark" : "light";
+        const theme = preference === "system" ? (isDark ? "dark" : "light") : preference;
         document.documentElement.dataset.theme = theme;
         document.documentElement.style.colorScheme = theme;
       })();

--- a/src/app/locales/resources/shell/en-US.ts
+++ b/src/app/locales/resources/shell/en-US.ts
@@ -17,6 +17,10 @@ export const shellEnUS = {
     headerAside: "Application shell baseline",
     collapseSidenav: "Collapse navigation",
     expandSidenav: "Expand navigation",
+    theme: {
+      switchToDark: "Switch to dark mode",
+      switchToLight: "Switch to light mode",
+    },
     language: {
       label: "Language",
       zhCN: "中文",

--- a/src/app/locales/resources/shell/zh-CN.ts
+++ b/src/app/locales/resources/shell/zh-CN.ts
@@ -17,6 +17,10 @@ export const shellZhCN = {
     headerAside: "统一应用壳层",
     collapseSidenav: "收起导航",
     expandSidenav: "展开导航",
+    theme: {
+      switchToDark: "切换到深色模式",
+      switchToLight: "切换到浅色模式",
+    },
     language: {
       label: "语言",
       zhCN: "中文",

--- a/src/app/shell/TopBar.tsx
+++ b/src/app/shell/TopBar.tsx
@@ -11,6 +11,8 @@ import {
   GlobalOutlined,
   CrownOutlined,
   LogoutOutlined,
+  MoonOutlined,
+  SunOutlined,
   UserOutlined,
 } from "@ant-design/icons";
 import { Dropdown } from "antd";
@@ -20,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import { useMatches, useNavigate, useParams } from "react-router-dom";
 
 import { getConsoleNavTrail } from "@/app/shell/console-navigation";
+import { useResolvedTheme, useToggleTheme } from "@/app/theme/theme-context";
 import openBknLogo from "@/assets/brand/openbkn-logo-compact.webp";
 import type { AppRouteHandle } from "@/app/shell/route-meta";
 import { logout } from "@/framework/auth/oauth";
@@ -37,6 +40,8 @@ export function TopBar() {
   const { networkId } = useParams<{ networkId?: string }>();
   const runtimeConfig = useRuntimeConfig();
   const updateLocale = useUpdateLocale();
+  const resolvedTheme = useResolvedTheme();
+  const toggleTheme = useToggleTheme();
   const entitlement = useEntitlement();
   const { snapshot } = useEntitlementContext();
   const routeHandle = matches[matches.length - 1]?.handle as AppRouteHandle | undefined;
@@ -264,6 +269,20 @@ export function TopBar() {
       </div>
 
       <div className="console-topbar-actions">
+        <button
+          aria-label={t(
+            resolvedTheme === "dark" ? "shell.theme.switchToLight" : "shell.theme.switchToDark",
+          )}
+          aria-pressed={resolvedTheme === "dark"}
+          className="console-theme-toggle"
+          onClick={toggleTheme}
+          title={t(
+            resolvedTheme === "dark" ? "shell.theme.switchToLight" : "shell.theme.switchToDark",
+          )}
+          type="button"
+        >
+          {resolvedTheme === "dark" ? <SunOutlined /> : <MoonOutlined />}
+        </button>
         <Dropdown
           menu={{ items: userMenuItems }}
           placement="bottomRight"

--- a/src/app/theme/ThemeProvider.test.tsx
+++ b/src/app/theme/ThemeProvider.test.tsx
@@ -5,12 +5,13 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ThemeProvider } from "@/app/theme/ThemeProvider";
-import { useResolvedTheme } from "@/app/theme/theme-context";
+import { useResolvedTheme, useToggleTheme } from "@/app/theme/theme-context";
+import { THEME_PREFERENCE_STORAGE_KEY } from "@/app/theme/theme-mode";
 
 type MediaChangeListener = (event: MediaQueryListEvent) => void;
 
@@ -78,6 +79,20 @@ function ThemeValue() {
   return <output>{useResolvedTheme()}</output>;
 }
 
+function ThemeControls() {
+  const resolvedTheme = useResolvedTheme();
+  const toggleTheme = useToggleTheme();
+
+  return (
+    <>
+      <output>{resolvedTheme}</output>
+      <button type="button" onClick={toggleTheme}>
+        toggle
+      </button>
+    </>
+  );
+}
+
 function renderWithTheme(children: ReactNode) {
   return render(<ThemeProvider>{children}</ThemeProvider>);
 }
@@ -85,6 +100,7 @@ function renderWithTheme(children: ReactNode) {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  window.localStorage.clear();
   delete document.documentElement.dataset.theme;
   document.documentElement.style.removeProperty("color-scheme");
 });
@@ -124,5 +140,17 @@ describe("ThemeProvider", () => {
     });
 
     expect(screen.getByRole("status").textContent).toBe("dark");
+  });
+
+  it("uses and persists an explicit theme selected by the user", () => {
+    installMatchMedia(false);
+    window.localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, "dark");
+
+    renderWithTheme(<ThemeControls />);
+
+    expect(screen.getByRole("status").textContent).toBe("dark");
+    fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+    expect(screen.getByRole("status").textContent).toBe("light");
+    expect(window.localStorage.getItem(THEME_PREFERENCE_STORAGE_KEY)).toBe("light");
   });
 });

--- a/src/app/theme/ThemeProvider.tsx
+++ b/src/app/theme/ThemeProvider.tsx
@@ -6,32 +6,40 @@
  */
 
 import type { PropsWithChildren } from "react";
-import { useLayoutEffect, useSyncExternalStore } from "react";
+import { useCallback, useLayoutEffect, useState, useSyncExternalStore } from "react";
 
-import { ThemeContext } from "./theme-context";
+import { ThemeContext, ThemeToggleContext } from "./theme-context";
 
 import {
   applyDocumentTheme,
+  getStoredThemePreference,
   getSystemTheme,
   resolveTheme,
+  storeThemePreference,
   subscribeToSystemTheme,
   type ResolvedTheme,
-  type ThemePreference,
 } from "./theme-mode";
-
-const DEFAULT_THEME_PREFERENCE: ThemePreference = "system";
 
 function getServerTheme(): ResolvedTheme {
   return "light";
 }
 
 export function ThemeProvider({ children }: PropsWithChildren) {
+  const [themePreference, setThemePreference] = useState(getStoredThemePreference);
   const systemTheme = useSyncExternalStore(
     subscribeToSystemTheme,
     getSystemTheme,
     getServerTheme,
   );
-  const resolvedTheme = resolveTheme(DEFAULT_THEME_PREFERENCE, systemTheme);
+  const resolvedTheme = resolveTheme(themePreference, systemTheme);
+  const toggleTheme = useCallback(() => {
+    setThemePreference((currentPreference) => {
+      const currentTheme = resolveTheme(currentPreference, systemTheme);
+      const nextTheme = currentTheme === "dark" ? "light" : "dark";
+      storeThemePreference(nextTheme);
+      return nextTheme;
+    });
+  }, [systemTheme]);
 
   // The initial document theme is set synchronously in index.html. Keep the DOM in sync with
   // operating-system changes before the browser paints the React update.
@@ -39,5 +47,9 @@ export function ThemeProvider({ children }: PropsWithChildren) {
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
 
-  return <ThemeContext.Provider value={resolvedTheme}>{children}</ThemeContext.Provider>;
+  return (
+    <ThemeToggleContext.Provider value={toggleTheme}>
+      <ThemeContext.Provider value={resolvedTheme}>{children}</ThemeContext.Provider>
+    </ThemeToggleContext.Provider>
+  );
 }

--- a/src/app/theme/theme-context.ts
+++ b/src/app/theme/theme-context.ts
@@ -12,7 +12,12 @@ import type { ResolvedTheme } from "./theme-mode";
 // A light fallback keeps isolated widgets and their tests usable; the mounted application always
 // provides the resolved operating-system theme.
 export const ThemeContext = createContext<ResolvedTheme>("light");
+export const ThemeToggleContext = createContext<() => void>(() => undefined);
 
 export function useResolvedTheme(): ResolvedTheme {
   return useContext(ThemeContext);
+}
+
+export function useToggleTheme(): () => void {
+  return useContext(ThemeToggleContext);
 }

--- a/src/app/theme/theme-mode.ts
+++ b/src/app/theme/theme-mode.ts
@@ -14,6 +14,7 @@ export type ResolvedTheme = "dark" | "light";
 export type ThemePreference = "dark" | "light" | "system";
 
 export const SYSTEM_THEME_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+export const THEME_PREFERENCE_STORAGE_KEY = "openbkn-theme-preference";
 
 export function resolveTheme(
   preference: ThemePreference,
@@ -28,6 +29,27 @@ export function getSystemTheme(): ResolvedTheme {
   }
 
   return window.matchMedia(SYSTEM_THEME_MEDIA_QUERY).matches ? "dark" : "light";
+}
+
+export function getStoredThemePreference(): ThemePreference {
+  if (typeof window === "undefined") {
+    return "system";
+  }
+
+  try {
+    const preference = window.localStorage.getItem(THEME_PREFERENCE_STORAGE_KEY);
+    return preference === "dark" || preference === "light" ? preference : "system";
+  } catch {
+    return "system";
+  }
+}
+
+export function storeThemePreference(preference: ResolvedTheme): void {
+  try {
+    window.localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, preference);
+  } catch {
+    // Theme switching still works for the current page when storage is unavailable.
+  }
 }
 
 export function subscribeToSystemTheme(onChange: () => void): () => void {

--- a/src/modules/knowledge-network/components/preview/OntologyGraphView.module.css
+++ b/src/modules/knowledge-network/components/preview/OntologyGraphView.module.css
@@ -6,9 +6,15 @@
  */
 
 .wrap {
+  --ontology-grid-dot-opacity: 0.28;
+
   position: relative;
   width: 100%;
   height: 100%;
+}
+
+:global(:root[data-theme="dark"]) .wrap {
+  --ontology-grid-dot-opacity: 0.18;
 }
 
 /* 右上角工具条：重新排列 + 边名开关 同一排 */
@@ -149,14 +155,27 @@
   pointer-events: none;
 }
 
+.gridDot {
+  fill: var(--color-text-faint);
+  opacity: var(--ontology-grid-dot-opacity);
+}
+
+.edgeArrow {
+  fill: var(--color-text-faint);
+}
+
+.edgeArrowActive {
+  fill: var(--color-primary-600);
+}
+
 .edge line {
-  stroke: #c4ccd8;
+  stroke: var(--color-text-faint);
   stroke-width: 1.6;
   transition: stroke 0.15s ease, opacity 0.15s ease;
 }
 
 .edgeActive line {
-  stroke: #2e68ff;
+  stroke: var(--color-primary-600);
   stroke-width: 2.4;
 }
 
@@ -164,25 +183,41 @@
   opacity: 0.22;
 }
 
+.edgeDim:hover {
+  opacity: 0.9;
+}
+
 .edgeLabelBg {
   fill: var(--color-bg-raised);
   stroke: var(--color-border);
   stroke-width: 1;
+  transition: fill 0.15s ease, stroke 0.15s ease;
 }
 
 .edgeLabel {
-  fill: #5b6472;
+  fill: var(--color-text-primary);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   pointer-events: none;
+  transition: fill 0.15s ease;
+}
+
+.edge:hover .edgeLabelBg {
+  fill: var(--color-hover);
+  stroke: var(--color-primary-border);
+}
+
+.edge:hover .edgeLabel {
+  fill: var(--color-text-link);
 }
 
 .edgeActive .edgeLabelBg {
+  fill: var(--color-primary-100);
   stroke: var(--color-primary-border);
 }
 
 .edgeActive .edgeLabel {
-  fill: #2e68ff;
+  fill: var(--color-text-link);
 }
 
 .node {

--- a/src/modules/knowledge-network/components/preview/OntologyGraphView.test.tsx
+++ b/src/modules/knowledge-network/components/preview/OntologyGraphView.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OntologyGraphView } from "./OntologyGraphView";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const graph = {
+  nodes: [
+    { color: "#2563eb", id: "customer", name: "Customer" },
+    { color: "#16a34a", id: "order", name: "Order" },
+  ],
+  edges: [
+    { id: "places", name: "Places", sourceId: "customer", targetId: "order" },
+  ],
+};
+
+describe("OntologyGraphView", () => {
+  it("renders grid dots and edge markers through theme-aware CSS classes", () => {
+    const { container } = render(
+      <OntologyGraphView
+        graph={graph}
+        indexedIds={new Set()}
+        selectedId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const gridDot = container.querySelector("pattern circle");
+    const edgeArrows = container.querySelectorAll("marker path");
+
+    expect(gridDot?.getAttribute("class")).toContain("gridDot");
+    expect(gridDot?.hasAttribute("fill")).toBe(false);
+    expect(edgeArrows[0]?.getAttribute("class")).toContain("edgeArrow");
+    expect(edgeArrows[0]?.hasAttribute("fill")).toBe(false);
+    expect(edgeArrows[1]?.getAttribute("class")).toContain("edgeArrowActive");
+    expect(screen.getByText("Places").getAttribute("class")).toContain("edgeLabel");
+  });
+
+  it("keeps relation labels readable in default, hover, and active states", () => {
+    const css = readFileSync(
+      resolve(
+        process.cwd(),
+        "src/modules/knowledge-network/components/preview/OntologyGraphView.module.css",
+      ),
+      "utf8",
+    );
+
+    expect(css).toMatch(
+      /\.gridDot\s*{[^}]*fill:\s*var\(--color-text-faint\);[^}]*opacity:\s*var\(--ontology-grid-dot-opacity\);/s,
+    );
+    expect(css).toMatch(
+      /:global\(:root\[data-theme="dark"\]\) \.wrap\s*{[^}]*--ontology-grid-dot-opacity:\s*0\.18;/s,
+    );
+    expect(css).toMatch(
+      /\.edgeLabel\s*{[^}]*fill:\s*var\(--color-text-primary\);/s,
+    );
+    expect(css).toMatch(
+      /\.edge:hover \.edgeLabelBg\s*{[^}]*fill:\s*var\(--color-hover\);[^}]*stroke:\s*var\(--color-primary-border\);/s,
+    );
+    expect(css).toMatch(
+      /\.edge:hover \.edgeLabel\s*{[^}]*fill:\s*var\(--color-text-link\);/s,
+    );
+    expect(css).toMatch(
+      /\.edgeActive \.edgeLabelBg\s*{[^}]*fill:\s*var\(--color-primary-100\);[^}]*stroke:\s*var\(--color-primary-border\);/s,
+    );
+    expect(css).toMatch(
+      /\.edgeActive \.edgeLabel\s*{[^}]*fill:\s*var\(--color-text-link\);/s,
+    );
+    expect(css).not.toMatch(/\.edgeLabel\s*{[^}]*fill:\s*#[0-9a-f]{3,8}/is);
+  });
+});

--- a/src/modules/knowledge-network/components/preview/OntologyGraphView.test.tsx
+++ b/src/modules/knowledge-network/components/preview/OntologyGraphView.test.tsx
@@ -5,9 +5,6 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
-
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -49,36 +46,4 @@ describe("OntologyGraphView", () => {
     expect(screen.getByText("Places").getAttribute("class")).toContain("edgeLabel");
   });
 
-  it("keeps relation labels readable in default, hover, and active states", () => {
-    const css = readFileSync(
-      resolve(
-        process.cwd(),
-        "src/modules/knowledge-network/components/preview/OntologyGraphView.module.css",
-      ),
-      "utf8",
-    );
-
-    expect(css).toMatch(
-      /\.gridDot\s*{[^}]*fill:\s*var\(--color-text-faint\);[^}]*opacity:\s*var\(--ontology-grid-dot-opacity\);/s,
-    );
-    expect(css).toMatch(
-      /:global\(:root\[data-theme="dark"\]\) \.wrap\s*{[^}]*--ontology-grid-dot-opacity:\s*0\.18;/s,
-    );
-    expect(css).toMatch(
-      /\.edgeLabel\s*{[^}]*fill:\s*var\(--color-text-primary\);/s,
-    );
-    expect(css).toMatch(
-      /\.edge:hover \.edgeLabelBg\s*{[^}]*fill:\s*var\(--color-hover\);[^}]*stroke:\s*var\(--color-primary-border\);/s,
-    );
-    expect(css).toMatch(
-      /\.edge:hover \.edgeLabel\s*{[^}]*fill:\s*var\(--color-text-link\);/s,
-    );
-    expect(css).toMatch(
-      /\.edgeActive \.edgeLabelBg\s*{[^}]*fill:\s*var\(--color-primary-100\);[^}]*stroke:\s*var\(--color-primary-border\);/s,
-    );
-    expect(css).toMatch(
-      /\.edgeActive \.edgeLabel\s*{[^}]*fill:\s*var\(--color-text-link\);/s,
-    );
-    expect(css).not.toMatch(/\.edgeLabel\s*{[^}]*fill:\s*#[0-9a-f]{3,8}/is);
-  });
 });

--- a/src/modules/knowledge-network/components/preview/OntologyGraphView.tsx
+++ b/src/modules/knowledge-network/components/preview/OntologyGraphView.tsx
@@ -435,14 +435,14 @@ export function OntologyGraphView({
         onPointerLeave={onPointerUp}
       >
       <defs>
-        <pattern id="kn-onto-grid" width="26" height="26" patternUnits="userSpaceOnUse">
-          <circle cx="1.4" cy="1.4" r="1.3" fill="#eef1f6" />
+        <pattern id="kn-onto-grid" width="32" height="32" patternUnits="userSpaceOnUse">
+          <circle className={styles.gridDot} cx="1.2" cy="1.2" r="1.1" />
         </pattern>
         <marker id="kn-onto-arrow" markerWidth="11" markerHeight="11" refX="8" refY="4" orient="auto">
-          <path d="M0,0 L8,4 L0,8 z" fill="#b3bdcf" />
+          <path className={styles.edgeArrow} d="M0,0 L8,4 L0,8 z" />
         </marker>
         <marker id="kn-onto-arrow-hi" markerWidth="11" markerHeight="11" refX="8" refY="4" orient="auto">
-          <path d="M0,0 L8,4 L0,8 z" fill="#2e68ff" />
+          <path className={styles.edgeArrowActive} d="M0,0 L8,4 L0,8 z" />
         </marker>
       </defs>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -312,6 +312,39 @@ select {
   margin-left: auto;
 }
 
+.console-theme-toggle {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: var(--color-bg-surface);
+  color: var(--color-text-secondary);
+  font-size: 18px;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.console-theme-toggle:hover {
+  border-color: var(--color-primary-border);
+  background: var(--color-hover);
+  color: var(--color-primary-600);
+  transform: translateY(-1px);
+}
+
+.console-theme-toggle:focus-visible {
+  outline: 2px solid var(--color-primary-600);
+  outline-offset: 2px;
+}
+
 .console-topbar-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Improve relation-label contrast and reduce grid prominence in the ontology preview canvas.
- [x] Add a persistent light/dark theme toggle to the top bar.
- [x] Add regression coverage for theme persistence and theme-aware canvas styling.

---

## Why

- Related Issue: Closes #542
- Related Feature: Dark theme experience
- Background: In dark mode, relation labels and the ontology grid had insufficient visual hierarchy. Users also needed an explicit control to switch between light and dark themes.

---

## How

- Key implementation points:
  - Replaced hard-coded SVG colors with semantic theme tokens for grid dots, relation lines, arrows, and labels.
  - Added readable default, hover, and active relation-label states, with a lower-opacity and wider-spaced grid.
  - Added a top-bar sun/moon toggle that stores the selected theme in local storage.
  - Applied the stored preference before React starts to avoid a theme flash on reload.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment — Not applicable before PR; manually verified in the local mock environment.

Test notes:

    node scripts/check-license-headers.mjs
    pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
    pnpm exec vitest --run
    pnpm exec tsc -b --pretty false
    pnpm exec vite build
    pnpm audit --prod

- The full Vitest run was limited to 2 workers locally; 251 files and 1,343 tests passed.
- Manually verified light/dark switching, refresh persistence, and canvas default/hover/selected states in the local mock environment.

---

## Risk & Rollback

- Potential risks: A stale or invalid stored theme value could otherwise cause a theme mismatch; invalid values are ignored and storage failures fall back to the system preference.
- Rollback plan: Revert this PR to restore system-only theme selection and the previous canvas styling.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: The toggle is placed immediately to the left of the user menu, matching the requested top-bar location.
