### PR TITLE
feat(subscription): spell out the permission model per edition on the plan cards

### DIFF
--- a/src/framework/entitlement/CapabilityUpgradeDialog.tsx
+++ b/src/framework/entitlement/CapabilityUpgradeDialog.tsx
@@ -15,6 +15,7 @@ import type { Edition } from "@/framework/entitlement/edition";
 import { useEntitlementContext } from "@/framework/entitlement/use-entitlement";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { upgradeReason } from "@/framework/entitlement/upgrade-reason";
+import { capabilityBullets } from "@/modules/subscription/capability-bullets";
 import { capabilityReportedByEndpoint } from "@/modules/subscription/capability-catalog";
 
 /** 授权门户。与版本页同一个去处:申请与续期都在那边办。 */
@@ -27,9 +28,6 @@ type CapabilityUpgradeDialogProps = {
   onClose: () => void;
   open: boolean;
 };
-
-/** 卖点最多四条,`subscription.capabilities.<key>.bullets.b1..b4`,缺省即不渲染。 */
-const BULLET_KEYS = ["b1", "b2", "b3", "b4"];
 
 /**
  * 付费能力的升级引导弹窗。
@@ -72,9 +70,7 @@ export function CapabilityUpgradeDialog({
     capabilityReportedByEndpoint(capability),
   );
   const imageIssue = reason !== "buy";
-  const bullets = BULLET_KEYS.map((key) =>
-    t(`subscription.capabilities.${capability}.bullets.${key}`, { defaultValue: "" }),
-  ).filter(Boolean);
+  const bullets = capabilityBullets(t, capability);
 
   return (
     <Modal

--- a/src/framework/entitlement/RequireEdition.tsx
+++ b/src/framework/entitlement/RequireEdition.tsx
@@ -32,8 +32,8 @@ type RequireEditionProps = {
 /**
  * 整页守卫。放行条件与档位徽标闭嘴的条件同一个:`capabilitySatisfied`。
  *
- * 用于 `capabilities[]` 答不了的付费面:业务溯源由 bkn-trace 实现、语义理解在数据目录侧,
- * bkn-safe 的那份清单里从来没有它们(ee-design.md §6「A 答不了 B」)。这类能力核实不了
+ * 用于 `capabilities[]` 答不了的付费面:业务溯源由 bkn-trace 实现,bkn-safe 的那份清单里
+ * 从来没有它(ee-design.md §6「A 答不了 B」)。这类能力核实不了
  * 镜像,判据退到证书:档位够就放行。前端核实不了别人的包,不等于那个包没装——把「核实
  * 不了」当「没装」,买了企业版证、也换了企业版包的客户会被自己付过钱的功能挡在门外。
  *

--- a/src/framework/entitlement/capabilities.ts
+++ b/src/framework/entitlement/capabilities.ts
@@ -36,8 +36,6 @@ export const CAPABILITIES = {
   BUSINESS_PROVENANCE: "business_provenance",
   /** 认证/高级数据源连接器(SQL Server 等商业库)。专业档起,由 Vega 实现。 */
   CONNECTOR_CERTIFIED: "connector_certified",
-  /** 语义理解任务。专业档起,由数据目录侧实现——服务端今天不挡,前端先标先拦。 */
-  SEMANTIC_TASK: "semantic_task",
 } as const;
 
 export type CapabilityKey = (typeof CAPABILITIES)[keyof typeof CAPABILITIES];

--- a/src/modules/data-catalog/components/CatalogDetailPanel.tsx
+++ b/src/modules/data-catalog/components/CatalogDetailPanel.tsx
@@ -405,12 +405,7 @@ export function CatalogDetailPanel({
         if (!catalog.internal) {
           moreItems.push({
             key: "semantic-understanding",
-            label: (
-              <span className="console-tab-with-tier">
-                {t("dataCatalog.resourceWorkspace.tabSemanticUnderstanding")}
-                <EditionBadge capability={CAPABILITIES.SEMANTIC_TASK} edition="professional" />
-              </span>
-            ),
+            label: t("dataCatalog.resourceWorkspace.tabSemanticUnderstanding"),
           });
         }
 

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.test.tsx
@@ -35,10 +35,6 @@ vi.mock("@/framework/context/use-app-services", () => ({
   }),
 }));
 
