### PR TITLE
fix(system-admin): keep the caller's own authorize row locked without a grant point

### DIFF
--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
@@ -17,7 +17,7 @@ const listUsersPageMock = vi.hoisted(() => vi.fn());
 const appServices = vi.hoisted(() => ({
   message: { error: vi.fn(), success: vi.fn() },
   modal: { confirm: vi.fn() },
-  runtimeConfig: { currentUser: { permissions: [] as string[] } },
+  runtimeConfig: { currentUser: { id: "u-owner", permissions: [] as string[] } },
 }));
 
 vi.mock("react-i18next", async (importOriginal) => ({
@@ -81,6 +81,7 @@ function lockedCardCount() {
 describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    appServices.runtimeConfig.currentUser.id = "u-owner";
     appServices.runtimeConfig.currentUser.permissions = [];
     listUsersPageMock.mockResolvedValue({ total: 0, users: [] });
     listObjectGrantsForObjectMock.mockResolvedValue({
@@ -132,11 +133,38 @@ describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
   // so the rows stay removable — reading administrator status off the grant point alone took the
   // remove control away from them.
   it("leaves every row removable for a revoke-only administrator", async () => {
+    appServices.runtimeConfig.currentUser.id = "u-admin";
     appServices.runtimeConfig.currentUser.permissions = [
       "admin-authz:view",
       "admin-authz:revoke",
     ];
     renderDrawer({ objectAuthorized: false });
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(0);
+    expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(3);
+  });
+
+  // Restoring `authorize` is a grant, and a revoke-only administrator holds no grant point: dropping
+  // it from their own row would leave them outside the object with no control here to undo it. The
+  // rows they can put back stay open.
+  it("keeps a revoke-only administrator from dropping their own authorize", async () => {
+    appServices.runtimeConfig.currentUser.permissions = [
+      "admin-authz:view",
+      "admin-authz:revoke",
+    ];
+    renderDrawer();
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(1);
+    // Their own row is the locked one; the public row and the ordinary grant stay removable.
+    expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(2);
+  });
+
+  // The same caller holding the grant point can restore what they drop, so nothing is locked.
+  it("leaves the caller's own authorize row open once they hold the grant point", async () => {
+    appServices.runtimeConfig.currentUser.permissions = ["admin-authz:grant"];
+    renderDrawer();
     await act(async () => {});
 
     expect(lockedCardCount()).toBe(0);

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.test.tsx
@@ -73,9 +73,26 @@ function renderDrawer({ objectAuthorized = true } = {}) {
   );
 }
 
-/** The lock icon marks a row the caller may not write; each card renders one at most. */
+/** The lock icon marks a row the caller may not erase; each card renders one at most. */
 function lockedCardCount() {
   return document.querySelectorAll('[aria-label="lock"]').length;
+}
+
+/** The operation chip for `opKey` on the card of the grantee rendered under `granteeName`. */
+function findChip(granteeName: string, opKey: string) {
+  // authzWhoName -> authzWho -> authzCardHead -> authzCard
+  const card = screen.getByText(granteeName).closest("div")?.parentElement;
+  return [...(card?.querySelectorAll("button") ?? [])].find((button) =>
+    button.textContent?.includes(opKey),
+  );
+}
+
+function chipOn(granteeName: string, opKey: string) {
+  const chip = findChip(granteeName, opKey);
+  if (!chip) {
+    throw new Error(`no ${opKey} chip on the ${granteeName} card`);
+  }
+  return chip;
 }
 
 describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
@@ -159,6 +176,33 @@ describe("ObjectAuthorizeDrawer rows a delegate may not write", () => {
     expect(lockedCardCount()).toBe(1);
     // Their own row is the locked one; the public row and the ordinary grant stay removable.
     expect(screen.getAllByText("systemAdmin.objectGrants.remove")).toHaveLength(2);
+    // Only the erasing direction is pinned. Adding an operation to their own row is a POST of the
+    // union and leaves `authorize` standing, so the rest of the card stays live. (#518 already
+    // keeps the `authorize` chip itself off this surface — offering it would be a grant.)
+    expect(findChip("u-owner", "authorize")).toBeUndefined();
+    expect(chipOn("u-owner", "modify").disabled).toBe(false);
+  });
+
+  // Unchecking the last operation on a row is a DELETE, so it runs on the revoke point — the one
+  // route by which a chip, not the remove control, can erase an `authorize`-only row. The platform
+  // authorization page passes no objectAuthorized, which is where that chip renders.
+  it("pins an authorize-only row of the caller's own", async () => {
+    appServices.runtimeConfig.currentUser.permissions = [
+      "admin-authz:view",
+      "admin-authz:revoke",
+    ];
+    listObjectGrantsForObjectMock.mockResolvedValue({
+      accounts: [],
+      grants: [grant("u-owner", ["authorize"]), grant("u-mate", ["authorize"])],
+    });
+    renderDrawer({ objectAuthorized: false });
+    await act(async () => {});
+
+    expect(lockedCardCount()).toBe(1);
+    expect(chipOn("u-owner", "authorize").disabled).toBe(true);
+    // Someone else's authorize-only row is still theirs to revoke, and that is what the point is
+    // for — so this proves the lock reads the accessor, not the caller's missing grant point.
+    expect(chipOn("u-mate", "authorize").disabled).toBe(false);
   });
 
   // The same caller holding the grant point can restore what they drop, so nothing is locked.

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
@@ -27,6 +27,10 @@ import { extractRequestErrorMessage } from "@/framework/request/error-message";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { hasPermissions } from "@/framework/permission/has-permissions";
 import { authzPoints } from "@/modules/system-admin/permissions";
+import {
+  isDelegateProtectedGrant,
+  isSelfAuthorizeLockout,
+} from "@/modules/system-admin/utils/object-grant-guards";
 import { chipTogglePoint } from "@/modules/system-admin/utils/authz-actions";
 import { listUsersPage } from "@/modules/system-admin/services/admin.service";
 import {
@@ -96,27 +100,6 @@ function mergeObjectGrants(
 ) {
   const others = allGrants.filter((grant) => !(grant.objType === objType && grant.objId === objId));
   return [...others, ...objectGrants];
-}
-
-/** The subject bkn-safe writes when the execution factory publishes something to everyone. */
-const PUBLIC_ACCESSOR_ID = "00000000-0000-0000-0000-000000000000";
-
-/**
- * Whether bkn-safe will refuse a non-administrator write against this row
- * (its protectAuthorizeHolder guard), so the drawer can lock it rather than offer a control that
- * always 403s.
- *
- * Two rows are off limits to a delegate, and both because the write erases: POST is
- * replace-semantics and DELETE removes everything the accessor holds.
- *
- * - A row carrying `authorize` — the object's creator, or anyone an administrator trusted with
- *   sharing. Letting a delegate rewrite it would let them take the object away from the person who
- *   made it, and `authorize` is administrator-conferred, so nobody inside the drawer could put it
- *   back. This covers the caller's OWN row: an owner cannot drop their own authorize either.
- * - The public-access row, whose removal would un-publish the object platform-wide.
- */
-function isDelegateProtected(grant: ObjectGrant) {
-  return grant.accessorId === PUBLIC_ACCESSOR_ID || grant.operations.includes("authorize");
 }
 
 export function ObjectAuthorizeDrawer({
@@ -527,20 +510,19 @@ export function ObjectAuthorizeDrawer({
             <div className={styles.authzList}>
               {grants.map((grant) => {
                 const builtinLocked = isProtected(grant.accessorId);
-                // Both writes erase, and putting `authorize` back is a grant. A caller without
-                // `admin-authz:grant` who drops it from their own row leaves the drawer with no way
-                // back in: the chip that would restore it is the one their point does not cover, and
-                // objectAuthorized — the other route to canGrant — dies with the row. So their own
-                // row stays locked even where bkn-safe would take the write. (An `authorize` held
-                // through a department grant is the same trap, but membership is not resolved here.)
-                const selfAuthorizeLockout =
-                  !isAdminGrantor &&
-                  currentUserId !== null &&
-                  grant.accessorId === currentUserId &&
-                  grant.operations.includes("authorize");
-                const delegateLocked =
-                  isDelegateProtected(grant) && (!isPlatformAuthzAdmin || selfAuthorizeLockout);
+                const delegateLocked = !isPlatformAuthzAdmin && isDelegateProtectedGrant(grant);
+                const selfAuthorizeLocked = isSelfAuthorizeLockout({
+                  currentUserId,
+                  grant,
+                  isAdminGrantor,
+                });
+                // Two locks of different reach. bkn-safe refuses a delegate any write against these
+                // rows, so that one takes the whole card. The self-lockout is about what the caller
+                // could undo, and only the erasing directions can strand them: dropping the row, or
+                // unchecking `authorize` on it. Adding operations to their own row still goes
+                // through — POST sends the union and leaves `authorize` standing.
                 const locked = builtinLocked || delegateLocked;
+                const eraseLocked = locked || selfAuthorizeLocked;
                 const grantee = resolveGrantee(grant.accessorId);
                 return (
                   <div className={styles.authzCard} key={grant.accessorId}>
@@ -557,14 +539,14 @@ export function ObjectAuthorizeDrawer({
                             : t("systemAdmin.objectGrants.granteeUser")}
                         </Tag>
                       </span>
-                      {locked ? (
+                      {eraseLocked ? (
                         <Tooltip
                           title={t(
                             builtinLocked
                               ? "systemAdmin.objectGrants.adminLocked"
-                              : isPlatformAuthzAdmin
-                                ? "systemAdmin.objectGrants.selfAuthorizeLocked"
-                                : "systemAdmin.objectGrants.delegateLocked",
+                              : delegateLocked
+                                ? "systemAdmin.objectGrants.delegateLocked"
+                                : "systemAdmin.objectGrants.selfAuthorizeLocked",
                           )}
                         >
                           <span className={styles.subText}>
@@ -598,7 +580,12 @@ export function ObjectAuthorizeDrawer({
                             styles.chipOpt,
                             selected ? styles.chipOptSelected : "",
                           ].join(" ")}
-                          disabled={busy || locked || !allowed}
+                          disabled={
+                            busy ||
+                            locked ||
+                            (selfAuthorizeLocked && op.key === "authorize") ||
+                            !allowed
+                          }
                           key={op.key}
                           onClick={() => void toggleOp(grant, op.key)}
                           type="button"

--- a/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
+++ b/src/modules/system-admin/components/ObjectAuthorizeDrawer.tsx
@@ -157,6 +157,7 @@ export function ObjectAuthorizeDrawer({
   // of rows the backend accepts from them. Which control they get is still decided per direction by
   // canGrant/canRevoke below.
   const isPlatformAuthzAdmin = isAdminGrantor || isAdminRevoker;
+  const currentUserId = runtimeConfig.currentUser.id;
   const canGrant = objectAuthorized || isAdminGrantor;
   const canRevoke = objectAuthorized || isAdminRevoker;
   const canManageGrants = canGrant || canRevoke;
@@ -526,7 +527,19 @@ export function ObjectAuthorizeDrawer({
             <div className={styles.authzList}>
               {grants.map((grant) => {
                 const builtinLocked = isProtected(grant.accessorId);
-                const delegateLocked = !isPlatformAuthzAdmin && isDelegateProtected(grant);
+                // Both writes erase, and putting `authorize` back is a grant. A caller without
+                // `admin-authz:grant` who drops it from their own row leaves the drawer with no way
+                // back in: the chip that would restore it is the one their point does not cover, and
+                // objectAuthorized — the other route to canGrant — dies with the row. So their own
+                // row stays locked even where bkn-safe would take the write. (An `authorize` held
+                // through a department grant is the same trap, but membership is not resolved here.)
+                const selfAuthorizeLockout =
+                  !isAdminGrantor &&
+                  currentUserId !== null &&
+                  grant.accessorId === currentUserId &&
+                  grant.operations.includes("authorize");
+                const delegateLocked =
+                  isDelegateProtected(grant) && (!isPlatformAuthzAdmin || selfAuthorizeLockout);
                 const locked = builtinLocked || delegateLocked;
                 const grantee = resolveGrantee(grant.accessorId);
                 return (
@@ -549,7 +562,9 @@ export function ObjectAuthorizeDrawer({
                           title={t(
                             builtinLocked
                               ? "systemAdmin.objectGrants.adminLocked"
-                              : "systemAdmin.objectGrants.delegateLocked",
+                              : isPlatformAuthzAdmin
+                                ? "systemAdmin.objectGrants.selfAuthorizeLocked"
+                                : "systemAdmin.objectGrants.delegateLocked",
                           )}
                         >
                           <span className={styles.subText}>

--- a/src/modules/system-admin/locales/en-US.ts
+++ b/src/modules/system-admin/locales/en-US.ts
@@ -173,6 +173,7 @@ export const systemAdminEnUS = {
       removeLastOpConfirm: "This subject will have no operations left and the permission rule will be removed. Continue?",
       adminLocked: "The administrator holds all permissions and cannot be adjusted or removed here.",
       delegateLocked: "Only a platform administrator can adjust or remove this grant — including your own.",
+      selfAuthorizeLocked: "This grant carries your own authorize permission. Your role cannot grant it back, so it stays locked here.",
       revokeTitle: "Revoke permissions",
       revokeConfirm: "Revoke \"{{name}}\"'s permissions on \"{{object}}\"?",
       stats: {

--- a/src/modules/system-admin/locales/zh-CN.ts
+++ b/src/modules/system-admin/locales/zh-CN.ts
@@ -171,6 +171,7 @@ export const systemAdminZhCN = {
       removeLastOpConfirm: "该权限主体将不再拥有任何操作，权限配置会被移除。是否继续？",
       adminLocked: "管理员拥有全部权限，不可在此调整或移除。",
       delegateLocked: "这条权限配置只有平台管理员能调整或移除，你自己的那条也一样。",
+      selfAuthorizeLocked: "这条带着你自己的授权权限。你的角色无法重新授予它，移除后装不回来，因此锁定。",
       revokeTitle: "撤销权限",
       revokeConfirm: "确定撤销「{{name}}」对「{{object}}」的权限吗？",
       stats: {

--- a/src/modules/system-admin/scenes/ObjectAuthorizationScene.test.tsx
+++ b/src/modules/system-admin/scenes/ObjectAuthorizationScene.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ObjectGrant } from "@/modules/system-admin/types/authz";
+
+const listObjectGrantsPageMock = vi.hoisted(() => vi.fn());
+const revokeObjectGrantMock = vi.hoisted(() => vi.fn());
+const appServices = vi.hoisted(() => ({
+  message: { error: vi.fn(), success: vi.fn() },
+  modal: { confirm: vi.fn() },
+  runtimeConfig: { currentUser: { id: "u-owner", permissions: [] as string[] } },
+}));
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ i18n: { language: "zh-CN" }, t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => appServices,
+}));
+
+vi.mock("@/modules/system-admin/services/authz.service", () => ({
+  listObjectGrantsPage: listObjectGrantsPageMock,
+  listObjectGroups: vi.fn(() => Promise.resolve({ groups: [], total: 0 })),
+  revokeObjectGrant: revokeObjectGrantMock,
+}));
+
+vi.mock("@/modules/system-admin/services/authz-objects.service", () => ({
+  resolveGrantNames: (grants: ObjectGrant[]) => Promise.resolve(grants),
+}));
+
+vi.mock("@/modules/system-admin/utils/audit-lookup-cache", () => ({
+  getCachedDepartments: vi.fn(() => Promise.resolve([])),
+  getCachedUserSync: vi.fn(() => undefined),
+  hydrateUserLookup: vi.fn(() => Promise.resolve(undefined)),
+  primeUserLookupCache: vi.fn(),
+}));
+
+// The drawer has loaders of its own and is covered by its own suite; the list page's action menu is
+// what this file is about.
+vi.mock("@/modules/system-admin/components/ObjectAuthorizeDrawer", () => ({
+  ObjectAuthorizeDrawer: () => null,
+}));
+
+import { ObjectAuthorizationScene } from "./ObjectAuthorizationScene";
+
+function grant(accessorId: string, operations: string[]): ObjectGrant {
+  return {
+    accessorId,
+    objId: `catalog-${accessorId}`,
+    objName: `conn_${accessorId}`,
+    objType: "catalog",
+    operations,
+  };
+}
+
+/** Opens the action menu on the row at `index` and returns its revoke item. */
+async function openRevokeItem(index: number) {
+  const triggers = screen.getAllByLabelText("systemAdmin.objectGrants.columns.actions");
+  fireEvent.click(triggers[index]);
+  await act(async () => {});
+  const label = screen.getByText("systemAdmin.objectGrants.revoke");
+  const item = label.closest("li");
+  if (!item) {
+    throw new Error("revoke menu item not rendered");
+  }
+  return item;
+}
+
+describe("ObjectAuthorizationScene revoke action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appServices.runtimeConfig.currentUser.id = "u-owner";
+    appServices.runtimeConfig.currentUser.permissions = [
+      "admin-authz:view",
+      "admin-authz:revoke",
+    ];
+    listObjectGrantsPageMock.mockResolvedValue({
+      grants: [grant("u-owner", ["view_detail", "authorize"]), grant("u-mate", ["view_detail"])],
+      total: 2,
+      summary: { grants: 2, objects: 2, grantees: 2 },
+    });
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    }));
+  });
+
+  // This menu reaches the same DELETE the drawer's remove control does. Without the guard a caller
+  // holding no `admin-authz:grant` could drop their own `authorize` here and land outside the
+  // object with nothing in the UI to undo it.
+  it("refuses to revoke the caller's own authorize row", async () => {
+    render(<ObjectAuthorizationScene />);
+    await act(async () => {});
+
+    expect((await openRevokeItem(0)).getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("leaves someone else's row revocable", async () => {
+    render(<ObjectAuthorizationScene />);
+    await act(async () => {});
+
+    expect((await openRevokeItem(1)).getAttribute("aria-disabled")).not.toBe("true");
+  });
+});

--- a/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
+++ b/src/modules/system-admin/scenes/ObjectAuthorizationScene.tsx
@@ -51,6 +51,7 @@ import {
   hydrateUserLookup,
 } from "@/modules/system-admin/utils/audit-lookup-cache";
 import { AUTHZ_OBJECT_TYPES, authzObjectTypeOptions } from "@/modules/system-admin/utils/authz-catalog";
+import { isSelfAuthorizeLockout } from "@/modules/system-admin/utils/object-grant-guards";
 import { operationLabel, resourceTypeLabel } from "@/modules/system-admin/utils/resource-catalog";
 
 import styles from "./admin.module.css";
@@ -93,6 +94,7 @@ export function ObjectAuthorizationScene() {
     requiredPermissions: authzPoints.grant,
   });
   const canManageGrants = canGrant || canRevokeGrant;
+  const currentUserId = runtimeConfig.currentUser.id;
   const { pageState, setPagination } = usePageState();
 
   const [grants, setGrants] = useState<ObjectGrant[]>([]);
@@ -388,41 +390,61 @@ export function ObjectAuthorizationScene() {
   );
 
   const buildGrantActionMenu = useCallback(
-    (grant: ObjectGrant): MenuProps => ({
-      items: [
-        {
-          key: "manage",
-          label: t(
-            canManageGrants
-              ? "systemAdmin.objectGrants.manage"
-              : "systemAdmin.objectGrants.viewDetail",
-          ),
-        },
-        canRevokeGrant
-          ? {
-              danger: true,
-              key: "revoke",
-              label: t("systemAdmin.objectGrants.revoke"),
+    (grant: ObjectGrant): MenuProps => {
+      // Revoking here deletes the row outright, stranding a caller who holds no admin-authz:grant
+      // on their own `authorize` exactly as the drawer's remove control would. The drawer locks that
+      // row; this menu is the list's own way to the same DELETE, and refuses it on the same terms.
+      const selfAuthorizeLocked = isSelfAuthorizeLockout({
+        currentUserId,
+        grant,
+        isAdminGrantor: canGrant,
+      });
+      return {
+        items: [
+          {
+            key: "manage",
+            label: t(
+              canManageGrants
+                ? "systemAdmin.objectGrants.manage"
+                : "systemAdmin.objectGrants.viewDetail",
+            ),
+          },
+          canRevokeGrant
+            ? {
+                danger: true,
+                disabled: selfAuthorizeLocked,
+                key: "revoke",
+                label: selfAuthorizeLocked ? (
+                  <Tooltip title={t("systemAdmin.objectGrants.selfAuthorizeLocked")}>
+                    <span>{t("systemAdmin.objectGrants.revoke")}</span>
+                  </Tooltip>
+                ) : (
+                  t("systemAdmin.objectGrants.revoke")
+                ),
+              }
+            : null,
+        ].filter(Boolean),
+        onClick: ({ key, domEvent }) => {
+          domEvent.stopPropagation();
+          if (key === "manage") {
+            openDrawer({
+              id: grant.objId,
+              name: grant.objName,
+              sub: grant.objSub,
+              type: grant.objType,
+            });
+            return;
+          }
+          if (key === "revoke") {
+            if (selfAuthorizeLocked) {
+              return;
             }
-          : null,
-      ].filter(Boolean),
-      onClick: ({ key, domEvent }) => {
-        domEvent.stopPropagation();
-        if (key === "manage") {
-          openDrawer({
-            id: grant.objId,
-            name: grant.objName,
-            sub: grant.objSub,
-            type: grant.objType,
-          });
-          return;
-        }
-        if (key === "revoke") {
-          confirmRevoke(grant);
-        }
-      },
-    }),
-    [canManageGrants, canRevokeGrant, confirmRevoke, openDrawer, t],
+            confirmRevoke(grant);
+          }
+        },
+      };
+    },
+    [canGrant, canManageGrants, canRevokeGrant, confirmRevoke, currentUserId, openDrawer, t],
   );
 
   const columns: ColumnsType<ObjectGrant> = useMemo(() => [

--- a/src/modules/system-admin/utils/object-grant-guards.test.ts
+++ b/src/modules/system-admin/utils/object-grant-guards.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ObjectGrant } from "@/modules/system-admin/types/authz";
+import {
+  PUBLIC_ACCESSOR_ID,
+  isDelegateProtectedGrant,
+  isSelfAuthorizeLockout,
+} from "@/modules/system-admin/utils/object-grant-guards";
+
+function grant(accessorId: string, operations: string[]): ObjectGrant {
+  return {
+    accessorId,
+    objId: "catalog-1",
+    objName: "nb_test_conn",
+    objType: "catalog",
+    operations,
+  };
+}
+
+describe("isDelegateProtectedGrant", () => {
+  it("covers the rows bkn-safe refuses from a delegate", () => {
+    expect(isDelegateProtectedGrant(grant("u-owner", ["view_detail", "authorize"]))).toBe(true);
+    expect(isDelegateProtectedGrant(grant(PUBLIC_ACCESSOR_ID, ["view_detail"]))).toBe(true);
+  });
+
+  it("leaves an ordinary grant alone", () => {
+    expect(isDelegateProtectedGrant(grant("u-mate", ["view_detail", "modify"]))).toBe(false);
+  });
+});
+
+describe("isSelfAuthorizeLockout", () => {
+  const own = grant("u-owner", ["view_detail", "authorize"]);
+
+  it("holds for a caller who cannot grant `authorize` back", () => {
+    expect(
+      isSelfAuthorizeLockout({ currentUserId: "u-owner", grant: own, isAdminGrantor: false }),
+    ).toBe(true);
+  });
+
+  it("clears once the caller holds the grant point", () => {
+    expect(
+      isSelfAuthorizeLockout({ currentUserId: "u-owner", grant: own, isAdminGrantor: true }),
+    ).toBe(false);
+  });
+
+  it("is about the caller's own row, not every authorize holder", () => {
+    expect(
+      isSelfAuthorizeLockout({ currentUserId: "u-mate", grant: own, isAdminGrantor: false }),
+    ).toBe(false);
+  });
+
+  it("ignores a row of theirs that carries no authorize", () => {
+    expect(
+      isSelfAuthorizeLockout({
+        currentUserId: "u-owner",
+        grant: grant("u-owner", ["view_detail"]),
+        isAdminGrantor: false,
+      }),
+    ).toBe(false);
+  });
+
+  // An unauthenticated runtime carries a null id; matching it against an accessor would lock rows
+  // at random.
+  it("never fires without a known caller", () => {
+    expect(isSelfAuthorizeLockout({ currentUserId: null, grant: own, isAdminGrantor: false })).toBe(
+      false,
+    );
+  });
+});

--- a/src/modules/system-admin/utils/object-grant-guards.ts
+++ b/src/modules/system-admin/utils/object-grant-guards.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ObjectGrant } from "@/modules/system-admin/types/authz";
+
+/** The subject bkn-safe writes when the execution factory publishes something to everyone. */
+export const PUBLIC_ACCESSOR_ID = "00000000-0000-0000-0000-000000000000";
+
+/**
+ * Whether bkn-safe will refuse a non-administrator write against this row (its
+ * protectAuthorizeHolder guard), so a surface can lock it rather than offer a control that
+ * always 403s.
+ *
+ * Two rows are off limits to a delegate, and both because the write erases: POST is
+ * replace-semantics and DELETE removes everything the accessor holds.
+ *
+ * - A row carrying `authorize` — the object's creator, or anyone an administrator trusted with
+ *   sharing. Letting a delegate rewrite it would let them take the object away from the person who
+ *   made it, and `authorize` is administrator-conferred, so nobody outside the admin points could
+ *   put it back. This covers the caller's OWN row.
+ * - The public-access row, whose removal would un-publish the object platform-wide.
+ */
+export function isDelegateProtectedGrant(grant: ObjectGrant) {
+  return grant.accessorId === PUBLIC_ACCESSOR_ID || grant.operations.includes("authorize");
+}
+
+/**
+ * Whether erasing this row would strip the caller's own `authorize` with nothing in the UI to put
+ * it back: the row is theirs, it carries `authorize`, and they hold no `admin-authz:grant`.
+ *
+ * Restoring `authorize` is a grant. Without that point the only other route is the object-level
+ * `authorize` itself — and that dies with the row — so the caller lands outside the object and
+ * needs a second administrator to let them back in. bkn-safe would take the write; the guard is
+ * about what the caller can undo, which is why it holds for an administrator too.
+ *
+ * It deliberately does not cover `authorize` reached through a department grant: the same trap,
+ * but membership is not resolved on these surfaces.
+ */
+export function isSelfAuthorizeLockout({
+  currentUserId,
+  grant,
+  isAdminGrantor,
+}: {
+  currentUserId: string | null;
+  grant: ObjectGrant;
+  isAdminGrantor: boolean;
+}) {
+  return (
+    !isAdminGrantor &&
+    currentUserId !== null &&
+    grant.accessorId === currentUserId &&
+    grant.operations.includes("authorize")
+  );
+}


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `system-admin`: a caller who holds no `admin-authz:grant` can no longer erase their own `authorize` row — from the drawer **or** from the object authorization list's action menu
- [x] The guard moves to `utils/object-grant-guards.ts`; the drawer and the list scene share it
- [x] The drawer's lock splits: the delegate lock still freezes the card, the self-lockout covers only the erasing directions
- [x] i18n: `systemAdmin.objectGrants.selfAuthorizeLocked` in zh-CN and en-US
- [x] Tests: guard unit tests, the drawer's chip-level behaviour, and the list page's action menu

---

## Why

- Related Issue: follow-up to #572, plus both 待确认项 from this PR's own first review

#572 released the row lock for either `admin-authz` point, which was right for the platform authorization page. It also released it where `objectAuthorized` is passed, so a revoke-only administrator who owns the object got the Remove control and live chips on their own `authorize` row.

Both writes erase, and putting `authorize` back is a grant: the chip is gated on `isAdminGrantor`, and `canGrant`'s only other route, `objectAuthorized`, dies with the row it comes from. So the click removed their own access and left no control here to undo it — the trap #518 closed for owners, reopened for this role shape.

The first pass at that (commit 1 here) had two problems of its own, both raised in review:

1. **It only closed one of two doors.** `ObjectAuthorizationScene`'s action menu gates revoke on `admin-authz:revoke` alone and calls `revokeObjectGrant` directly. The same caller could drop the same row from the list page.
2. **The lock was too wide.** It froze the whole card, so a revoke-only administrator lost the ability to *add* operations to their own row — a POST of the union, which leaves `authorize` in place and strands nobody.

---

## How

- `utils/object-grant-guards.ts` holds `isDelegateProtectedGrant` (moved out of the drawer, unchanged) and `isSelfAuthorizeLockout`. One definition, two callers — the list page's guard cannot drift from the drawer's.
- The drawer now carries two locks. `locked` is the delegate lock and still disables the card; `eraseLocked` adds the self-lockout and covers the remove control, while the chip row disables only `authorize` under it.
- The list page's revoke item goes `disabled` with `selfAuthorizeLocked` on its tooltip, and the click handler refuses it too.
- Known gap, left alone deliberately and documented on the guard: `authorize` reached through a **department** grant is the same trap, and department membership is not resolved on either surface.
- Breaking changes (API, config, database, etc.): none.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable
- [ ] Verified in test environment — the revoke-only role is still not provisioned on the dev VM; pinned by unit tests

```
node scripts/check-license-headers.mjs                          exit 0
node scripts/scan-hardcoded-zh.mjs                              exit 0
eslint --config eslint.config.typechecked.js --max-warnings 0   exit 0 (changed files)
tsc -b --force                                                  exit 0
vitest --run src/modules/system-admin                           67 passed / 15 files
```

Each new case was run against the code it guards, with the guard removed:

| case | without the fix |
| --- | --- |
| `refuses to revoke the caller's own authorize row` (scene) | `expected null to be 'true'` — the menu item renders enabled |
| `pins an authorize-only row of the caller's own` (drawer chip) | `expected false to be true` — unchecking the last op is a DELETE, so the revoke point alone opens it |
| `keeps a revoke-only administrator from dropping their own authorize` (drawer, adding ops) | `expected true to be false` — the whole-card lock kills the `modify` chip |

Full `vitest --run`: 112 failed / 1312 passed with this branch, 112 failed / 1302 passed on the same branch without these commits — the 10 new tests, no new failures. Those 112 are the `window.localStorage.getItem is not a function` jsdom drift; their file list shifts run to run (`LicenseManagementScene` failed in one full run and passed in the next, and passes in isolation), which is worth its own look but is not from this change.

---

## Risk & Rollback

- Potential risks: a caller without the grant point loses the revoke entry on their own `authorize` row in two places. Recovering that row already needed a second administrator, so nothing they could previously repair is now out of reach.
- Rollback plan: revert both commits; `object-grant-guards.ts` and the new string have no other reference.

---

## Additional Notes

- Backported to `release/0.1.4` on `fix/system-admin/protect-authorize-rows-release-014` (#519).
- Still unverified from #518's review: `PUBLIC_ACCESSOR_ID` (`00000000-0000-0000-0000-000000000000`) has no second occurrence in this repo, so if bkn-safe marks public grants some other way, that half of `isDelegateProtectedGrant` never fires.
