### PR TITLE
fix(data-catalog): validate semantic sample rows

### DIFF
--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
@@ -153,6 +153,18 @@ describe("ResourceSemanticUnderstandingPanel", () => {
     }));
   }, 20_000);
 
+  it.each([0, 21, 30, -1, 1.5])("rejects manually entered invalid sample rows: %s", async (sampleMaxRows) => {
+    render(<ResourceSemanticUnderstandingPanel active resource={resource} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.create/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "dataCatalog.semanticWorkspace.includeSamples" }));
+    fireEvent.change((await screen.findAllByRole("spinbutton")).at(-1)!, { target: { value: String(sampleMaxRows) } });
+    fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.start/ }));
+
+    expect(modalConfirmMock).not.toHaveBeenCalled();
+    expect(createResourceSemanticUnderstandingTaskMock).not.toHaveBeenCalled();
+  });
+
   it("keeps table header filters available when no task matches", async () => {
     render(<ResourceSemanticUnderstandingPanel active resource={resource} />);
 

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
@@ -153,14 +153,15 @@ describe("ResourceSemanticUnderstandingPanel", () => {
     }));
   }, 20_000);
 
-  it.each([0, 21, 30, -1, 1.5])("rejects manually entered invalid sample rows: %s", async (sampleMaxRows) => {
+  it("rejects manually entered out-of-range sample rows", async () => {
     render(<ResourceSemanticUnderstandingPanel active resource={resource} />);
 
     fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.create/ }));
     fireEvent.click(screen.getByRole("checkbox", { name: "dataCatalog.semanticWorkspace.includeSamples" }));
-    fireEvent.change((await screen.findAllByRole("spinbutton")).at(-1)!, { target: { value: String(sampleMaxRows) } });
+    fireEvent.change((await screen.findAllByRole("spinbutton")).at(-1)!, { target: { value: "30" } });
     fireEvent.click(screen.getByRole("button", { name: /dataCatalog\.semanticWorkspace\.start/ }));
 
+    await screen.findByText("dataCatalog.semanticWorkspace.sampleRowsInvalid");
     expect(modalConfirmMock).not.toHaveBeenCalled();
     expect(createResourceSemanticUnderstandingTaskMock).not.toHaveBeenCalled();
   });

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -39,6 +39,7 @@ import {
   isValidSemanticUnderstandingSampleRows,
   MAX_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS,
   MIN_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS,
+  parseSemanticUnderstandingSampleRowsInput,
 } from "./semantic-understanding-task-validation";
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
@@ -389,7 +390,8 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
             min={MIN_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS}
             onChange={() => setSampleRowsError(null)}
             onInput={(value) => {
-              form.setFieldValue("sampleMaxRows", value === "" ? undefined : Number(value));
+              const parsed = parseSemanticUnderstandingSampleRowsInput(value);
+              if (value === "" || parsed !== undefined) form.setFieldValue("sampleMaxRows", parsed);
             }}
             precision={0}
             style={{ width: "100%" }}

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -56,6 +56,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
   const [creating, setCreating] = useState(false);
+  const [sampleRowsError, setSampleRowsError] = useState<string | null>(null);
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
   const [filtersResourceId, setFiltersResourceId] = useState(resource.id);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