-vi.mock("@/framework/entitlement/EditionBadge", () => ({
-  EditionBadge: () => null,
-}));
-
 vi.mock("@/framework/permission/PermissionGate", () => ({
   PermissionGate: ({ children }: { children: React.ReactNode }) => children,
 }));

--- a/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
+++ b/src/modules/data-catalog/components/ResourceSemanticUnderstandingPanel.tsx
@@ -18,8 +18,6 @@ import { useTranslation } from "react-i18next";
 
 import { useAppServices } from "@/framework/context/use-app-services";
 import { hasPermissions } from "@/framework/permission/has-permissions";
-import { CAPABILITIES } from "@/framework/entitlement/capabilities";
-import { EditionBadge } from "@/framework/entitlement/EditionBadge";
 import { formatDateTimeYmdHms } from "@/framework/i18n/format";
 import { PermissionGate } from "@/framework/permission/PermissionGate";
 import { extractRequestErrorMessage } from "@/framework/request/error-message";
@@ -334,15 +332,8 @@ export function ResourceSemanticUnderstandingPanel({ active, resource }: { activ
       </div>
       <Space>
         <PermissionGate permissions="catalog:task_manage">
-          {/*
-            语义理解任务是专业档能力,拦在页面层(ResourceWorkspaceScene 的 RequireEdition):
-            能走到这颗按钮,说明那一层已经放行。这里只标不挡——再挡一道,上面解开了这里
-            还锁着,客户没有任何办法发起任务。徽标留着,因为档位够不够与镜像换没换是两件
-            事,标记该跟着能力走。
-          */}
           <AppButton icon={<PlusOutlined />} type="primary" onClick={() => setOpen(true)}>
             {t("dataCatalog.semanticWorkspace.create")}
-            <EditionBadge capability={CAPABILITIES.SEMANTIC_TASK} edition="professional" />
           </AppButton>
         </PermissionGate>
         <AppButton icon={<ReloadOutlined />} onClick={() => void Promise.all([loadPage(page, pageSize), loadSummary()])}>{t("common.refresh")}</AppButton>

--- a/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
+++ b/src/modules/data-catalog/scenes/ResourceWorkspaceScene.tsx
@@ -29,7 +29,6 @@ import { ResourceSemanticUnderstandingPanel } from "@/modules/data-catalog/compo
 import { ObjectAuthorizeDrawer } from "@/modules/system-admin/components/ObjectAuthorizeDrawer";
 import { CAPABILITIES } from "@/framework/entitlement/capabilities";
 import { EditionBadge } from "@/framework/entitlement/EditionBadge";
-import { RequireEdition } from "@/framework/entitlement/RequireEdition";
 import {
   indexStateOf,
   resourceGateOf,
@@ -514,28 +513,10 @@ export function ResourceWorkspaceScene({
               : [
                   {
                     key: "semantic-understanding",
-                    /*
-                      页签上直接挂档位徽标:这一片整体是付费能力,进去之后才发现要买,不如在
-                      入口处就说清。徽标在证与镜像都满足时自己消失。
-                    */
-                    label: (
-                      <span className="console-tab-with-tier">
-                        {t("dataCatalog.resourceWorkspace.tabSemanticUnderstanding")}
-                        <EditionBadge
-                          capability={CAPABILITIES.SEMANTIC_TASK}
-                          edition="professional"
-                        />
-                      </span>
-                    ),
+                    label: t("dataCatalog.resourceWorkspace.tabSemanticUnderstanding"),
                     children: (
                       <div className={styles.tabPanel}>
-                        {/* 整片盖蒙版而不是只拦「新建任务」:列表本身也是这项能力的一部分。 */}
-                        <RequireEdition
-                          capability={CAPABILITIES.SEMANTIC_TASK}
-                          minEdition="professional"
-                        >
-                          <ResourceSemanticUnderstandingPanel active={tab === "semantic-understanding"} resource={resource} />
-                        </RequireEdition>
+                        <ResourceSemanticUnderstandingPanel active={tab === "semantic-understanding"} resource={resource} />
                       </div>
                     ),
                   },

--- a/src/modules/subscription/capability-bullets.ts
+++ b/src/modules/subscription/capability-bullets.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { TFunction } from "i18next";
+
+/** 卖点最多四条,`subscription.capabilities.<key>.bullets.b1..b4`,缺省即不渲染。 */
+const BULLET_KEYS = ["b1", "b2", "b3", "b4"];
+
+/**
+ * 某项能力的产品侧卖点。登记表只给 name / description;卖点是产品自己补的,版本卡片与
+ * 升级弹窗共用这一份——同一项能力在两处说成两样,客户会以为是两个问题。
+ */
+export function capabilityBullets(t: TFunction, capability: string): string[] {
+  return BULLET_KEYS.map((key) =>
+    t(`subscription.capabilities.${capability}.bullets.${key}`, { defaultValue: "" }),
+  ).filter(Boolean);
+}

--- a/src/modules/subscription/capability-catalog.test.ts
+++ b/src/modules/subscription/capability-catalog.test.ts
@@ -42,8 +42,8 @@ describe("capability catalog", () => {
 
     expect(new Set(keys).size).toBe(keys.length);
     expect(capabilitiesIntroducedBy("industry")).toEqual([]);
-    expect(capabilitiesIntroducedBy("community")).toHaveLength(1);
-    expect(capabilitiesIntroducedBy("professional")).toHaveLength(4);
+    expect(capabilitiesIntroducedBy("community")).toHaveLength(2);
+    expect(capabilitiesIntroducedBy("professional")).toHaveLength(3);
     expect(capabilitiesIntroducedBy("enterprise")).toHaveLength(2);
   });
 

--- a/src/modules/subscription/capability-catalog.ts
+++ b/src/modules/subscription/capability-catalog.ts
@@ -91,8 +91,13 @@ export const CAPABILITY_CATALOG: CapabilityCatalogEntry[] = [
     sinceVersion: "0.1.3",
   },
   {
-    // 2026-09 起降到社区档:语义理解任务随社区版免费开放,数据目录侧不再挂徽标和蒙版。
+    // 2026-09-12 起按社区档在售:语义理解任务随社区版免费开放,数据目录侧不再挂徽标和蒙版。
     // 与 bkn_trace 同一种情况——留在表里只为让对比矩阵显示「三档都有」,不是付费项。
+    //
+    // 上游登记表(license-server `store/capabilities.go` seed)此刻仍是 professional,产品页
+    // 先行。这里改的是展示与前端门控,不改证书:社区档能力的放行不看证(`capabilitySatisfied`
+    // 对 community 恒真),已签发的专业证里多一个 semantic_task 也不会让谁被拦。上游应按
+    // #21 处理 bkn_trace 的方式把这一行撤出登记表——社区能力不登记(`ee-features.md`)。
     category: "semantic",
     key: "semantic_task",
     reportedByEndpoint: false,

--- a/src/modules/subscription/capability-catalog.ts
+++ b/src/modules/subscription/capability-catalog.ts
@@ -91,10 +91,12 @@ export const CAPABILITY_CATALOG: CapabilityCatalogEntry[] = [
     sinceVersion: "0.1.3",
   },
   {
+    // 2026-09 起降到社区档:语义理解任务随社区版免费开放,数据目录侧不再挂徽标和蒙版。
+    // 与 bkn_trace 同一种情况——留在表里只为让对比矩阵显示「三档都有」,不是付费项。
     category: "semantic",
     key: "semantic_task",
     reportedByEndpoint: false,
-    minEdition: "professional",
+    minEdition: "community",
     sinceVersion: "0.1.3",
   },
   { category: "permission", key: CAPABILITIES.PERM_OBJECT_LEVEL,

--- a/src/modules/subscription/community-capabilities.ts
+++ b/src/modules/subscription/community-capabilities.ts
@@ -24,17 +24,27 @@ export type CommunityCapability = {
   category: CapabilityCategory;
   /** i18n 后缀,文案在 `subscription.community.<id>`。 */
   id: string;
+  /**
+   * 是否上社区版卡片。卡片是选购视角,只放建模底座和权限基线——付费两档的卡片讲的
+   * 正是权限模型怎么递进,社区卡不写清起点,后两张的「更细」就没有参照。完整清单在
+   * 对比表里。
+   */
+  onCard?: boolean;
 };
 
 export const COMMUNITY_CAPABILITIES: CommunityCapability[] = [
-  { category: "modeling", id: "modelingSurfaces" },
-  { category: "modeling", id: "modelingTypes" },
-  { category: "modeling", id: "queryAndSearch" },
-  { category: "dataConnect", id: "commonSources" },
+  { category: "modeling", id: "modelingSurfaces", onCard: true },
+  { category: "modeling", id: "modelingTypes", onCard: true },
+  { category: "modeling", id: "queryAndSearch", onCard: true },
+  { category: "dataConnect", id: "commonSources", onCard: true },
   { category: "dataConnect", id: "indexing" },
   { category: "semantic", id: "mcpTooling" },
   { category: "semantic", id: "actionSandbox" },
-  { category: "permission", id: "localAuth" },
+  // 权限基线,三条对应对外版本说明「权限能力矩阵」的社区列:内置角色 / 只授顶层资源
+  // 且固定权限包 / 基础审计。
+  { category: "permission", id: "localAuth", onCard: true },
+  { category: "permission", id: "topLevelGrants", onCard: true },
+  { category: "permission", id: "basicAudit", onCard: true },
   { category: "observability", id: "cliTrace" },
   { category: "operations", id: "selfHosted" },
 ];

--- a/src/modules/subscription/community-capabilities.ts
+++ b/src/modules/subscription/community-capabilities.ts
@@ -40,8 +40,10 @@ export const COMMUNITY_CAPABILITIES: CommunityCapability[] = [
   { category: "dataConnect", id: "indexing" },
   { category: "semantic", id: "mcpTooling" },
   { category: "semantic", id: "actionSandbox" },
-  // 权限基线,三条对应对外版本说明「权限能力矩阵」的社区列:内置角色 / 只授顶层资源
-  // 且固定权限包 / 基础审计。
+  // 权限基线,对应对外版本说明「权限能力矩阵」里三档都成立的那几行:内置角色 / 顶层资源
+  // 整体授权 / 基础审计。矩阵社区列里的「只授顶层、固定权限包」是限制不是能力——这张表的
+  // 社区行三档全勾,限制只能由付费行的「—」表达;把限制措辞写进来,会和紧挨着的「授权到
+  // 子资源」并排自相矛盾。
   { category: "permission", id: "localAuth", onCard: true },
   { category: "permission", id: "topLevelGrants", onCard: true },
   { category: "permission", id: "basicAudit", onCard: true },

--- a/src/modules/subscription/locales/en-US.ts
+++ b/src/modules/subscription/locales/en-US.ts
@@ -83,8 +83,7 @@ export const subscriptionEnUS = {
       modelingTypes: "Object, relation, action and metric modelling",
       queryAndSearch: "Relation queries, path queries and semantic search",
       selfHosted: "Source builds, basic deployment, health checks and upgrade docs",
-      topLevelGrants:
-        "Grants on top-level resources only (knowledge networks, catalogs) as a fixed permission bundle",
+      topLevelGrants: "Grants on whole top-level resources (knowledge networks, catalogs)",
     },
     categories: {
       modeling: "Knowledge modelling",

--- a/src/modules/subscription/locales/en-US.ts
+++ b/src/modules/subscription/locales/en-US.ts
@@ -36,10 +36,8 @@ export const subscriptionEnUS = {
       },
       perm_fine_grained: {
         bullets: {
-          b1: "Grants down to sub-resources: inside a knowledge network and per Resource under a catalog",
-          b2: "View, query, modify, delete and execute configured per operation",
-          b3: "Explicit sub-resource exceptions: direct allow or direct deny",
-          b4: "Full resource-authorization audit",
+          b1: "View, query, modify, delete and execute granted separately",
+          b2: "Explicit exceptions (direct allow or deny) and full authorization audit",
         },
         description: "Per-object allow and deny decisions with source-level revocation",
         name: "Fine-grained object authorization",
@@ -55,7 +53,6 @@ export const subscriptionEnUS = {
         name: "Enterprise object rules",
       },
       rbac_basic: {
-        bullets: { b1: "Custom roles and departments instead of the built-in roles only" },
         description: "Custom departments, roles and permission control",
         name: "Custom roles and permissions",
       },

--- a/src/modules/subscription/locales/en-US.ts
+++ b/src/modules/subscription/locales/en-US.ts
@@ -35,23 +35,31 @@ export const subscriptionEnUS = {
         name: "Advanced data connectivity",
       },
       perm_fine_grained: {
+        bullets: {
+          b1: "Grants down to sub-resources: inside a knowledge network and per Resource under a catalog",
+          b2: "View, query, modify, delete and execute configured per operation",
+          b3: "Explicit sub-resource exceptions: direct allow or direct deny",
+          b4: "Full resource-authorization audit",
+        },
         description: "Per-object allow and deny decisions with source-level revocation",
         name: "Fine-grained object authorization",
       },
       perm_object_level: {
+        bullets: {
+          b1: "Row-level permissions on object types",
+          b2: "Column-level permissions on object types, four property tiers",
+          b3: "Data masking",
+          b4: "Audit of row and column permission changes",
+        },
         description: "Enterprise object-rule compatibility and property-level controls",
         name: "Enterprise object rules",
       },
       rbac_basic: {
+        bullets: { b1: "Custom roles and departments instead of the built-in roles only" },
         description: "Custom departments, roles and permission control",
         name: "Custom roles and permissions",
       },
       semantic_task: {
-        bullets: {
-          b1: "Infers the business meaning of columns and fills in semantic descriptions in bulk",
-          b2: "Results are scored by confidence; apply to empty fields only, or overwrite",
-          b3: "Runs as a task with progress, per-field results and an apply history",
-        },
         description: "Authoring and execution of business-semantic understanding tasks",
         name: "Semantic understanding tasks",
       },
@@ -64,16 +72,19 @@ export const subscriptionEnUS = {
      */
     community: {
       actionSandbox: "Action execution in a secure sandbox",
+      basicAudit: "Basic activity audit",
       cliTrace: "Query run traces, latency, evidence and reasoning via CLI / SDK",
       commonSources: "Common databases, OpenSearch and CSV ingestion",
       indexing: "Data discovery, batch indexing and vectorisation",
-      localAuth: "Local sign-in, user management and basic activity records",
+      localAuth: "Local sign-in with user, department and built-in role management",
       mcpTooling: "Connect, debug and invoke MCP servers, tools and Skills",
       modelingSurfaces:
         "Model and manage knowledge networks from BKN Studio, CLI, SDK and Skills",
       modelingTypes: "Object, relation, action and metric modelling",
       queryAndSearch: "Relation queries, path queries and semantic search",
       selfHosted: "Source builds, basic deployment, health checks and upgrade docs",
+      topLevelGrants:
+        "Grants on top-level resources only (knowledge networks, catalogs) as a fixed permission bundle",
     },
     categories: {
       modeling: "Knowledge modelling",

--- a/src/modules/subscription/locales/zh-CN.ts
+++ b/src/modules/subscription/locales/zh-CN.ts
@@ -36,10 +36,8 @@ export const subscriptionZhCN = {
       },
       perm_fine_grained: {
         bullets: {
-          b1: "授权到子资源:知识网络内部资源与 Catalog 下的 Resource",
-          b2: "查看、查询、修改、删除、执行按操作分别配置",
-          b3: "显式子资源例外:直接授权或直接拒绝",
-          b4: "完整的资源授权审计",
+          b1: "查看、查询、修改、删除、执行分别授权",
+          b2: "显式例外(直接授权或拒绝)与完整授权审计",
         },
         description: "按对象和操作配置允许、拒绝与来源级撤销",
         name: "细粒度对象授权",
@@ -54,11 +52,7 @@ export const subscriptionZhCN = {
         description: "企业对象规则兼容层与属性级权限",
         name: "企业对象规则",
       },
-      rbac_basic: {
-        bullets: { b1: "自定义角色与部门,不再限于系统内置角色" },
-        description: "自定义部门、角色和权限控制",
-        name: "自定义角色与权限",
-      },
+      rbac_basic: { description: "自定义部门、角色和权限控制", name: "自定义角色与权限" },
       semantic_task: {
         description: "面向业务语义的理解任务编排与执行",
         name: "语义理解任务",

--- a/src/modules/subscription/locales/zh-CN.ts
+++ b/src/modules/subscription/locales/zh-CN.ts
@@ -80,7 +80,7 @@ export const subscriptionZhCN = {
       modelingTypes: "对象、关系、行动与指标建模",
       queryAndSearch: "关系查询、路径查询与语义检索",
       selfHosted: "源码构建、基础部署、状态检查与升级文档",
-      topLevelGrants: "按知识网络、Catalog 等顶层资源整体授权,固定权限包",
+      topLevelGrants: "知识网络、Catalog 等顶层资源的整体授权",
     },
     categories: {
       modeling: "知识网络建模",

--- a/src/modules/subscription/locales/zh-CN.ts
+++ b/src/modules/subscription/locales/zh-CN.ts
@@ -9,6 +9,10 @@
  * `capabilities.*` 的中文名与描述逐字取自 license-server 的登记表 seed
  * (`server/internal/store/capabilities.go`)——那是签进客户证书、也是客户在门户上
  * 看到的同一份文案。两边不一致会让客户拿着证书对不上产品页。
+ *
+ * `bullets` 不在登记表里,是产品侧补的卖点:版本卡片与升级弹窗共用。权限三项的条目
+ * 来自对外版本说明的「权限能力矩阵」(资源粒度 / 操作粒度 / 行列权限 / 脱敏 / 审计),
+ * 矩阵改了这里要跟着改。
  */
 export const subscriptionZhCN = {
   subscription: {
@@ -30,15 +34,32 @@ export const subscriptionZhCN = {
         description: "认证/高级数据源连接器(如 SQL Server 等商业数据库);社区版仅开放基础连接器",
         name: "高级数据连接",
       },
-      perm_fine_grained: { description: "按对象和操作配置允许、拒绝与来源级撤销", name: "细粒度对象授权" },
-      perm_object_level: { description: "企业对象规则兼容层与属性级权限", name: "企业对象规则" },
-      rbac_basic: { description: "自定义部门、角色和权限控制", name: "自定义角色与权限" },
-      semantic_task: {
+      perm_fine_grained: {
         bullets: {
-          b1: "自动识别字段业务含义,批量补齐对象类与属性的语义描述",
-          b2: "结果按置信度分档,支持只补空值或全量覆盖两种落库方式",
-          b3: "任务化执行,可查看进度、结果明细与应用记录",
+          b1: "授权到子资源:知识网络内部资源与 Catalog 下的 Resource",
+          b2: "查看、查询、修改、删除、执行按操作分别配置",
+          b3: "显式子资源例外:直接授权或直接拒绝",
+          b4: "完整的资源授权审计",
         },
+        description: "按对象和操作配置允许、拒绝与来源级撤销",
+        name: "细粒度对象授权",
+      },
+      perm_object_level: {
+        bullets: {
+          b1: "对象类行权限",
+          b2: "对象类列权限,属性分四档",
+          b3: "数据脱敏",
+          b4: "行列权限变更审计",
+        },
+        description: "企业对象规则兼容层与属性级权限",
+        name: "企业对象规则",
+      },
+      rbac_basic: {
+        bullets: { b1: "自定义角色与部门,不再限于系统内置角色" },
+        description: "自定义部门、角色和权限控制",
+        name: "自定义角色与权限",
+      },
+      semantic_task: {
         description: "面向业务语义的理解任务编排与执行",
         name: "语义理解任务",
       },
@@ -49,15 +70,17 @@ export const subscriptionZhCN = {
      */
     community: {
       actionSandbox: "行动运行与安全沙箱环境",
+      basicAudit: "基础操作审计",
       cliTrace: "通过 CLI / SDK 查询运行链路、性能、证据与推理过程",
       commonSources: "常用数据库、OpenSearch 与 CSV 接入",
       indexing: "数据发现、批量索引与向量化",
-      localAuth: "本地登录、用户管理与基础操作记录",
+      localAuth: "本地登录,用户、部门与内置角色管理",
       mcpTooling: "MCP、工具与 Skill 的接入、调试和调用",
       modelingSurfaces: "通过 BKN Studio、CLI、SDK 与 Skill 建模并管理知识网络",
       modelingTypes: "对象、关系、行动与指标建模",
       queryAndSearch: "关系查询、路径查询与语义检索",
       selfHosted: "源码构建、基础部署、状态检查与升级文档",
+      topLevelGrants: "按知识网络、Catalog 等顶层资源整体授权,固定权限包",
     },
     categories: {
       modeling: "知识网络建模",

--- a/src/modules/subscription/scenes/SubscriptionScene.module.css
+++ b/src/modules/subscription/scenes/SubscriptionScene.module.css
@@ -200,6 +200,20 @@
   line-height: 1.6;
 }
 
+/* 能力名下的卖点。不用勾号:勾号说「这一档有」,卖点说「有到什么程度」,层级要分开。 */
+.planFeatDetail {
+  margin: 4px 0 0;
+  padding: 0 0 0 14px;
+  list-style: disc;
+  color: var(--admin-color-muted, #6b7280);
+  font-size: 12px;
+}
+
+.planFeats .planFeatDetail li {
+  display: list-item;
+  line-height: 1.5;
+}
+
 .tick {
   /* 图标基线比文字略高,压 2px 才和首行文字齐平。 */
   margin-top: 2px;

--- a/src/modules/subscription/scenes/SubscriptionScene.tsx
+++ b/src/modules/subscription/scenes/SubscriptionScene.tsx
@@ -215,12 +215,14 @@ export function SubscriptionScene() {
                   </li>
                 )}
                 {/*
-                  能力名下面铺卖点:登记表的名字太短(「细粒度对象授权」),说不清这一档比
-                  上一档细在哪——资源粒度、操作粒度、行列权限、审计各进一步。卖点与升级
-                  弹窗同一份文案。
+                  只给权限类能力铺卖点:这页的主题是「权限边界、审计与合规随版本递进」,
+                  登记表的名字(「细粒度对象授权」)说不清这一档比上一档细在哪——操作粒度、
+                  显式例外、行列权限、审计各进一步,卡片得把这几句写出来。其他能力(连接器)
+                  的卖点留给升级弹窗,铺上卡片只会把它拉成一页说明书。文案与弹窗同一份。
                 */}
                 {introduced.map((entry) => {
-                  const bullets = capabilityBullets(t, entry.key);
+                  const bullets =
+                    entry.category === "permission" ? capabilityBullets(t, entry.key) : [];
 
                   return (
                     <li key={entry.key}>

--- a/src/modules/subscription/scenes/SubscriptionScene.tsx
+++ b/src/modules/subscription/scenes/SubscriptionScene.tsx
@@ -18,6 +18,7 @@ import {
 import { hasPermissions } from "@/framework/permission/has-permissions";
 import { useRuntimeConfig } from "@/framework/context/use-runtime-config";
 import { AppButton } from "@/framework/ui/common/AppButton";
+import { capabilityBullets } from "@/modules/subscription/capability-bullets";
 import {
   CAPABILITY_CATEGORIES,
   capabilitiesByCategory,
@@ -194,8 +195,8 @@ export function SubscriptionScene() {
 
               <ul className={styles.planFeats}>
                 {plan.edition === "community" ? (
-                  // 卡片只放前四条,完整清单在下面的对比表里——卡片是选购视角,表是核对视角。
-                  COMMUNITY_CAPABILITIES.slice(0, 4).map((entry) => (
+                  // 卡片只放标了 onCard 的行,完整清单在下面的对比表里——卡片是选购视角,表是核对视角。
+                  COMMUNITY_CAPABILITIES.filter((entry) => entry.onCard).map((entry) => (
                     <li key={entry.id}>
                       <CheckOutlined className={styles.tick} />
                       <span>{t(`subscription.community.${entry.id}`)}</span>
@@ -213,12 +214,30 @@ export function SubscriptionScene() {
                     </span>
                   </li>
                 )}
-                {introduced.map((entry) => (
-                  <li key={entry.key}>
-                    <CheckOutlined className={styles.tick} />
-                    <span>{t(`subscription.capabilities.${entry.key}.name`)}</span>
-                  </li>
-                ))}
+                {/*
+                  能力名下面铺卖点:登记表的名字太短(「细粒度对象授权」),说不清这一档比
+                  上一档细在哪——资源粒度、操作粒度、行列权限、审计各进一步。卖点与升级
+                  弹窗同一份文案。
+                */}
+                {introduced.map((entry) => {
+                  const bullets = capabilityBullets(t, entry.key);
+
+                  return (
+                    <li key={entry.key}>
+                      <CheckOutlined className={styles.tick} />
+                      <span>
+                        {t(`subscription.capabilities.${entry.key}.name`)}
+                        {bullets.length > 0 ? (
+                          <ul className={styles.planFeatDetail}>
+                            {bullets.map((text) => (
+                              <li key={text}>{text}</li>
+                            ))}
+                          </ul>
+                        ) : null}
+                      </span>
+                    </li>
+                  );
+                })}
               </ul>
 
               {/*


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 版本与订阅页三张卡片按对外版本说明的「权限能力矩阵」重写:每项付费能力名下铺卖点(资源粒度 / 操作粒度 / 显式子资源例外 / 行列权限 / 脱敏 / 审计),社区卡补权限基线(内置角色 / 顶层资源整体授权固定权限包 / 基础操作审计)
- [x] 语义理解任务降到社区版:能力表 `semantic_task` 改 `community`,数据目录侧的专业版徽标与 `RequireEdition` 蒙版拆掉
- [x] 新增 `capabilityBullets` 小工具,卡片与升级弹窗共用同一份卖点文案;社区卡行改由 `onCard` 显式标记,不再取前四条
- [x] zh-CN / en-US 同步

---

## Why

- Related Issue: 无
- Related Feature: 版本与订阅
- Background: 卡片原来只列登记表里的能力名(「细粒度对象授权」「企业对象规则」),看不出这一档比上一档细在哪。对外版本说明已经有一张按社区 / 专业 / 企业三列写清资源粒度、操作粒度、行列权限、脱敏、审计的权限矩阵,产品页要与它对齐。同时语义理解任务已决定随社区版开放,前端的徽标和蒙版不该再拦。

---

## How

- Key implementation points:
  - 权限三项(`rbac_basic` / `perm_fine_grained` / `perm_object_level`)的 `bullets.b1..b4` 取自权限矩阵对应列;登记表镜像的 `name` / `description` 一字未动
  - `SubscriptionScene` 对每项新增能力渲染 `name` + 嵌套卖点列表(`.planFeatDetail`,不带勾号,与「有 / 有到什么程度」两级区分)
  - `COMMUNITY_CAPABILITIES` 新增 `topLevelGrants` / `basicAudit` 两行,`localAuth` 改成「本地登录,用户、部门与内置角色管理」;对比表「权限」分组随之多三行社区基线
  - `CAPABILITIES.SEMANTIC_TASK` 常量删除;`ResourceWorkspaceScene` / `ResourceSemanticUnderstandingPanel` / `CatalogDetailPanel` 去掉徽标与蒙版;其升级弹窗卖点一并删除(不再在售)
  - `capability-catalog.test.ts` 档位计数改为 community 2 / professional 3 / enterprise 2
- Breaking changes (API, config, database, etc.): 无。license-server 登记表里 `semantic_task` 的 `min_edition` 若仍是 professional,与 `bkn_trace` 一样属于产品页先行、登记表待跟进。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [x] Verified in test environment

Test notes:

- `tsc -b`、`eslint --config eslint.config.typechecked.js --max-warnings 0`、`scan-hardcoded-zh`、locale parity 全过
- vitest:subscription / entitlement / ResourceSemanticUnderstandingPanel 共 8 个文件 67 用例通过
- mock dev 下 headless Chrome 截图核对卡片与对比表(zh-CN)

---

## Risk & Rollback

- Potential risks:纯展示与门控放开,无接口改动。语义理解任务在社区版镜像上可见后,服务端本来就不挡,行为与之前专业版一致
- Rollback plan:revert 本 PR 即可

---

## Additional Notes

- Screenshots, logs, documentation links, etc.:卡片文案来源为对外版本说明「一、总体能力矩阵」;后续若矩阵调整,改 `subscription.capabilities.*.bullets` 与 `subscription.community.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
