### PR TITLE
fix(execution-factory): stop detail and tool-list pages from bouncing on back

### DIFF
--- a/src/modules/execution-factory/scenes/McpDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/McpDetailScene.tsx
@@ -20,7 +20,7 @@ import {
 import { Alert, Empty, Layout, Spin, Tag } from "antd";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import type { McpDetailSceneProps } from "@/modules/execution-factory/contracts/scenes";
 import { PermissionGate } from "@/framework/permission/PermissionGate";
@@ -43,6 +43,7 @@ import {
   listMcpTools,
 } from "@/modules/execution-factory/services/mcp.service";
 import type { McpDetail, McpProxyTool, McpStatus } from "@/modules/execution-factory/types/mcp";
+import { readReturnTo } from "@/modules/execution-factory/utils/back-navigation";
 import { buildMcpToolCapabilityManifest } from "@/modules/execution-factory/utils/capability-manifest";
 import {
   formatOptionalTimestamp,
@@ -77,6 +78,7 @@ function resolveModeLabel(mode: McpDetail["mode"], t: (key: string) => string) {
 export function McpDetailScene({ mcpId, onBack }: McpDetailSceneProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const catalogContext = searchParams.get("from") === "catalog";
   const [record, setRecord] = useState<McpDetail | null>(null);
@@ -144,15 +146,14 @@ export function McpDetailScene({ mcpId, onBack }: McpDetailSceneProps) {
       return;
     }
 
-    if (window.history.length > 1) {
-      void navigate(-1);
-      return;
-    }
-
+    // A knowledge network's capability list links here and names itself in location state; every
+    // other entry returns to the list. Not `navigate(-1)`: it cannot tell a direct hit apart and
+    // leaves the app when this page was the first one opened (#386).
     void navigate(
-      catalogContext
-        ? "/execution-factory/catalog?activeTab=mcp"
-        : "/execution-factory/units?activeTab=mcp",
+      readReturnTo(location.state) ??
+        (catalogContext
+          ? "/execution-factory/catalog?activeTab=mcp"
+          : "/execution-factory/units?activeTab=mcp"),
     );
   };
 

--- a/src/modules/execution-factory/scenes/SkillDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/SkillDetailScene.tsx
@@ -21,7 +21,7 @@ import {
 import { Alert, Empty, Layout, Spin, Tag } from "antd";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import type { SkillDetailSceneProps } from "@/modules/execution-factory/contracts/scenes";
 import { PermissionGate } from "@/framework/permission/PermissionGate";
@@ -51,6 +51,7 @@ import {
   resolveSkillCategoryLabel,
 } from "@/modules/execution-factory/utils/detail-display";
 import { formatAuditUserDisplay } from "@/modules/execution-factory/utils/audit-user-display";
+import { readReturnTo } from "@/modules/execution-factory/utils/back-navigation";
 import { formatExecutionUnitTime } from "@/modules/execution-factory/utils/format-timestamp";
 import { useAuditUserDirectory } from "@/modules/execution-factory/utils/use-audit-user-directory";
 
@@ -83,6 +84,7 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
   const { t } = useTranslation();
   const auditUserDirectory = useAuditUserDirectory();
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const catalogContext = searchParams.get("from") === "catalog";
   const [record, setRecord] = useState<SkillRecord | null>(null);
@@ -201,15 +203,14 @@ export function SkillDetailScene({ skillId, onBack }: SkillDetailSceneProps) {
       return;
     }
 
-    if (window.history.length > 1) {
-      void navigate(-1);
-      return;
-    }
-
+    // A knowledge network's capability list links here and names itself in location state; every
+    // other entry returns to the list. Not `navigate(-1)`: it cannot tell a direct hit apart and
+    // leaves the app when this page was the first one opened (#386).
     void navigate(
-      catalogContext
-        ? "/execution-factory/catalog?activeTab=skill"
-        : "/execution-factory/units?activeTab=skill",
+      readReturnTo(location.state) ??
+        (catalogContext
+          ? "/execution-factory/catalog?activeTab=skill"
+          : "/execution-factory/units?activeTab=skill"),
     );
   };
 

--- a/src/modules/execution-factory/scenes/ToolDetailScene.back.test.tsx
+++ b/src/modules/execution-factory/scenes/ToolDetailScene.back.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ToolDetailScene } from "@/modules/execution-factory/scenes/ToolDetailScene";
+import { ToolboxToolsScene } from "@/modules/execution-factory/scenes/ToolboxToolsScene";
+import { buildReturnToState } from "@/modules/execution-factory/utils/back-navigation";
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => ({
+    message: { destroy: vi.fn(), error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+    modal: { confirm: vi.fn() },
+    runtimeConfig: {
+      currentUser: {
+        permissions: [
+          "execution-factory:tool:create",
+          "execution-factory:tool:debug",
+          "execution-factory:tool:delete",
+          "execution-factory:tool:edit",
+          "execution-factory:toolbox:edit",
+        ],
+      },
+    },
+  }),
+}));
+
+// The two scenes under test only need their chrome; everything that talks to the backend or
+// renders an editor is stubbed so the test exercises routing and nothing else.
+vi.mock("@/modules/execution-factory/components/HttpToolLifecyclePanel", () => ({
+  HttpToolLifecyclePanel: ({ businessFields }: { businessFields: ReactNode }) => (
+    <>{businessFields}</>
+  ),
+}));
+vi.mock("@/modules/execution-factory/components/OpenApiDefinitionFields", () => ({
+  OpenApiDefinitionFields: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/FunctionDefinitionFields", () => ({
+  FunctionDefinitionFields: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/ToolDebugPanel", () => ({
+  ToolDebugPanel: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/ToolIoPanel", () => ({
+  ToolIoPanel: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/ToolDebugModal", () => ({
+  ToolDebugModal: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/ToolFormDrawer", () => ({
+  ToolFormDrawer: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/create-menu/AddCapabilityWizard", () => ({
+  AddCapabilityWizard: () => null,
+}));
+vi.mock("@/modules/execution-factory/utils/use-audit-user-directory", () => ({
+  useAuditUserDirectory: () => new Map<string, string>(),
+}));
+vi.mock("@/modules/execution-factory/utils/use-impex-export", () => ({
+  useImpexExport: () => ({ exportComponentById: vi.fn(), isExporting: () => false }),
+}));
+
+const { getToolbox, getToolboxMarket } = vi.hoisted(() => ({
+  getToolbox: vi.fn(),
+  getToolboxMarket: vi.fn(),
+}));
+
+vi.mock("@/modules/execution-factory/services/toolbox.service", () => ({
+  getToolbox,
+  getToolboxMarket,
+}));
+
+const { deleteTools, getToolDetail, listTools, updateTool, updateToolStatus } = vi.hoisted(() => ({
+  deleteTools: vi.fn(),
+  getToolDetail: vi.fn(),
+  listTools: vi.fn(),
+  updateTool: vi.fn(),
+  updateToolStatus: vi.fn(),
+}));
+
+vi.mock("@/modules/execution-factory/services/tool.service", () => ({
+  deleteTools,
+  getToolDetail,
+  listTools,
+  updateTool,
+  updateToolStatus,
+}));
+
+const LIST_URL = "/execution-factory/units?activeTab=toolbox";
+const TOOLS_URL = "/execution-factory/toolboxes/box-1/tools";
+const DETAIL_URL = "/execution-factory/toolboxes/box-1/tools/tool-1/edit";
+const CAPABILITY_LIST_URL = "/knowledge-network/kn-1/capabilities?kind=function";
+
+/** Reports the current location and offers the browser's own back, which no scene may rely on. */
+function LocationProbe() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <output data-testid="location">{`${location.pathname}${location.search}`}</output>
+      <button onClick={() => void navigate(-1)} type="button">
+        browser back
+      </button>
+    </>
+  );
+}
+
+function ToolDetailRoute() {
+  const { boxId, toolId } = useParams<{ boxId: string; toolId: string }>();
+  return <ToolDetailScene boxId={boxId ?? ""} toolId={toolId ?? ""} />;
+}
+
+function ToolboxToolsRoute() {
+  const { boxId } = useParams<{ boxId: string }>();
+  return <ToolboxToolsScene boxId={boxId ?? ""} />;
+}
+
+function renderAt(entries: Array<string | { pathname: string; search?: string; state?: unknown }>) {
+  return render(
+    <MemoryRouter initialEntries={entries} initialIndex={entries.length - 1}>
+      <LocationProbe />
+      <Routes>
+        <Route element={<output>toolbox list</output>} path="/execution-factory/units" />
+        <Route element={<output>catalog</output>} path="/execution-factory/catalog" />
+        <Route element={<ToolboxToolsRoute />} path="/execution-factory/toolboxes/:boxId/tools" />
+        <Route
+          element={<ToolDetailRoute />}
+          path="/execution-factory/toolboxes/:boxId/tools/:toolId/edit"
+        />
+        <Route element={<output>capability list</output>} path="/knowledge-network/*" />
+        <Route element={<output>elsewhere</output>} path="*" />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function currentLocation() {
+  return screen.getByTestId("location").textContent;
+}
+
+async function clickBack() {
+  const button = await screen.findByRole("button", { name: "common.back" });
+  fireEvent.click(button);
+}
+
+describe("tool config back navigation (#386)", () => {
+  beforeAll(() => {
+    // A real tab always holds more than one entry; jsdom reports one, which would let a scene
+    // that still consulted `window.history.length` before `navigate(-1)` pass by accident.
+    Object.defineProperty(window.history, "length", { configurable: true, value: 5 });
+
+    // antd's grid subscribes to breakpoints through matchMedia, which jsdom does not provide.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        addEventListener: vi.fn(),
+        addListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        matches: false,
+        media: "",
+        onchange: null,
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    );
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getToolbox.mockResolvedValue({
+      boxId: "box-1",
+      name: "Box",
+      metadataType: "openapi",
+      status: "enabled",
+    });
+    getToolboxMarket.mockResolvedValue({
+      boxId: "box-1",
+      name: "Box",
+      metadataType: "openapi",
+      status: "enabled",
+    });
+    listTools.mockResolvedValue({ items: [], total: 0 });
+    getToolDetail.mockResolvedValue({
+      toolId: "tool-1",
+      name: "Tool",
+      metadataType: "openapi",
+      status: "enabled",
+    });
+  });
+
+  it("walks from the wizard's config page to the tool list and on to the toolbox list", async () => {
+    // The wizard pushes the config page straight on top of the toolbox list.
+    renderAt([LIST_URL, DETAIL_URL]);
+    expect(currentLocation()).toBe(DETAIL_URL);
+
+    await clickBack();
+    await waitFor(() => expect(currentLocation()).toBe(TOOLS_URL));
+
+    await clickBack();
+    await waitFor(() =>
+      expect(currentLocation()).toBe(`${LIST_URL}&toolboxView=openapi`),
+    );
+    expect(screen.getByText("toolbox list")).toBeTruthy();
+  });
+
+  it("does not leave the config page behind for the browser's back to land on", async () => {
+    renderAt([LIST_URL, DETAIL_URL]);
+
+    await clickBack();
+    await waitFor(() => expect(currentLocation()).toBe(TOOLS_URL));
+
+    fireEvent.click(screen.getByRole("button", { name: "browser back" }));
+    await waitFor(() => expect(currentLocation()).toBe(LIST_URL));
+    expect(screen.queryByText("executionFactory.toolDetailTitle")).toBeNull();
+  });
+
+  it("returns to a knowledge network's capability list when that is where the visitor came from", async () => {
+    renderAt([
+      CAPABILITY_LIST_URL,
+      {
+        pathname: "/execution-factory/toolboxes/box-1/tools/tool-1/edit",
+        state: buildReturnToState({
+          pathname: "/knowledge-network/kn-1/capabilities",
+          search: "?kind=function",
+        }),
+      },
+    ]);
+
+    await clickBack();
+    await waitFor(() => expect(currentLocation()).toBe(CAPABILITY_LIST_URL));
+    expect(screen.getByText("capability list")).toBeTruthy();
+  });
+
+  it("sends the tool list back to its own list page instead of whatever the history holds", async () => {
+    renderAt(["/somewhere/else", TOOLS_URL]);
+
+    await clickBack();
+    await waitFor(() =>
+      expect(currentLocation()).toBe(`${LIST_URL}&toolboxView=openapi`),
+    );
+  });
+
+  it("sends a marketplace preview of the tool list back to the catalog", async () => {
+    renderAt(["/somewhere/else", `${TOOLS_URL}?from=catalog`]);
+
+    await clickBack();
+    await waitFor(() =>
+      expect(currentLocation()).toBe("/execution-factory/catalog?activeTab=toolbox&toolboxView=openapi"),
+    );
+  });
+});

--- a/src/modules/execution-factory/scenes/ToolDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/ToolDetailScene.tsx
@@ -8,7 +8,7 @@
 import { Alert, Form, Input, Spin } from "antd";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import type { ToolDetailSceneProps } from "@/modules/execution-factory/contracts/scenes";
 import { useAppServices } from "@/framework/context/use-app-services";
@@ -32,6 +32,7 @@ import type {
   ToolRunLogEntry,
 } from "@/modules/execution-factory/types/tool";
 import type { FunctionParameterDef } from "@/modules/execution-factory/types/function-input";
+import { readReturnTo } from "@/modules/execution-factory/utils/back-navigation";
 import { validateOpenApiDocumentText } from "@/modules/execution-factory/utils/metadata-content";
 import { parseOpenApiEndpointDetail } from "@/modules/execution-factory/utils/openapi-detail";
 
@@ -52,6 +53,7 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
   const { t } = useTranslation();
   const { message } = useAppServices();
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const [form] = Form.useForm<ToolFormValues>();
   const [loading, setLoading] = useState(true);
@@ -115,15 +117,14 @@ export function ToolDetailScene({ boxId, onBack, toolId }: ToolDetailSceneProps)
       return;
     }
 
