### PR TITLE
fix(clipboard): support copying over HTTP

### DIFF
--- a/src/app/locales/resources/common/en-US.ts
+++ b/src/app/locales/resources/common/en-US.ts
@@ -13,6 +13,8 @@ export const commonEnUS = {
     create: "Create",
     import: "Import",
     copy: "Copy",
+    copySuccess: "Copied",
+    copyFailed: "Copy failed",
     viewDetails: "View details",
     hideDetails: "Hide details",
     back: "Back",

--- a/src/app/locales/resources/common/zh-CN.ts
+++ b/src/app/locales/resources/common/zh-CN.ts
@@ -13,6 +13,8 @@ export const commonZhCN = {
     create: "新建",
     import: "导入",
     copy: "复制",
+    copySuccess: "已复制",
+    copyFailed: "复制失败",
     viewDetails: "查看详情",
     hideDetails: "收起详情",
     back: "返回",

--- a/src/framework/compat/clipboard-boundary.test.ts
+++ b/src/framework/compat/clipboard-boundary.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function sourceFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return sourceFiles(entryPath);
+    }
+    return /\.[jt]sx?$/.test(entry.name) && !entry.name.includes(".test.")
+      ? [entryPath]
+      : [];
+  });
+}
+
+describe("clipboard compatibility boundary", () => {
+  it("keeps direct Clipboard API access inside the compatibility adapter", () => {
+    const sourceRoot = path.resolve("src");
+    const adapterPath = path.resolve("src/framework/compat/clipboard.ts");
+    const violations = sourceFiles(sourceRoot)
+      .filter((file) => file !== adapterPath)
+      .flatMap((file) =>
+        fs
+          .readFileSync(file, "utf8")
+          .split("\n")
+          .flatMap((line, index) =>
+            line.includes("navigator.clipboard")
+              ? [`${path.relative(sourceRoot, file)}:${index + 1}`]
+              : [],
+          ),
+      );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/framework/compat/clipboard.test.ts
+++ b/src/framework/compat/clipboard.test.ts
@@ -79,4 +79,15 @@ describe("writeTextToClipboard", () => {
 
     expect(execCommand).toHaveBeenCalledWith("copy");
   });
+
+  it("rejects when neither clipboard strategy can copy the text", async () => {
+    setClipboard(undefined);
+    setExecCommand(() => false);
+
+    await expect(writeTextToClipboard("manual copy required")).rejects.toThrow(
+      "Copy command was rejected",
+    );
+
+    expect(document.querySelector("textarea")).toBeNull();
+  });
 });

--- a/src/framework/ui/common/RequestErrorAlert.test.tsx
+++ b/src/framework/ui/common/RequestErrorAlert.test.tsx
@@ -5,10 +5,13 @@
  * Conditions. See LICENSE for the full text.
  */
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RequestErrorAlert } from "./RequestErrorAlert";
+
+const messageMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+const writeTextToClipboardMock = vi.hoisted(() => vi.fn());
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>();
@@ -21,7 +24,19 @@ vi.mock("react-i18next", async (importOriginal) => {
   };
 });
 