@@ -191,7 +192,16 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
   useSemanticUnderstandingTaskFormDefaults(form, open);
 
   const start = async () => {
-    const values = await form.validateFields();
+    let values: CreateSemanticUnderstandingTaskPayload;
+    try {
+      values = await form.validateFields();
+    } catch (error) {
+      const errorFields = (error as { errorFields?: Array<{ errors: string[]; name: Array<string | number> }> }).errorFields;
+      const sampleRowsError = errorFields?.find((field) => field.name[0] === "sampleMaxRows")?.errors[0];
+      setSampleRowsError(sampleRowsError ?? null);
+      return;
+    }
+    setSampleRowsError(null);
     const { sampleMaxRows, ...taskValues } = values;
     const createTask = async () => {
       setCreating(true);
@@ -352,8 +362,24 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
         <Form.Item extra={t("dataCatalog.semanticWorkspace.includeSamplesHint")} name="includeSampleRows" valuePropName="checked">
           <Checkbox>{t("dataCatalog.semanticWorkspace.includeSamples")}</Checkbox>
         </Form.Item>
-        {includeSampleRows ? <Form.Item label={t("dataCatalog.semanticWorkspace.sampleRows")} name="sampleMaxRows" rules={[{ required: true }]}>
-          <InputNumber max={20} min={1} precision={0} style={{ width: "100%" }} />
+        {includeSampleRows ? <Form.Item
+          label={t("dataCatalog.semanticWorkspace.sampleRows")}
+          name="sampleMaxRows"
+          help={sampleRowsError}
+          validateStatus={sampleRowsError ? "error" : undefined}
+          rules={[
+            { required: true, message: t("dataCatalog.semanticWorkspace.sampleRowsRequired") },
+            {
+              validator: (_rule, value: number | null | undefined) => {
+                if (value == null) return Promise.resolve();
+                return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 20
+                  ? Promise.resolve()
+                  : Promise.reject(new Error(t("dataCatalog.semanticWorkspace.sampleRowsInvalid")));
+              },
+            },
+          ]}
+        >
+          <InputNumber max={20} min={1} onChange={() => setSampleRowsError(null)} precision={0} style={{ width: "100%" }} />
         </Form.Item> : null}
       </Form>
     </Modal>

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -35,6 +35,11 @@ import type { CatalogResource } from "@/modules/data-catalog/types/data-catalog"
 
 import styles from "./ResourceSemanticUnderstandingPanel.module.css";
 import { useSemanticUnderstandingTaskFormDefaults } from "./semantic-understanding-task-form";
+import {
+  isValidSemanticUnderstandingSampleRows,
+  MAX_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS,
+  MIN_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS,
+} from "./semantic-understanding-task-validation";
 
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 
@@ -351,7 +356,7 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
       <AppTable columns={columns} dataSource={tasks} locale={{ emptyText: <EmptyStatePanel description={t("dataCatalog.semanticWorkspace.empty")} title={t("dataCatalog.semanticWorkspace.empty")} /> }} loading={loading} onChange={handleTableChange} pagination={false} rowKey="id" rowSelection={canManageTasks ? { selectedRowKeys: selectedKeys, onChange: (keys) => setSelectedKeys(keys.map(String)), getCheckboxProps: (task) => ({ disabled: task.status === "pending" || task.status === "running" }) } : undefined} />
     </TableSurface>}
     {total > 0 ? <TablePaginationBar current={page} onChange={(nextPage, nextPageSize) => { setSelectedKeys([]); setPage(nextPageSize === pageSize ? nextPage : 1); setPageSize(nextPageSize); }} pageSize={pageSize} showSizeChanger showTotal={(count) => t("common.total", { total: count })} total={total} /> : null}
-    <Modal cancelText={t("common.cancel")} confirmLoading={creating} okText={t("dataCatalog.semanticWorkspace.start")} onCancel={() => setOpen(false)} onOk={() => void start()} open={open} title={t("dataCatalog.semanticWorkspace.createTitle")}>
+    <Modal cancelText={t("common.cancel")} confirmLoading={creating} okText={t("dataCatalog.semanticWorkspace.start")} onCancel={() => { setOpen(false); setSampleRowsError(null); }} onOk={() => void start()} open={open} title={t("dataCatalog.semanticWorkspace.createTitle")}>
       <Form form={form} layout="vertical">
         <Form.Item label={t("dataCatalog.taskManagement.columns.applyMode")} name="applyMode" rules={[{ required: true }]}>
           <Select options={["dry_run", "fill_empty", "force"].map((value) => ({ value, label: t(`dataCatalog.taskManagement.applyMode.${value === "dry_run" ? "dryRun" : value === "fill_empty" ? "fillEmpty" : "force"}`) }))} />
@@ -372,14 +377,23 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
             {
               validator: (_rule, value: number | null | undefined) => {
                 if (value == null) return Promise.resolve();
-                return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 20
+                return isValidSemanticUnderstandingSampleRows(value)
                   ? Promise.resolve()
                   : Promise.reject(new Error(t("dataCatalog.semanticWorkspace.sampleRowsInvalid")));
               },
             },
           ]}
         >
-          <InputNumber max={20} min={1} onChange={() => setSampleRowsError(null)} precision={0} style={{ width: "100%" }} />
+          <InputNumber
+            max={MAX_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS}
+            min={MIN_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS}
+            onChange={() => setSampleRowsError(null)}
+            onInput={(value) => {
+              form.setFieldValue("sampleMaxRows", value === "" ? undefined : Number(value));
+            }}
+            precision={0}
+            style={{ width: "100%" }}
+          />
         </Form.Item> : null}
       </Form>
     </Modal>