-    // Return where the visitor came from — a knowledge network's capability list links straight
-    // here, and sending it to the toolset's tool list strands them in another module. Skill and MCP
-    // detail already do this; the fixed path stays as the fallback for a direct hit.
-    if (window.history.length > 1) {
-      void navigate(-1);
-      return;
-    }
-
-    void navigate(`/execution-factory/toolboxes/${boxId}/tools`);
+    // The toolset's tool list is this page's parent. A knowledge network's capability list links
+    // straight here and says so in location state, since sending it to the tool list would strand
+    // it in another module. Neither case may use `navigate(-1)`: the tool list answered its own
+    // back the same way and the two pages bounced between each other (#386). `replace` keeps this
+    // page out of the history stack so the browser's back from the parent does not land here.
+    void navigate(readReturnTo(location.state) ?? `/execution-factory/toolboxes/${boxId}/tools`, {
+      replace: true,
+    });
   };
 
   const handleSubmit = async () => {

--- a/src/modules/execution-factory/scenes/ToolboxToolsScene.tsx
+++ b/src/modules/execution-factory/scenes/ToolboxToolsScene.tsx
@@ -171,12 +171,9 @@ export function ToolboxToolsScene({ boxId, onBack }: ToolboxToolsSceneProps) {
       return;
     }
 
-    if (window.history.length > 1) {
-      void navigate(-1);
-      return;
-    }
-
     // Toolboxes split into API and function views; return to the one containing the toolbox.
+    // Always go there explicitly: `navigate(-1)` re-entered the tool config page that had just
+    // sent the visitor here (#386), and leaves the app when this page was the first one opened.
     const viewQuery = `&toolboxView=${isFunctionToolbox ? "function" : "openapi"}`;
     void navigate(
       catalogContext

--- a/src/modules/execution-factory/utils/back-navigation.test.ts
+++ b/src/modules/execution-factory/utils/back-navigation.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReturnToState,
+  readReturnTo,
+} from "@/modules/execution-factory/utils/back-navigation";
+
+describe("back-navigation return-to state", () => {
+  it("round-trips the origin's path and query", () => {
+    const state = buildReturnToState({
+      pathname: "/knowledge-network/kn-1/capabilities",
+      search: "?kind=skill",
+    });
+
+    expect(readReturnTo(state)).toBe("/knowledge-network/kn-1/capabilities?kind=skill");
+  });
+
+  it("ignores state that is missing, malformed, or not an in-app path", () => {
+    expect(readReturnTo(null)).toBeUndefined();
+    expect(readReturnTo(undefined)).toBeUndefined();
+    expect(readReturnTo("/x")).toBeUndefined();
+    expect(readReturnTo({})).toBeUndefined();
+    expect(readReturnTo({ returnTo: 42 })).toBeUndefined();
+    expect(readReturnTo({ returnTo: "https://example.com/" })).toBeUndefined();
+    expect(readReturnTo({ returnTo: "relative" })).toBeUndefined();
+  });
+});

--- a/src/modules/execution-factory/utils/back-navigation.ts
+++ b/src/modules/execution-factory/utils/back-navigation.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { Location } from "react-router-dom";
+
+/**
+ * Where a detail scene's back button should go when the visitor came from another module.
+ *
+ * Detail scenes must not answer their back button with `navigate(-1)`: the history stack cannot
+ * tell an in-app entry apart from a direct hit, and a list page that also relied on `navigate(-1)`
+ * bounced the visitor between itself and the config page it had just been sent from (#386). The
+ * origin that needs a destination other than the scene's fixed parent (a knowledge network's
+ * capability list) declares it in location state instead; a scene without it uses its parent page.
+ */
+export type ReturnToState = {
+  returnTo?: string;
+};
+
+export function buildReturnToState(
+  location: Pick<Location, "pathname" | "search">,
+): ReturnToState {
+  return { returnTo: `${location.pathname}${location.search}` };
+}
+
+/** Only an in-app path is honoured; anything else falls through to the scene's own fallback. */
+export function readReturnTo(state: unknown): string | undefined {
+  if (!state || typeof state !== "object") {
+    return undefined;
+  }
+
+  const { returnTo } = state as ReturnToState;
+  return typeof returnTo === "string" && returnTo.startsWith("/") ? returnTo : undefined;
+}

--- a/src/modules/knowledge-network/components/capability/CapabilityListPanel.test.tsx
+++ b/src/modules/knowledge-network/components/capability/CapabilityListPanel.test.tsx
@@ -22,6 +22,7 @@ vi.mock("react-i18next", async (importOriginal) => ({
 
 vi.mock("react-router-dom", async (importOriginal) => ({
   ...(await importOriginal<typeof import("react-router-dom")>()),
+  useLocation: () => ({ pathname: "/knowledge-network/kn-1/capabilities", search: "?kind=all" }),
   useNavigate: () => mocks.navigate,
 }));
 
@@ -193,6 +194,9 @@ describe("CapabilityListPanel restricted empty state", () => {
     renderPanel(kind, false, dataFor(kind));
     fireEvent.click(screen.getByRole("button", { name: "Visible capability" }));
 
-    expect(mocks.navigate).toHaveBeenCalledWith(expectedPath);
+    // The detail scene's back button must return to this list, not to its own list page (#386).
+    expect(mocks.navigate).toHaveBeenCalledWith(expectedPath, {
+      state: { returnTo: "/knowledge-network/kn-1/capabilities?kind=all" },
+    });
   });
 });

--- a/src/modules/knowledge-network/components/capability/CapabilityListPanel.tsx
+++ b/src/modules/knowledge-network/components/capability/CapabilityListPanel.tsx
@@ -17,13 +17,14 @@ import { Alert, Empty, Input, Table, Tag, Tooltip } from "antd";
 import type { TableProps } from "antd";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { useAppServices } from "@/framework/context/use-app-services";
 import { hasPermissions } from "@/framework/permission/has-permissions";
 import { AppButton } from "@/framework/ui/common/AppButton";
 import { TablePaginationBar } from "@/framework/ui/common/TablePaginationBar";
 import { executionFactoryViewPermissionByTab } from "@/modules/execution-factory/permissions";
+import { buildReturnToState } from "@/modules/execution-factory/utils/back-navigation";
 import { CapabilityMountModal } from "@/modules/knowledge-network/components/capability/CapabilityMountModal";
 import { usePersistentPageSize } from "@/modules/knowledge-network/components/shared/usePersistentPageSize";
 import {
@@ -157,6 +158,7 @@ export function CapabilityListPanel({
 }: CapabilityListPanelProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const { message, modal, runtimeConfig } = useAppServices();
   const [keyword, setKeyword] = useState("");
   const [page, setPage] = useState(1);
@@ -305,7 +307,8 @@ export function CapabilityListPanel({
         return canViewCapabilityDetail ? (
           <AppButton
             onClick={() => {
-              void navigate(executionFactoryPath(record));
+              // The detail scene's back button returns here rather than to its own list page.
+              void navigate(executionFactoryPath(record), { state: buildReturnToState(location) });
             }}
             type="link"
           >


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] `execution-factory`: `ToolDetailScene`, `ToolboxToolsScene`, `McpDetailScene` and `SkillDetailScene` no longer answer their back button with `navigate(-1)`; each goes to an explicit destination.
- [x] `execution-factory`: new `utils/back-navigation.ts` (`buildReturnToState` / `readReturnTo`) so an origin in another module can say where a detail page should return to via location state.
- [x] `knowledge-network`: `CapabilityListPanel` passes that state when it links to a tool, skill or MCP detail page, so those pages still return to the capability list.
- [ ] Docs: none (pure routing fix).

---

## Why

- Related Issue: Closes #386
- Related Feature: execution factory tool config / toolbox tool list navigation
- Background: both pages guarded `navigate(-1)` with `window.history.length > 1`. That cannot tell an in-app entry from a direct hit, so a config page opened from the wizard (or in a fresh tab) pushed the tool list, and the tool list's `navigate(-1)` sent the visitor straight back to the config page. Neither page ever reached the toolbox list, and in a fresh tab the guard walked out of the application. The same guard in the skill and MCP detail pages has the fresh-tab problem, so the issue asked for them to be evaluated together.

---

## How

- Key implementation points:
  - `ToolDetailScene.handleBack` → `readReturnTo(location.state) ?? /execution-factory/toolboxes/:boxId/tools`, with `replace: true`, so the config page is not left on the history stack for the browser's back to land on.
  - `ToolboxToolsScene.handleBack` → always the toolbox list view holding the toolbox (`units?activeTab=toolbox&toolboxView=…`, or the catalog variant), matching `FunctionWorkbenchScene` / `ToolboxFormScene`.
  - `McpDetailScene` / `SkillDetailScene` → `readReturnTo(location.state) ?? <list page>` (push, as before).
  - `CapabilityListPanel` navigates with `{ state: buildReturnToState(location) }`; `readReturnTo` only honours an in-app path (`/…`).
- Breaking changes (API, config, database, etc.): none. No backend, schema or permission change.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — n/a, no Playwright spec covers this flow
- [ ] Verified in test environment — not run; the change is routing-only and the acceptance criteria ask for a regression test + CI

Test notes:

- New `ToolDetailScene.back.test.tsx` renders both scenes under a `MemoryRouter` and covers: wizard → config → back → tool list → back → toolbox list; browser back from the tool list does not return to the config page; capability-list origin returns to the capability list; tool list returns to its list page regardless of history; `from=catalog` returns to the catalog.
- With the two scene fixes stashed, 4 of those 5 cases fail. The test pins `window.history.length` above 1, because jsdom reports 1 and would otherwise never exercise the old `navigate(-1)` branch.
- `back-navigation.test.ts` covers valid and malformed state; `CapabilityListPanel.test.tsx` now asserts the `returnTo` state.
- Ran: `node scripts/check-license-headers.mjs`, `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`, `pnpm exec vitest --run` (294 files / 1646 tests), `pnpm test:execution-factory`, `pnpm exec tsc -b --pretty false`, `pnpm exec vite build`, `pnpm audit --prod` (1 high, pre-existing and ignored), `pnpm i18n:check`. All green.

---

## Risk & Rollback

- Potential risks: a page that used to rely on `navigate(-1)` to restore list state now lands on the explicit list URL; the execution-factory list keeps its tab/view in the URL, so nothing observable is lost. Capability-list origins depend on the new state, which is set only by `CapabilityListPanel`.
- Rollback plan: revert this single commit; no data or config involved.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
