### PR TITLE
fix(execution-factory): use action-accurate labels in lifecycle confirmation dialogs

### DIFF
--- a/src/modules/execution-factory/locales/en-US.ts
+++ b/src/modules/execution-factory/locales/en-US.ts
@@ -470,6 +470,7 @@ export const executionFactoryEnUS = {
     },
     statusChangeConfirmTitle: "Update operator status",
     statusChangeConfirmDescription: 'Change "{{name}}" to "{{status}}"?',
+    statusChangeConfirmOk: "Confirm",
     deleteConfirmTitle: "Delete operator",
     deleteConfirmDescription: 'Delete "{{name}}"? This action cannot be undone.',
     toolboxStatusChangeConfirmTitle: "Update toolbox status",

--- a/src/modules/execution-factory/locales/zh-CN.ts
+++ b/src/modules/execution-factory/locales/zh-CN.ts
@@ -463,6 +463,7 @@ export const executionFactoryZhCN = {
     },
     statusChangeConfirmTitle: "更新算子状态",
     statusChangeConfirmDescription: '确认将“{{name}}”的状态变更为“{{status}}”吗？',
+    statusChangeConfirmOk: "确认",
     deleteConfirmTitle: "删除算子",
     deleteConfirmDescription: '确认删除“{{name}}”吗？该操作不可撤销。',
     toolboxStatusChangeConfirmTitle: "更新工具箱状态",

