### PR TITLE
feat(system-admin): add knowledge network execute grant

### DIFF
--- a/src/modules/system-admin/utils/resource-catalog.test.ts
+++ b/src/modules/system-admin/utils/resource-catalog.test.ts
@@ -106,6 +106,10 @@ describe("resource-catalog", () => {
     }
   });
 
+  it("offers action execution on a knowledge network", () => {
+    expect(operationsForType("knowledge_network").map((item) => item.key)).toContain("execute");
+  });
+
   it("localizes every knowledge-network child resource type in Chinese", async () => {
     await i18n.changeLanguage("zh-CN");
 

--- a/src/modules/system-admin/utils/resource-catalog.ts
+++ b/src/modules/system-admin/utils/resource-catalog.ts
@@ -130,6 +130,7 @@ export const RESOURCE_TYPES: ResourceTypeDef[] = [
     "query_data",
     "authorize",
     "task_manage",
+    "execute",
   ]),
   resourceType("concept_group", KNOWLEDGE_NETWORK_CHILD_AUTHZ),
   resourceType("object_type", KNOWLEDGE_NETWORK_CHILD_AUTHZ),


### PR DESCRIPTION
# Add Knowledge Network Execute Role Grant

## What Changed

- [x] System Admin role permission editor
  - Added `execute` to the `knowledge_network` operation list.
  - Displays the operation as “执行” / “Execute”.
- [x] Regression tests
  - Added coverage that confirms knowledge-network grants expose `execute`.

---

## Why

- Related Issue: N/A
- Related Feature: Knowledge network action execution authorization
- Background:
  - Administrators need a Studio entry point to configure the new `knowledge_network:execute` permission enforced by bkn-safe and ontology-query.

---

## How

- Key implementation points:
  - Extended the shared System Admin resource catalog for `knowledge_network`.
  - Reused the existing localized `execute` operation label.
- Breaking changes:
  - None in Studio. The permission takes effect only when the matching backend PR is deployed.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable
- [ ] Verified in test environment — not performed

Test notes:

- Passed:
  - `node_modules/.bin/vitest --run src/modules/system-admin/utils/resource-catalog.test.ts`
  - 10 tests passed.

---

## Risk & Rollback

- Potential risks:
  - Administrators can grant a permission that requires the matching bkn-safe and ontology-query deployment to take effect.
- Rollback plan:
  - Revert commit `7fccf9d7`.

---

## Additional Notes

- Deploy this PR together with the matching bkn-foundry PR.
- No existing role is granted this permission automatically.