### PR TITLE
fix(system-admin): treat either admin-authz point as administrator for row locks

### DIFF
--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
@@ -60,10 +60,10 @@ function grant(accessorId: string, operations: string[]): ObjectGrant {
   };
 }
 
-function renderDrawer() {
+function renderDrawer({ objectAuthorized = true } = {}) {
   return render(
     <ObjectAuthorizeDrawer
-      objectAuthorized
+      objectAuthorized={objectAuthorized}
       objId="catalog-1"
       objName="nb_test_conn"
       objType="catalog"
@@ -121,6 +121,22 @@ describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
       "admin-authz:revoke",
     ];
     renderDrawer();
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(0);
+    expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(3);
+  });
+
+  // The two admin-authz points are configured separately, and the platform authorization page does
+  // not pass objectAuthorized. A role holding revoke alone is still an administrator to bkn-safe,
+  // so the rows stay removable — reading administrator status off the grant point alone took the
+  // remove control away from them.
+  it("leaves every row removable for a revoke-only administrator", async () => {
+    appServices.runtimeConfig.currentUser.permissions = [
+      "admin-authz:view",
+      "admin-authz:revoke",
+    ];
+    renderDrawer({ objectAuthorized: false });
     await act(async () => {});
 
     expect(lockedCardCount()).toBe(0);

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
@@ -147,13 +147,18 @@ export function ObjectAuthorizeDrawer({
     currentPermissions,
     requiredPermissions: authzPoints.grant,
   });
+  const isAdminRevoker = hasPermissions({
+    currentPermissions,
+    requiredPermissions: authzPoints.revoke,
+  });
+  // Either admin-authz point makes the caller a platform administrator, the party bkn-safe exempts
+  // from its per-row guard. The two points are held separately — a review role may carry `revoke`
+  // alone — so reading administrator status off `grant` would lock a revoke-only administrator out
+  // of rows the backend accepts from them. Which control they get is still decided per direction by
+  // canGrant/canRevoke below.
+  const isPlatformAuthzAdmin = isAdminGrantor || isAdminRevoker;
   const canGrant = objectAuthorized || isAdminGrantor;
-  const canRevoke =
-    objectAuthorized ||
-    hasPermissions({
-      currentPermissions,
-      requiredPermissions: authzPoints.revoke,
-    });
+  const canRevoke = objectAuthorized || isAdminRevoker;
   const canManageGrants = canGrant || canRevoke;
   const [grants, setGrants] = useState<ObjectGrant[]>([]);
   const [departments, setDepartments] = useState<AdminDepartment[]>([]);
@@ -521,7 +526,7 @@ export function ObjectAuthorizeDrawer({
             <div className={styles.authzList}>
               {grants.map((grant) => {
                 const builtinLocked = isProtected(grant.accessorId);
-                const delegateLocked = !isAdminGrantor && isDelegateProtected(grant);
+                const delegateLocked = !isPlatformAuthzAdmin && isDelegateProtected(grant);
                 const locked = builtinLocked || delegateLocked;
                 const grantee = resolveGrantee(grant.accessorId);
                 return (


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `system-admin`: `ObjectAuthorizeDrawer` reads platform-administrator status off **either** `admin-authz` point (`isPlatformAuthzAdmin`), not `admin-authz:grant` alone, when deciding whether a row is locked to delegates
- [x] `canRevoke` reuses the same `admin-authz:revoke` check instead of recomputing it
- [x] Tests: `ObjectAuthorizeDrawer.test.tsx` pins the revoke-only administrator

---

## Why

- Related Issue: follow-up to #518

#518 locks the rows bkn-safe refuses from a non-administrator — any row carrying `authorize`, and the public-access row. It decided who counts as an administrator with `isAdminGrantor`, which reads `admin-authz:grant` only.

The two `admin-authz` points are configured separately per role, and the platform object authorization page passes no `objectAuthorized` (nor do execution-factory and model-resources). So a role holding `admin-authz:view` + `admin-authz:revoke` opened the drawer there and saw the `authorize` rows and the public row turn into lock icons: the **Remove** control gone, every operation chip disabled, under a tooltip saying only a platform administrator may adjust or remove them — addressed to a caller who is one, on rows they could revoke before #518.

The component already models the two directions separately: `canGrant` / `canRevoke` split the write controls, and `chipTogglePoint` picks the point per chip precisely because "revoke-only users have the inverse access". The row lock was the one place that collapsed both into the grant point.

---

## How

- `isPlatformAuthzAdmin = isAdminGrantor || isAdminRevoker` carries the lock. Which control the caller then gets is still decided per direction by `canGrant` / `canRevoke`, unchanged.
- `ops` still gates the `authorize` chip on `isAdminGrantor` — that is the grant direction, and it stays as #518 left it.
- Breaking changes (API, config, database, etc.): none. A grant-holding administrator, an owner, and a read-only reviewer all see exactly what they saw after #518.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable
- [ ] Verified in test environment — the revoke-only role was not provisioned on the dev VM; the case is pinned by the new unit test instead

Test notes:

```
node scripts/check-license-headers.mjs          exit 0
node scripts/scan-hardcoded-zh.mjs              exit 0
eslint --config eslint.config.typechecked.js --max-warnings 0   exit 0 (changed files)
tsc -b --force                                  exit 0
vitest --run src/modules/system-admin           51 passed
```

The new case (`view` + `revoke`, `objectAuthorized: false`) fails on the pre-change component with `expected 2 to be +0` — the two rows it locked — and passes after. The owner and grant-holding-administrator cases from #518 pass either way.

Full `vitest --run` on this branch: 105 failed / 1134 passed. The same run on `origin/main` without this change: 105 failed / 1133 passed — the identical 105, none in `system-admin`. They fail on `window.localStorage.getItem is not a function` from a jsdom/node drift (`oauth`, `http`, `config`, `bootstrap` and 7 more), which also takes `npm run i18n:check` to exit 1 on a clean checkout. Pre-existing and unrelated; worth a separate look.

---

## Risk & Rollback

- Potential risks: a revoke-only administrator now sees the Remove control on `authorize` and public rows again. That is the state before #518, and bkn-safe's `protectAuthorizeHolder` exempts administrators — but the exemption was read from the backend guard, not exercised with a revoke-only account, so a 403 there is the failure mode rather than data loss.
- Rollback plan: revert the commit; `isPlatformAuthzAdmin` has no other reference.

---

## Additional Notes

- Backported to `release/0.1.4` on `fix/system-admin/protect-authorize-rows-release-014` (#519), byte-identical in both touched files.
- Still open from #518's review: `PUBLIC_ACCESSOR_ID` (`00000000-0000-0000-0000-000000000000`) appears nowhere else in the repo, and `listObjectGrantsForObject` passes `accessor_id` through verbatim. If bkn-safe marks public grants some other way, that half of the lock never fires. Not verifiable from this repo.
