### PR TITLE
feat(knowledge-network): add permission-aware detail actions

### DIFF
--- a/src/modules/knowledge-network/components/concept-group/ConceptGroupListPanel.tsx
+++ b/src/modules/knowledge-network/components/concept-group/ConceptGroupListPanel.tsx
@@ -33,10 +33,10 @@ import {
   getKnowledgeNetworkConceptGroup,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
 import type {
-  ConceptGroupDetail,
   ConceptGroupRecord,
   KnowledgeNetworkImportMode,
 } from "@/modules/knowledge-network/types/knowledge-network";
+import { downloadConceptGroupExport } from "@/modules/knowledge-network/utils/concept-group-export";
 import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 
 import styles from "@/modules/knowledge-network/components/shared/ResourceListPanel.module.css";
@@ -54,18 +54,6 @@ type ConceptGroupListPanelProps = {
   ) => Promise<void>;
   onRefresh: () => Promise<void>;
 };
-
-function downloadConceptGroupExport(detail: ConceptGroupDetail) {
-  const blob = new Blob([JSON.stringify(detail, null, 2)], {
-    type: "application/json;charset=utf-8",
-  });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = `${detail.name}.json`;
-  link.click();
-  URL.revokeObjectURL(url);
-}
 
 export function ConceptGroupListPanel({
   canDelete,

--- a/src/modules/knowledge-network/components/object-type/ObjectTypePropertyTable.test.tsx
+++ b/src/modules/knowledge-network/components/object-type/ObjectTypePropertyTable.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { ObjectTypeDataProperty } from "@/modules/knowledge-network/types/object-type";
+
+import { ObjectTypePropertyTable } from "./ObjectTypePropertyTable";
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function createProperty(overrides: Partial<ObjectTypeDataProperty>): ObjectTypeDataProperty {
+  return {
+    displayKey: false,
+    displayName: "Order ID",
+    incrementalKey: false,
+    name: "order_id",
+    primaryKey: true,
+    type: "string",
+    ...overrides,
+  };
+}
+
+const nativeGetComputedStyle = window.getComputedStyle;
+
+beforeAll(() => {
+  vi.spyOn(window, "getComputedStyle").mockImplementation((element) =>
+    nativeGetComputedStyle.call(window, element),
+  );
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    matches: false,
+    media: query,
+    onchange: null,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ObjectTypePropertyTable", () => {
+  it("shows property descriptions with a consistent empty value and ellipsis styling", () => {
+    const longDescription = "A long property description that should stay inside the fixed table column.";
+
+    render(
+      <ObjectTypePropertyTable
+        properties={[
+          createProperty({ comment: longDescription }),
+          createProperty({ comment: "   ", displayName: "Customer ID", name: "customer_id" }),
+        ]}
+        showToolbar={false}
+      />,
+    );
+
+    expect(
+      screen.getAllByText("knowledgeNetwork.objectTypePropertyDescription").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText(longDescription).className).toContain("cellEllipsis");
+
+    const emptyDescriptionRow = screen.getByText("customer_id").closest("tr");
+    expect(emptyDescriptionRow).not.toBeNull();
+    expect(within(emptyDescriptionRow as HTMLTableRowElement).getAllByText("—").length).toBeGreaterThan(0);
+  });
+});

--- a/src/modules/knowledge-network/components/object-type/ObjectTypePropertyTable.tsx
+++ b/src/modules/knowledge-network/components/object-type/ObjectTypePropertyTable.tsx
@@ -36,6 +36,22 @@ type ObjectTypePropertyTableColumnSettingsProps = {
   visibleColumnKeys: string[];
 };
 
+type ObjectTypePropertyDescriptionCellProps = {
+  value?: string;
+};
+
+export function ObjectTypePropertyDescriptionCell({
+  value,
+}: ObjectTypePropertyDescriptionCellProps) {
+  const text = value?.trim() || "—";
+
+  return (
+    <Tooltip title={text}>
+      <span className={styles.cellEllipsis}>{text}</span>
+    </Tooltip>
+  );
+}
+
 export function ObjectTypePropertyTableColumnSettings({
   tableState,
   visibleColumnKeys,
@@ -95,6 +111,14 @@ export function ObjectTypePropertyTable({
                 </Tooltip>
               );
             },
+          };
+        case "comment":
+          return {
+            key: "comment",
+            dataIndex: "comment",
+            title: t("knowledgeNetwork.objectTypePropertyDescription"),
+            width: 240,
+            render: (value?: string) => <ObjectTypePropertyDescriptionCell value={value} />,
           };
         case "type":
           return {

--- a/src/modules/knowledge-network/components/object-type/ObjectTypePropertyTableColumns.tsx
+++ b/src/modules/knowledge-network/components/object-type/ObjectTypePropertyTableColumns.tsx
@@ -12,6 +12,7 @@ import type { DetailTableColumnDefinition } from "@/modules/knowledge-network/co
 export const ObjectTypePropertyTableColumns: DetailTableColumnDefinition[] = [
   { key: "name", labelKey: "knowledgeNetwork.objectTypePropertyName", required: true },
   { key: "displayName", labelKey: "knowledgeNetwork.objectTypePropertyDisplayName" },
+  { key: "comment", labelKey: "knowledgeNetwork.objectTypePropertyDescription" },
   { key: "type", labelKey: "knowledgeNetwork.objectTypePropertyType" },
   { key: "mappedField", labelKey: "knowledgeNetwork.objectTypePropertyMappedField" },
   { key: "primaryKey", labelKey: "knowledgeNetwork.objectTypePropertyPrimaryKey" },

--- a/src/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions.test.tsx
+++ b/src/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { KnowledgeNetworkResourceDetailActions } from "./KnowledgeNetworkResourceDetailActions";
+
+describe("KnowledgeNetworkResourceDetailActions", () => {
+  const createActions = () => [
+    {
+      key: "edit",
+      label: "Edit",
+      onClick: vi.fn(),
+      operation: "modify",
+      type: "primary" as const,
+    },
+    {
+      danger: true,
+      key: "delete",
+      label: "Delete",
+      onClick: vi.fn(),
+      operation: "delete",
+    },
+  ];
+
+  it("renders and runs only actions granted by the record", () => {
+    const actions = createActions();
+
+    render(
+      <KnowledgeNetworkResourceDetailActions
+        actions={actions}
+        record={{ operations: ["modify"] }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(actions[0].onClick).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+  });
+
+  it("renders no buttons without matching operations", () => {
+    const { container } = render(
+      <KnowledgeNetworkResourceDetailActions actions={createActions()} record={{ operations: [] }} />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("supports wildcard access", () => {
+    render(
+      <KnowledgeNetworkResourceDetailActions
+        actions={createActions()}
+        record={{ operations: ["*"] }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeTruthy();
+  });
+});

--- a/src/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions.tsx
+++ b/src/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ButtonProps } from "antd";
+import type { ReactNode } from "react";
+
+import { AppButton } from "@/framework/ui/common/AppButton";
+import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
+
+type OperationRecord = {
+  operations?: string[];
+};
+
+export type KnowledgeNetworkResourceDetailAction = {
+  danger?: boolean;
+  key: string;
+  label: ReactNode;
+  onClick: () => void;
+  operation: string;
+  type?: ButtonProps["type"];
+};
+
+type KnowledgeNetworkResourceDetailActionsProps = {
+  actions: KnowledgeNetworkResourceDetailAction[];
+  record: OperationRecord;
+};
+
+export function KnowledgeNetworkResourceDetailActions({
+  actions,
+  record,
+}: KnowledgeNetworkResourceDetailActionsProps) {
+  const visibleActions = actions.filter((action) =>
+    hasKnowledgeNetworkRecordOperation(record, action.operation),
+  );
+
+  if (visibleActions.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {visibleActions.map((action) => (
+        <AppButton
+          danger={action.danger}
+          key={action.key}
+          onClick={action.onClick}
+          type={action.type}
+        >
+          {action.label}
+        </AppButton>
+      ))}
+    </>
+  );
+}

--- a/src/modules/knowledge-network/locales/en-US/object-type.ts
+++ b/src/modules/knowledge-network/locales/en-US/object-type.ts
@@ -228,6 +228,7 @@ export const objecttypePart = {
       "Identifies a unique object instance and can be composed from multiple fields.",
     objectTypePrimaryKeyRequired: "Set at least one primary key.",
     objectTypePropertyDisplayName: "Display name",
+    objectTypePropertyDescription: "Property description",
     objectTypePropertyDuplicateDisplayName: "Display name already exists.",
     objectTypePropertyDuplicateMapping: "This resource field is already mapped to another property.",
     objectTypePropertyDuplicateName: "Property name already exists.",

--- a/src/modules/knowledge-network/locales/zh-CN/object-type.ts
+++ b/src/modules/knowledge-network/locales/zh-CN/object-type.ts
@@ -202,6 +202,7 @@ export const objecttypePart = {
       "\u7528\u4e8e\u6807\u8bc6\u552f\u4e00\u5bf9\u8c61\u5b9e\u4f8b\uff0c\u652f\u6301\u7531\u591a\u4e2a\u5b57\u6bb5\u7ec4\u6210\u3002\u5f53\u6240\u9009\u4e3b\u952e\u5b57\u6bb5\u7684\u6570\u636e\u5b58\u5728\u91cd\u590d\u65f6\uff0c\u5bf9\u8be5\u503c\u5c06\u8fdb\u884c\u878d\u5408\u786e\u4fdd\u552f\u4e00\u6027\u3002",
     objectTypePrimaryKeyRequired: "请至少设置一个主键。",
     objectTypePropertyDisplayName: "属性显示名",
+    objectTypePropertyDescription: "属性描述",
     objectTypePropertyDuplicateDisplayName: "显示名已存在。",
     objectTypePropertyDuplicateMapping: "该资源字段已被其他属性映射。",
     objectTypePropertyDuplicateName: "属性名已存在。",

--- a/src/modules/knowledge-network/scenes/ActionTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ActionTypeDetailScene.tsx
@@ -13,12 +13,13 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useAppServices } from "@/framework/context/use-app-services";
 import { hasPermissions } from "@/framework/permission/has-permissions";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
-import { AppButton } from "@/framework/ui/common/AppButton";
 import { ActionTypeOverviewPanel } from "@/modules/knowledge-network/components/action-type/ActionTypeOverviewPanel";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { KnowledgeNetworkObjectAuthorizeDrawer } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkObjectAuthorizeDrawer";
-import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
+import { KnowledgeNetworkResourceDetailActions } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions";
 import {
+  deleteKnowledgeNetworkActionType,
   getKnowledgeNetworkActionTypeDetail,
   listKnowledgeNetworkObjectTypes,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
@@ -32,7 +33,7 @@ import styles from "./ActionTypeDetailScene.module.css";
 export function ActionTypeDetailScene() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { runtimeConfig } = useAppServices();
+  const { message, modal, runtimeConfig } = useAppServices();
   const { actionTypeId = "", networkId = "" } = useParams<{
     actionTypeId: string;
     networkId: string;
@@ -56,6 +57,28 @@ export function ActionTypeDetailScene() {
     actionSource.type === "manual" ||
     (actionSource.type === "tool" ? canViewToolbox : canViewMcp);
   const listPath = `/knowledge-network/workspace/${networkId}/action-types`;
+
+  const confirmDelete = () => {
+    if (!detail) {
+      return;
+    }
+
+    void modal.confirm({
+      cancelText: t("common.cancel"),
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      content: t("knowledgeNetwork.actionTypeDeleteDescription", { name: detail.name }),
+      okButtonProps: { danger: true, type: "primary" },
+      okText: t("common.delete"),
+      onOk: async () => {
+        await deleteKnowledgeNetworkActionType(networkId, actionTypeId);
+        void message.success(t("common.success"));
+        void navigate(listPath);
+      },
+      title: t("knowledgeNetwork.actionTypeDeleteTitle"),
+      width: 520,
+    });
+  };
 
   const loadData = useCallback(async () => {
     if (!networkId || !actionTypeId) {
@@ -104,9 +127,45 @@ export function ActionTypeDetailScene() {
     <>
       <KnowledgeNetworkResourceConfigShell
         actions={
-          hasKnowledgeNetworkRecordOperation(detail, "authorize") ? (
-            <AppButton onClick={() => setAuthorizeOpen(true)}>{t("knowledgeNetwork.authorizeAction")}</AppButton>
-          ) : null
+          <KnowledgeNetworkResourceDetailActions
+            actions={[
+              {
+                key: "edit",
+                label: t("common.edit"),
+                onClick: () => {
+                  void navigate(
+                    `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/edit`,
+                  );
+                },
+                operation: "modify",
+                type: "primary",
+              },
+              {
+                key: "execution",
+                label: t("knowledgeNetwork.actionTypeExecutionEntry"),
+                onClick: () => {
+                  void navigate(
+                    `/knowledge-network/workspace/${networkId}/action-types/${actionTypeId}/execution`,
+                  );
+                },
+                operation: "task_manage",
+              },
+              {
+                key: "authorize",
+                label: t("knowledgeNetwork.authorizeAction"),
+                onClick: () => setAuthorizeOpen(true),
+                operation: "authorize",
+              },
+              {
+                danger: true,
+                key: "delete",
+                label: t("common.delete"),
+                onClick: confirmDelete,
+                operation: "delete",
+              },
+            ]}
+            record={detail}
+          />
         }
       onBack={() => {
         void navigate(listPath);

--- a/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.test.tsx
+++ b/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/framework/context/use-app-services", () => ({
       success: vi.fn(),
       warning: vi.fn(),
     },
+    modal: { confirm: vi.fn() },
   }),
 }));
 
@@ -42,6 +43,7 @@ vi.mock("@/modules/knowledge-network/hooks/useKnowledgeNetworkCanModify", () => 
 }));
 
 vi.mock("@/modules/knowledge-network/services/knowledge-network.service", () => ({
+  deleteKnowledgeNetworkConceptGroup: vi.fn(),
   getKnowledgeNetworkConceptGroup: getConceptGroup,
   removeObjectTypesFromKnowledgeNetworkConceptGroup: vi.fn(),
 }));
@@ -97,7 +99,7 @@ afterEach(() => {
 });
 
 describe("ConceptGroupDetailScene", () => {
-  it("renders Configure Permissions in the loaded detail header when authorized", async () => {
+  it("renders every operation granted by the loaded detail record", async () => {
     getConceptGroup.mockResolvedValue({
       actionTypes: [],
       description: "Source data layer",
@@ -107,7 +109,7 @@ describe("ConceptGroupDetailScene", () => {
       relationTypes: [],
       tags: [],
       updateTime: "2026-08-20 16:09:36",
-      operations: ["authorize"],
+      operations: ["query_data", "modify", "authorize", "delete"],
     });
 
     render(<ConceptGroupDetailScene />);
@@ -115,8 +117,8 @@ describe("ConceptGroupDetailScene", () => {
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("true");
     expect(await screen.findAllByText("Source Layer")).not.toHaveLength(0);
     expect(screen.getByText("knowledgeNetwork.authorizeAction")).not.toBeNull();
-    expect(screen.queryByText("common.edit")).toBeNull();
-    expect(screen.queryByText("knowledgeNetwork.conceptGroupExport")).toBeNull();
-    expect(screen.queryByText("common.delete")).toBeNull();
+    expect(screen.getByText("common.edit")).not.toBeNull();
+    expect(screen.getByText("knowledgeNetwork.conceptGroupExport")).not.toBeNull();
+    expect(screen.getByText("common.delete")).not.toBeNull();
   });
 });

--- a/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ConceptGroupDetailScene.tsx
@@ -20,11 +20,13 @@ import { useAppServices } from "@/framework/context/use-app-services";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { ConceptGroupAddObjectTypesModal } from "@/modules/knowledge-network/components/concept-group/ConceptGroupAddObjectTypesModal";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { KnowledgeNetworkObjectAuthorizeDrawer } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkObjectAuthorizeDrawer";
-import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 import { renderResourceIcon } from "@/modules/knowledge-network/components/shared/ResourceIconSelect";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
+import { KnowledgeNetworkResourceDetailActions } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions";
 import {
+  deleteKnowledgeNetworkConceptGroup,
   getKnowledgeNetworkConceptGroup,
   removeObjectTypesFromKnowledgeNetworkConceptGroup,
 } from "@/modules/knowledge-network/services/knowledge-network.service";
@@ -34,6 +36,7 @@ import type {
   ConceptGroupRelatedItem,
   KnowledgeNetworkActionTypeKind,
 } from "@/modules/knowledge-network/types/knowledge-network";
+import { downloadConceptGroupExport } from "@/modules/knowledge-network/utils/concept-group-export";
 
 import styles from "./ConceptGroupDetailScene.module.css";
 
@@ -112,7 +115,7 @@ function renderObjectRefCell(
 export function ConceptGroupDetailScene() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { message } = useAppServices();
+  const { message, modal } = useAppServices();
   const { conceptGroupId = "", networkId = "" } = useParams<{
     conceptGroupId: string;
     networkId: string;
@@ -133,6 +136,28 @@ export function ConceptGroupDetailScene() {
   const canModify = operationAccess.modify;
 
   const listPath = `/knowledge-network/workspace/${networkId}/concept-groups`;
+
+  const confirmDelete = () => {
+    if (!detail) {
+      return;
+    }
+
+    void modal.confirm({
+      cancelText: t("common.cancel"),
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      content: t("knowledgeNetwork.conceptGroupDeleteDescription", { name: detail.name }),
+      okButtonProps: { danger: true, type: "primary" },
+      okText: t("common.delete"),
+      onOk: async () => {
+        await deleteKnowledgeNetworkConceptGroup(networkId, conceptGroupId);
+        void message.success(t("common.success"));
+        void navigate(listPath);
+      },
+      title: t("knowledgeNetwork.conceptGroupDeleteTitle"),
+      width: 520,
+    });
+  };
 
   const loadData = useCallback(async () => {
     if (!networkId || !conceptGroupId) {
@@ -390,11 +415,6 @@ export function ConceptGroupDetailScene() {
   if (loading) {
     return (
       <KnowledgeNetworkResourceConfigShell
-        actions={
-          hasKnowledgeNetworkRecordOperation(detail, "authorize") ? (
-            <AppButton onClick={() => setAuthorizeOpen(true)}>{t("knowledgeNetwork.authorizeAction")}</AppButton>
-          ) : null
-        }
         loading
         onBack={() => {
           void navigate(listPath);
@@ -413,9 +433,44 @@ export function ConceptGroupDetailScene() {
     <>
       <KnowledgeNetworkResourceConfigShell
         actions={
-          hasKnowledgeNetworkRecordOperation(detail, "authorize") ? (
-            <AppButton onClick={() => setAuthorizeOpen(true)}>{t("knowledgeNetwork.authorizeAction")}</AppButton>
-          ) : null
+          <KnowledgeNetworkResourceDetailActions
+            actions={[
+              {
+                key: "export",
+                label: t("knowledgeNetwork.conceptGroupExport"),
+                onClick: () => {
+                  downloadConceptGroupExport(detail);
+                  void message.success(t("knowledgeNetwork.conceptGroupExportSuccess"));
+                },
+                operation: "query_data",
+              },
+              {
+                key: "edit",
+                label: t("common.edit"),
+                onClick: () => {
+                  void navigate(
+                    `/knowledge-network/workspace/${networkId}/concept-groups/${conceptGroupId}/edit`,
+                  );
+                },
+                operation: "modify",
+                type: "primary",
+              },
+              {
+                key: "authorize",
+                label: t("knowledgeNetwork.authorizeAction"),
+                onClick: () => setAuthorizeOpen(true),
+                operation: "authorize",
+              },
+              {
+                danger: true,
+                key: "delete",
+                label: t("common.delete"),
+                onClick: confirmDelete,
+                operation: "delete",
+              },
+            ]}
+            record={detail}
+          />
         }
         onBack={() => {
           void navigate(listPath);

--- a/src/modules/knowledge-network/scenes/DetailSceneHeaderActions.test.tsx
+++ b/src/modules/knowledge-network/scenes/DetailSceneHeaderActions.test.tsx
@@ -5,7 +5,7 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -18,6 +18,8 @@ const mocks = vi.hoisted(() => ({
   listKnowledgeNetworkMetrics: vi.fn(),
   listKnowledgeNetworkObjectTypes: vi.fn(),
   listKnowledgeNetworkRelationTypes: vi.fn(),
+  modalConfirm: vi.fn(),
+  navigate: vi.fn(),
   routeParams: {
     current: {},
   },
@@ -31,7 +33,7 @@ vi.mock("react-i18next", async (importOriginal) => ({
 vi.mock("react-router-dom", async (importOriginal) => ({
   ...(await importOriginal<typeof import("react-router-dom")>()),
   useLocation: () => ({ state: null }),
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mocks.navigate,
   useParams: () => mocks.routeParams.current,
   useSearchParams: () => [new URLSearchParams(), vi.fn()],
 }));
@@ -42,6 +44,8 @@ vi.mock("@/framework/context/use-runtime-config", () => ({
 
 vi.mock("@/framework/context/use-app-services", () => ({
   useAppServices: () => ({
+    message: { success: vi.fn() },
+    modal: { confirm: mocks.modalConfirm },
     runtimeConfig: { currentUser: { permissions: [] } },
   }),
 }));
@@ -68,6 +72,10 @@ vi.mock(
 );
 
 vi.mock("@/modules/knowledge-network/services/knowledge-network.service", () => ({
+  deleteKnowledgeNetworkActionType: vi.fn(),
+  deleteKnowledgeNetworkMetric: vi.fn(),
+  deleteKnowledgeNetworkObjectType: vi.fn(),
+  deleteKnowledgeNetworkRelationType: vi.fn(),
   getKnowledgeNetworkActionTypeDetail: mocks.getKnowledgeNetworkActionTypeDetail,
   getKnowledgeNetworkMetric: mocks.getKnowledgeNetworkMetric,
   getKnowledgeNetworkObjectTypeDetail: mocks.getKnowledgeNetworkObjectTypeDetail,
@@ -116,14 +124,8 @@ beforeEach(() => {
   mocks.listKnowledgeNetworkRelationTypes.mockResolvedValue([]);
 });
 
-function expectEmptyHeaderActions() {
-  expect(screen.getByTestId("detail-header-actions").childElementCount).toBe(0);
-  expect(screen.queryByText("common.edit")).toBeNull();
-  expect(screen.queryByText("common.delete")).toBeNull();
-}
-
 describe("knowledge network detail scene headers", () => {
-  it("keeps the action type detail header free of management actions", async () => {
+  it("shows action type operations granted by the detail record", async () => {
     mocks.routeParams.current = { actionTypeId: "action-1", networkId: "network-1" };
     mocks.getKnowledgeNetworkActionTypeDetail.mockResolvedValue({
       actionKind: "update",
@@ -139,6 +141,7 @@ describe("knowledge network detail scene headers", () => {
       name: "Update order",
       objectTypeId: "object-1",
       objectTypeName: "Order",
+      operations: ["modify", "task_manage", "authorize", "delete"],
       tags: [],
       updateTime: "2026-08-20 16:09:36",
       updaterName: "admin",
@@ -149,11 +152,18 @@ describe("knowledge network detail scene headers", () => {
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("true");
     expect(await screen.findByText("Update order")).not.toBeNull();
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("false");
-    expectEmptyHeaderActions();
-    expect(screen.queryByText("knowledgeNetwork.actionTypeExecutionEntry")).toBeNull();
+    expect(screen.getByText("common.edit")).not.toBeNull();
+    expect(screen.getByText("knowledgeNetwork.actionTypeExecutionEntry")).not.toBeNull();
+    expect(screen.getByText("knowledgeNetwork.authorizeAction")).not.toBeNull();
+    expect(screen.getByText("common.delete")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("knowledgeNetwork.actionTypeExecutionEntry"));
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/knowledge-network/workspace/network-1/action-types/action-1/execution",
+    );
   });
 
-  it("keeps the object type detail header free of management actions", async () => {
+  it("shows object type operations granted by the detail record", async () => {
     mocks.routeParams.current = { networkId: "network-1", objectTypeId: "object-1" };
     mocks.getKnowledgeNetworkObjectTypeDetail.mockResolvedValue({
       color: "#126ee3",
@@ -167,6 +177,7 @@ describe("knowledge network detail scene headers", () => {
       incrementalKey: "",
       logicProperties: [],
       name: "Order",
+      operations: ["modify", "authorize", "delete"],
       primaryKeys: [],
       tags: [],
       updateTime: "2026-08-20 16:09:36",
@@ -178,10 +189,20 @@ describe("knowledge network detail scene headers", () => {
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("true");
     expect(await screen.findByText("Order")).not.toBeNull();
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("false");
-    expectEmptyHeaderActions();
+    expect(screen.getByText("common.edit")).not.toBeNull();
+    expect(screen.getByText("knowledgeNetwork.authorizeAction")).not.toBeNull();
+    expect(screen.getByText("common.delete")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("common.edit"));
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/knowledge-network/workspace/network-1/object-types/object-1/edit",
+    );
+
+    fireEvent.click(screen.getByText("common.delete"));
+    expect(mocks.modalConfirm).toHaveBeenCalledOnce();
   });
 
-  it("keeps the relation type detail header free of management actions", async () => {
+  it("shows relation type operations granted by the detail record", async () => {
     mocks.routeParams.current = { networkId: "network-1", relationTypeId: "relation-1" };
     mocks.getKnowledgeNetworkRelationTypeDetail.mockResolvedValue({
       color: "#126ee3",
@@ -189,6 +210,7 @@ describe("knowledge network detail scene headers", () => {
       id: "relation-1",
       mappingMode: "direct",
       name: "Contains",
+      operations: ["modify", "authorize", "delete"],
       propertyMappings: [],
       resourceMappings: [],
       sourceObjectTypeId: "object-1",
@@ -205,11 +227,18 @@ describe("knowledge network detail scene headers", () => {
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("true");
     expect(await screen.findByText("Contains")).not.toBeNull();
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("false");
-    expectEmptyHeaderActions();
-    expect(screen.queryByText("knowledgeNetwork.relationTypeMappingEntry")).toBeNull();
+    expect(screen.getByText("common.edit")).not.toBeNull();
+    expect(screen.getByText("knowledgeNetwork.relationTypeMappingEntry")).not.toBeNull();
+    expect(screen.getByText("knowledgeNetwork.authorizeAction")).not.toBeNull();
+    expect(screen.getByText("common.delete")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("knowledgeNetwork.relationTypeMappingEntry"));
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/knowledge-network/workspace/network-1/relation-types/relation-1/mapping",
+    );
   });
 
-  it("keeps the metric detail header free of management actions", async () => {
+  it("shows metric operations granted by the detail record", async () => {
     mocks.routeParams.current = { metricId: "metric-1", networkId: "network-1" };
     mocks.getKnowledgeNetworkMetric.mockResolvedValue({
       calculationFormula: {
@@ -219,6 +248,7 @@ describe("knowledge network detail scene headers", () => {
       id: "metric-1",
       metricType: "atomic",
       name: "Order count",
+      operations: ["modify", "authorize", "delete"],
       scopeRef: "subgraph-1",
       scopeType: "subgraph",
       tags: [],
@@ -231,6 +261,13 @@ describe("knowledge network detail scene headers", () => {
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("true");
     expect(await screen.findByText("Order count")).not.toBeNull();
     expect(screen.getByTestId("detail-shell").dataset.loading).toBe("false");
-    expectEmptyHeaderActions();
+    expect(screen.getByText("common.edit")).not.toBeNull();
+    expect(screen.getByText("knowledgeNetwork.authorizeAction")).not.toBeNull();
+    expect(screen.getByText("common.delete")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("common.edit"));
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/knowledge-network/workspace/network-1/metrics/metric-1/edit",
+    );
   });
 });

--- a/src/modules/knowledge-network/scenes/MetricDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/MetricDetailScene.tsx
@@ -11,15 +11,17 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { useAppServices } from "@/framework/context/use-app-services";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
-import { AppButton } from "@/framework/ui/common/AppButton";
 import { MetricDataQueryPanel } from "@/modules/knowledge-network/components/metric/MetricDataQueryPanel";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { KnowledgeNetworkObjectAuthorizeDrawer } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkObjectAuthorizeDrawer";
-import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
+import { KnowledgeNetworkResourceDetailActions } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions";
 import type { MetricDetailSceneProps } from "@/modules/knowledge-network/contracts/scenes";
 import { useResolvedUpdaterName } from "@/modules/knowledge-network/hooks/useAccountDirectory";
 import {
+  deleteKnowledgeNetworkMetric,
   getKnowledgeNetworkMetric,
   getKnowledgeNetworkObjectTypeDetail,
   listKnowledgeNetworkObjectTypes,
@@ -51,6 +53,7 @@ export function MetricDetailScene({
 }: MetricDetailSceneProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { message, modal } = useAppServices();
   const params = useParams<{
     metricId: string;
     networkId: string;
@@ -67,6 +70,37 @@ export function MetricDetailScene({
   const resolvedUpdaterName = useResolvedUpdaterName(detail?.updaterName);
 
   const listPath = `/knowledge-network/workspace/${networkId}/metrics`;
+
+  const leaveDetail = () => {
+    if (onBack) {
+      onBack();
+      return;
+    }
+
+    void navigate(listPath);
+  };
+
+  const confirmDelete = () => {
+    if (!detail) {
+      return;
+    }
+
+    void modal.confirm({
+      cancelText: t("common.cancel"),
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      content: t("knowledgeNetwork.metricDeleteDescription", { name: detail.name }),
+      okButtonProps: { danger: true, type: "primary" },
+      okText: t("common.delete"),
+      onOk: async () => {
+        await deleteKnowledgeNetworkMetric(networkId, metricId);
+        void message.success(t("common.success"));
+        leaveDetail();
+      },
+      title: t("knowledgeNetwork.metricDeleteTitle"),
+      width: 520,
+    });
+  };
 
   const loadData = useCallback(async () => {
     if (!networkId || !metricId) {
@@ -108,14 +142,7 @@ export function MetricDetailScene({
     return (
       <KnowledgeNetworkResourceConfigShell
         loading
-        onBack={() => {
-          if (onBack) {
-            onBack();
-            return;
-          }
-
-          void navigate(listPath);
-        }}
+        onBack={leaveDetail}
         subtitle={t("knowledgeNetwork.metricDetailDescription")}
         title={t("knowledgeNetwork.metricDetailTitle")}
       />
@@ -133,18 +160,37 @@ export function MetricDetailScene({
     <>
       <KnowledgeNetworkResourceConfigShell
         actions={
-          hasKnowledgeNetworkRecordOperation(detail, "authorize") ? (
-            <AppButton onClick={() => setAuthorizeOpen(true)}>{t("knowledgeNetwork.authorizeAction")}</AppButton>
-          ) : null
+          <KnowledgeNetworkResourceDetailActions
+            actions={[
+              {
+                key: "edit",
+                label: t("common.edit"),
+                onClick: () => {
+                  void navigate(
+                    `/knowledge-network/workspace/${networkId}/metrics/${metricId}/edit`,
+                  );
+                },
+                operation: "modify",
+                type: "primary",
+              },
+              {
+                key: "authorize",
+                label: t("knowledgeNetwork.authorizeAction"),
+                onClick: () => setAuthorizeOpen(true),
+                operation: "authorize",
+              },
+              {
+                danger: true,
+                key: "delete",
+                label: t("common.delete"),
+                onClick: confirmDelete,
+                operation: "delete",
+              },
+            ]}
+            record={detail}
+          />
         }
-      onBack={() => {
-        if (onBack) {
-          onBack();
-          return;
-        }
-
-        void navigate(listPath);
-      }}
+      onBack={leaveDetail}
       subtitle={t("knowledgeNetwork.metricDetailDescription")}
       title={detail.name}
     >

--- a/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/ObjectTypeDetailScene.tsx
@@ -12,22 +12,24 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
 
+import { useAppServices } from "@/framework/context/use-app-services";
 import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
 import { hasPermissions } from "@/framework/permission/has-permissions";
 import { dataCatalogResourceStatusPermissions } from "@/modules/data-catalog/permissions";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
-import { AppButton } from "@/framework/ui/common/AppButton";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { getCatalogResources } from "@/modules/data-catalog/services/resource.service";
 import type { ResourceLocalIndexStatus } from "@/modules/data-catalog/types/data-catalog";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { formatResourceIndexStateLabel } from "@/modules/knowledge-network/utils/resource-index-state";
 import { KnowledgeNetworkObjectAuthorizeDrawer } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkObjectAuthorizeDrawer";
-import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
+import { KnowledgeNetworkResourceDetailActions } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions";
 import { renderResourceIcon } from "@/modules/knowledge-network/components/shared/ResourceIconSelect";
 import {
   ObjectTypePropertyTable,
   ObjectTypePropertyTableColumnSettings,
+  ObjectTypePropertyDescriptionCell,
 } from "@/modules/knowledge-network/components/object-type/ObjectTypePropertyTable";
 import { useObjectTypePropertyTableState } from "@/modules/knowledge-network/components/object-type/useObjectTypePropertyTableState";
 import { ObjectTypeDetailLogicPropertyTrialPanel } from "@/modules/knowledge-network/components/object-type/detail/ObjectTypeDetailLogicPropertyTrialPanel";
@@ -36,6 +38,7 @@ import { buildSampleRowKey } from "@/modules/knowledge-network/lib/object-type-i
 import { isMetricLogicProperty } from "@/modules/knowledge-network/lib/object-type-trial-metrics";
 import { buildActionTypeKindSelectOptions } from "@/modules/knowledge-network/constants/action-type-kinds";
 import {
+  deleteKnowledgeNetworkObjectType,
   getKnowledgeNetworkObjectTypeDetail,
   getObjectTypeSampleData,
   listKnowledgeNetworkActionTypes,
@@ -160,6 +163,7 @@ export function ObjectTypeDetailScene() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const { message, modal } = useAppServices();
   const runtimeConfig = useRuntimeConfig();
   const { networkId = "", objectTypeId = "" } = useParams<{
     networkId: string;
@@ -242,6 +246,28 @@ export function ObjectTypeDetailScene() {
     )
       ? locationState.knowledgeNetworkReturnTo
       : listPath;
+
+  const confirmDelete = () => {
+    if (!detail) {
+      return;
+    }
+
+    void modal.confirm({
+      cancelText: t("common.cancel"),
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      content: t("knowledgeNetwork.objectTypeDeleteDescription", { name: detail.name }),
+      okButtonProps: { danger: true, type: "primary" },
+      okText: t("common.delete"),
+      onOk: async () => {
+        await deleteKnowledgeNetworkObjectType(networkId, objectTypeId);
+        void message.success(t("common.success"));
+        void navigate(listPath);
+      },
+      title: t("knowledgeNetwork.objectTypeDeleteTitle"),
+      width: 520,
+    });
+  };
 
   const openMetricTrial = useCallback((metricId: string) => {
     setSearchParams((current) => {
@@ -867,9 +893,9 @@ export function ObjectTypeDetailScene() {
       {
         dataIndex: "comment",
         key: "comment",
-        ellipsis: true,
-        title: t("common.description"),
-        render: (value?: string) => value || "--",
+        title: t("knowledgeNetwork.objectTypePropertyDescription"),
+        render: (value?: string) => <ObjectTypePropertyDescriptionCell value={value} />,
+        width: 240,
       },
       {
         key: "actions",
@@ -1962,46 +1988,72 @@ export function ObjectTypeDetailScene() {
     <>
       <KnowledgeNetworkResourceConfigShell
         actions={
-          hasKnowledgeNetworkRecordOperation(detail, "authorize") ? (
-            <AppButton onClick={() => setAuthorizeOpen(true)}>{t("knowledgeNetwork.authorizeAction")}</AppButton>
-          ) : null
-        }
-      onBack={() => {
-        void navigate(returnPath);
-      }}
-      subtitle={detail.id}
-      title={detail.name}
-    >
-      <div className={styles.page}>
-        <section className={styles.tabCard}>
-          <Tabs
-            activeKey={activeTab}
-            items={[
+          <KnowledgeNetworkResourceDetailActions
+            actions={[
               {
-                children: overviewPanel,
-                key: "overview",
-                label: t("knowledgeNetwork.objectTypeDetailTabOverview"),
+                key: "edit",
+                label: t("common.edit"),
+                onClick: () => {
+                  void navigate(
+                    `/knowledge-network/workspace/${networkId}/object-types/${objectTypeId}/edit`,
+                  );
+                },
+                operation: "modify",
+                type: "primary",
               },
               {
-                children: propertiesPanel,
-                key: "properties",
-                label: t("knowledgeNetwork.objectTypeDetailTabProperties"),
+                key: "authorize",
+                label: t("knowledgeNetwork.authorizeAction"),
+                onClick: () => setAuthorizeOpen(true),
+                operation: "authorize",
               },
               {
-                children: dataPanel,
-                key: "data",
-                label: t("knowledgeNetwork.objectTypeDetailTabData"),
-              },
-              {
-                children: relatedPanel,
-                key: "related",
-                label: t("knowledgeNetwork.objectTypeDetailTabRelated"),
+                danger: true,
+                key: "delete",
+                label: t("common.delete"),
+                onClick: confirmDelete,
+                operation: "delete",
               },
             ]}
-            onChange={handleTabChange}
+            record={detail}
           />
-        </section>
-      </div>
+        }
+        onBack={() => {
+          void navigate(returnPath);
+        }}
+        subtitle={detail.id}
+        title={detail.name}
+      >
+        <div className={styles.page}>
+          <section className={styles.tabCard}>
+            <Tabs
+              activeKey={activeTab}
+              items={[
+                {
+                  children: overviewPanel,
+                  key: "overview",
+                  label: t("knowledgeNetwork.objectTypeDetailTabOverview"),
+                },
+                {
+                  children: propertiesPanel,
+                  key: "properties",
+                  label: t("knowledgeNetwork.objectTypeDetailTabProperties"),
+                },
+                {
+                  children: dataPanel,
+                  key: "data",
+                  label: t("knowledgeNetwork.objectTypeDetailTabData"),
+                },
+                {
+                  children: relatedPanel,
+                  key: "related",
+                  label: t("knowledgeNetwork.objectTypeDetailTabRelated"),
+                },
+              ]}
+              onChange={handleTabChange}
+            />
+          </section>
+        </div>
       </KnowledgeNetworkResourceConfigShell>
       <KnowledgeNetworkObjectAuthorizeDrawer
         networkId={networkId}

--- a/src/modules/knowledge-network/scenes/RelationTypeDetailScene.tsx
+++ b/src/modules/knowledge-network/scenes/RelationTypeDetailScene.tsx
@@ -11,13 +11,17 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
+import { useAppServices } from "@/framework/context/use-app-services";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
-import { AppButton } from "@/framework/ui/common/AppButton";
+import modalStyles from "@/modules/knowledge-network/components/network/KnowledgeNetworkFormModal.module.css";
 import { RelationTypeMappingConfigTable } from "@/modules/knowledge-network/components/relation-type/RelationTypeMappingConfigTable";
 import { KnowledgeNetworkObjectAuthorizeDrawer } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkObjectAuthorizeDrawer";
-import { hasKnowledgeNetworkRecordOperation } from "@/modules/knowledge-network/utils/record-operations";
 import { KnowledgeNetworkResourceConfigShell } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceConfigShell";
-import { getKnowledgeNetworkRelationTypeDetail } from "@/modules/knowledge-network/services/knowledge-network.service";
+import { KnowledgeNetworkResourceDetailActions } from "@/modules/knowledge-network/components/shared/KnowledgeNetworkResourceDetailActions";
+import {
+  deleteKnowledgeNetworkRelationType,
+  getKnowledgeNetworkRelationTypeDetail,
+} from "@/modules/knowledge-network/services/knowledge-network.service";
 import type { RelationTypeDetail } from "@/modules/knowledge-network/types/knowledge-network";
 
 import styles from "./RelationTypeDetailScene.module.css";
@@ -30,6 +34,7 @@ export function RelationTypeDetailScene() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const { message, modal } = useAppServices();
   const { networkId = "", relationTypeId = "" } = useParams<{
     networkId: string;
     relationTypeId: string;
@@ -48,6 +53,28 @@ export function RelationTypeDetailScene() {
     )
       ? locationState.knowledgeNetworkReturnTo
       : listPath;
+
+  const confirmDelete = () => {
+    if (!detail) {
+      return;
+    }
+
+    void modal.confirm({
+      cancelText: t("common.cancel"),
+      centered: true,
+      className: `${modalStyles.businessModal} ${modalStyles.resourceDeleteConfirmModal}`,
+      content: t("knowledgeNetwork.relationTypeDeleteDescription", { name: detail.name }),
+      okButtonProps: { danger: true, type: "primary" },
+      okText: t("common.delete"),
+      onOk: async () => {
+        await deleteKnowledgeNetworkRelationType(networkId, relationTypeId);
+        void message.success(t("common.success"));
+        void navigate(listPath);
+      },
+      title: t("knowledgeNetwork.relationTypeDeleteTitle"),
+      width: 520,
+    });
+  };
 
   const loadData = useCallback(async () => {
     if (!networkId || !relationTypeId) {
@@ -92,9 +119,45 @@ export function RelationTypeDetailScene() {
     <>
       <KnowledgeNetworkResourceConfigShell
         actions={
-          hasKnowledgeNetworkRecordOperation(detail, "authorize") ? (
-            <AppButton onClick={() => setAuthorizeOpen(true)}>{t("knowledgeNetwork.authorizeAction")}</AppButton>
-          ) : null
+          <KnowledgeNetworkResourceDetailActions
+            actions={[
+              {
+                key: "edit",
+                label: t("common.edit"),
+                onClick: () => {
+                  void navigate(
+                    `/knowledge-network/workspace/${networkId}/relation-types/${relationTypeId}/edit`,
+                  );
+                },
+                operation: "modify",
+                type: "primary",
+              },
+              {
+                key: "mapping",
+                label: t("knowledgeNetwork.relationTypeMappingEntry"),
+                onClick: () => {
+                  void navigate(
+                    `/knowledge-network/workspace/${networkId}/relation-types/${relationTypeId}/mapping`,
+                  );
+                },
+                operation: "modify",
+              },
+              {
+                key: "authorize",
+                label: t("knowledgeNetwork.authorizeAction"),
+                onClick: () => setAuthorizeOpen(true),
+                operation: "authorize",
+              },
+              {
+                danger: true,
+                key: "delete",
+                label: t("common.delete"),
+                onClick: confirmDelete,
+                operation: "delete",
+              },
+            ]}
+            record={detail}
+          />
         }
       onBack={() => {
         void navigate(returnPath);

--- a/src/modules/knowledge-network/services/action-type.service.ts
+++ b/src/modules/knowledge-network/services/action-type.service.ts
@@ -10,6 +10,7 @@ import {
   unwrapSingleEntryResponse,
   type SingleEntryResponse,
 } from "@/framework/request/normalize";
+import { ensureKnowledgeNetworkChildOperations } from "@/modules/knowledge-network/services/child-resource-operations.service";
 import type {
   ActionTypeDetail,
   ActionTypeExecutionLogDetail,
@@ -173,7 +174,11 @@ export async function getKnowledgeNetworkActionTypeDetail(
     return null;
   }
 
-  return mapActionTypeDetail(record);
+  return ensureKnowledgeNetworkChildOperations(
+    networkId,
+    "action-types",
+    mapActionTypeDetail(record),
+  );
 }
 
 export async function listKnowledgeNetworkActionTypeExecutionLogs(

--- a/src/modules/knowledge-network/services/child-resource-operations.service.test.ts
+++ b/src/modules/knowledge-network/services/child-resource-operations.service.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock },
+}));
+
+import { ensureKnowledgeNetworkChildOperations } from "./child-resource-operations.service";
+
+describe("ensureKnowledgeNetworkChildOperations", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it("keeps operations returned by a detail response without another request", async () => {
+    const detail = { id: "action-1", operations: ["modify"] };
+
+    await expect(
+      ensureKnowledgeNetworkChildOperations("kn-1", "action-types", detail),
+    ).resolves.toBe(detail);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "concept-groups",
+    "object-types",
+    "relation-types",
+    "action-types",
+    "metrics",
+  ] as const)(
+    "loads effective operations from the %s list when detail omits them",
+    async (collection) => {
+      getMock.mockResolvedValue({
+        data: {
+          entries: [
+            { id: "another", operations: ["view_detail"] },
+            {
+              id: "child-1",
+              operations: ["view_detail", "modify", "authorize", "delete"],
+            },
+          ],
+          total_count: 2,
+        },
+      });
+
+      const result = await ensureKnowledgeNetworkChildOperations("kn-1", collection, {
+        id: "child-1",
+      });
+
+      expect(result.operations).toEqual(["view_detail", "modify", "authorize", "delete"]);
+      expect(getMock).toHaveBeenCalledWith(
+        `/bkn-backend/v1/knowledge-networks/kn-1/${collection}`,
+        {
+          params: {
+            direction: "desc",
+            limit: -1,
+            offset: 0,
+            sort: "update_time",
+          },
+        },
+      );
+    },
+  );
+
+  it("fails closed when the detail is no longer present in the visible list", async () => {
+    getMock.mockResolvedValue({ data: { entries: [], total_count: 0 } });
+
+    const result = await ensureKnowledgeNetworkChildOperations("kn-1", "object-types", {
+      id: "object-1",
+    });
+
+    expect(result.operations).toEqual([]);
+  });
+});

--- a/src/modules/knowledge-network/services/child-resource-operations.service.ts
+++ b/src/modules/knowledge-network/services/child-resource-operations.service.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { http } from "@/framework/request/http";
+import type { BackendListResponse } from "@/modules/knowledge-network/services/mappers/backend-types";
+
+export type KnowledgeNetworkChildCollection =
+  | "action-types"
+  | "concept-groups"
+  | "metrics"
+  | "object-types"
+  | "relation-types";
+
+type OperationRecord = {
+  id: string;
+  operations?: string[];
+};
+
+/**
+ * Older bkn-backend detail responses omit operations even though their list response exposes the
+ * effective, inheritance-aware operation set. Keep the detail response as the primary source and
+ * fall back to the matching list record only when the field is absent.
+ */
+export async function ensureKnowledgeNetworkChildOperations<T extends OperationRecord>(
+  networkId: string,
+  collection: KnowledgeNetworkChildCollection,
+  record: T,
+): Promise<T & { operations: string[] }> {
+  if (record.operations !== undefined) {
+    return record as T & { operations: string[] };
+  }
+
+  const response = await http.get<BackendListResponse<OperationRecord>>(
+    `/bkn-backend/v1/knowledge-networks/${networkId}/${collection}`,
+    {
+      params: {
+        direction: "desc",
+        limit: -1,
+        offset: 0,
+        sort: "update_time",
+      },
+    },
+  );
+  const matchingRecord = response.data.entries.find((item) => item.id === record.id);
+
+  return {
+    ...record,
+    operations: matchingRecord?.operations ?? [],
+  };
+}

--- a/src/modules/knowledge-network/services/concept-group.service.ts
+++ b/src/modules/knowledge-network/services/concept-group.service.ts
@@ -11,6 +11,7 @@ import {
   unwrapSingleEntryResponse,
   type SingleEntryResponse,
 } from "@/framework/request/normalize";
+import { ensureKnowledgeNetworkChildOperations } from "@/modules/knowledge-network/services/child-resource-operations.service";
 import type {
   ConceptGroupDetail,
   ConceptGroupMutationPayload,
@@ -93,7 +94,13 @@ export async function getKnowledgeNetworkConceptGroup(networkId: string, groupId
   );
 
   const record = unwrapSingleEntryResponse(response.data);
-  return record ? mapConceptGroupDetail(record) : null;
+  return record
+    ? ensureKnowledgeNetworkChildOperations(
+        networkId,
+        "concept-groups",
+        mapConceptGroupDetail(record),
+      )
+    : null;
 }
 
 export async function createKnowledgeNetworkConceptGroup(

--- a/src/modules/knowledge-network/services/mappers/action-type-list.test.ts
+++ b/src/modules/knowledge-network/services/mappers/action-type-list.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
   mapActionKind,
   mapActionType,
+  mapActionTypeDetail,
   mapConceptGroupDetail,
   mapRecentObject,
 } from "@/modules/knowledge-network/services/mappers";
@@ -39,6 +40,17 @@ describe("action type list mapper", () => {
 
     expect(record.actionKind).toBe("update");
     expect(record.operations).toEqual(["authorize"]);
+  });
+
+  it("preserves operations for the action type detail", () => {
+    const detail = mapActionTypeDetail({
+      action_type: "modify",
+      id: "action-1",
+      name: "Edit order",
+      operations: ["modify", "authorize", "delete"],
+    });
+
+    expect(detail.operations).toEqual(["modify", "authorize", "delete"]);
   });
 
   it("maps concept group action type entries with lowercase backend enums", () => {

--- a/src/modules/knowledge-network/services/mappers/action-type.mapper.ts
+++ b/src/modules/knowledge-network/services/mappers/action-type.mapper.ts
@@ -301,6 +301,7 @@ export function mapActionTypeDetail(item: BackendActionType): ActionTypeDetail {
     actionKind: mapActionKindFromBackend(item.action_type),
     objectTypeId: item.object_type_id ?? item.object_type?.id ?? "",
     objectTypeName: item.object_type?.name ?? item.object_type_id ?? "-",
+    operations: item.operations,
     tags: item.tags ?? [],
     updateTime: formatTimestamp(item.update_time),
     updaterName: item.updater?.name ?? item.updater?.id ?? "-",

--- a/src/modules/knowledge-network/services/metric.service.ts
+++ b/src/modules/knowledge-network/services/metric.service.ts
@@ -10,6 +10,7 @@ import {
   unwrapSingleEntryResponse,
   type SingleEntryResponse,
 } from "@/framework/request/normalize";
+import { ensureKnowledgeNetworkChildOperations } from "@/modules/knowledge-network/services/child-resource-operations.service";
 import type {
   KnowledgeNetworkMetricMutationPayload,
   KnowledgeNetworkMetricRecord,
@@ -163,7 +164,9 @@ export async function getKnowledgeNetworkMetric(networkId: string, metricId: str
 
     updateMetricApiAvailability("ready");
     const item = unwrapSingleEntryResponse(response.data);
-    return item ? mapMetric(item) : null;
+    return item
+      ? ensureKnowledgeNetworkChildOperations(networkId, "metrics", mapMetric(item))
+      : null;
   } catch (error) {
     if (getErrorStatus(error) === 404) {
       updateMetricApiAvailability("unsupported");

--- a/src/modules/knowledge-network/services/object-type.service.ts
+++ b/src/modules/knowledge-network/services/object-type.service.ts
@@ -11,6 +11,7 @@ import {
   unwrapSingleEntryResponse,
   type SingleEntryResponse,
 } from "@/framework/request/normalize";
+import { ensureKnowledgeNetworkChildOperations } from "@/modules/knowledge-network/services/child-resource-operations.service";
 import type {
   KnowledgeNetworkImportMode,
   KnowledgeNetworkObjectTypeMutationPayload,
@@ -186,7 +187,13 @@ export async function getKnowledgeNetworkObjectTypeDetail(
   );
 
   const record = unwrapSingleEntryResponse(response.data);
-  return record ? mapObjectTypeDetail(record) : null;
+  return record
+    ? ensureKnowledgeNetworkChildOperations(
+        networkId,
+        "object-types",
+        mapObjectTypeDetail(record),
+      )
+    : null;
 }
 
 export async function getObjectTypeSampleData(

--- a/src/modules/knowledge-network/services/relation-type.service.ts
+++ b/src/modules/knowledge-network/services/relation-type.service.ts
@@ -10,6 +10,7 @@ import {
   unwrapSingleEntryResponse,
   type SingleEntryResponse,
 } from "@/framework/request/normalize";
+import { ensureKnowledgeNetworkChildOperations } from "@/modules/knowledge-network/services/child-resource-operations.service";
 import type {
   KnowledgeNetworkImportMode,
   KnowledgeNetworkRelationTypeMutationPayload,
@@ -198,7 +199,13 @@ export async function getKnowledgeNetworkRelationTypeDetail(
   );
 
   const record = unwrapSingleEntryResponse(response.data);
-  return record ? mapRelationTypeDetail(record) : null;
+  return record
+    ? ensureKnowledgeNetworkChildOperations(
+        networkId,
+        "relation-types",
+        mapRelationTypeDetail(record),
+      )
+    : null;
 }
 
 export async function createKnowledgeNetworkRelationType(

--- a/src/modules/knowledge-network/utils/concept-group-export.ts
+++ b/src/modules/knowledge-network/utils/concept-group-export.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ConceptGroupDetail } from "@/modules/knowledge-network/types/knowledge-network";
+
+export function downloadConceptGroupExport(detail: ConceptGroupDetail) {
+  const blob = new Blob([JSON.stringify(detail, null, 2)], {
+    type: "application/json;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${detail.name}.json`;
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Show each resource's permitted list actions in concept group, object type, relation type, action type, and metric detail headers.
- [x] Recover effective operations from the matching list record when an older detail response omits `operations`.
- [x] Add object-type property descriptions with localized headers and empty-value handling.

---

## Why

- Related Issue: Closes #541
- Related Feature: Knowledge network resource details
- Background: Detail pages did not expose the actions available from list rows, and the integration backend omits `operations` from detail responses.

---

## How

- Key implementation points:
  - Reuse one operation-filtering detail action component across all five resource types.
  - Prefer detail-response operations and fall back to the authorization-filtered list record only when the field is absent.
  - Reuse existing edit, mapping/execution, authorization, export, and delete workflows.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [x] Verified in test environment

Test notes:

- `node scripts/check-license-headers.mjs`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `NODE_OPTIONS=--max-old-space-size=2560 pnpm exec vitest --run --maxWorkers=2`
- `pnpm exec tsc -b --pretty false`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm exec vite build`
- `pnpm audit --prod`
- Manually verified all five detail pages against the real integration backend from the local Vite app; no mutating action was executed.

---

## Risk & Rollback

- Potential risks: Older backends require one additional authorization-filtered list request when a detail response omits `operations`; the request is skipped when detail operations are present.
- Rollback plan: Revert this PR to restore the previous detail headers and property table.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: Not applicable.
