### PR TITLE
fix(data-catalog): configure semantic sample rows

### DIFF
--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
@@ -47,6 +47,7 @@ vi.mock("@/modules/data-catalog/services/semantic-understanding-task.service", (
 }));
 
 import { ResourceSemanticUnderstandingPanel } from "./ResourceSemanticUnderstandingPanel";
+import { semanticUnderstandingTaskFormDefaults } from "./semantic-understanding-task-form";
 
 const resource: CatalogResource = {
   catalogId: "catalog-1",
@@ -77,6 +78,15 @@ describe("ResourceSemanticUnderstandingPanel", () => {
       removeEventListener: vi.fn(),
       removeListener: vi.fn(),
     }));
+  });
+
+  it("resets sample rows to ten in the creation defaults", () => {
+    expect(semanticUnderstandingTaskFormDefaults).toMatchObject({
+      applyMode: "fill_empty",
+      confidenceThreshold: 0.75,
+      includeSampleRows: false,
+      sampleMaxRows: 10,
+    });
   });
 
   it("initializes the semantic task defaults before opening the creation dialog", async () => {
@@ -119,21 +129,6 @@ describe("ResourceSemanticUnderstandingPanel", () => {
       resourceId: "resource-1",
       sampleMaxRows: 20,
     }));
-  });
-
-  it("resets sample rows after cancelling the creation dialog", async () => {
-    render(<ResourceSemanticUnderstandingPanel active resource={resource} />);
-
-    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.create/ }));
-    fireEvent.click(screen.getByRole("checkbox", { name: "dataCatalog.semanticWorkspace.includeSamples" }));
-    const sampleRowsInput = (await screen.findAllByRole("spinbutton")).at(-1);
-    fireEvent.change(sampleRowsInput!, { target: { value: "20" } });
-    fireEvent.click(screen.getByRole("button", { name: "common.cancel" }));
-
-    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.create/ }));
-    fireEvent.click(screen.getByRole("checkbox", { name: "dataCatalog.semanticWorkspace.includeSamples" }));
-
-    await waitFor(() => expect(screen.getAllByRole("spinbutton").at(-1)?.getAttribute("value")).toBe("10"));
   });
 
   it("keeps table header filters available when no task matches", async () => {

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
@@ -121,6 +121,21 @@ describe("ResourceSemanticUnderstandingPanel", () => {
     }));
   });
 