--- a/src/modules/execution-factory/scenes/ExecutionUnitListScene.confirm-labels.test.tsx
+++ b/src/modules/execution-factory/scenes/ExecutionUnitListScene.confirm-labels.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { ModalFuncProps } from "antd";
+import { MemoryRouter } from "react-router-dom";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "@/app/locales/i18n";
+import { ExecutionUnitListScene } from "@/modules/execution-factory/scenes/ExecutionUnitListScene";
+
+const services = vi.hoisted(() => ({
+  message: { destroy: vi.fn(), error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+  modal: { confirm: vi.fn<(config: ModalFuncProps) => void>() },
+  runtimeConfig: {
+    currentUser: {
+      permissions: [
+        "execution-factory:mcp:view",
+        "execution-factory:skill:view",
+        "execution-factory:toolbox:view",
+      ],
+    },
+  },
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => services,
+}));
+
+// A fresh directory per render would re-create the page loader on every render and refetch forever.
+const auditUserDirectory = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("@/modules/execution-factory/utils/use-audit-user-directory", () => ({
+  useAuditUserDirectory: () => auditUserDirectory,
+}));
+
+// Only the card grid and the confirmation it opens are under test.
+vi.mock("@/modules/execution-factory/components/create-menu/CreateMenu", () => ({
+  CreateMenu: () => null,
+}));
+vi.mock("@/modules/execution-factory/scenes/ExecutionUnitListOverlays", () => ({
+  ExecutionUnitListOverlays: () => null,
+}));
+vi.mock("@/modules/system-admin/components/ObjectAuthorizeDrawer", () => ({
+  ObjectAuthorizeDrawer: () => null,
+}));
+
+const api = vi.hoisted(() => ({
+  deleteMcp: vi.fn(),
+  deleteOperator: vi.fn(),
+  deleteSkill: vi.fn(),
+  deleteToolbox: vi.fn(),
+  downloadComponentExport: vi.fn(),
+  downloadSkillPackage: vi.fn(),
+  getToolDetail: vi.fn(),
+  listMcpMarket: vi.fn(),
+  listMcps: vi.fn(),
+  listOperatorCategories: vi.fn(),
+  listOperatorMarket: vi.fn(),
+  listOperators: vi.fn(),
+  listSkillMarket: vi.fn(),
+  listSkills: vi.fn(),
+  listToolboxMarket: vi.fn(),
+  listToolboxes: vi.fn(),
+  listTools: vi.fn(),
+  updateMcpStatus: vi.fn(),
+  updateOperatorStatus: vi.fn(),
+  updateSkillStatus: vi.fn(),
+  updateToolboxStatus: vi.fn(),
+}));
+
+vi.mock("@/modules/execution-factory/services/mcp.service", () => ({
+  deleteMcp: api.deleteMcp,
+  listMcpMarket: api.listMcpMarket,
+  listMcps: api.listMcps,
+  updateMcpStatus: api.updateMcpStatus,
+}));
+vi.mock("@/modules/execution-factory/services/operator.service", () => ({
+  deleteOperator: api.deleteOperator,
+  listOperatorMarket: api.listOperatorMarket,
+  listOperators: api.listOperators,
+  updateOperatorStatus: api.updateOperatorStatus,
+}));
+vi.mock("@/modules/execution-factory/services/skill.service", () => ({
+  deleteSkill: api.deleteSkill,
+  downloadSkillPackage: api.downloadSkillPackage,
+  listSkillMarket: api.listSkillMarket,
+  listSkills: api.listSkills,
+  updateSkillStatus: api.updateSkillStatus,
+}));
+vi.mock("@/modules/execution-factory/services/toolbox.service", () => ({
+  deleteToolbox: api.deleteToolbox,
+  listToolboxMarket: api.listToolboxMarket,
+  listToolboxes: api.listToolboxes,
+  updateToolboxStatus: api.updateToolboxStatus,
+}));
+vi.mock("@/modules/execution-factory/services/tool.service", () => ({
+  getToolDetail: api.getToolDetail,
+  listTools: api.listTools,
+}));
+vi.mock("@/modules/execution-factory/services/impex.service", () => ({
+  downloadComponentExport: api.downloadComponentExport,
+}));
+vi.mock("@/modules/execution-factory/services/category.service", () => ({
+  listOperatorCategories: api.listOperatorCategories,
+}));
+
+const LOCALES = ["en-US", "zh-CN"] as const;
+
+function renderScene(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/execution-factory/units${search}`]}>
+      <ExecutionUnitListScene
+        descriptionKey="executionFactory.unitsDescription"
+        titleKey="executionFactory.unitsTitle"
+        toolbarHintKey="executionFactory.unitsToolbarHint"
+      />
+    </MemoryRouter>,
+  );
+}
+
+/** Opens the card's action menu and picks the lifecycle item, the way a user starts the change. */
+async function chooseCardAction(cardName: string, actionLabel: string) {
+  await screen.findByText(cardName);
+  fireEvent.click(screen.getByRole("button", { name: i18n.t("executionFactory.cardMenu.more") }));
+  fireEvent.click(within(screen.getByRole("menu")).getByText(actionLabel));
+}
+
+async function confirmedDialog() {
+  await waitFor(() => expect(services.modal.confirm).toHaveBeenCalledTimes(1));
+  return services.modal.confirm.mock.calls[0][0];
+}
+
+describe("ExecutionUnitListScene lifecycle confirmation labels (#491)", () => {
+  beforeAll(() => {
+    // antd's responsive observers subscribe through matchMedia, which jsdom does not provide.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        addEventListener: vi.fn(),
+        addListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        matches: false,
+        media: query,
+        onchange: null,
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    );
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    api.listOperatorCategories.mockResolvedValue([]);
+    api.listOperators.mockResolvedValue({ items: [], total: 0 });
+    api.listSkills.mockResolvedValue({ items: [], total: 0 });
+    api.listToolboxes.mockResolvedValue({ items: [], total: 0 });
+    api.listMcps.mockResolvedValue({ items: [], total: 0 });
+  });
+
+  describe.each(LOCALES)("in %s", (locale) => {
+    beforeEach(async () => {
+      await i18n.changeLanguage(locale);
+    });
+
+    it("names the MCP publish confirmation after the action instead of Save", async () => {
+      api.listMcps.mockResolvedValue({
+        items: [{ mcpId: "mcp-1", name: "Weather MCP", status: "unpublish" }],
+        total: 1,
+      });
+
+      renderScene("?activeTab=mcp");
+      await chooseCardAction("Weather MCP", i18n.t("executionFactory.publish"));
+
+      const dialog = await confirmedDialog();
+      expect(dialog.okText).toBe(locale === "en-US" ? "Publish" : "发布");
+      expect(dialog.okText).not.toBe(i18n.t("common.save"));
+      expect(dialog.cancelText).toBe(locale === "en-US" ? "Cancel" : "取消");
+    });
+
+    it("names the MCP unpublish confirmation after the action instead of Save", async () => {
+      api.listMcps.mockResolvedValue({
+        items: [{ mcpId: "mcp-1", name: "Weather MCP", status: "published" }],
+        total: 1,
+      });
+
+      renderScene("?activeTab=mcp");
+      await chooseCardAction("Weather MCP", i18n.t("executionFactory.offline"));
+
+      const dialog = await confirmedDialog();
+      expect(dialog.okText).toBe(locale === "en-US" ? "Unpublish" : "取消发布");
+      expect(dialog.okText).not.toBe(i18n.t("common.save"));
+      expect(dialog.cancelText).toBe(locale === "en-US" ? "Cancel" : "取消");
+    });
+
+    it("names a clean toolbox publish Publish, and keeps Publish anyway when preflight finds issues", async () => {
+      api.listToolboxes.mockResolvedValue({
+        items: [{ boxId: "box-1", metadataType: "openapi", name: "Weather Toolbox", status: "unpublish" }],
+        total: 1,
+      });
+      api.listTools.mockResolvedValue({
+        items: [
+          {
+            description: "Look up the weather",
+            metadataType: "openapi",
+            name: "get_weather",
+            status: "enabled",
+            toolId: "tool-1",
+          },
+        ],
+        total: 1,
+      });
+
+      const { unmount } = renderScene("?activeTab=toolbox&toolboxView=openapi");
+      await chooseCardAction("Weather Toolbox", i18n.t("executionFactory.publish"));
+
+      const clean = await confirmedDialog();
+      expect(clean.okText).toBe(locale === "en-US" ? "Publish" : "发布");
+
+      // An empty toolbox trips preflight; the existing, already accurate override must still win.
+      unmount();
+      services.modal.confirm.mockClear();
+      api.listTools.mockResolvedValue({ items: [], total: 0 });
+
+      renderScene("?activeTab=toolbox&toolboxView=openapi");
+      await chooseCardAction("Weather Toolbox", i18n.t("executionFactory.publish"));
+
+      const withIssues = await confirmedDialog();
+      expect(withIssues.okText).toBe(locale === "en-US" ? "Publish Anyway" : "仍然发布");
+      expect(withIssues.okButtonProps).toEqual({ danger: true });
+    });
+  });
+});

--- a/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
+++ b/src/modules/execution-factory/scenes/ExecutionUnitListScene.tsx
@@ -67,6 +67,7 @@ import {
   resolveLifecycleActionStatus,
   resolveListStatusQueries,
 } from "@/modules/execution-factory/utils/execution-unit-lifecycle";
+import { resolveStatusChangeOkTextKey } from "@/modules/execution-factory/utils/status-confirm-ok-text";
 import {
   collectLocalResourceIds,
   invalidateLocalResourceIdsCache,
@@ -938,7 +939,7 @@ export function ExecutionUnitListScene({
             </>
           ),
           okButtonProps: options?.danger ? { danger: true } : undefined,
-          okText: t(options?.okTextKey ?? "common.save"),
+          okText: t(options?.okTextKey ?? resolveStatusChangeOkTextKey(nextStatus)),
           cancelText: t("common.cancel"),
           onOk: async () => {
             try {

--- a/src/modules/execution-factory/scenes/FunctionWorkbenchScene.confirm-labels.test.tsx
+++ b/src/modules/execution-factory/scenes/FunctionWorkbenchScene.confirm-labels.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { ModalFuncProps } from "antd";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "@/app/locales/i18n";
+import { FunctionWorkbenchScene } from "@/modules/execution-factory/scenes/FunctionWorkbenchScene";
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+const services = vi.hoisted(() => ({
+  message: { destroy: vi.fn(), error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+  modal: { confirm: vi.fn<(config: ModalFuncProps) => void>() },
+  runtimeConfig: {
+    currentUser: {
+      permissions: [
+        "execution-factory:tool:create",
+        "execution-factory:tool:debug",
+        "execution-factory:tool:delete",
+        "execution-factory:tool:edit",
+        "execution-factory:toolbox:edit",
+      ],
+    },
+  },
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => services,
+}));
+
+// Only the function rail, the bulk bar, and the confirmation they open are under test.
+vi.mock("@/modules/execution-factory/components/CodeEditor", () => ({
+  CodeEditor: ({ value }: { value?: string }) => <textarea readOnly value={value ?? ""} />,
+}));
+vi.mock("@/modules/execution-factory/components/FunctionAiGenerateModal", () => ({
+  FunctionAiGenerateModal: () => null,
+}));
+vi.mock("@/modules/execution-factory/scenes/function-workbench/FunctionDependencyPanel", () => ({
+  FunctionDependencyPanel: () => null,
+}));
+vi.mock("@/modules/model-resources/services/llm.service", () => ({
+  listLlmModels: vi.fn().mockResolvedValue({ items: [] }),
+}));
+vi.mock("@/modules/execution-factory/services/category.service", () => ({
+  listOperatorCategories: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/modules/execution-factory/services/function.service", () => ({
+  executeFunction: vi.fn(),
+  inferFunctionSchema: vi.fn(),
+}));
+
+const api = vi.hoisted(() => ({
+  createTool: vi.fn(),
+  deleteTools: vi.fn(),
+  getToolDetail: vi.fn(),
+  getToolbox: vi.fn(),
+  listTools: vi.fn(),
+  updateTool: vi.fn(),
+  updateToolStatus: vi.fn(),
+  updateToolbox: vi.fn(),
+  updateToolboxStatus: vi.fn(),
+}));
+
+vi.mock("@/modules/execution-factory/services/toolbox.service", () => ({
+  getToolbox: api.getToolbox,
+  updateToolbox: api.updateToolbox,
+  updateToolboxStatus: api.updateToolboxStatus,
+}));
+vi.mock("@/modules/execution-factory/services/tool.service", () => ({
+  createTool: api.createTool,
+  deleteTools: api.deleteTools,
+  getToolDetail: api.getToolDetail,
+  listTools: api.listTools,
+  updateTool: api.updateTool,
+  updateToolStatus: api.updateToolStatus,
+}));
+
+const FUNCTIONS = [
+  { description: "desc", name: "sum_orders", status: "enabled", toolId: "tool-1" },
+  { description: "desc", name: "rank_customers", status: "disabled", toolId: "tool-2" },
+];
+
+const LABELS = {
+  "en-US": { cancel: "Cancel", disable: "Disable", enable: "Enable", save: "Save" },
+  "zh-CN": { cancel: "取消", disable: "禁用", enable: "启用", save: "保存" },
+} as const;
+
+async function railItem(name: string) {
+  return within(await screen.findByRole("option", { name: new RegExp(name) }));
+}
+
+/** antd spaces out two-character CJK button labels ("启 用"), so compare names without whitespace. */
+function buttonNamed(label: string) {
+  return (accessibleName: string) => accessibleName.replace(/\s/g, "") === label;
+}
+
+async function confirmedDialog() {
+  await waitFor(() => expect(services.modal.confirm).toHaveBeenCalledTimes(1));
+  return services.modal.confirm.mock.calls[0][0];
+}
+
+describe("FunctionWorkbenchScene function status confirmation labels (#491)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getToolbox.mockResolvedValue({
+      boxId: "box-1",
+      metadataType: "function",
+      name: "Orders",
+      status: "unpublish",
+    });
+    api.listTools.mockResolvedValue({
+      boxId: "box-1",
+      items: FUNCTIONS,
+      page: 1,
+      pageSize: 50,
+      total: FUNCTIONS.length,
+    });
+    api.getToolDetail.mockImplementation((_boxId: string, toolId: string) => {
+      const item = FUNCTIONS.find((candidate) => candidate.toolId === toolId);
+      return Promise.resolve({
+        ...item,
+        functionInput: { code: "def handler(event):\n    return event\n", inputs: [], outputs: [] },
+      });
+    });
+  });
+
+  describe.each(["en-US", "zh-CN"] as const)("in %s", (locale) => {
+    const labels = LABELS[locale];
+
+    beforeEach(async () => {
+      await i18n.changeLanguage(locale);
+    });
+
+    it("names a single function's switch confirmation Disable or Enable instead of Save", async () => {
+      render(<FunctionWorkbenchScene boxId="box-1" />);
+
+      fireEvent.click((await railItem("sum_orders")).getByRole("switch"));
+      const disable = await confirmedDialog();
+      expect(disable.okText).toBe(labels.disable);
+      expect(disable.okText).not.toBe(labels.save);
+      expect(disable.cancelText).toBe(labels.cancel);
+
+      services.modal.confirm.mockClear();
+      fireEvent.click((await railItem("rank_customers")).getByRole("switch"));
+      const enable = await confirmedDialog();
+      expect(enable.okText).toBe(labels.enable);
+      expect(enable.okText).not.toBe(labels.save);
+      expect(enable.cancelText).toBe(labels.cancel);
+    });
+
+    it("names the bulk confirmation after the bulk action instead of Save", async () => {
+      render(<FunctionWorkbenchScene boxId="box-1" />);
+
+      fireEvent.click((await railItem("sum_orders")).getByRole("checkbox"));
+      fireEvent.click((await railItem("rank_customers")).getByRole("checkbox"));
+
+      fireEvent.click(await screen.findByRole("button", { name: buttonNamed(labels.enable) }));
+      const enable = await confirmedDialog();
+      expect(enable.okText).toBe(labels.enable);
+      expect(enable.okText).not.toBe(labels.save);
+      expect(enable.cancelText).toBe(labels.cancel);
+
+      services.modal.confirm.mockClear();
+      fireEvent.click(screen.getByRole("button", { name: buttonNamed(labels.disable) }));
+      const disable = await confirmedDialog();
+      expect(disable.okText).toBe(labels.disable);
+      expect(disable.okText).not.toBe(labels.save);
+      expect(disable.cancelText).toBe(labels.cancel);
+    });
+  });
+});

--- a/src/modules/execution-factory/scenes/FunctionWorkbenchScene.tsx
+++ b/src/modules/execution-factory/scenes/FunctionWorkbenchScene.tsx
@@ -73,6 +73,7 @@ import {
 } from "@/modules/execution-factory/utils/function-templates";
 import { buildSampleEvent } from "@/modules/execution-factory/utils/function-sample-event";
 import { buildJsonSchemaFromParameters } from "@/modules/execution-factory/utils/function-parameter-schema";
+import { resolveToolStatusOkTextKey } from "@/modules/execution-factory/utils/status-confirm-ok-text";
 import { collectToolboxPublishIssues } from "@/modules/execution-factory/utils/toolbox-publish-preflight";
 
 import { FunctionDependencyPanel } from "./function-workbench/FunctionDependencyPanel";
@@ -547,7 +548,7 @@ export function FunctionWorkbenchScene({ boxId, onBack }: FunctionWorkbenchScene
         name: target.name || t("executionFactory.workbenchUnnamedFunction"),
         status: t(`executionFactory.toolStatuses.${nextStatus}`),
       }),
-      okText: t("common.save"),
+      okText: t(resolveToolStatusOkTextKey(nextStatus)),
       cancelText: t("common.cancel"),
       onOk: async () => {
         await updateToolStatus(boxId, [toolId], nextStatus);
@@ -687,7 +688,7 @@ export function FunctionWorkbenchScene({ boxId, onBack }: FunctionWorkbenchScene
         count: targets.length,
         status: t(`executionFactory.toolStatuses.${nextStatus}`),
       }),
-      okText: t("common.save"),
+      okText: t(resolveToolStatusOkTextKey(nextStatus)),
       cancelText: t("common.cancel"),
       onOk: async () => {
         try {

--- a/src/modules/execution-factory/scenes/McpListScene.tsx
+++ b/src/modules/execution-factory/scenes/McpListScene.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/modules/execution-factory/services/mcp.service";
 import type { McpRecord, McpStatus } from "@/modules/execution-factory/types/mcp";
 import { formatExecutionUnitTime } from "@/modules/execution-factory/utils/format-timestamp";
+import { resolveStatusChangeOkTextKey } from "@/modules/execution-factory/utils/status-confirm-ok-text";
 
 import styles from "./execution-factory-list.module.css";
 
@@ -90,7 +91,7 @@ export function McpListScene() {
         name: record.name,
         status: t(`executionFactory.mcpStatuses.${status}`),
       }),
-      okText: t("common.save"),
+      okText: t(resolveStatusChangeOkTextKey(status)),
       cancelText: t("common.cancel"),
       onOk: async () => {
         await updateMcpStatus(record.mcpId, status);

--- a/src/modules/execution-factory/scenes/SkillListScene.tsx
+++ b/src/modules/execution-factory/scenes/SkillListScene.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/modules/execution-factory/services/skill.service";
 import type { SkillRecord, SkillStatus } from "@/modules/execution-factory/types/skill";
 import { formatExecutionUnitTime } from "@/modules/execution-factory/utils/format-timestamp";
+import { resolveStatusChangeOkTextKey } from "@/modules/execution-factory/utils/status-confirm-ok-text";
 
 import styles from "./execution-factory-list.module.css";
 
@@ -91,7 +92,7 @@ export function SkillListScene() {
         name: record.name,
         status: t(`executionFactory.skillStatuses.${status}`),
       }),
-      okText: t("common.save"),
+      okText: t(resolveStatusChangeOkTextKey(status)),
       cancelText: t("common.cancel"),
       onOk: async () => {
         await updateSkillStatus(record.skillId, status);

--- a/src/modules/execution-factory/scenes/ToolboxToolsScene.confirm-labels.test.tsx
+++ b/src/modules/execution-factory/scenes/ToolboxToolsScene.confirm-labels.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { ModalFuncProps } from "antd";
+import { MemoryRouter } from "react-router-dom";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "@/app/locales/i18n";
+import { ToolboxToolsScene } from "@/modules/execution-factory/scenes/ToolboxToolsScene";
+
+const services = vi.hoisted(() => ({
+  message: { destroy: vi.fn(), error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+  modal: { confirm: vi.fn<(config: ModalFuncProps) => void>() },
+  runtimeConfig: {
+    currentUser: {
+      permissions: [
+        "execution-factory:tool:create",
+        "execution-factory:tool:delete",
+        "execution-factory:tool:edit",
+        "execution-factory:toolbox:edit",
+      ],
+    },
+  },
+}));
+
+vi.mock("@/framework/context/use-app-services", () => ({
+  useAppServices: () => services,
+}));
+
+// Only the tool rail, the bulk bar, and the confirmation they open are under test.
+vi.mock("@/modules/execution-factory/components/ToolDebugModal", () => ({
+  ToolDebugModal: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/ToolFormDrawer", () => ({
+  ToolFormDrawer: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/ToolIoPanel", () => ({
+  ToolIoPanel: () => null,
+}));
+vi.mock("@/modules/execution-factory/components/create-menu/AddCapabilityWizard", () => ({
+  AddCapabilityWizard: () => null,
+}));
+
+const auditUserDirectory = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("@/modules/execution-factory/utils/use-audit-user-directory", () => ({
+  useAuditUserDirectory: () => auditUserDirectory,
+}));
+vi.mock("@/modules/execution-factory/utils/use-impex-export", () => ({
+  useImpexExport: () => ({ exportComponentById: vi.fn(), isExporting: () => false }),
+}));
+
+const api = vi.hoisted(() => ({
+  deleteTools: vi.fn(),
+  getToolDetail: vi.fn(),
+  getToolbox: vi.fn(),
+  getToolboxMarket: vi.fn(),
+  listTools: vi.fn(),
+  updateTool: vi.fn(),
+  updateToolStatus: vi.fn(),
+}));
+
+vi.mock("@/modules/execution-factory/services/toolbox.service", () => ({
+  getToolbox: api.getToolbox,
+  getToolboxMarket: api.getToolboxMarket,
+}));
+vi.mock("@/modules/execution-factory/services/tool.service", () => ({
+  deleteTools: api.deleteTools,
+  getToolDetail: api.getToolDetail,
+  listTools: api.listTools,
+  updateTool: api.updateTool,
+  updateToolStatus: api.updateToolStatus,
+}));
+
+const TOOLS = [
+  { metadataType: "openapi", name: "get_weather", status: "enabled", toolId: "tool-1" },
+  { metadataType: "openapi", name: "get_forecast", status: "disabled", toolId: "tool-2" },
+];
+
+const LABELS = {
+  "en-US": { cancel: "Cancel", disable: "Disable", enable: "Enable", save: "Save" },
+  "zh-CN": { cancel: "取消", disable: "禁用", enable: "启用", save: "保存" },
+} as const;
+
+function renderScene() {
+  return render(
+    <MemoryRouter initialEntries={["/execution-factory/toolboxes/box-1/tools"]}>
+      <ToolboxToolsScene boxId="box-1" />
+    </MemoryRouter>,
+  );
+}
+
+async function railItem(name: string) {
+  return within(await screen.findByRole("option", { name: new RegExp(name) }));
+}
+
+/** antd spaces out two-character CJK button labels ("启 用"), so compare names without whitespace. */
+function buttonNamed(label: string) {
+  return (accessibleName: string) => accessibleName.replace(/\s/g, "") === label;
+}
+
+async function confirmedDialog() {
+  await waitFor(() => expect(services.modal.confirm).toHaveBeenCalledTimes(1));
+  return services.modal.confirm.mock.calls[0][0];
+}
+
+describe("ToolboxToolsScene tool status confirmation labels (#491)", () => {
+  beforeAll(() => {
+    // antd's responsive observers subscribe through matchMedia, which jsdom does not provide.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        addEventListener: vi.fn(),
+        addListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        matches: false,
+        media: query,
+        onchange: null,
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    );
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getToolbox.mockResolvedValue({
+      boxId: "box-1",
+      metadataType: "openapi",
+      name: "Weather Toolbox",
+      status: "unpublish",
+    });
+    api.listTools.mockResolvedValue({ items: TOOLS, total: TOOLS.length });
+    api.getToolDetail.mockImplementation((_boxId: string, toolId: string) =>
+      Promise.resolve(TOOLS.find((tool) => tool.toolId === toolId)),
+    );
+  });
+
+  describe.each(["en-US", "zh-CN"] as const)("in %s", (locale) => {
+    const labels = LABELS[locale];
+
+    beforeEach(async () => {
+      await i18n.changeLanguage(locale);
+    });
+
+    it("names a single tool's switch confirmation Disable or Enable instead of Save", async () => {
+      renderScene();
+
+      fireEvent.click((await railItem("get_weather")).getByRole("switch"));
+      const disable = await confirmedDialog();
+      expect(disable.okText).toBe(labels.disable);
+      expect(disable.okText).not.toBe(labels.save);
+      expect(disable.cancelText).toBe(labels.cancel);
+
+      services.modal.confirm.mockClear();
+      fireEvent.click((await railItem("get_forecast")).getByRole("switch"));
+      const enable = await confirmedDialog();
+      expect(enable.okText).toBe(labels.enable);
+      expect(enable.okText).not.toBe(labels.save);
+      expect(enable.cancelText).toBe(labels.cancel);
+    });
+
+    it("names the bulk confirmation after the bulk action instead of Save", async () => {
+      renderScene();
+
+      fireEvent.click((await railItem("get_weather")).getByRole("checkbox"));
+      fireEvent.click((await railItem("get_forecast")).getByRole("checkbox"));
+
+      fireEvent.click(await screen.findByRole("button", { name: buttonNamed(labels.enable) }));
+      const enable = await confirmedDialog();
+      expect(enable.okText).toBe(labels.enable);
+      expect(enable.okText).not.toBe(labels.save);
+      expect(enable.cancelText).toBe(labels.cancel);
+
+      services.modal.confirm.mockClear();
+      fireEvent.click(screen.getByRole("button", { name: buttonNamed(labels.disable) }));
+      const disable = await confirmedDialog();
+      expect(disable.okText).toBe(labels.disable);
+      expect(disable.okText).not.toBe(labels.save);
+      expect(disable.cancelText).toBe(labels.cancel);
+    });
+  });
+});

--- a/src/modules/execution-factory/scenes/ToolboxToolsScene.tsx
+++ b/src/modules/execution-factory/scenes/ToolboxToolsScene.tsx
@@ -66,6 +66,7 @@ import {
 import { buildToolboxBasicInfoItems } from "@/modules/execution-factory/utils/toolbox-info-items";
 import { formatAuditUserDisplay } from "@/modules/execution-factory/utils/audit-user-display";
 import { formatExecutionUnitTime } from "@/modules/execution-factory/utils/format-timestamp";
+import { resolveToolStatusOkTextKey } from "@/modules/execution-factory/utils/status-confirm-ok-text";
 import { useAuditUserDirectory } from "@/modules/execution-factory/utils/use-audit-user-directory";
 import { useImpexExport } from "@/modules/execution-factory/utils/use-impex-export";
 
@@ -306,7 +307,7 @@ export function ToolboxToolsScene({ boxId, onBack }: ToolboxToolsSceneProps) {
         name: tool.name,
         status: t(`executionFactory.toolStatuses.${nextStatus}`),
       }),
-      okText: t("common.save"),
+      okText: t(resolveToolStatusOkTextKey(nextStatus)),
       cancelText: t("common.cancel"),
       onOk: async () => {
         await updateToolStatus(boxId, [tool.toolId], nextStatus);
@@ -332,7 +333,7 @@ export function ToolboxToolsScene({ boxId, onBack }: ToolboxToolsSceneProps) {
         count: selectedToolIds.length,
         status: t(`executionFactory.toolStatuses.${nextStatus}`),
       }),
-      okText: t("common.save"),
+      okText: t(resolveToolStatusOkTextKey(nextStatus)),
       cancelText: t("common.cancel"),
       onOk: async () => {
         await updateToolStatus(boxId, selectedToolIds, nextStatus);

--- a/src/modules/execution-factory/utils/status-confirm-ok-text.test.ts
+++ b/src/modules/execution-factory/utils/status-confirm-ok-text.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import i18n from "@/app/locales/i18n";
+import {
+  resolveStatusChangeOkTextKey,
+  resolveToolStatusOkTextKey,
+} from "@/modules/execution-factory/utils/status-confirm-ok-text";
+
+const en = i18n.getFixedT("en-US");
+const zh = i18n.getFixedT("zh-CN");
+
+describe("status-change confirmation OK labels (#491)", () => {
+  it.each([
+    ["published", "Publish", "发布"],
+    ["offline", "Unpublish", "取消发布"],
+    // No single action fits these, so the button falls back to a generic Confirm.
+    ["unpublish", "Confirm", "确认"],
+    ["editing", "Confirm", "确认"],
+  ])("labels a change to %s as %s / %s", (status, enLabel, zhLabel) => {
+    const key = resolveStatusChangeOkTextKey(status);
+
+    expect(en(key)).toBe(enLabel);
+    expect(zh(key)).toBe(zhLabel);
+  });
+
+  it.each([
+    ["enabled", "Enable", "启用"],
+    ["disabled", "Disable", "禁用"],
+  ] as const)("labels a tool change to %s as %s / %s", (status, enLabel, zhLabel) => {
+    const key = resolveToolStatusOkTextKey(status);
+
+    expect(en(key)).toBe(enLabel);
+    expect(zh(key)).toBe(zhLabel);
+  });
+
+  it("never falls back to Save, which these dialogs do not do", () => {
+    const keys = [
+      ...["published", "offline", "unpublish", "editing", ""].map(resolveStatusChangeOkTextKey),
+      ...(["enabled", "disabled"] as const).map(resolveToolStatusOkTextKey),
+    ];
+
+    for (const key of keys) {
+      expect(en(key)).not.toBe(en("common.save"));
+      expect(zh(key)).not.toBe(zh("common.save"));
+    }
+  });
+});

--- a/src/modules/execution-factory/utils/status-confirm-ok-text.ts
+++ b/src/modules/execution-factory/utils/status-confirm-ok-text.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import type { ToolStatus } from "@/modules/execution-factory/types/tool";
+
+/**
+ * OK-button labels for status-change confirmations.
+ *
+ * These dialogs call a status API and never persist form content, so their OK button must not
+ * read Save. It names the action instead, reusing the label of the button or menu item that
+ * opened the dialog.
+ */
+
+export type StatusChangeOkTextKey =
+  | "executionFactory.publish"
+  | "executionFactory.offline"
+  | "executionFactory.statusChangeConfirmOk";
+
+export type ToolStatusOkTextKey = "executionFactory.enable" | "executionFactory.disable";
+
+/**
+ * Label for publishing or unpublishing an operator, toolbox, MCP, or SKILL. A target status that
+ * maps to no single action falls back to a generic Confirm.
+ */
+export function resolveStatusChangeOkTextKey(status: string): StatusChangeOkTextKey {
+  if (status === "published") {
+    return "executionFactory.publish";
+  }
+
+  if (status === "offline") {
+    return "executionFactory.offline";
+  }
+
+  return "executionFactory.statusChangeConfirmOk";
+}
+
+/** Label for enabling or disabling tools and functions, one at a time or in bulk. */
+export function resolveToolStatusOkTextKey(status: ToolStatus): ToolStatusOkTextKey {
+  return status === "enabled" ? "executionFactory.enable" : "executionFactory.disable";
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Status-change confirmation dialogs in Execution Factory showed **Save / 保存** as the OK button even though they only call a status API and never persist form content. The OK button now names the action:

| Dialog | Before | After (en / zh) |
|---|---|---|
| Operator / Toolbox / MCP / Skill publish (unified Execution Units list) | Save / 保存 | Publish / 发布 |
| Operator / Toolbox / MCP / Skill unpublish (unified Execution Units list) | Save / 保存 | Unpublish / 取消发布 |
| Tool enable / disable, single and bulk (`ToolboxToolsScene`) | Save / 保存 | Enable / 启用, Disable / 禁用 |
| Function enable / disable, single and bulk (`FunctionWorkbenchScene`) | Save / 保存 | Enable / 启用, Disable / 禁用 |
| Deprecated `McpListScene` / `SkillListScene` status change | Save / 保存 | Publish / Unpublish, generic Confirm fallback |

The Cancel button stays **Cancel / 取消**.

## Why

- Related Issue: closes #491
- "Save" misleads users into thinking they are persisting edits when they are actually changing the lifecycle state.

## How

- New helper `utils/status-confirm-ok-text.ts` maps the target status to a label key, reusing the existing keys of the menu items and buttons that open these dialogs (`executionFactory.publish`, `.offline`, `.enable`, `.disable`). The dialog button therefore always matches the control the user clicked.
- When no single action fits the target status, the helper falls back to a new, module-scoped `executionFactory.statusChangeConfirmOk` key (en "Confirm", zh "确认"). `common.confirm` (zh "确定") is untouched, as the issue asks.
- The issue suggests zh 停用 for Disable. This PR keeps 禁用 because that is the product's existing term for this action: it is what the triggering switch and bulk button already say, and the status label reads 已禁用.
- Already accurate labels are unchanged: `Publish anyway / 仍然发布` (preflight override) and delete confirmations. Real save flows keep Save, including the function workbench `saveAll()` dialog, the create-operator modal, the schedule forms and the knowledge network form.
- No API, precheck, permission, route or business-flow changes.
- Breaking changes: none.

## Testing

- [x] Unit tests passed locally
- [x] Verified in test environment

Test notes:

- New regression tests cover en-US and zh-CN for the unified Execution Units MCP publish/unpublish flow, toolbox publish (including the `Publish anyway` override), Toolbox tool enable/disable (single + bulk) and Function workbench enable/disable (single + bulk). They assert the OK text is the action name, not Save, and that Cancel is unchanged.
- Red-then-green: reverting the fix in `ToolboxToolsScene` and `ExecutionUnitListScene` turns the two new scene suites red (10/10 failing); restoring turns them green again.
- `pnpm exec tsc -b --force`: pass. `pnpm i18n:check`: pass, 0 hardcoded-zh findings, locale parity OK. `eslint` on the changed files: pass. `vitest run src/modules/execution-factory`: 58 files, 274 tests, all pass.
- Real-data check against test server 14.103.77.23. Method: local vite dev server proxied to the server, driven by Playwright; the script only ever clicks Cancel, so no status was changed.

  | Dialog | Before | After |
  |---|---|---|
  | MCP unpublish (必应搜索中文) | 保存 / Save | 取消发布 / Unpublish |
  | MCP publish | 保存 / Save | 发布 / Publish |
  | Tool switch in toolbox `013回归` | 保存 / Save | 禁用 / Disable |

  Cancel read 取消 / Cancel in every case. Before/after screenshots were captured for all six dialogs.

## Risk & Rollback

- Potential risks: copy-only change inside the confirmation dialogs.
- Rollback: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