+vi.mock("@/framework/compat/clipboard", () => ({
+  writeTextToClipboard: writeTextToClipboardMock,
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({ message: messageMock }),
+}));
+
 describe("RequestErrorAlert", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -53,5 +68,26 @@ describe("RequestErrorAlert", () => {
     expect(screen.getByText("common.error.details: No key")).toBeTruthy();
     void act(() => vi.advanceTimersByTime(10000));
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("reports feedback after copying expanded error details", async () => {
+    writeTextToClipboardMock.mockResolvedValue(undefined);
+    render(
+      <RequestErrorAlert
+        autoDismissMs={0}
+        error={{ code: "BuildTask.CreateFailed", description: "Build failed" }}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("common.viewDetails"));
+    fireEvent.click(screen.getByText("common.copy"));
+
+    await waitFor(() => {
+      expect(writeTextToClipboardMock).toHaveBeenCalledWith(
+        "Build failed\ncommon.error.code: BuildTask.CreateFailed",
+      );
+      expect(messageMock.success).toHaveBeenCalledWith("common.copySuccess");
+    });
   });
 });

--- a/src/framework/ui/common/RequestErrorAlert.tsx
+++ b/src/framework/ui/common/RequestErrorAlert.tsx
@@ -9,6 +9,8 @@ import { Alert, Space } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
+import { useAppServices } from "@/framework/context/use-app-services";
 import type { RequestErrorDetails } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 
@@ -26,6 +28,7 @@ export function RequestErrorAlert({
   onDismiss,
 }: RequestErrorAlertProps) {
   const { t } = useTranslation();
+  const { message } = useAppServices();
   const [expanded, setExpanded] = useState(false);
   const hasDetails = Boolean(error.code || error.details || error.solution || error.errorLink);
   const copyText = useMemo(
@@ -56,7 +59,9 @@ export function RequestErrorAlert({
   }, [autoDismissMs, expanded, onDismiss]);
 
   const copyDetails = () => {
-    void navigator.clipboard?.writeText(copyText);
+    void writeTextToClipboard(copyText)
+      .then(() => message.success(t("common.copySuccess")))
+      .catch(() => message.error(t("common.copyFailed")));
   };
 
   return (

--- a/src/modules/api-keys/components/ApiKeySecretModal.tsx
+++ b/src/modules/api-keys/components/ApiKeySecretModal.tsx
@@ -9,6 +9,7 @@ import { CopyOutlined, WarningFilled } from "@ant-design/icons";
 import { Alert, Modal } from "antd";
 import { useTranslation } from "react-i18next";
 
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { useAppServices } from "@/framework/context/use-app-services";
 import type { IssuedApiKey } from "@/modules/api-keys/types/api-key";
 
@@ -28,8 +29,7 @@ export function ApiKeySecretModal({
     if (!secret) {
       return;
     }
-    void navigator.clipboard
-      ?.writeText(secret.key)
+    void writeTextToClipboard(secret.key)
       .then(() => message.success(t("apiKeys.secretModal.copied")))
       .catch(() => message.error(t("apiKeys.secretModal.copyFailed")));
   };

--- a/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.tsx
+++ b/src/modules/bkn-trace/business-provenance/BusinessProvenanceScene.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import i18n from "@/app/locales/i18n";
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import {
   getBusinessProvenanceAnalysisHistory,
   getBusinessProvenanceConversations,
@@ -386,8 +387,12 @@ export function BusinessProvenanceScene() {
 
   const copyMarkdown = useCallback(async () => {
     if (!selectedInteraction || !analysisMarkdown) return;
-    await navigator.clipboard?.writeText(analysisMarkdown);
-    message.success(bpText("agent.markdownCopied"));
+    try {
+      await writeTextToClipboard(analysisMarkdown);
+      message.success(bpText("agent.markdownCopied"));
+    } catch {
+      message.error(bpText("agent.copyFailed"));
+    }
   }, [analysisMarkdown, selectedInteraction]);
 
   const downloadMarkdown = useCallback(() => {
@@ -565,7 +570,7 @@ function AnalysisResult({ result, onRestart }: { result: Record<string, unknown>
     <h3>{bpText("agent.recommendations")}</h3>
     {advice.suggestions.length ? advice.suggestions.map((suggestion, index) => <article className={styles.recommendation} key={`${suggestion.id ?? "recommendation"}-${index}`}><header><strong>{suggestion.change || bpText("agent.suggestionTitleMissing")}</strong><span>{suggestion.id || `REC-${index + 1}`}</span></header><dl><dt>{bpText("agent.category")}</dt><dd>{suggestion.category || missing}</dd><dt>{bpText("agent.location")}</dt><dd>{suggestion.location || missing}</dd><dt>{bpText("agent.problem")}</dt><dd>{suggestion.problem || missing}</dd><dt>{bpText("agent.sourceEvidence")}</dt><dd>{suggestion.sourceEvidence || missing}</dd><dt>{bpText("agent.verificationEvidence")}</dt><dd>{suggestion.verificationEvidence || missing}</dd><dt>{bpText("agent.change")}</dt><dd>{suggestion.change || missing}</dd><dt>{bpText("agent.acceptance")}</dt><dd>{suggestion.acceptance || missing}</dd></dl></article>) : <div className={styles.agentSection}>{bpText("agent.noStrictSuggestion")}</div>}
     <h3>{bpText("agent.unableToDetermine")}</h3><div className={styles.agentSection}>{advice.notEvaluable || bpText("none")}</div>
-    <footer><Button onClick={() => { void navigator.clipboard?.writeText(adviceMarkdown(advice)); }}>{bpText("agent.copyAdviceMarkdown")}</Button><Button type="primary" onClick={onRestart}>{bpText("agent.restart")}</Button></footer>
+    <footer><Button onClick={() => { void writeTextToClipboard(adviceMarkdown(advice)).then(() => message.success(bpText("agent.adviceMarkdownCopied"))).catch(() => message.error(bpText("agent.copyFailed"))); }}>{bpText("agent.copyAdviceMarkdown")}</Button><Button type="primary" onClick={onRestart}>{bpText("agent.restart")}</Button></footer>
   </section>;
 }
 

--- a/src/modules/bkn-trace/components/LogDetailDrawer.tsx
+++ b/src/modules/bkn-trace/components/LogDetailDrawer.tsx
@@ -11,6 +11,8 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { buildAppPath } from "@/app/router/app-paths";
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
+import { useAppServices } from "@/framework/context/use-app-services";
 import { presentAuthMethod, presentLogAction, presentLogActor, presentLogTarget, presentTargetType } from "@/modules/bkn-trace/components/log-presentation";
 import styles from "@/modules/bkn-trace/scenes/ObservabilityWorkspace.module.css";
 import { getLogDetail, type LogDetailResult } from "@/modules/bkn-trace/services/observability.service";
@@ -23,6 +25,7 @@ type Props = {
 
 export function LogDetailDrawer({ logId, onClose }: Props) {
   const { t } = useTranslation();
+  const { message } = useAppServices();
   const userDirectory = useAuditUserDirectory();
   const [detail, setDetail] = useState<LogDetailResult>();
   const [error, setError] = useState<string>();
@@ -43,6 +46,12 @@ export function LogDetailDrawer({ logId, onClose }: Props) {
   const record = detail?.data;
   const target = record ? presentLogTarget(record, t) : undefined;
   const actor = record ? presentLogActor(record, t, userDirectory) : undefined;
+  const copyRawFacts = () => {
+    if (!record) return;
+    void writeTextToClipboard(JSON.stringify(record, null, 2))
+      .then(() => message.success(t("bknTrace.logs.detail.rawFactsCopied")))
+      .catch(() => message.error(t("bknTrace.logs.detail.copyFailed")));
+  };
   return (
     <Drawer
       className={styles.compactDrawer}
@@ -123,7 +132,7 @@ export function LogDetailDrawer({ logId, onClose }: Props) {
               key: "raw",
               label: t("bknTrace.logs.detail.rawFacts"),
               children: <>
-              <Button onClick={() => void navigator.clipboard?.writeText(JSON.stringify(record, null, 2))} size="small">
+              <Button onClick={copyRawFacts} size="small">
                 {t("bknTrace.logs.detail.copyRawFacts")}
               </Button>
               <pre className={styles.attributeBlock}>{JSON.stringify({ facts: record.facts, attributes: record.attributes }, null, 2)}</pre>

--- a/src/modules/bkn-trace/locales/en-US.ts
+++ b/src/modules/bkn-trace/locales/en-US.ts
@@ -21,7 +21,7 @@ export const bknTraceEnUS = {
         actions: { analyze: "Analyze with BKN Agent", back: "Back to conversations", copyMarkdown: "Copy Markdown", downloadMarkdown: "Download Markdown", query: "Query", refresh: "Refresh", reset: "Reset filters" },
         agent: {
           acceptance: "Acceptance", analyzing: "Analyzing", analyzingRound: "Analyzing the current interaction", backToEdit: "Back to editor", category: "Category", change: "Change", close: "Close BKN Agent analysis",
-          copyAdviceMarkdown: "Copy advice Markdown", copyCurrentMarkdown: "Copy this Markdown", currentRound: "Current interaction analysis",
+          adviceMarkdownCopied: "Advice Markdown copied", copyAdviceMarkdown: "Copy advice Markdown", copyCurrentMarkdown: "Copy this Markdown", copyFailed: "Copy failed", currentRound: "Current interaction analysis",
           editorDescription: "This contains only call-process facts from the current interaction. Edits affect this analysis only and do not modify the Trace.", failed: "Analysis failed", failurePrefix: "Analysis failed: ", failureReasonMissing: "No failure reason returned",
           failureWithReason: "Analysis failed: {{reason}}", generatingMarkdown: "Generating process-fact Markdown…", history: "Analysis history", historyItem: "Analysis {{index}} · {{time}} · {{status}}",
           httpFailure: "Business provenance analysis request failed (HTTP {{status}})", intro: "Review or edit the Markdown before starting. The Agent receives exactly this content. It may query the source BKN for verification but must not invent facts absent from the Trace.",
@@ -75,7 +75,9 @@ export const bknTraceEnUS = {
       callDetail: "Call details",
       closeDetail: "Close call details",
       copy: "Copy",
+      copyFailed: "Copy failed",
       copyFullText: "Copy full text",
+      copySuccess: "Copied",
       columns: { agent: "Agent / App", duration: "Duration", rootOperation: "Root call", startedAt: "Started", status: "Status" },
       diagnostics: {
         missingTerminal: "The call has no terminal record, so its final outcome cannot be confirmed.",
@@ -165,10 +167,10 @@ export const bknTraceEnUS = {
       outcomes: { canceled: "Canceled", denied: "Denied", failure: "Failed", success: "Successful", unknown: "Unknown" },
       detail: {
         action: "Action", actor: "Actor", actorAndSource: "Actor and source", actorId: "Actor ID", associations: "Related records", authMethod: "Authentication", businessObject: "Business operation", conversationId: "Conversation ID",
-        businessContext: "Business context", clientIp: "Client IP", copyRawFacts: "Copy raw facts", event: "Event type", facts: "Operation facts",
+        businessContext: "Business context", clientIp: "Client IP", copyFailed: "Copy failed", copyRawFacts: "Copy raw facts", event: "Event type", facts: "Operation facts",
         credential: "Credential", eventId: "Event ID", failure: "Failure", openBusinessProvenance: "Open related business provenance", openTrace: "Open related trace",
         method: "Request method", operation: "Operation summary", operationStatus: "Operation status", operationType: "Operation type", rawFacts: "Raw facts (collapsed)", recordedAt: "Recorded at", requestId: "Request ID", source: "Source", statusCode: "Status code", target: "Target", targetId: "Target ID", taskId: "Task ID", traceId: "Trace ID",
-        rawAction: "Raw action", targetType: "Target type", technicalIds: "Technical identifiers", time: "Operation time", title: "Operation log details",
+        rawAction: "Raw action", rawFactsCopied: "Raw facts copied", targetType: "Target type", technicalIds: "Technical identifiers", time: "Operation time", title: "Operation log details",
       },
       domainAction: "{{action}} {{target}}",
       domainAuditActions: { add_members: "Add members to {{target}}", create: "Create", delete: "Delete", import: "Import", remove_members: "Remove members from {{target}}", update: "Update" },

--- a/src/modules/bkn-trace/locales/zh-CN.ts
+++ b/src/modules/bkn-trace/locales/zh-CN.ts
@@ -21,7 +21,7 @@ export const bknTraceZhCN = {
         actions: { analyze: "交给 BKN Agent 分析", back: "返回业务会话", copyMarkdown: "复制 Markdown", downloadMarkdown: "下载 Markdown", query: "查询", refresh: "刷新", reset: "重置筛选" },
         agent: {
           acceptance: "验收", analyzing: "分析中", analyzingRound: "正在分析当前交互轮次", backToEdit: "返回编辑", category: "类别", change: "修改方式", close: "关闭 BKN Agent 分析",
-          copyAdviceMarkdown: "复制建议 Markdown", copyCurrentMarkdown: "复制本次 Markdown", currentRound: "当前交互轮次分析",
+          adviceMarkdownCopied: "建议 Markdown 已复制", copyAdviceMarkdown: "复制建议 Markdown", copyCurrentMarkdown: "复制本次 Markdown", copyFailed: "复制失败", currentRound: "当前交互轮次分析",
           editorDescription: "仅包含当前交互轮次的调用过程事实；编辑只影响本次分析，不修改 Trace。", failed: "分析失败", failurePrefix: "分析失败：", failureReasonMissing: "未返回失败原因",
           failureWithReason: "分析失败：{{reason}}", generatingMarkdown: "正在生成过程事实 Markdown…", history: "历史分析记录", historyItem: "分析记录 {{index}} · {{time}} · {{status}}",
           httpFailure: "业务溯源分析请求失败（HTTP {{status}}）", intro: "先确认或编辑待分析 Markdown，再启动分析。Agent 实际收到的内容与此处完全相同；可按需查询源 BKN 进行核验，但不得补写 Trace 中不存在的事实。",
@@ -75,7 +75,9 @@ export const bknTraceZhCN = {
       callDetail: "调用详情",
       closeDetail: "关闭调用详情",
       copy: "复制",
+      copyFailed: "复制失败",
       copyFullText: "复制全文",
+      copySuccess: "已复制",
       columns: { agent: "Agent / 应用", duration: "耗时", rootOperation: "根调用", startedAt: "开始时间", status: "状态" },
       diagnostics: {
         missingTerminal: "调用缺少结束记录，无法确认最终结果。",
@@ -165,10 +167,10 @@ export const bknTraceZhCN = {
       outcomes: { canceled: "已取消", denied: "已拒绝", failure: "失败", success: "成功", unknown: "未知" },
       detail: {
         action: "操作", actor: "操作者", actorAndSource: "操作者与来源", actorId: "操作者 ID", associations: "关联记录", authMethod: "认证方式", businessObject: "业务操作", conversationId: "会话 ID",
-        businessContext: "业务上下文", clientIp: "来源 IP", copyRawFacts: "复制原始事实", event: "事件类型", facts: "操作事实",
+        businessContext: "业务上下文", clientIp: "来源 IP", copyFailed: "复制失败", copyRawFacts: "复制原始事实", event: "事件类型", facts: "操作事实",
         credential: "使用凭证", eventId: "事件 ID", failure: "失败原因", openBusinessProvenance: "打开关联业务溯源", openTrace: "打开关联 Trace",
         method: "请求方法", operation: "操作摘要", operationStatus: "执行状态", operationType: "操作类型", rawFacts: "原始事实（默认收起）", recordedAt: "记录时间", requestId: "请求 ID", source: "来源", statusCode: "状态码", target: "操作对象", targetId: "对象 ID", taskId: "任务 ID", traceId: "Trace ID",
-        rawAction: "原始动作", targetType: "对象类型", technicalIds: "技术标识", time: "操作时间", title: "操作日志详情",
+        rawAction: "原始动作", rawFactsCopied: "原始事实已复制", targetType: "对象类型", technicalIds: "技术标识", time: "操作时间", title: "操作日志详情",
       },
       domainAction: "{{action}}{{target}}",
       domainAuditActions: { add_members: "向{{target}}添加成员", create: "创建", delete: "删除", import: "导入", remove_members: "从{{target}}移除成员", update: "更新" },

--- a/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.test.tsx
+++ b/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.test.tsx
@@ -16,6 +16,9 @@ import {
 } from "@/modules/bkn-trace/trace-analysis/trace-analysis.service";
 
 vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({ message: { error: vi.fn(), success: vi.fn() } }),
+}));
 vi.mock("@/modules/bkn-trace/trace-analysis/trace-analysis.service", () => ({
   getReferencedPayload: vi.fn(),
   getTechnicalTrace: vi.fn(),

--- a/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.tsx
+++ b/src/modules/bkn-trace/trace-analysis/TraceAnalysisScene.tsx
@@ -36,6 +36,8 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { buildAppPath } from "@/app/router/app-paths";
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
+import { useAppServices } from "@/framework/context/use-app-services";
 import type { PayloadEnvelope } from "@/modules/bkn-trace/shared/operation-fact.types";
 import styles from "@/modules/bkn-trace/trace-analysis/TraceAnalysisScene.module.css";
 import {
@@ -436,10 +438,16 @@ function PayloadView({ interactionId, payload }: { interactionId: string; payloa
 
 function InlinePayload({ value }: { value: unknown }) {
   const { t } = useTranslation();
+  const { message } = useAppServices();
   const content = JSON.stringify(value, null, 2) ?? "null";
+  const copyContent = () => {
+    void writeTextToClipboard(content)
+      .then(() => message.success(t("bknTrace.traceWorkspace.copySuccess")))
+      .catch(() => message.error(t("bknTrace.traceWorkspace.copyFailed")));
+  };
   return (
     <div className={styles.payloadBlock}>
-      <Button icon={<CopyOutlined />} onClick={() => void navigator.clipboard?.writeText(content)} size="small">
+      <Button icon={<CopyOutlined />} onClick={copyContent} size="small">
         {t("bknTrace.traceWorkspace.copy")}
       </Button>
       <pre className={styles.payload}>{content}</pre>
@@ -449,6 +457,7 @@ function InlinePayload({ value }: { value: unknown }) {
 
 function SummaryText({ label, text }: { label: string; text?: string }) {
   const { t } = useTranslation();
+  const { message } = useAppServices();
   const [open, setOpen] = useState(false);
   const [overflow, setOverflow] = useState(false);
   const ref = useRef<HTMLButtonElement>(null);
@@ -463,6 +472,11 @@ function SummaryText({ label, text }: { label: string; text?: string }) {
     return () => observer.disconnect();
   }, [text]);
   const content = text || "-";
+  const copyContent = () => {
+    void writeTextToClipboard(content)
+      .then(() => message.success(t("bknTrace.traceWorkspace.copySuccess")))
+      .catch(() => message.error(t("bknTrace.traceWorkspace.copyFailed")));
+  };
   const button = <button className={styles.clampedText} onClick={() => setOpen(true)} ref={ref} type="button">{content}</button>;
   return (
     <div className={styles.summaryText}>
@@ -470,7 +484,7 @@ function SummaryText({ label, text }: { label: string; text?: string }) {
       {overflow ? <Tooltip mouseEnterDelay={0.3} placement="bottomLeft" title={content}>{button}</Tooltip> : button}
       <Modal
         footer={(
-          <Button icon={<CopyOutlined />} onClick={() => void navigator.clipboard?.writeText(content)}>
+          <Button icon={<CopyOutlined />} onClick={copyContent}>
             {t("bknTrace.traceWorkspace.copyFullText")}
           </Button>
         )}

--- a/src/modules/execution-factory-lab/scenes/SandboxRuntimeScene.tsx
+++ b/src/modules/execution-factory-lab/scenes/SandboxRuntimeScene.tsx
@@ -26,6 +26,7 @@ import dayjs from "dayjs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { PermissionGate } from "@/framework/permission/PermissionGate";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { executionFactoryLabPermissions } from "@/modules/execution-factory-lab/permissions";
@@ -265,7 +266,7 @@ export function SandboxRuntimeScene() {
       return;
     }
     try {
-      await navigator.clipboard.writeText(buildDiagnostics(selected));
+      await writeTextToClipboard(buildDiagnostics(selected));
       message.success(t("executionFactoryLab.sandboxRuntimeCopied"));
     } catch {
       message.error(t("executionFactoryLab.sandboxRuntimeCopyFailed"));

--- a/src/modules/home/scenes/HomeScene.tsx
+++ b/src/modules/home/scenes/HomeScene.tsx
@@ -22,6 +22,7 @@ import { type ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
 import type { PermissionCheckMode } from "@/framework/permission/has-permissions";
@@ -393,12 +394,7 @@ export function HomeScene() {
   const currentStage = PLATFORM_STAGES.find((stage) => stage.id === activeStage) ?? PLATFORM_STAGES[0];
 
   const copyInstallCommand = (command: string) => {
-    if (!navigator.clipboard) {
-      message.error(t("home.engineering.install.copyFailed"));
-      return;
-    }
-
-    void navigator.clipboard.writeText(command).then(
+    void writeTextToClipboard(command).then(
       () => message.success(t("home.engineering.install.copied")),
       () => message.error(t("home.engineering.install.copyFailed")),
     );

--- a/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
+++ b/src/modules/knowledge-network/components/agent-chat/AgentChat.tsx
@@ -19,6 +19,7 @@ import type { TFunction } from "i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { normalizeSupportedLocale } from "@/framework/i18n/locale";
 import { listLlmModels } from "@/modules/model-resources/services/llm.service";
 import type { LlmModel } from "@/modules/model-resources/types/llm";
@@ -702,8 +703,7 @@ export function AgentChat({
   const copyReportMd = useCallback(() => {
     const md = buildMarkdown();
     if (!md) return;
-    void navigator.clipboard
-      ?.writeText(md)
+    void writeTextToClipboard(md)
       .then(() => message.success(t("knowledgeNetwork.agentChat.report.copySuccess")))
       .catch(() => message.error(t("knowledgeNetwork.agentChat.report.copyFailed")));
   }, [buildMarkdown, message, t]);

--- a/src/modules/knowledge-network/pages/KnowledgeNetworkIntegrationPage.test.tsx
+++ b/src/modules/knowledge-network/pages/KnowledgeNetworkIntegrationPage.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KnowledgeNetworkIntegrationPage } from "./KnowledgeNetworkIntegrationPage";
+
+const messageMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+
+vi.mock("antd", () => ({
+  App: { useApp: () => ({ message: messageMock }) },
+}));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/framework/auth/oauth", () => ({ gatewayOrigin: () => "" }));
+
+vi.mock("@/modules/knowledge-network/scenes/ExperienceScene", () => ({
+  ExperienceScene: () => null,
+}));
+
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+
+function installHttpClipboardFallback(result: boolean) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: undefined,
+  });
+  const copiedTexts: string[] = [];
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: vi.fn(() => {
+      const copiedText = document.querySelector("textarea")?.value;
+      if (copiedText) {
+        copiedTexts.push(copiedText);
+      }
+      return result;
+    }),
+  });
+  return copiedTexts;
+}
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={["/knowledge-network/integration"]}>
+      <KnowledgeNetworkIntegrationPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  if (clipboardDescriptor) {
+    Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
+  if (execCommandDescriptor) {
+    Object.defineProperty(document, "execCommand", execCommandDescriptor);
+  } else {
+    Reflect.deleteProperty(document, "execCommand");
+  }
+});
+
+describe("KnowledgeNetworkIntegrationPage clipboard fallback", () => {
+  it("copies SDK and CLI commands when the Clipboard API is unavailable on HTTP", async () => {
+    const copiedTexts = installHttpClipboardFallback(true);
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole("tab", { name: /knowledgeNetwork\.integration\.tabs\.sdk/ }),
+    );
+    const sdkCopyButtons = screen.getAllByRole("button", {
+      name: /knowledgeNetwork\.integration\.copy/,
+    });
+    fireEvent.click(sdkCopyButtons[0]);
+    fireEvent.click(sdkCopyButtons[1]);
+
+    fireEvent.click(
+      screen.getByRole("tab", { name: /knowledgeNetwork\.integration\.tabs\.cli/ }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /knowledgeNetwork\.integration\.copy/ }),
+    );
+
+    await waitFor(() => {
+      expect(copiedTexts).toEqual([
+        "npm install @openbkn/bkn-sdk",
+        "knowledgeNetwork.integration.sdk.examples.quick-start.code",
+        "knowledgeNetwork.integration.cli.examples.setup.code",
+      ]);
+      expect(messageMock.success).toHaveBeenCalledTimes(3);
+    });
+    expect(messageMock.error).not.toHaveBeenCalled();
+  });
+
+  it("reports a clear error when HTTP fallback copying is rejected", async () => {
+    installHttpClipboardFallback(false);
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole("tab", { name: /knowledgeNetwork\.integration\.tabs\.sdk/ }),
+    );
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: /knowledgeNetwork\.integration\.copy/,
+      })[0],
+    );
+
+    await waitFor(() => {
+      expect(messageMock.error).toHaveBeenCalledWith(
+        "knowledgeNetwork.integration.copyFailed",
+      );
+    });
+    expect(messageMock.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/knowledge-network/pages/KnowledgeNetworkIntegrationPage.tsx
+++ b/src/modules/knowledge-network/pages/KnowledgeNetworkIntegrationPage.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router-dom";
 
 import { gatewayOrigin } from "@/framework/auth/oauth";
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { buildApiKeyPagePath } from "@/modules/api-keys/utils/api-key-handoff";
 import { ExperienceScene } from "@/modules/knowledge-network/scenes/ExperienceScene";
 
@@ -82,7 +83,7 @@ function CodeIntegrationPanel<T extends string>({
 
   const copyText = async (text: string, successText: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeTextToClipboard(text);
       void message.success(successText);
     } catch {
       void message.error(copyFailedMessage);

--- a/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.test.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { KnowledgeNetworkRecord } from "@/modules/knowledge-network/types/knowledge-network";
+
+import { WorkspaceOverviewSection } from "./WorkspaceOverviewSection";
+
+const messageMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({ message: messageMock }),
+}));
+
+vi.mock("@/modules/knowledge-network/components/preview/OverviewOntologyBlock", () => ({
+  OverviewOntologyBlock: () => null,
+}));
+
+vi.mock("@/modules/system-admin/components/ObjectAuthorizeDrawer", () => ({
+  ObjectAuthorizeDrawer: () => null,
+}));
+
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+
+const detail: KnowledgeNetworkRecord = {
+  color: "#1677ff",
+  createTime: "2026-09-05 10:00:00",
+  creatorName: "Builder",
+  description: "",
+  id: "network-1",
+  identifier: "ecommerce_ops_bkn",
+  name: "Ecommerce Operations",
+  operations: ["view_detail"],
+  statistics: {
+    actionTypesTotal: 0,
+    conceptGroupsTotal: 0,
+    metricsTotal: 0,
+    objectTypesTotal: 0,
+    relationTypesTotal: 0,
+  },
+  tags: [],
+  updateTime: "2026-09-05 10:00:00",
+  updaterName: "Builder",
+};
+
+function installHttpClipboardFallback(result: boolean) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: undefined,
+  });
+  const copiedTexts: string[] = [];
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: vi.fn(() => {
+      const copiedText = document.querySelector("textarea")?.value;
+      if (copiedText) {
+        copiedTexts.push(copiedText);
+      }
+      return result;
+    }),
+  });
+  return copiedTexts;
+}
+
+function renderOverview() {
+  render(
+    <MemoryRouter>
+      <WorkspaceOverviewSection
+        canModify={false}
+        detail={detail}
+        loadRecentObjects={vi.fn().mockResolvedValue(undefined)}
+        networkId="network-1"
+        onEdit={vi.fn()}
+        recentObjects={[]}
+      />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  if (clipboardDescriptor) {
+    Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
+  if (execCommandDescriptor) {
+    Object.defineProperty(document, "execCommand", execCommandDescriptor);
+  } else {
+    Reflect.deleteProperty(document, "execCommand");
+  }
+});
+
+describe("WorkspaceOverviewSection clipboard fallback", () => {
+  it("copies the knowledge-network identifier and reports success on HTTP", async () => {
+    const copiedTexts = installHttpClipboardFallback(true);
+    renderOverview();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "knowledgeNetwork.copyNetworkIdentifier" }),
+    );
+
+    await waitFor(() => {
+      expect(copiedTexts).toEqual(["ecommerce_ops_bkn"]);
+      expect(messageMock.success).toHaveBeenCalledWith(
+        "knowledgeNetwork.networkIdentifierCopied",
+      );
+    });
+    expect(messageMock.error).not.toHaveBeenCalled();
+  });
+
+  it("reports a clear error when both clipboard strategies fail", async () => {
+    installHttpClipboardFallback(false);
+    renderOverview();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "knowledgeNetwork.copyNetworkIdentifier" }),
+    );
+
+    await waitFor(() => {
+      expect(messageMock.error).toHaveBeenCalledWith(
+        "knowledgeNetwork.copyNetworkIdentifierFailed",
+      );
+    });
+    expect(messageMock.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.tsx
+++ b/src/modules/knowledge-network/scenes/workspace/WorkspaceOverviewSection.tsx
@@ -24,6 +24,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { formatNumber } from "@/framework/i18n/format";
 import { useAppServices } from "@/framework/context/use-app-services";
 import { AppButton } from "@/framework/ui/common/AppButton";
@@ -85,8 +86,7 @@ export function WorkspaceOverviewSection({
       return;
     }
 
-    void navigator.clipboard
-      ?.writeText(networkIdentifier)
+    void writeTextToClipboard(networkIdentifier)
       .then(() => message.success(t("knowledgeNetwork.networkIdentifierCopied")))
       .catch(() => message.error(t("knowledgeNetwork.copyNetworkIdentifierFailed")));
   };

--- a/src/modules/model-resources/components/models/api-guide/ModelApiGuideCopyButton.tsx
+++ b/src/modules/model-resources/components/models/api-guide/ModelApiGuideCopyButton.tsx
@@ -8,6 +8,7 @@
 import { CopyOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { useAppServices } from "@/framework/context/use-app-services";
 import { AppButton } from "@/framework/ui/common/AppButton";
 
@@ -22,7 +23,7 @@ export function ModelApiGuideCopyButton({ className, text }: ModelApiGuideCopyBu
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeTextToClipboard(text);
       message.success(t("modelResources.models.apiGuide.copySuccess"));
     } catch {
       message.error(t("modelResources.models.apiGuide.copyFailed"));

--- a/src/modules/system-admin/scenes/LicenseManagementScene.tsx
+++ b/src/modules/system-admin/scenes/LicenseManagementScene.tsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { writeTextToClipboard } from "@/framework/compat/clipboard";
 import { useAppServices } from "@/framework/context/use-app-services";
 import { LicenseStateBanner } from "@/framework/entitlement/LicenseStateBanner";
 import { useRefreshEntitlement } from "@/framework/entitlement/use-entitlement";
@@ -72,13 +73,6 @@ function translatedLicenseKey(
   key: string,
 ) {
   return t(`systemAdmin.license.${category}.${key}`, { defaultValue: key });
-}
-
-function copySupported() {
-  return (
-    typeof navigator !== "undefined" &&
-    typeof navigator.clipboard?.writeText === "function"
-  );
 }
 
 export function LicenseManagementScene() {
@@ -165,12 +159,12 @@ export function LicenseManagementScene() {
     if (!value) {
       return;
     }
-    if (!copySupported()) {
+    try {
+      await writeTextToClipboard(value);
+      await message.success(t("systemAdmin.license.copySuccess"));
+    } catch {
       await message.warning(t("systemAdmin.license.copyUnsupported"));
-      return;
     }
-    await navigator.clipboard.writeText(value);
-    await message.success(t("systemAdmin.license.copySuccess"));
   };
 
   const refreshAfterAction = async (next?: LicenseDetail) => {

--- a/src/modules/system-admin/scenes/LicenseManagementScene.tsx
+++ b/src/modules/system-admin/scenes/LicenseManagementScene.tsx
@@ -163,7 +163,7 @@ export function LicenseManagementScene() {
       await writeTextToClipboard(value);
       await message.success(t("systemAdmin.license.copySuccess"));
     } catch {
-      await message.warning(t("systemAdmin.license.copyUnsupported"));
+      await message.warning(t("common.copyFailed"));
     }
   };
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Route every application copy action through the shared clipboard compatibility adapter.
- [x] Add localized success and failure feedback to copy actions that were previously silent or reported false success.
- [x] Add HTTP fallback, consumer regression, locale parity, and architectural boundary coverage.

---

## Why

- Related Issue: Closes #528
- Related Feature: Cross-application clipboard compatibility
- Background: The Clipboard API may be unavailable or reject writes on non-secure HTTP origins. Several copy buttons called it directly, so they either did nothing, reported a false success, or failed without useful feedback.

---

## How

- Key implementation points:
  - Reuse writeTextToClipboard, which tries the Clipboard API and falls back to a selected textarea with document.execCommand("copy").
  - Migrate copy actions in request errors, API keys, observability, sandbox diagnostics, home commands, knowledge-network tools, model API guides, and license management.
  - Remove feature checks that prevented the fallback from running.
  - Add shared and module-specific localized feedback.
  - Add a source-boundary test to prevent direct Clipboard API use outside the compatibility adapter.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment — Not applicable before PR; HTTP behavior was simulated locally.

Test notes:

- License header check passed.
- Type-aware ESLint passed with zero warnings.
- Full Vitest run passed: 257 test files and 1362 tests, limited to two workers.
- TypeScript project build passed.
- Vite production build passed with existing chunk-size and mixed-import warnings.
- Production dependency audit completed successfully and reported one ignored high-severity advisory.
- Focused HTTP clipboard coverage simulates a missing or rejected Clipboard API, a successful fallback, and a rejected fallback.
- A real Windows non-secure HTTP deployment was not manually tested.

---

## Risk & Rollback

- Potential risks: document.execCommand("copy") is a legacy fallback and may still be rejected by some browsers; affected actions now surface a localized failure instead of silently failing.
- Rollback plan: Revert this PR to restore the previous direct Clipboard API calls.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: No visual layout changes.
