### PR TITLE
fix(data-catalog): avoid task totals in index summary

### DIFF
--- a/src/modules/data-catalog/components/ResourceIndexPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceIndexPanel.test.tsx
@@ -131,6 +131,25 @@ function buildTask(overrides: Partial<BuildTask>): BuildTask {
 }
 
 describe("ResourceIndexPanel", () => {
+  it("does not present a batch task total as the current index document count", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ResourceIndexPanel
+          active
+          catalog={null}
+          indexView="tasks"
+          indexViewExplicit
+          onIndexViewChange={vi.fn()}
+          onRefresh={vi.fn()}
+          resource={{ ...resource, localIndexStatus: "available" }}
+          tasks={[buildTask({ totalCount: 72000 })]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(container.textContent).not.toContain("dataCatalog.indexWorkspace.indexedRowsShort");
+  });
+
   it("uses the shared colored status tag and an overflow action menu", () => {
     render(
       <MemoryRouter>

--- a/src/modules/data-catalog/components/ResourceIndexPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceIndexPanel.tsx
@@ -35,7 +35,7 @@ import { useBuildTaskActions } from "@/modules/data-catalog/hooks/use-build-task
 import { deleteBuildTask } from "@/modules/data-catalog/services/build-task.service";
 import { summarizeBuildTaskError } from "@/modules/data-catalog/lib/build-task-error";
 import type { ResourceIndexView } from "@/modules/data-catalog/lib/index-build-filters";
-import { formatCount, timeAgo } from "@/modules/data-catalog/lib/format";
+import { timeAgo } from "@/modules/data-catalog/lib/format";
 import { indexStateOf, resourceGateOf, sortTasks } from "@/modules/data-catalog/lib/index-state";
 import { resourceQueryBlockReason } from "@/modules/data-catalog/lib/resource-query-availability";
 import {
@@ -108,11 +108,6 @@ function buildStatusSummary(
   const parts = [
     formatEffectiveState(effective, t),
     t(`dataCatalog.modes.${effective.mode}`),
-    t("dataCatalog.indexWorkspace.indexedRowsShort", {
-      count: formatCount(
-        effective.mode === "streaming" ? effective.syncedCount : effective.totalCount,
-      ) as never,
-    }),
   ];
 
   if (effective.mode === "streaming") {


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Stop presenting a batch task total as the Resource current indexed-document count.
- [x] Add a regression test for the summary.
- [ ] Docs/doc 1 (not needed)

---

## Why

- Related Issue: Closes #569
- Related Feature: Incremental index build
- Background: A task-range total is not a reliable current OpenSearch document count after incremental work resumes.

---

## How

- Key implementation points: Keep the status, mode, and completion time summary while omitting the unsupported document count.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run; no deployed dependencies used)
- [ ] Verified in test environment (not run)

Test notes: License check, type-aware ESLint, Vitest, TypeScript build, and Vite build passed. `pnpm audit --prod` reports one ignored high-severity advisory.

---

## Risk & Rollback

- Potential risks: The resource summary no longer shows a misleading row count until a real index-document count contract exists.
- Rollback plan: Revert this commit.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: No API contract changes.