+  it("resets sample rows after cancelling the creation dialog", async () => {
+    render(<ResourceSemanticUnderstandingPanel active resource={resource} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.create/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "dataCatalog.semanticWorkspace.includeSamples" }));
+    const sampleRowsInput = (await screen.findAllByRole("spinbutton")).at(-1);
+    fireEvent.change(sampleRowsInput!, { target: { value: "20" } });
+    fireEvent.click(screen.getByRole("button", { name: "common.cancel" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.create/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "dataCatalog.semanticWorkspace.includeSamples" }));
+
+    await waitFor(() => expect(screen.getAllByRole("spinbutton").at(-1)?.getAttribute("value")).toBe("10"));
+  });
+
   it("keeps table header filters available when no task matches", async () => {
     render(<ResourceSemanticUnderstandingPanel active resource={resource} />);
 

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { FormInstance } from "antd";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import sharedStyles from "@/modules/data-catalog/components/shared.module.css";
@@ -47,7 +48,7 @@ vi.mock("@/modules/data-catalog/services/semantic-understanding-task.service", (
 }));
 
 import { ResourceSemanticUnderstandingPanel } from "./ResourceSemanticUnderstandingPanel";
-import { semanticUnderstandingTaskFormDefaults } from "./semantic-understanding-task-form";
+import { semanticUnderstandingTaskFormDefaults, useSemanticUnderstandingTaskFormDefaults } from "./semantic-understanding-task-form";
 
 const resource: CatalogResource = {
   catalogId: "catalog-1",
@@ -63,6 +64,14 @@ const resource: CatalogResource = {
   updateTime: "2026-08-11T00:00:00Z",
   expectedUpdateTime: 0,
 };
+
+function SemanticUnderstandingTaskFormDefaultsHarness({ form, open }: {
+  form: Pick<FormInstance, "setFieldsValue">;
+  open: boolean;
+}) {
+  useSemanticUnderstandingTaskFormDefaults(form, open);
+  return null;
+}
 
 describe("ResourceSemanticUnderstandingPanel", () => {
   beforeEach(() => {
@@ -80,13 +89,17 @@ describe("ResourceSemanticUnderstandingPanel", () => {
     }));
   });
 
-  it("resets sample rows to ten in the creation defaults", () => {
-    expect(semanticUnderstandingTaskFormDefaults).toMatchObject({
-      applyMode: "fill_empty",
-      confidenceThreshold: 0.75,
-      includeSampleRows: false,
-      sampleMaxRows: 10,
-    });
+  it("resets sample rows to ten each time the creation dialog opens", () => {
+    const form = { setFieldsValue: vi.fn() } as unknown as Pick<FormInstance, "setFieldsValue">;
+    const { rerender } = render(<SemanticUnderstandingTaskFormDefaultsHarness form={form} open={false} />);
+
+    rerender(<SemanticUnderstandingTaskFormDefaultsHarness form={form} open />);
+    expect(form.setFieldsValue).toHaveBeenCalledWith(semanticUnderstandingTaskFormDefaults);
+
+    vi.mocked(form.setFieldsValue).mockClear();
+    rerender(<SemanticUnderstandingTaskFormDefaultsHarness form={form} open={false} />);
+    rerender(<SemanticUnderstandingTaskFormDefaultsHarness form={form} open />);
+    expect(form.setFieldsValue).toHaveBeenCalledWith(semanticUnderstandingTaskFormDefaults);
   });
 
   it("initializes the semantic task defaults before opening the creation dialog", async () => {

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
@@ -99,6 +99,28 @@ describe("ResourceSemanticUnderstandingPanel", () => {
     }));
   });
 
+  it("lets users choose up to twenty sample rows", async () => {
+    createResourceSemanticUnderstandingTaskMock.mockResolvedValue({ id: "task-1" });
+
+    render(<ResourceSemanticUnderstandingPanel active resource={resource} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.create/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "dataCatalog.semanticWorkspace.includeSamples" }));
+
+    const sampleRowsInput = (await screen.findAllByRole("spinbutton")).at(-1);
+    expect(sampleRowsInput?.getAttribute("value")).toBe("10");
+    fireEvent.change(sampleRowsInput!, { target: { value: "20" } });
+    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.start/ }));
+
+    await waitFor(() => expect(createResourceSemanticUnderstandingTaskMock).toHaveBeenCalledWith({
+      applyMode: "fill_empty",
+      confidenceThreshold: 0.75,
+      includeSampleRows: true,
+      resourceId: "resource-1",
+      sampleMaxRows: 20,
+    }));
+  });
+
   it("keeps table header filters available when no task matches", async () => {
     render(<ResourceSemanticUnderstandingPanel active resource={resource} />);
 

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -34,6 +34,7 @@ import { createResourceSemanticUnderstandingTask, deleteSemanticUnderstandingTas
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 
 import styles from "./ResourceSemanticUnderstandingPanel.module.css";
+import { semanticUnderstandingTaskFormDefaults } from "./semantic-understanding-task-form";
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 
@@ -118,12 +119,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
 
   useEffect(() => {
     if (!open) return;
-    form.setFieldsValue({
-      applyMode: "fill_empty",
-      confidenceThreshold: 0.75,
-      includeSampleRows: false,
-      sampleMaxRows: 10,
-    });
+    form.setFieldsValue(semanticUnderstandingTaskFormDefaults);
   }, [form, open]);
 
   const start = async () => {

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -46,6 +46,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
   const { t } = useTranslation();
   const { message, modal, runtimeConfig } = useAppServices();
   const [form] = Form.useForm<CreateSemanticUnderstandingTaskPayload>();
+  const includeSampleRows = Form.useWatch("includeSampleRows", form) ?? false;
   const [tasks, setTasks] = useState<SemanticUnderstandingTaskSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -294,6 +295,9 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
         <Form.Item extra={t("dataCatalog.semanticWorkspace.includeSamplesHint")} name="includeSampleRows" valuePropName="checked">
           <Checkbox>{t("dataCatalog.semanticWorkspace.includeSamples")}</Checkbox>
         </Form.Item>
+        {includeSampleRows ? <Form.Item initialValue={10} label={t("dataCatalog.semanticWorkspace.sampleRows")} name="sampleMaxRows" rules={[{ required: true }]}>
+          <InputNumber max={20} min={1} precision={0} style={{ width: "100%" }} />
+        </Form.Item> : null}
       </Form>
     </Modal>
     {detailTaskId ? <SemanticUnderstandingTaskDetailDrawer onClose={() => setDetailTaskId(null)} open taskId={detailTaskId} /> : null}

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -122,14 +122,20 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
       applyMode: "fill_empty",
       confidenceThreshold: 0.75,
       includeSampleRows: false,
+      sampleMaxRows: 10,
     });
   }, [form, open]);
 
   const start = async () => {
     const values = await form.validateFields();
+    const { sampleMaxRows, ...taskValues } = values;
     setCreating(true);
     try {
-      await createResourceSemanticUnderstandingTask({ ...values, resourceId: resource.id });
+      await createResourceSemanticUnderstandingTask({
+        ...taskValues,
+        ...(taskValues.includeSampleRows ? { sampleMaxRows } : {}),
+        resourceId: resource.id,
+      });
       message.success(t("dataCatalog.semanticWorkspace.started"));
       setOpen(false);
       form.resetFields();
@@ -295,7 +301,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
         <Form.Item extra={t("dataCatalog.semanticWorkspace.includeSamplesHint")} name="includeSampleRows" valuePropName="checked">
           <Checkbox>{t("dataCatalog.semanticWorkspace.includeSamples")}</Checkbox>
         </Form.Item>
-        {includeSampleRows ? <Form.Item initialValue={10} label={t("dataCatalog.semanticWorkspace.sampleRows")} name="sampleMaxRows" rules={[{ required: true }]}>
+        {includeSampleRows ? <Form.Item label={t("dataCatalog.semanticWorkspace.sampleRows")} name="sampleMaxRows" rules={[{ required: true }]}>
           <InputNumber max={20} min={1} precision={0} style={{ width: "100%" }} />
         </Form.Item> : null}
       </Form>

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -34,7 +34,7 @@ import { createResourceSemanticUnderstandingTask, deleteSemanticUnderstandingTas
 import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog";
 
 import styles from "./ResourceSemanticUnderstandingPanel.module.css";
-import { semanticUnderstandingTaskFormDefaults } from "./semantic-understanding-task-form";
+import { useSemanticUnderstandingTaskFormDefaults } from "./semantic-understanding-task-form";
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 
@@ -117,10 +117,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
                 ? { className: styles.summaryValueError, label: t("dataCatalog.semanticWorkspace.failed") }
                 : { className: styles.summaryValueMuted, label: t("dataCatalog.semanticWorkspace.cancelled") };
 
-  useEffect(() => {
-    if (!open) return;
-    form.setFieldsValue(semanticUnderstandingTaskFormDefaults);
-  }, [form, open]);
+  useSemanticUnderstandingTaskFormDefaults(form, open);
 
   const start = async () => {
     const values = await form.validateFields();

--- a/src/modules/data-catalog/components/semantic-understanding-task-form.ts
+++ b/src/modules/data-catalog/components/semantic-understanding-task-form.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export const semanticUnderstandingTaskFormDefaults = {
+  applyMode: "fill_empty" as const,
+  confidenceThreshold: 0.75,
+  includeSampleRows: false,
+  sampleMaxRows: 10,
+};

--- a/src/modules/data-catalog/components/semantic-understanding-task-form.ts
+++ b/src/modules/data-catalog/components/semantic-understanding-task-form.ts
@@ -5,9 +5,23 @@
  * Conditions. See LICENSE for the full text.
  */
 
+import type { FormInstance } from "antd";
+import { useEffect } from "react";
+
+import type { CreateSemanticUnderstandingTaskPayload } from "@/modules/data-catalog/services/semantic-understanding-task.service";
+
 export const semanticUnderstandingTaskFormDefaults = {
   applyMode: "fill_empty" as const,
   confidenceThreshold: 0.75,
   includeSampleRows: false,
   sampleMaxRows: 10,
 };
+
+export function useSemanticUnderstandingTaskFormDefaults(
+  form: Pick<FormInstance<CreateSemanticUnderstandingTaskPayload>, "setFieldsValue">,
+  open: boolean,
+) {
+  useEffect(() => {
+    if (open) form.setFieldsValue(semanticUnderstandingTaskFormDefaults);
+  }, [form, open]);
+}

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -8,43 +8,9 @@
 export const dataCatalogEnUS = {
   dataCatalog: {
     title: "Data Catalog",
-    description:
-      "Browse and govern data resources. Filter by connection to inspect tables, views, and index status.",
+    description: "Browse and govern data resources. Filter by connection to inspect tables, views, and index status.",
     catalogDetailTitle: "Resources",
     resourceDetailTitle: "Resource Detail",
-    resourceWorkspace: {
-      currentResource: "Current Resource",
-      tabDetail: "Detail",
-      tabPreview: "Data Preview",
-      tabIndex: "Data Index",
-      tabSemanticUnderstanding: "Semantic Understanding",
-      discardChangesTitle: "Discard unsaved changes?",
-      discardChangesDescription: "Switching tabs will discard the current unsaved changes and cannot be undone.",
-      discardChangesConfirm: "Discard and switch",
-      discoveryFailedTitle: "The latest resource discovery failed",
-      discoveryFailedNoSchemaDescription:
-        "No usable field metadata is available. Refresh discovery before previewing, querying, or indexing this resource.",
-      discoveryFailedStaleSchemaDescription:
-        "The last successfully discovered fields are still available, but they may be out of date.",
-      resourceMissingTitle: "Resource is missing from its source",
-      resourceMissingDescription:
-        "Discovery could not find this resource. Restore it at the source and run discovery again before querying or building an index.",
-      resourceDisabledTitle: "Resource is disabled",
-      resourceDisabledDescription:
-        "This resource is disabled. Enable it before previewing, querying, or building an index.",
-      resourceStaleTitle: "Resource is stale",
-      resourceStaleDescription:
-        "This resource is stale and cannot be previewed, queried, or indexed, even though field metadata remains.",
-      metadataUnavailableTitle: "Resource metadata is not ready",
-      metadataUnavailableDescription:
-        "No usable field metadata is available. Add or refresh the resource fields before querying or building an index.",
-      statusMessageDetail: "Status details: {{message}}",
-      openDiscovery: "Open discovery",
-      refreshMetadata: "Refresh Metadata",
-      discoveryQueued: "Resource metadata refresh task created.",
-      enableSuccess: "Resource enabled.",
-      disableSuccess: "Resource disabled.",
-    },
     indexWorkspace: {
       backToOverview: "Back to Tasks",
       configTabHint: "Choose how fields are indexed. Saving does not change the live index yet.",
@@ -65,34 +31,161 @@ export const dataCatalogEnUS = {
       goConfigure: "Configure Index",
       launchConfigTitle: "Current resource config",
       editConfigLink: "Edit",
-      launchConfigSummary:
-        "Primary key {{primaryKey}} · incremental {{incremental}} · embedding {{embedding}} · fulltext {{fulltext}} · model {{model}} · analyzer {{analyzer}}",
+      launchConfigSummary: "Primary key {{primaryKey}} · incremental {{incremental}} · embedding {{embedding}} · fulltext {{fulltext}} · model {{model}} · analyzer {{analyzer}}",
       viewConfig: "Configure Index",
       viewTasks: "Index Tasks",
       tasksUnavailableForDataset: "Dataset resources do not support index tasks yet.",
       embeddingModel: "Embedding Model",
       fulltextAnalyzer: "Analyzer",
     },
+    resourceWorkspace: {
+      currentResource: "Current Resource",
+      tabDetail: "Detail",
+      tabPreview: "Data Preview",
+      tabIndex: "Data Index",
+      tabSemanticUnderstanding: "Semantic Understanding",
+      discardChangesTitle: "Discard unsaved changes?",
+      discardChangesDescription: "Switching tabs will discard the current unsaved changes and cannot be undone.",
+      discardChangesConfirm: "Discard and switch",
+      discoveryFailedTitle: "The latest resource discovery failed",
+      discoveryFailedNoSchemaDescription: "No usable field metadata is available. Refresh discovery before previewing, querying, or indexing this resource.",
+      discoveryFailedStaleSchemaDescription: "The last successfully discovered fields are still available, but they may be out of date.",
+      resourceMissingTitle: "Resource is missing from its source",
+      resourceMissingDescription: "Discovery could not find this resource. Restore it at the source and run discovery again before querying or building an index.",
+      resourceDisabledTitle: "Resource is disabled",
+      resourceDisabledDescription: "This resource is disabled. Enable it before previewing, querying, or building an index.",
+      resourceStaleTitle: "Resource is stale",
+      resourceStaleDescription: "This resource is stale and cannot be previewed, queried, or indexed, even though field metadata remains.",
+      metadataUnavailableTitle: "Resource metadata is not ready",
+      metadataUnavailableDescription: "No usable field metadata is available. Add or refresh the resource fields before querying or building an index.",
+      statusMessageDetail: "Status details: {{message}}",
+      openDiscovery: "Open discovery",
+      refreshMetadata: "Refresh Metadata",
+      discoveryQueued: "Resource metadata refresh task created.",
+      enableSuccess: "Resource enabled.",
+      disableSuccess: "Resource disabled.",
+    },
     indexBuildTitle: "Task Management",
-    indexBuildDescription:
-      "Manage data-resource tasks, including viewing, pausing, restarting, and deleting tasks.",
+    indexBuildDescription: "Manage data-resource tasks, including viewing, pausing, restarting, and deleting tasks.",
     taskManagement: {
-      tabs: { indexBuild: "Index Build Tasks", discover: "Discover Tasks", semanticUnderstanding: "Semantic Understanding Tasks" },
-      columns: { task: "Task ID", catalog: "Catalog", resource: "Associated Resource", strategy: "Discover Strategy", trigger: "Trigger", scope: "Task Scope", applyMode: "Apply Mode", confidence: "Confidence", applied: "Application Status" },
-      scope: { catalog: "Data Directory", resource: "Data Resource" },
-      applyMode: { dryRun: "Preview only", fillEmpty: "Fill empty fields", force: "Force overwrite" },
-      applied: { applied: "Applied", notApplied: "Not applied" },
+      tabs: {
+        indexBuild: "Index Build Tasks",
+        discover: "Discover Tasks",
+        semanticUnderstanding: "Semantic Understanding Tasks"
+      },
+      columns: {
+        task: "Task ID",
+        catalog: "Catalog",
+        resource: "Associated Resource",
+        strategy: "Discover Strategy",
+        trigger: "Trigger",
+        scope: "Task Scope",
+        applyMode: "Apply Mode",
+        confidence: "Confidence",
+        applied: "Application Status"
+      },
+      scope: {
+        catalog: "Data Directory",
+        resource: "Data Resource"
+      },
+      applyMode: {
+        dryRun: "Preview only",
+        fillEmpty: "Fill empty fields",
+        force: "Force overwrite"
+      },
+      applied: {
+        applied: "Applied",
+        notApplied: "Not applied"
+      },
       moreFilters: "More filters",
       moreFiltersWithCount: "More filters ({{count}})",
       clearAdvancedFilters: "Clear more filters",
-      semanticStatus: { pending: "Pending", running: "Running", completed: "Completed", failed: "Failed", cancelled: "Cancelled" },
-      details: { taskInformation: "Task Information", taskScope: "Task Scope", scheduleId: "Schedule ID", startTime: "Started", message: "Message", agentId: "Agent ID", failureReason: "Failure Reason" },
-      discover: { empty: "No discover tasks" },
-      semantic: { empty: "No semantic-understanding tasks", deleteTitle: "Delete semantic-understanding task", deleteDescription: "Delete semantic-understanding task “{{id}}”?", detailSections: { task: "Task Information", execution: "Execution & Apply", quality: "Quality & Field Application", payload: "Input & Result", audit: "Audit Information" }, fields: { catalogId: "Catalog ID", resourceId: "Resource ID", agentTaskId: "Agent Task ID", confidenceThreshold: "Confidence Threshold", confidenceDetail: "Confidence Detail", applyDetail: "Apply Detail", inputHash: "Input Hash", input: "Input Snapshot", result: "Understanding Result", resourceEffective: "Resource Enhancement", fieldEffective: "Effective Field Enhancements", warnings: "Processing Notes", field: "Field", updated: "Updated Attributes", reason: "Reason" }, values: { effective: "Effective", notEffective: "No effective update", fieldEffective: "{{effective}} / {{total}} fields" }, fieldStatus: { updated: "Updated", partial: "Partially updated", unchanged: "Unchanged", skipped: "Skipped" }, mock: { customerCatalog: "CRM Master Data", phoneInsufficientSamplesWarning: "The phone field has insufficient sample values, so no semantic suggestion was generated.", insufficientSamples: "Insufficient sample values", customerSemanticSummary: "Field semantics were added for customer master data." } },
+      semanticStatus: {
+        pending: "Pending",
+        running: "Running",
+        completed: "Completed",
+        failed: "Failed",
+        cancelled: "Cancelled"
+      },
+      details: {
+        taskInformation: "Task Information",
+        taskScope: "Task Scope",
+        scheduleId: "Schedule ID",
+        startTime: "Started",
+        message: "Message",
+        agentId: "Agent ID",
+        failureReason: "Failure Reason"
+      },
+      discover: {
+        empty: "No discover tasks"
+      },
+      semantic: {
+        empty: "No semantic-understanding tasks",
+        deleteTitle: "Delete semantic-understanding task",
+        deleteDescription: "Delete semantic-understanding task “{{id}}”?",
+        detailSections: {
+          task: "Task Information",
+          execution: "Execution & Apply",
+          quality: "Quality & Field Application",
+          payload: "Input & Result",
+          audit: "Audit Information"
+        },
+        fields: {
+          catalogId: "Catalog ID",
+          resourceId: "Resource ID",
+          agentTaskId: "Agent Task ID",
+          confidenceThreshold: "Confidence Threshold",
+          confidenceDetail: "Confidence Detail",
+          applyDetail: "Apply Detail",
+          inputHash: "Input Hash",
+          input: "Input Snapshot",
+          result: "Understanding Result",
+          resourceEffective: "Resource Enhancement",
+          fieldEffective: "Effective Field Enhancements",
+          warnings: "Processing Notes",
+          field: "Field",
+          updated: "Updated Attributes",
+          reason: "Reason"
+        },
+        values: {
+          effective: "Effective",
+          notEffective: "No effective update",
+          fieldEffective: "{{effective}} / {{total}} fields"
+        },
+        fieldStatus: {
+          updated: "Updated",
+          partial: "Partially updated",
+          unchanged: "Unchanged",
+          skipped: "Skipped"
+        },
+        mock: {
+          customerCatalog: "CRM Master Data",
+          phoneInsufficientSamplesWarning: "The phone field has insufficient sample values, so no semantic suggestion was generated.",
+          insufficientSamples: "Insufficient sample values",
+          customerSemanticSummary: "Field semantics were added for customer master data."
+        }
+      },
     },
-    semanticWorkspace: { summary: "Semantic Understanding Result", noResult: "No result", applied: "Applied", generatedNotApplied: "Generated, not applied", pending: "Pending", running: "Running", failed: "Generation failed", cancelled: "Cancelled", create: "Create Task", createTitle: "Create Semantic Understanding Task", start: "Start", started: "Semantic understanding task started", empty: "No semantic-understanding tasks", confidenceThreshold: "Confidence threshold", includeSamples: "Include sample data", includeSamplesHint: "Sample data will be sent to the semantic-understanding service without masking." },
-    emptyDescription:
-      "Create and discover a connection first, then browse resources and build indexes here. If the platform already holds connections you cannot see here, access to their catalogs has not been granted to you.",
+    semanticWorkspace: {
+      summary: "Semantic Understanding Result",
+      noResult: "No result",
+      applied: "Applied",
+      generatedNotApplied: "Generated, not applied",
+      pending: "Pending",
+      running: "Running",
+      failed: "Generation failed",
+      cancelled: "Cancelled",
+      create: "Create Task",
+      createTitle: "Create Semantic Understanding Task",
+      start: "Start",
+      started: "Semantic understanding task started",
+      empty: "No semantic-understanding tasks",
+      confidenceThreshold: "Confidence threshold",
+      includeSamples: "Include sample data",
+      includeSamplesHint: "Sample data will be sent to the semantic-understanding service without masking.",
+      sampleRows: "Sample rows (1–20)"
+    },
+    emptyDescription: "Create and discover a connection first, then browse resources and build indexes here. If the platform already holds connections you cannot see here, access to their catalogs has not been granted to you.",
     backToCatalog: "Back to Data Catalog",
     buildChip: "Building · {{count}}",
     format: {
@@ -113,25 +206,20 @@ export const dataCatalogEnUS = {
     taskErrors: {
       dataTooLong: {
         title: "Build checkpoint write failed",
-        syncedMarkMessage:
-          "The sync checkpoint is longer than the task table column can store, so the backend could not update the task status.",
-        columnMessage:
-          "Column {{column}} received a value longer than the database column allows, so the task status update failed.",
-        syncedMarkSuggestion:
-          "Increase the task table f_synced_mark column length, or shorten the connector checkpoint before rebuilding.",
+        syncedMarkMessage: "The sync checkpoint is longer than the task table column can store, so the backend could not update the task status.",
+        columnMessage: "Column {{column}} received a value longer than the database column allows, so the task status update failed.",
+        syncedMarkSuggestion: "Increase the task table f_synced_mark column length, or shorten the connector checkpoint before rebuilding.",
         columnSuggestion: "Check and increase the column length, then rebuild.",
       },
       duplicateEntry: {
         title: "Task state write conflict",
         message: "The backend hit a unique-key conflict while writing task state.",
-        suggestion:
-          "Refresh the task list and remove the conflicting task before retrying if needed.",
+        suggestion: "Refresh the task list and remove the conflicting task before retrying if needed.",
       },
       missingDocumentId: {
         title: "Index documents are missing IDs",
         message: "Index write failed because some documents did not include a stable id field.",
-        suggestion:
-          "Check the resource build key or primary-key mapping, save the index configuration, then rebuild.",
+        suggestion: "Check the resource build key or primary-key mapping, save the index configuration, then rebuild.",
       },
       unknown: {
         title: "Build task failed",
@@ -185,11 +273,9 @@ export const dataCatalogEnUS = {
       logicalNamePlaceholder: "e.g. team_analytics",
       logicalDescriptionPlaceholder: "Optional description",
       deleteLogicalTitle: "Delete logical group",
-      deleteLogicalDescription:
-        'Delete logical group "{{name}}"? This removes {{resources}} resources and cancels {{semanticTasks}} pending semantic tasks.',
+      deleteLogicalDescription: 'Delete logical group "{{name}}"? This removes {{resources}} resources and cancels {{semanticTasks}} pending semantic tasks.',
       deleteLogicalBlockedTitle: "Logical group cannot be deleted",
-      deleteLogicalBlockedDescription:
-        "Resolve the following blockers before trying again:",
+      deleteLogicalBlockedDescription: "Resolve the following blockers before trying again:",
       deleteLogicalBlockers: {
         protected_resources: "{{count}} protected resources",
         protected_resources_one: "{{count}} protected resource",
@@ -221,8 +307,7 @@ export const dataCatalogEnUS = {
       goConnection: "Data Connection",
       goScan: "Discover Tasks",
       goDiscoverToDiscover: "Discover resources",
-      emptyResourcesPhysical:
-        "No resources yet. Run discovery from Data Connection to discover resources from the source.",
+      emptyResourcesPhysical: "No resources yet. Run discovery from Data Connection to discover resources from the source.",
       emptyResourcesLogical: "No resources yet",
     },
     resource: {
@@ -245,7 +330,11 @@ export const dataCatalogEnUS = {
       rowCount: "Rows",
       indexState: "Index State",
       indexName: "Local Index Name",
-      localIndexStatuses: { available: "Available", stale: "Stale", unavailable: "Unavailable" },
+      localIndexStatuses: {
+        available: "Available",
+        stale: "Stale",
+        unavailable: "Unavailable"
+      },
       searchPlaceholder: "Search resource name",
       noMatch: "No resources match the current filters",
       fieldCount: "Fields",
@@ -259,11 +348,9 @@ export const dataCatalogEnUS = {
       tags: "Tags",
       updater: "Updated by",
       sourceIdentifierPlaceholder: "e.g. crm_core.customers or a SQL statement",
-      sourceIdentifierHint:
-        "Table name / view definition in the source; resources found by discover fill this automatically.",
+      sourceIdentifierHint: "Table name / view definition in the source; resources found by discover fill this automatically.",
       schemaDefinition: "Schema Definition",
-      schemaHint:
-        "One field per line: name type. Leave empty to use the default schema (id / name / updated_at); discover can complete it later.",
+      schemaHint: "One field per line: name type. Leave empty to use the default schema (id / name / updated_at); discover can complete it later.",
       fieldName: "Field Name",
       fieldDisplayName: "Business Name",
       fieldDescription: "Description",
@@ -278,30 +365,22 @@ export const dataCatalogEnUS = {
       effectiveVersion: "Effective Version",
       effectiveActive: "Active",
       latestTask: "Latest Build Task",
-      noEffectiveIndex:
-        "No effective index yet - once a build succeeds, vector retrieval becomes available.",
-      noIndexHint:
-        "This resource has no index yet. Build one to enable vector retrieval in knowledge networks.",
-      rebuildFailedTitle:
-        "Rebuild failed. Retrieval is unaffected and still served by index {{version}}.",
-      rebuildFailedHint:
-        "Rebuild failed: {{error}}. Retrieval is unaffected and still served by index {{version}}.",
+      noEffectiveIndex: "No effective index yet - once a build succeeds, vector retrieval becomes available.",
+      noIndexHint: "This resource has no index yet. Build one to enable vector retrieval in knowledge networks.",
+      rebuildFailedTitle: "Rebuild failed. Retrieval is unaffected and still served by index {{version}}.",
+      rebuildFailedHint: "Rebuild failed: {{error}}. Retrieval is unaffected and still served by index {{version}}.",
       notFound: "Resource not found; it may have been deleted",
     },
     actions: {
       preview: "Preview Data",
-      previewMissingHint:
-        "The source resource is missing. Restore it and run discovery again before previewing.",
+      previewMissingHint: "The source resource is missing. Restore it and run discovery again before previewing.",
       previewDisabledHint: "This resource is disabled. Enable it before previewing.",
       previewStaleHint: "This resource is stale and cannot be previewed.",
-      previewMetadataUnavailableHint:
-        "This resource has no usable field metadata and cannot be previewed yet.",
-      indexMissingHint:
-        "The source resource is missing. Restore it and run discovery again before building an index.",
+      previewMetadataUnavailableHint: "This resource has no usable field metadata and cannot be previewed yet.",
+      indexMissingHint: "The source resource is missing. Restore it and run discovery again before building an index.",
       indexDisabledHint: "This resource is disabled. Enable it before building an index.",
       indexStaleHint: "This resource is stale and cannot be indexed.",
-      indexMetadataUnavailableHint:
-        "This resource has no usable field metadata and cannot be indexed yet.",
+      indexMetadataUnavailableHint: "This resource has no usable field metadata and cannot be indexed yet.",
       dataIndex: "Data Index",
       more: "More actions",
     },
@@ -313,36 +392,32 @@ export const dataCatalogEnUS = {
       unchanged: "Unchanged",
       updated: "Updated",
     },
-    resourceStatuses: { active: "Active", deprecated: "Deprecated", stale: "Stale" },
+    resourceStatuses: {
+      active: "Active",
+      deprecated: "Deprecated",
+      stale: "Stale"
+    },
     gate: {
-      catalogDisabled:
-        "Connection \"{{name}}\" is disabled; preview and build are unavailable.",
+      catalogDisabled: "Connection \"{{name}}\" is disabled; preview and build are unavailable.",
       catalogDisabledShort: "Connection disabled",
       goEnable: "Open connections",
     },
     preview: {
       noQueryPermission: "No permission to read this data",
-      noQueryPermissionDescription:
-        "You can see this table's structure, but reading its rows is granted separately. Ask an administrator for query permission on this table or the catalog it belongs to.",
+      noQueryPermissionDescription: "You can see this table's structure, but reading its rows is granted separately. Ask an administrator for query permission on this table or the catalog it belongs to.",
       summary: "Showing {{visibleRows}} · {{totalRows}} total",
       empty: "No data",
       metadataDiscoveryFailed: "Resource metadata discovery failed",
-      metadataDiscoveryFailedDescription:
-        "Preview is unavailable because no field metadata was discovered. Refresh discovery and try again.",
+      metadataDiscoveryFailedDescription: "Preview is unavailable because no field metadata was discovered. Refresh discovery and try again.",
       metadataUnavailable: "Resource metadata is not ready",
-      metadataUnavailableDescription:
-        "Preview is unavailable until resource fields have been added or refreshed.",
+      metadataUnavailableDescription: "Preview is unavailable until resource fields have been added or refreshed.",
       resourceMissing: "Source resource is missing",
-      resourceMissingDescription:
-        "This resource can no longer be found at its source. Restore it and run discovery again before previewing.",
+      resourceMissingDescription: "This resource can no longer be found at its source. Restore it and run discovery again before previewing.",
       resourceDisabled: "Resource is disabled",
-      resourceDisabledDescription:
-        "This resource is disabled. Enable it before previewing data.",
+      resourceDisabledDescription: "This resource is disabled. Enable it before previewing data.",
       resourceStale: "Resource is stale",
-      resourceStaleDescription:
-        "This resource is stale and cannot be previewed, even though field metadata remains.",
-      mockLongText:
-        "This is the long text content in row {{row}}, used to verify truncation and hover display.",
+      resourceStaleDescription: "This resource is stale and cannot be previewed, even though field metadata remains.",
+      mockLongText: "This is the long text content in row {{row}}, used to verify truncation and hover display.",
     },
     build: {
       submit: "Start Build",
@@ -350,38 +425,28 @@ export const dataCatalogEnUS = {
       saveConfig: "Save Config",
       saveIndexConfig: "Save Index Config",
       saveConfigSuccess: "Index config saved",
-      unsavedIndexConfig:
-        "Index config has unsaved changes. Save it before starting a build.",
+      unsavedIndexConfig: "Index config has unsaved changes. Save it before starting a build.",
       needConfigFirst: "Complete the configuration under Configure Index before starting a build.",
       editTitle: "Configure Index",
       editSubmit: "Start Build",
       editConfirmTitle: "Start a new build?",
-      editConfirmContent:
-        "A new build task will use the resource's current config. The previous index keeps serving search until the new build succeeds (when still usable).",
+      editConfirmContent: "A new build task will use the resource's current config. The previous index keeps serving search until the new build succeeds (when still usable).",
       editConfirmOk: "Start Build",
       edited: "A new build task was created",
-      streamingActiveLocked:
-        "A streaming task is still running or listening. Pause/stop it before changing config or creating a new streaming build.",
-      streamingRecreateHint:
-        "Streaming tasks cannot be edited in place. Save resource config first, then create a new streaming build under Task Management.",
-      activeTaskLocked:
-        "This resource already has an active build task, so the entire configuration page is locked. Wait for it to finish or stop it before changing config or starting a new build.",
-      configConflict:
-        "An active build task blocks index config updates. Stop the task, then save again.",
-      startRejected:
-        "Could not start this task (config may have changed, or a newer successful build exists). Save the latest config under Configure Index, then create a new build.",
+      streamingActiveLocked: "A streaming task is still running or listening. Pause/stop it before changing config or creating a new streaming build.",
+      streamingRecreateHint: "Streaming tasks cannot be edited in place. Save resource config first, then create a new streaming build under Task Management.",
+      activeTaskLocked: "This resource already has an active build task, so the entire configuration page is locked. Wait for it to finish or stop it before changing config or starting a new build.",
+      configConflict: "An active build task blocks index config updates. Stop the task, then save again.",
+      startRejected: "Could not start this task (config may have changed, or a newer successful build exists). Save the latest config under Configure Index, then create a new build.",
       created: "Build task created: {{id}}",
-      conflict:
-        "This resource already has an active build task; wait for it or pause listening first.",
+      conflict: "This resource already has an active build task; wait for it or pause listening first.",
       resource: "Resource",
-      resourceHint:
-        "Configure how fields are indexed under Configure Index; run builds under Task Management.",
+      resourceHint: "Configure how fields are indexed under Configure Index; run builds under Task Management.",
       mode: "Build Mode",
       batchLabel: "Batch",
       batchDescription: "One-shot sync and indexing.",
       streamingLabel: "Streaming",
-      streamingDescription:
-        "Continuous incremental sync with a standing listener; a build key is required.",
+      streamingDescription: "Continuous incremental sync with a standing listener; a build key is required.",
       executeType: "Execution",
       executeFull: "Full",
       executeFullDescription: "Sync all rows from the source and rebuild the index. Use it for first builds or full refreshes.",
@@ -391,17 +456,13 @@ export const dataCatalogEnUS = {
       schemaEmpty: "This resource has no fields yet; run a discover to discover its schema.",
       fulltextTypeHint: "Text-type fields only",
       keyFields: "Primary and Incremental Fields",
-      keyFieldsHint:
-        "The left-to-right tag order determines the field order for composite keys and incremental cursors.",
+      keyFieldsHint: "The left-to-right tag order determines the field order for composite keys and incremental cursors.",
       primaryKeyFieldsPlaceholder: "Select primary key",
       incrementalFieldsPlaceholder: "Select incremental key",
-      primaryKeyFieldsHint:
-        "Choose fields that uniquely identify a source row; composite keys follow tag order. Primary-key fields not covered by the incremental key are appended to the internal batch cursor.",
-      incrementalFieldsHint:
-        "Choose fields that advance batch-build cursors; ensure they can be stably sorted in tag order. Missing primary-key fields are appended internally.",
+      primaryKeyFieldsHint: "Choose fields that uniquely identify a source row; composite keys follow tag order. Primary-key fields not covered by the incremental key are appended to the internal batch cursor.",
+      incrementalFieldsHint: "Choose fields that advance batch-build cursors; ensure they can be stably sorted in tag order. Missing primary-key fields are appended internally.",
       fieldFeatureConfig: "Field Feature Configuration",
-      fieldFeatureConfigHint:
-        "Configure embedding and full-text features for text fields.",
+      fieldFeatureConfigHint: "Configure embedding and full-text features for text fields.",
       roleEmbedding: "Embedding",
       primaryKeyFieldCount: "Primary key fields",
       incrementalFieldCount: "Incremental fields",
@@ -409,8 +470,7 @@ export const dataCatalogEnUS = {
       fulltextFieldCount: "Full-text fields",
       rolePrimaryKey: "Primary key",
       roleIncrementalKey: "Incremental key",
-      invalidKeyFields:
-        "Invalid primary-key or incremental-key configuration: {{fields}}. Select schema fields with supported types.",
+      invalidKeyFields: "Invalid primary-key or incremental-key configuration: {{fields}}. Select schema fields with supported types.",
       removeInvalidKeyFields: "Remove invalid fields",
       roleFulltext: "Full-text search",
       unsupportedSchemaFields: "This resource contains other-type fields unsupported for index builds: {{fields}}. Correct the source field type or its discovery mapping before building.",
@@ -420,16 +480,13 @@ export const dataCatalogEnUS = {
       fulltextAnalyzer: "Analyzer",
       defaultFulltextAnalyzer: "Default Analyzer",
       defaultEmbeddingModel: "Default Embedding Model",
-      defaultAnalyzerRequired:
-        "Full-text fields are selected; set the resource default analyzer.",
+      defaultAnalyzerRequired: "Full-text fields are selected; set the resource default analyzer.",
       configCanBuild: "Buildable",
       configCanBuildYes: "Ready",
       configCannotBuild: "Configuration incomplete",
       resourceDefaultsTitle: "Resource Defaults",
-      resourceDefaultsHint:
-        "Features use these defaults when no override is selected.",
-      fulltextAnalyzerOverrides:
-        "Field analyzers override the default: {{overrides}}. Update them in Field Feature Config or choose Use default.",
+      resourceDefaultsHint: "Features use these defaults when no override is selected.",
+      fulltextAnalyzerOverrides: "Field analyzers override the default: {{overrides}}. Update them in Field Feature Config or choose Use default.",
       fieldEmbeddingModel: "Embedding Model",
       fieldFulltextAnalyzer: "Analyzer",
       inheritDefaultAnalyzer: "Use default",
@@ -449,21 +506,15 @@ export const dataCatalogEnUS = {
       featureNotEnabled: "Off",
       featureConfiguredCount: "Configured",
       removeFeatureType: "Remove Type",
-      duplicateFeatureTypeUnsupported:
-        "Only one feature of each type is supported per field. Remove duplicate features: {{features}}.",
+      duplicateFeatureTypeUnsupported: "Only one feature of each type is supported per field. Remove duplicate features: {{features}}.",
       featureSummaryEmpty: "No features",
       featureUnsupported: "Unsupported",
-      defaultEmbeddingModelHint:
-        "Available options are the embedding models connected in the current environment.",
-      defaultEmbeddingModelUsageHint:
-        "Used to convert selected embedding fields into vector representations.",
+      defaultEmbeddingModelHint: "Available options are the embedding models connected in the current environment.",
+      defaultEmbeddingModelUsageHint: "Used to convert selected embedding fields into vector representations.",
       fulltextAnalyzerHint: "Available options come from the current environment.",
-      fulltextAnalyzerEnglishHint:
-        "standard is for English / general text; english performs English stemming.",
-      fulltextChineseAnalyzerAvailableHint:
-        "Chinese-text analyzer enabled in this environment: {{analyzers}}.",
-      fulltextChineseAnalyzerUnavailableHint:
-        "No Chinese analyzer such as IK/HanLP is enabled in this environment. standard and english do not provide Chinese word segmentation, so Chinese search recall and relevance may be limited. Ask an administrator to enable a Chinese analyzer.",
+      fulltextAnalyzerEnglishHint: "standard is for English / general text; english performs English stemming.",
+      fulltextChineseAnalyzerAvailableHint: "Chinese-text analyzer enabled in this environment: {{analyzers}}.",
+      fulltextChineseAnalyzerUnavailableHint: "No Chinese analyzer such as IK/HanLP is enabled in this environment. standard and english do not provide Chinese word segmentation, so Chinese search recall and relevance may be limited. Ask an administrator to enable a Chinese analyzer.",
       analyzerSelectionUnavailable: "Analyzer capabilities are unavailable.",
       analyzers: {
         standard: "standard · English / general",
@@ -478,22 +529,18 @@ export const dataCatalogEnUS = {
       noAnalyzers: "No full-text analyzers are available; index configuration cannot be saved.",
       savedAnalyzerUnavailable: "Saved analyzer configuration is unavailable: {{analyzers}}. Choose an available analyzer to continue.",
       fieldsRequired: "Select at least one embedding or full-text field.",
-      keyFieldsRequired:
-        "Batch mode requires both primary-key and incremental fields. Select them under Configure Index.",
+      keyFieldsRequired: "Batch mode requires both primary-key and incremental fields. Select them under Configure Index.",
       model: "Embedding Model",
       modelRequired: "Select an embedding model.",
-      noModels:
-        "No embedding models connected; cannot save a config that includes embedding fields.",
+      noModels: "No embedding models connected; cannot save a config that includes embedding fields.",
       goConnectModel: "Connect a model",
       modelsLoading: "Loading embedding models…",
       modelsLoadError: "Failed to load embedding models: {{message}}",
       modelsLoadErrorFallback: "Retry later or check model management service",
       retryLoadModels: "Retry",
-      savedModelUnavailable:
-        'Saved embedding model "{{model}}" is not registered in this environment. Select a connected model.',
+      savedModelUnavailable: 'Saved embedding model "{{model}}" is not registered in this environment. Select a connected model.',
       dimensions: "Vector Dimensions",
-      dimensionsHint:
-        "(preview from model; server writes actual dimensions when the build runs)",
+      dimensionsHint: "(preview from model; server writes actual dimensions when the build runs)",
     },
     task: {
       column: "Task",
@@ -502,18 +549,21 @@ export const dataCatalogEnUS = {
       detail: "Task Detail",
       buildDetail: "Build Task Detail",
       semanticDetail: "Semantic Understanding Task Detail",
-      detailSections: { status: "Task Status", task: "Task Information", execution: "Execution Information", audit: "Audit Information" },
+      detailSections: {
+        status: "Task Status",
+        task: "Task Information",
+        execution: "Execution Information",
+        audit: "Audit Information"
+      },
       rawError: "Raw error",
       modalTitle: "Build Task",
       progress: "Progress",
       statusFilterPlaceholder: "All statuses",
       empty: "No index tasks",
       emptyVisible: "No tasks you can see",
-      emptyUnauthorizedDescription:
-        "Only tasks you may see are listed, and that is decided on the catalog each task belongs to. Ask an administrator to grant you access to the catalogs whose tasks you expect here.",
+      emptyUnauthorizedDescription: "Only tasks you may see are listed, and that is decided on the catalog each task belongs to. Ask an administrator to grant you access to the catalogs whose tasks you expect here.",
       visibleCount: "{{count}} on this page",
-      emptyDescription:
-        "No tasks match the current filters. Configure and submit a build from a resource's Data Index tab in Data Catalog.",
+      emptyDescription: "No tasks match the current filters. Configure and submit a build from a resource's Data Index tab in Data Catalog.",
       pauseListening: "Pause Listening",
       resumeListening: "Resume Listening",
       paused: "Listening paused",
@@ -530,21 +580,17 @@ export const dataCatalogEnUS = {
       rerunResume: "Resume from the checkpoint",
       rerunReset: "Restart from the beginning",
       rebuildFullConfirmTitle: "Full reset this task?",
-      rebuildFullConfirmContent:
-        "This starts the task with reset=true (ignore cursor). If resource index config drifted relative to this task, start may be rejected — create a new build instead.",
+      rebuildFullConfirmContent: "This starts the task with reset=true (ignore cursor). If resource index config drifted relative to this task, start may be rejected — create a new build instead.",
       retried: "Build task resubmitted: {{id}}",
-      startRejected:
-        "Could not start this task (config may have changed, or a newer successful build exists). Open Data Index, save config, and create a new build.",
+      startRejected: "Could not start this task (config may have changed, or a newer successful build exists). Open Data Index, save config, and create a new build.",
       deleteConfirmTitle: "Delete build task {{id}}?",
       deleteConfirmContent: "The task record cannot be recovered after deletion.",
-      deleteConfirmContentActive:
-        "The task is still running and will be stopped before deletion; the record cannot be recovered.",
+      deleteConfirmContentActive: "The task is still running and will be stopped before deletion; the record cannot be recovered.",
       batchDelete: "Batch Delete",
       batchDeleteConfirmTitle: "Delete {{count}} build tasks",
       batchDeleteConfirmTitle_one: "Delete {{count}} build task",
       batchDeleteConfirmTitle_other: "Delete {{count}} build tasks",
-      batchDeleteConfirmContent:
-        "Deleted task records cannot be recovered; running tasks are stopped before deletion.",
+      batchDeleteConfirmContent: "Deleted task records cannot be recovered; running tasks are stopped before deletion.",
       batchDeletePartial: "Failed to delete: {{failed}}/{{total}}",
       model: "Model",
       finishedAt: "Finished At",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -31,8 +31,7 @@ export const dataCatalogZhCN = {
       goConfigure: "配置索引",
       launchConfigTitle: "当前资源配置",
       editConfigLink: "去修改",
-      launchConfigSummary:
-        "主键 {{primaryKey}} · 增量键 {{incremental}} · 向量 {{embedding}} · 全文 {{fulltext}} · 模型 {{model}} · 分词器 {{analyzer}}",
+      launchConfigSummary: "主键 {{primaryKey}} · 增量键 {{incremental}} · 向量 {{embedding}} · 全文 {{fulltext}} · 模型 {{model}} · 分词器 {{analyzer}}",
       viewConfig: "配置索引",
       viewTasks: "索引任务",
       tasksUnavailableForDataset: "Dataset 资源暂不支持索引任务。",
@@ -49,10 +48,8 @@ export const dataCatalogZhCN = {
       discardChangesDescription: "切换 Tab 将丢失当前未保存的修改，且无法恢复。",
       discardChangesConfirm: "放弃并切换",
       discoveryFailedTitle: "资源最近一次探查失败",
-      discoveryFailedNoSchemaDescription:
-        "当前没有可用的字段元数据，请重新执行探查后再预览、查询或构建索引。",
-      discoveryFailedStaleSchemaDescription:
-        "仍可使用上一次成功探查的字段，但这些字段可能已经过期。",
+      discoveryFailedNoSchemaDescription: "当前没有可用的字段元数据，请重新执行探查后再预览、查询或构建索引。",
+      discoveryFailedStaleSchemaDescription: "仍可使用上一次成功探查的字段，但这些字段可能已经过期。",
       resourceMissingTitle: "资源已从源端消失",
       resourceMissingDescription: "探查未在源端找到该资源，请恢复源端对象并重新探查后再查询或构建索引。",
       resourceDisabledTitle: "资源已停用",
@@ -71,22 +68,124 @@ export const dataCatalogZhCN = {
     indexBuildTitle: "任务管理",
     indexBuildDescription: "管理数据资源相关任务，支持任务查看，暂停，重启，删除等操作。",
     taskManagement: {
-      tabs: { indexBuild: "索引构建任务", discover: "探查任务", semanticUnderstanding: "语义理解任务" },
-      columns: { task: "任务 ID", catalog: "所属目录", resource: "所属资源", strategy: "探查策略", trigger: "触发方式", scope: "任务范围", applyMode: "应用方式", confidence: "置信度", applied: "应用状态" },
-      scope: { catalog: "数据目录", resource: "数据资源" },
-      applyMode: { dryRun: "仅预览", fillEmpty: "填充空值", force: "强制覆盖" },
-      applied: { applied: "已应用", notApplied: "未应用" },
+      tabs: {
+        indexBuild: "索引构建任务",
+        discover: "探查任务",
+        semanticUnderstanding: "语义理解任务"
+      },
+      columns: {
+        task: "任务 ID",
+        catalog: "所属目录",
+        resource: "所属资源",
+        strategy: "探查策略",
+        trigger: "触发方式",
+        scope: "任务范围",
+        applyMode: "应用方式",
+        confidence: "置信度",
+        applied: "应用状态"
+      },
+      scope: {
+        catalog: "数据目录",
+        resource: "数据资源"
+      },
+      applyMode: {
+        dryRun: "仅预览",
+        fillEmpty: "填充空值",
+        force: "强制覆盖"
+      },
+      applied: {
+        applied: "已应用",
+        notApplied: "未应用"
+      },
       moreFilters: "更多筛选",
       moreFiltersWithCount: "更多筛选（{{count}}）",
       clearAdvancedFilters: "清空更多筛选",
-      semanticStatus: { pending: "等待中", running: "执行中", completed: "已完成", failed: "失败", cancelled: "已取消" },
-      details: { taskInformation: "任务信息", taskScope: "任务范围", scheduleId: "计划 ID", startTime: "开始时间", message: "执行信息", agentId: "Agent ID", failureReason: "失败原因" },
-      discover: { empty: "暂无探查任务" },
-      semantic: { empty: "暂无语义理解任务", deleteTitle: "删除语义理解任务", deleteDescription: "确认删除语义理解任务“{{id}}”吗？", detailSections: { task: "任务信息", execution: "执行与应用", quality: "质量与字段应用", payload: "输入与结果", audit: "审计信息" }, fields: { catalogId: "目录 ID", resourceId: "资源 ID", agentTaskId: "Agent 任务 ID", confidenceThreshold: "置信度阈值", confidenceDetail: "置信度明细", applyDetail: "应用明细", inputHash: "输入哈希", input: "输入快照", result: "理解结果", resourceEffective: "资源语义增强", fieldEffective: "有效字段增强", warnings: "处理提示", field: "字段", updated: "已更新属性", reason: "原因" }, values: { effective: "有效", notEffective: "无有效更新", fieldEffective: "{{effective}} / {{total}} 个字段" }, fieldStatus: { updated: "已更新", partial: "部分更新", unchanged: "无变更", skipped: "已跳过" }, mock: { customerCatalog: "CRM 主数据", phoneInsufficientSamplesWarning: "字段 phone 的样本值不足，未生成语义建议。", insufficientSamples: "样本值不足", customerSemanticSummary: "已为客户主数据补充字段语义。" } },
+      semanticStatus: {
+        pending: "等待中",
+        running: "执行中",
+        completed: "已完成",
+        failed: "失败",
+        cancelled: "已取消"
+      },
+      details: {
+        taskInformation: "任务信息",
+        taskScope: "任务范围",
+        scheduleId: "计划 ID",
+        startTime: "开始时间",
+        message: "执行信息",
+        agentId: "Agent ID",
+        failureReason: "失败原因"
+      },
+      discover: {
+        empty: "暂无探查任务"
+      },
+      semantic: {
+        empty: "暂无语义理解任务",
+        deleteTitle: "删除语义理解任务",
+        deleteDescription: "确认删除语义理解任务“{{id}}”吗？",
+        detailSections: {
+          task: "任务信息",
+          execution: "执行与应用",
+          quality: "质量与字段应用",
+          payload: "输入与结果",
+          audit: "审计信息"
+        },
+        fields: {
+          catalogId: "目录 ID",
+          resourceId: "资源 ID",
+          agentTaskId: "Agent 任务 ID",
+          confidenceThreshold: "置信度阈值",
+          confidenceDetail: "置信度明细",
+          applyDetail: "应用明细",
+          inputHash: "输入哈希",
+          input: "输入快照",
+          result: "理解结果",
+          resourceEffective: "资源语义增强",
+          fieldEffective: "有效字段增强",
+          warnings: "处理提示",
+          field: "字段",
+          updated: "已更新属性",
+          reason: "原因"
+        },
+        values: {
+          effective: "有效",
+          notEffective: "无有效更新",
+          fieldEffective: "{{effective}} / {{total}} 个字段"
+        },
+        fieldStatus: {
+          updated: "已更新",
+          partial: "部分更新",
+          unchanged: "无变更",
+          skipped: "已跳过"
+        },
+        mock: {
+          customerCatalog: "CRM 主数据",
+          phoneInsufficientSamplesWarning: "字段 phone 的样本值不足，未生成语义建议。",
+          insufficientSamples: "样本值不足",
+          customerSemanticSummary: "已为客户主数据补充字段语义。"
+        }
+      },
     },
-    semanticWorkspace: { summary: "语义理解结果", noResult: "暂无结果", applied: "已应用", generatedNotApplied: "已生成，未应用", pending: "等待中", running: "执行中", failed: "生成失败", cancelled: "已取消", create: "新建任务", createTitle: "新建语义理解任务", start: "开始语义理解", started: "已开始语义理解任务", empty: "暂无语义理解任务", confidenceThreshold: "置信度阈值", includeSamples: "包含样本数据", includeSamplesHint: "样本数据将以未脱敏形式发送给语义理解服务。" },
-    emptyDescription:
-      "在数据连接中新建并探查后，即可在此浏览资源并构建索引。若平台已有数据连接却看不到，说明尚未获得对应目录的授权。",
+    semanticWorkspace: {
+      summary: "语义理解结果",
+      noResult: "暂无结果",
+      applied: "已应用",
+      generatedNotApplied: "已生成，未应用",
+      pending: "等待中",
+      running: "执行中",
+      failed: "生成失败",
+      cancelled: "已取消",
+      create: "新建任务",
+      createTitle: "新建语义理解任务",
+      start: "开始语义理解",
+      started: "已开始语义理解任务",
+      empty: "暂无语义理解任务",
+      confidenceThreshold: "置信度阈值",
+      includeSamples: "包含样本数据",
+      includeSamplesHint: "样本数据将以未脱敏形式发送给语义理解服务。",
+      sampleRows: "样本行数（1–20）"
+    },
+    emptyDescription: "在数据连接中新建并探查后，即可在此浏览资源并构建索引。若平台已有数据连接却看不到，说明尚未获得对应目录的授权。",
     backToCatalog: "返回数据目录",
     buildChip: "构建中 · {{count}}",
     format: {
@@ -107,12 +206,9 @@ export const dataCatalogZhCN = {
     taskErrors: {
       dataTooLong: {
         title: "任务进度标记写入失败",
-        syncedMarkMessage:
-          "同步游标内容超过任务表可保存长度，导致后端更新任务状态失败。",
-        columnMessage:
-          "字段 {{column}} 的内容超过数据库可保存长度，导致任务状态更新失败。",
-        syncedMarkSuggestion:
-          "建议将任务表的 f_synced_mark 字段扩容，或缩短连接器返回的同步游标后重新构建。",
+        syncedMarkMessage: "同步游标内容超过任务表可保存长度，导致后端更新任务状态失败。",
+        columnMessage: "字段 {{column}} 的内容超过数据库可保存长度，导致任务状态更新失败。",
+        syncedMarkSuggestion: "建议将任务表的 f_synced_mark 字段扩容，或缩短连接器返回的同步游标后重新构建。",
         columnSuggestion: "建议检查对应字段长度配置，扩容后重新构建。",
       },
       duplicateEntry: {
@@ -177,11 +273,9 @@ export const dataCatalogZhCN = {
       logicalNamePlaceholder: "例如 team_analytics",
       logicalDescriptionPlaceholder: "可选，说明该逻辑分组用途",
       deleteLogicalTitle: "删除逻辑分组",
-      deleteLogicalDescription:
-        '确认删除逻辑分组「{{name}}」吗？将删除 {{resources}} 个资源，并取消 {{semanticTasks}} 个待执行语义理解任务。',
+      deleteLogicalDescription: '确认删除逻辑分组「{{name}}」吗？将删除 {{resources}} 个资源，并取消 {{semanticTasks}} 个待执行语义理解任务。',
       deleteLogicalBlockedTitle: "当前无法删除逻辑分组",
-      deleteLogicalBlockedDescription:
-        "请先处理以下阻断项，然后重试：",
+      deleteLogicalBlockedDescription: "请先处理以下阻断项，然后重试：",
       deleteLogicalBlockers: {
         protected_resources: "受保护资源 {{count}} 个",
         protected_resources_one: "受保护资源 {{count}} 个",
@@ -236,7 +330,11 @@ export const dataCatalogZhCN = {
       rowCount: "行数",
       indexState: "索引状态",
       indexName: "本地索引名称",
-      localIndexStatuses: { available: "可用", stale: "已失效", unavailable: "不可用" },
+      localIndexStatuses: {
+        available: "可用",
+        stale: "已失效",
+        unavailable: "不可用"
+      },
       searchPlaceholder: "搜索资源名称",
       noMatch: "没有符合筛选条件的资源",
       fieldCount: "字段数",
@@ -250,11 +348,9 @@ export const dataCatalogZhCN = {
       tags: "标签",
       updater: "更新人",
       sourceIdentifierPlaceholder: "如 crm_core.customers 或一段 SQL",
-      sourceIdentifierHint:
-        "数据源中的表名 / 视图定义；探查（discover）发现的资源会自动填写。",
+      sourceIdentifierHint: "数据源中的表名 / 视图定义；探查（discover）发现的资源会自动填写。",
       schemaDefinition: "Schema 定义",
-      schemaHint:
-        "每行一个字段：名称 类型。留空时使用默认 schema（id / name / updated_at），后续可由探查补全。",
+      schemaHint: "每行一个字段：名称 类型。留空时使用默认 schema（id / name / updated_at），后续可由探查补全。",
       fieldName: "字段名",
       fieldDisplayName: "业务名称",
       fieldDescription: "描述",
@@ -272,8 +368,7 @@ export const dataCatalogZhCN = {
       noEffectiveIndex: "暂无生效索引——构建成功后即可在知识网络中进行向量检索。",
       noIndexHint: "该资源还没有索引。构建后即可在知识网络中进行向量检索。",
       rebuildFailedTitle: "重建失败。检索不受影响，仍由旧版索引 {{version}} 提供服务。",
-      rebuildFailedHint:
-        "重建失败:{{error}}。检索不受影响,仍由旧版索引 {{version}} 提供服务。",
+      rebuildFailedHint: "重建失败:{{error}}。检索不受影响,仍由旧版索引 {{version}} 提供服务。",
       notFound: "未找到该资源,可能已被删除",
     },
     actions: {
@@ -297,10 +392,13 @@ export const dataCatalogZhCN = {
       unchanged: "未变化",
       updated: "已更新",
     },
-    resourceStatuses: { active: "活跃", deprecated: "已废弃", stale: "已失效" },
+    resourceStatuses: {
+      active: "活跃",
+      deprecated: "已废弃",
+      stale: "已失效"
+    },
     gate: {
-      catalogDisabled:
-        "所属连接「{{name}}」已停用,无法预览数据或构建索引。",
+      catalogDisabled: "所属连接「{{name}}」已停用,无法预览数据或构建索引。",
       catalogDisabledShort: "连接已停用",
       goEnable: "去连接页处理",
     },
@@ -310,8 +408,7 @@ export const dataCatalogZhCN = {
       summary: "展示 {{visibleRows}} · 总计 {{totalRows}}",
       empty: "没有数据",
       metadataDiscoveryFailed: "资源元数据探查失败",
-      metadataDiscoveryFailedDescription:
-        "未探查到可用字段，暂时无法预览。请重新执行探查后再试。",
+      metadataDiscoveryFailedDescription: "未探查到可用字段，暂时无法预览。请重新执行探查后再试。",
       metadataUnavailable: "资源元数据尚未就绪",
       metadataUnavailableDescription: "补充或刷新资源字段后才能预览数据。",
       resourceMissing: "源端资源不存在",
@@ -320,8 +417,7 @@ export const dataCatalogZhCN = {
       resourceDisabledDescription: "当前资源处于停用状态，启用后才能预览数据。",
       resourceStale: "资源已失效",
       resourceStaleDescription: "当前资源已失效，即使保留了字段元数据也不能预览数据。",
-      mockLongText:
-        "\u8fd9\u662f\u7b2c {{row}} \u884c\u7684\u957f\u6587\u672c\u5185\u5bb9\uff0c\u7528\u4e8e\u9a8c\u8bc1\u622a\u65ad\u4e0e\u60ac\u505c\u5c55\u793a\u3002",
+      mockLongText: "\u8fd9\u662f\u7b2c {{row}} \u884c\u7684\u957f\u6587\u672c\u5185\u5bb9\uff0c\u7528\u4e8e\u9a8c\u8bc1\u622a\u65ad\u4e0e\u60ac\u505c\u5c55\u793a\u3002",
     },
     build: {
       submit: "开始构建",
@@ -334,20 +430,14 @@ export const dataCatalogZhCN = {
       editTitle: "配置索引",
       editSubmit: "开始构建",
       editConfirmTitle: "开始新的构建?",
-      editConfirmContent:
-        "将按资源当前配置创建新的构建任务。新索引成功前仍以旧索引服务检索（若仍可用）。",
+      editConfirmContent: "将按资源当前配置创建新的构建任务。新索引成功前仍以旧索引服务检索（若仍可用）。",
       editConfirmOk: "开始构建",
       edited: "已创建新的构建任务",
-      streamingActiveLocked:
-        "流式任务仍在运行或监听中。请先暂停/停止当前任务，再修改配置或新建流式构建。",
-      streamingRecreateHint:
-        "流式任务不支持原地改配置。请先保存资源配置，再到任务管理创建新的流式构建。",
-      activeTaskLocked:
-        "该资源已有进行中的构建任务，整个配置页面已锁定。请先等待完成或停止当前任务，再修改配置或发起新构建。",
-      configConflict:
-        "当前存在进行中的构建任务，无法修改索引配置。请先停止任务后再保存。",
-      startRejected:
-        "无法启动该任务（配置可能已变更，或已有更新的成功构建）。请到「配置索引」保存最新配置后，再新建构建。",
+      streamingActiveLocked: "流式任务仍在运行或监听中。请先暂停/停止当前任务，再修改配置或新建流式构建。",
+      streamingRecreateHint: "流式任务不支持原地改配置。请先保存资源配置，再到任务管理创建新的流式构建。",
+      activeTaskLocked: "该资源已有进行中的构建任务，整个配置页面已锁定。请先等待完成或停止当前任务，再修改配置或发起新构建。",
+      configConflict: "当前存在进行中的构建任务，无法修改索引配置。请先停止任务后再保存。",
+      startRejected: "无法启动该任务（配置可能已变更，或已有更新的成功构建）。请到「配置索引」保存最新配置后，再新建构建。",
       created: "构建任务已创建:{{id}}",
       conflict: "该资源已有进行中的构建任务,需等待完成或先暂停监听。",
       resource: "数据资源",
@@ -416,8 +506,7 @@ export const dataCatalogZhCN = {
       featureNotEnabled: "未启用",
       featureConfiguredCount: "已配置",
       removeFeatureType: "移除本类",
-      duplicateFeatureTypeUnsupported:
-        "每个字段的每类特征仅支持一组。请移除重复特征：{{features}}。",
+      duplicateFeatureTypeUnsupported: "每个字段的每类特征仅支持一组。请移除重复特征：{{features}}。",
       featureSummaryEmpty: "未配置特征",
       featureUnsupported: "暂不支持",
       defaultEmbeddingModelHint: "实际可选项以当前环境已接入的 Embedding 模型为准。",
@@ -425,8 +514,7 @@ export const dataCatalogZhCN = {
       fulltextAnalyzerHint: "实际可选项以当前环境服务端返回为准。",
       fulltextAnalyzerEnglishHint: "standard 适用于英文/通用文本，english 用于英文词干分析。",
       fulltextChineseAnalyzerAvailableHint: "当前已启用可用于中文文本的分词器：{{analyzers}}。",
-      fulltextChineseAnalyzerUnavailableHint:
-        "当前未启用 IK/HanLP 等中文分词器；standard 和 english 不提供中文分词能力，中文检索的召回和相关性可能受限。请联系管理员启用中文分词器。",
+      fulltextChineseAnalyzerUnavailableHint: "当前未启用 IK/HanLP 等中文分词器；standard 和 english 不提供中文分词能力，中文检索的召回和相关性可能受限。请联系管理员启用中文分词器。",
       analyzerSelectionUnavailable: "分词器能力当前不可用。",
       analyzers: {
         standard: "standard · 英文/通用",
@@ -450,8 +538,7 @@ export const dataCatalogZhCN = {
       modelsLoadError: "加载 embedding 模型失败：{{message}}",
       modelsLoadErrorFallback: "请稍后重试或检查模型管理服务",
       retryLoadModels: "重试",
-      savedModelUnavailable:
-        "已保存的 embedding 模型「{{model}}」不在当前环境注册表中，请重新选择已接入的模型。",
+      savedModelUnavailable: "已保存的 embedding 模型「{{model}}」不在当前环境注册表中，请重新选择已接入的模型。",
       dimensions: "向量维度",
       dimensionsHint: "(随模型联动预览；实际维度由服务端在构建时写入)",
     },
@@ -462,18 +549,21 @@ export const dataCatalogZhCN = {
       detail: "任务详情",
       buildDetail: "构建任务详情",
       semanticDetail: "语义理解任务详情",
-      detailSections: { status: "任务状态", task: "任务信息", execution: "执行信息", audit: "审计信息" },
+      detailSections: {
+        status: "任务状态",
+        task: "任务信息",
+        execution: "执行信息",
+        audit: "审计信息"
+      },
       rawError: "原始错误",
       modalTitle: "构建任务",
       progress: "进度",
       statusFilterPlaceholder: "全部状态",
       empty: "暂无索引任务",
       emptyVisible: "没有可见的任务",
-      emptyUnauthorizedDescription:
-        "这里只显示你有权查看的任务，可见性取决于任务所属目录的授权。若你认为应当看到某些任务，请联系管理员为对应目录授予权限。",
+      emptyUnauthorizedDescription: "这里只显示你有权查看的任务，可见性取决于任务所属目录的授权。若你认为应当看到某些任务，请联系管理员为对应目录授予权限。",
       visibleCount: "本页 {{count}} 条",
-      emptyDescription:
-        "当前筛选条件下没有任务。请在数据目录的资源「数据索引」中配置并提交构建。",
+      emptyDescription: "当前筛选条件下没有任务。请在数据目录的资源「数据索引」中配置并提交构建。",
       pauseListening: "暂停监听",
       resumeListening: "恢复监听",
       paused: "已暂停监听",
@@ -490,11 +580,9 @@ export const dataCatalogZhCN = {
       rerunResume: "从中断处继续构建",
       rerunReset: "从头开始重新构建",
       rebuildFullConfirmTitle: "确定全量重跑本任务?",
-      rebuildFullConfirmContent:
-        "将对该构建任务执行 reset=true：忽略游标从头同步。若资源索引配置相对该任务已变更，启动可能被拒绝，需新建构建。",
+      rebuildFullConfirmContent: "将对该构建任务执行 reset=true：忽略游标从头同步。若资源索引配置相对该任务已变更，启动可能被拒绝，需新建构建。",
       retried: "已重新提交构建任务:{{id}}",
-      startRejected:
-        "无法启动该任务（配置可能已变或已有更新的成功构建）。请到资源「数据索引」保存配置并新建构建。",
+      startRejected: "无法启动该任务（配置可能已变或已有更新的成功构建）。请到资源「数据索引」保存配置并新建构建。",
       deleteConfirmTitle: "删除构建任务 {{id}}?",
       deleteConfirmContent: "删除后任务记录不可恢复。",
       deleteConfirmContentActive: "任务仍在运行,将先停止再删除;删除后任务记录不可恢复。",

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.test.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.test.ts
@@ -7,10 +7,13 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const getMock = vi.hoisted(() => vi.fn());
+const { getMock, postMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  postMock: vi.fn(),
+}));
 
 vi.mock("@/framework/request/http", () => ({
-  http: { get: getMock },
+  http: { get: getMock, post: postMock },
 }));
 
 import {
@@ -41,6 +44,37 @@ describe("semantic-understanding task mocks", () => {
     } finally {
       await deleteSemanticUnderstandingTask(task.id);
     }
+  });
+});
+
+describe("createResourceSemanticUnderstandingTask", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("sends the selected sample row limit to Vega", async () => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    postMock.mockResolvedValue({ data: { id: "task-1" } });
+    const { createResourceSemanticUnderstandingTask: createTask } = await import(
+      "@/modules/data-catalog/services/semantic-understanding-task.service"
+    );
+
+    await createTask({
+      applyMode: "dry_run",
+      includeSampleRows: true,
+      resourceId: "resource-1",
+      sampleMaxRows: 20,
+    });
+
+    expect(postMock).toHaveBeenCalledWith("/vega-backend/v1/semantic-understanding-tasks", {
+      apply_mode: "dry_run",
+      confidence_threshold: undefined,
+      include_sample_rows: true,
+      resource_id: "resource-1",
+      sample_policy: { masked: false, max_rows: 20 },
+      scope: "resource",
+    });
   });
 });
 

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.ts
@@ -148,6 +148,7 @@ export type CreateSemanticUnderstandingTaskPayload = {
   confidenceThreshold?: number;
   includeSampleRows?: boolean;
   resourceId: string;
+  sampleMaxRows?: number;
 };
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
@@ -396,13 +397,14 @@ export async function createResourceSemanticUnderstandingTask(payload: CreateSem
     return task;
   }
   const includeSampleRows = payload.includeSampleRows ?? false;
+  const sampleMaxRows = payload.sampleMaxRows ?? 10;
   const response = await http.post<{ id: string }>("/vega-backend/v1/semantic-understanding-tasks", {
     scope: "resource",
     resource_id: payload.resourceId,
     apply_mode: payload.applyMode,
     confidence_threshold: payload.confidenceThreshold,
     include_sample_rows: includeSampleRows,
-    sample_policy: includeSampleRows ? { masked: false, max_rows: 10 } : undefined,
+    sample_policy: includeSampleRows ? { masked: false, max_rows: sampleMaxRows } : undefined,
   });
   return response.data;
 }


### PR DESCRIPTION
## What Changed

- [x] Expose a 1–20 row selector when semantic-understanding sample data is enabled.
- [x] Send the selected value as `sample_policy.max_rows`; preserve the prior default of 10.
- [x] Add English and Chinese labels plus focused component and service regression coverage.

---

## Why

- Related Issue: Closes #568
- Background: Studio previously hard-coded `max_rows: 10`, leaving the supported 11–20 row API path inaccessible from the UI.

---

## How

- Add `sampleMaxRows` to the Studio task payload and map it to the Vega request.
- Show an integer input constrained to 1–20 only when sample data is selected.
- Breaking changes: None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (repository Vitest suite)
- [ ] Verified in test environment (not run)

Test notes:

- `pnpm exec vitest --run`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vite build`
- `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`
- `node scripts/check-license-headers.mjs`
- `pnpm audit --prod`

---

## Risk & Rollback

- Potential risks: More unmasked sample rows may be sent when a user explicitly selects a value above 10; Vega enforces the existing 20-row and 128 KiB caps.
- Rollback plan: Revert this PR to restore the fixed 10-row Studio request.

---

## Additional Notes

- Locale key parity is covered by the existing locale-parity test.
- Vite retains pre-existing chunk-size warnings.