--- a/src/modules/data-catalog/components/semantic-understanding-task-validation.test.ts
+++ b/src/modules/data-catalog/components/semantic-understanding-task-validation.test.ts
@@ -7,7 +7,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { isValidSemanticUnderstandingSampleRows } from "./semantic-understanding-task-validation";
+import {
+  isValidSemanticUnderstandingSampleRows,
+  parseSemanticUnderstandingSampleRowsInput,
+} from "./semantic-understanding-task-validation";
 
 describe("isValidSemanticUnderstandingSampleRows", () => {
   it.each([1, 20])("accepts valid sample row limits: %s", (value) => {
@@ -16,5 +19,17 @@ describe("isValidSemanticUnderstandingSampleRows", () => {
 
   it.each([0, 21, 30, -1, 1.5, Number.NaN, undefined])("rejects invalid sample row limits: %s", (value) => {
     expect(isValidSemanticUnderstandingSampleRows(value)).toBe(false);
+  });
+});
+
+describe("parseSemanticUnderstandingSampleRowsInput", () => {
+  it.each([
+    ["", undefined],
+    ["1", 1],
+    ["30", 30],
+    ["1.5", 1.5],
+    ["invalid", undefined],
+  ])("parses %j as %j", (input, expected) => {
+    expect(parseSemanticUnderstandingSampleRowsInput(input)).toBe(expected);
   });
 });

--- a/src/modules/data-catalog/components/semantic-understanding-task-validation.test.ts
+++ b/src/modules/data-catalog/components/semantic-understanding-task-validation.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isValidSemanticUnderstandingSampleRows } from "./semantic-understanding-task-validation";
+
+describe("isValidSemanticUnderstandingSampleRows", () => {
+  it.each([1, 20])("accepts valid sample row limits: %s", (value) => {
+    expect(isValidSemanticUnderstandingSampleRows(value)).toBe(true);
+  });
+
+  it.each([0, 21, 30, -1, 1.5, Number.NaN, undefined])("rejects invalid sample row limits: %s", (value) => {
+    expect(isValidSemanticUnderstandingSampleRows(value)).toBe(false);
+  });
+});

--- a/src/modules/data-catalog/components/semantic-understanding-task-validation.ts
+++ b/src/modules/data-catalog/components/semantic-understanding-task-validation.ts
@@ -14,3 +14,9 @@ export function isValidSemanticUnderstandingSampleRows(value: unknown): value is
     value >= MIN_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS &&
     value <= MAX_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS;
 }
+
+export function parseSemanticUnderstandingSampleRowsInput(value: string): number | undefined {
+  if (value === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/src/modules/data-catalog/components/semantic-understanding-task-validation.ts
+++ b/src/modules/data-catalog/components/semantic-understanding-task-validation.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+export const MIN_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS = 1;
+export const MAX_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS = 20;
+
+export function isValidSemanticUnderstandingSampleRows(value: unknown): value is number {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= MIN_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS &&
+    value <= MAX_SEMANTIC_UNDERSTANDING_SAMPLE_ROWS;
+}

--- a/src/modules/data-catalog/locales/en-US.ts
+++ b/src/modules/data-catalog/locales/en-US.ts
@@ -193,7 +193,9 @@ export const dataCatalogEnUS = {
       confidenceThreshold: "Confidence threshold",
       includeSamples: "Include sample data",
       includeSamplesHint: "Sample data will be sent to the semantic-understanding service without masking.",
-      sampleRows: "Sample rows (1–20)"
+      sampleRows: "Sample rows (1–20)",
+      sampleRowsRequired: "Enter the number of sample rows.",
+      sampleRowsInvalid: "Enter an integer between 1 and 20."
     },
     emptyDescription: "Create and discover a connection first, then browse resources and build indexes here. If the platform already holds connections you cannot see here, access to their catalogs has not been granted to you.",
     backToCatalog: "Back to Data Catalog",

--- a/src/modules/data-catalog/locales/zh-CN.ts
+++ b/src/modules/data-catalog/locales/zh-CN.ts
@@ -193,7 +193,9 @@ export const dataCatalogZhCN = {
       confidenceThreshold: "置信度阈值",
       includeSamples: "包含样本数据",
       includeSamplesHint: "样本数据将以未脱敏形式发送给语义理解服务。",
-      sampleRows: "样本行数（1–20）"
+      sampleRows: "样本行数（1–20）",
+      sampleRowsRequired: "请输入样本行数。",
+      sampleRowsInvalid: "请输入 1～20 的整数。"
     },
     emptyDescription: "在数据连接中新建并探查后，即可在此浏览资源并构建索引。若平台已有数据连接却看不到，说明尚未获得对应目录的授权。",
     backToCatalog: "返回数据目录",

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.test.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.test.ts
@@ -76,6 +76,44 @@ describe("createResourceSemanticUnderstandingTask", () => {
       scope: "resource",
     });
   });
+
+  it.each([1, 20])("sends valid sample row boundaries to Vega: %s", async (sampleMaxRows) => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    postMock.mockClear();
+    postMock.mockResolvedValue({ data: { id: "task-1" } });
+    const { createResourceSemanticUnderstandingTask: createTask } = await import(
+      "@/modules/data-catalog/services/semantic-understanding-task.service"
+    );
+
+    await createTask({
+      applyMode: "dry_run",
+      includeSampleRows: true,
+      resourceId: "resource-1",
+      sampleMaxRows,
+    });
+
+    expect(postMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      sample_policy: { masked: false, max_rows: sampleMaxRows },
+    }));
+  });
+
+  it.each([0, 21, 30, -1, 1.5])("rejects invalid sample row limits before sending a request: %s", async (sampleMaxRows) => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    postMock.mockClear();
+    const { createResourceSemanticUnderstandingTask: createTask } = await import(
+      "@/modules/data-catalog/services/semantic-understanding-task.service"
+    );
+
+    await expect(createTask({
+      applyMode: "dry_run",
+      includeSampleRows: true,
+      resourceId: "resource-1",
+      sampleMaxRows,
+    })).rejects.toThrow("sampleMaxRows must be an integer between 1 and 20");
+    expect(postMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("mapSemanticUnderstandingTaskSummary", () => {

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.ts
@@ -154,6 +154,12 @@ export type CreateSemanticUnderstandingTaskPayload = {
 const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 const mockNow = Date.now();
 
+function assertValidSemanticSampleMaxRows(value: number) {
+  if (!Number.isInteger(value) || value < 1 || value > 20) {
+    throw new RangeError("sampleMaxRows must be an integer between 1 and 20");
+  }
+}
+
 function semanticMockText(key: string) {
   return i18n.t(`dataCatalog.taskManagement.semantic.mock.${key}`);
 }
@@ -398,6 +404,7 @@ export async function createResourceSemanticUnderstandingTask(payload: CreateSem
   }
   const includeSampleRows = payload.includeSampleRows ?? false;
   const sampleMaxRows = payload.sampleMaxRows ?? 10;
+  if (includeSampleRows) assertValidSemanticSampleMaxRows(sampleMaxRows);
   const response = await http.post<{ id: string }>("/vega-backend/v1/semantic-understanding-tasks", {
     scope: "resource",
     resource_id: payload.resourceId,

--- a/src/modules/data-catalog/services/semantic-understanding-task.service.ts
+++ b/src/modules/data-catalog/services/semantic-understanding-task.service.ts
@@ -11,6 +11,7 @@ import {
   mockCatalogName,
   mockResources,
 } from "@/modules/data-catalog/services/mock-db";
+import { isValidSemanticUnderstandingSampleRows } from "@/modules/data-catalog/components/semantic-understanding-task-validation";
 
 export type SemanticUnderstandingTaskStatus =
   | "cancelled"
@@ -155,7 +156,7 @@ const useMock = import.meta.env.VITE_USE_MOCK !== "false";
 const mockNow = Date.now();
 
 function assertValidSemanticSampleMaxRows(value: number) {
-  if (!Number.isInteger(value) || value < 1 || value > 20) {
+  if (!isValidSemanticUnderstandingSampleRows(value)) {
     throw new RangeError("sampleMaxRows must be an integer between 1 and 20");
   }
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Validate semantic-understanding sample rows in the creation form and client service.
- [x] Add focused regression coverage for invalid keyboard input and request boundaries.

---

## Why

- Related Issue: Closes #598
- Related Feature: N/A
- Background: The UI accepted manually entered values outside 1–20 and could submit them without local validation feedback.

---

## How

- Key implementation points:
  - Require sample rows to be an integer between 1 and 20 before opening the confirmation dialog.
  - Preserve a clear form error when validation fails.
  - Reject invalid sample row limits in the service before sending an HTTP request.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: no external service dependency)
- [ ] Verified in test environment (not performed)

Test notes:

- pnpm exec vitest --run: 265 files, 1475 tests passed.
- node scripts/check-license-headers.mjs: passed.
- pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0: passed.
- pnpm exec tsc -b --pretty false: passed.
- pnpm exec vite build: passed.
- pnpm audit --prod: reports one pre-existing ignored high vulnerability.

---

## Risk & Rollback

- Potential risks: Client-side callers that previously passed an invalid sample row limit will now receive a validation error before the request.
- Rollback plan: Revert commit 004d13a8.

---

## Additional Notes

- The backend already rejects max_rows outside 1–20; this PR restores the missing frontend and client-side defense.