### PR TITLE
feat(model-resources): remove model authorization UI

### DIFF
--- a/src/modules/model-resources/components/models/LargeModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/LargeModelListPanel.tsx
@@ -46,7 +46,6 @@ import {
   getModelTableColumnSortOrder,
   toggleModelSort,
 } from "@/modules/model-resources/utils/model-table-sort";
-import { ObjectAuthorizeDrawer } from "@/modules/system-admin/components/ObjectAuthorizeDrawer";
 
 import styles from "./ModelListPanels.module.css";
 
@@ -75,7 +74,6 @@ export function LargeModelListPanel() {
   const [formOpen, setFormOpen] = useState(false);
   const [guideOpen, setGuideOpen] = useState(false);
   const [monitorOpen, setMonitorOpen] = useState(false);
-  const [authorizeRecord, setAuthorizeRecord] = useState<LlmModel | null>(null);
   const [canCreate, setCanCreate] = useState(false);
   const [canSetDefaultOnCreate, setCanSetDefaultOnCreate] = useState(false);
   const userPermissions = runtimeConfig.currentUser.permissions;
@@ -216,7 +214,6 @@ export function LargeModelListPanel() {
   // Item actions are determined by the effective object operations returned by bkn-safe.
   const canModify = (record: LlmModel) => Boolean(record.operations?.includes("modify"));
   const canDelete = (record: LlmModel) => Boolean(record.operations?.includes("delete"));
-  const canAuthorize = (record: LlmModel) => Boolean(record.operations?.includes("authorize"));
   const canExecute = (record: LlmModel) => Boolean(record.operations?.includes("execute"));
   const canSetDefault = (record: LlmModel) => canModify(record) && !record.default;
   const canUnsetDefault = (record: LlmModel) => canModify(record) && Boolean(record.default);
@@ -302,9 +299,6 @@ export function LargeModelListPanel() {
       return;
     }
 
-    if (key === "authorize" && canAuthorize(record)) {
-      setAuthorizeRecord(record);
-    }
   };
 
   const columns: ColumnsType<LlmModel> = [
@@ -356,9 +350,6 @@ export function LargeModelListPanel() {
                 ? { key: "unsetDefault", label: t("modelResources.models.menus.unsetDefault") }
                 : null,
               { key: "monitor", label: t("modelResources.models.menus.modelMonitoring") },
-              canAuthorize(record)
-                ? { key: "authorize", label: t("modelResources.models.menus.authorizationManagement") }
-                : null,
             ].filter(Boolean),
             onClick: ({ key, domEvent }) => {
               domEvent.stopPropagation();
@@ -675,16 +666,6 @@ export function LargeModelListPanel() {
         open={monitorOpen}
         record={activeRecord}
       />
-      {authorizeRecord ? (
-        <ObjectAuthorizeDrawer
-          objId={authorizeRecord.modelId}
-          objName={authorizeRecord.modelName}
-          objSub={authorizeRecord.modelType}
-          objType="large_model"
-          onClose={() => setAuthorizeRecord(null)}
-          open={Boolean(authorizeRecord)}
-        />
-      ) : null}
     </div>
   );
 }

--- a/src/modules/model-resources/components/models/SmallModelListPanel.tsx
+++ b/src/modules/model-resources/components/models/SmallModelListPanel.tsx
@@ -40,7 +40,6 @@ import {
   getModelTableColumnSortOrder,
   toggleModelSort,
 } from "@/modules/model-resources/utils/model-table-sort";
-import { ObjectAuthorizeDrawer } from "@/modules/system-admin/components/ObjectAuthorizeDrawer";
 
 import styles from "./ModelListPanels.module.css";
 
@@ -69,7 +68,6 @@ export function SmallModelListPanel() {
   const [formMode, setFormMode] = useState<"create" | "edit" | "view">("create");
   const [formOpen, setFormOpen] = useState(false);
   const [guideOpen, setGuideOpen] = useState(false);
-  const [authorizeRecord, setAuthorizeRecord] = useState<SmallModel | null>(null);
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -177,7 +175,6 @@ export function SmallModelListPanel() {
 
   const canModify = (record: SmallModel) => record.operations?.includes("modify");
   const canDelete = (record: SmallModel) => record.operations?.includes("delete");
-  const canAuthorize = (record: SmallModel) => record.operations?.includes("authorize");
   const canSetDefault = (record: SmallModel) =>
     (record.modelType === "embedding" || record.modelType === "reranker") &&
     !record.default &&
@@ -266,9 +263,6 @@ export function SmallModelListPanel() {
       return;
     }
 
-    if (key === "authorize" && canAuthorize(record)) {
-      setAuthorizeRecord(record);
-    }
   };
 
   const columns: ColumnsType<SmallModel> = [
@@ -314,9 +308,6 @@ export function SmallModelListPanel() {
             : null,
           canUnsetDefault(record)
             ? { key: "unsetDefault", label: t("modelResources.models.menus.unsetDefault") }
-            : null,
-          canAuthorize(record)
-            ? { key: "authorize", label: t("modelResources.models.menus.authorizationManagement") }
             : null,
         ].filter(Boolean) as { key: string; label: string }[];
 
@@ -518,16 +509,6 @@ export function SmallModelListPanel() {
         open={guideOpen}
         record={activeRecord}
       />
-      {authorizeRecord ? (
-        <ObjectAuthorizeDrawer
-          objId={authorizeRecord.modelId}
-          objName={authorizeRecord.modelName}
-          objSub={authorizeRecord.modelType}
-          objType="small_model"
-          onClose={() => setAuthorizeRecord(null)}
-          open={Boolean(authorizeRecord)}
-        />
-      ) : null}
     </div>
   );
 }

--- a/src/modules/system-admin/utils/authz-catalog.test.ts
+++ b/src/modules/system-admin/utils/authz-catalog.test.ts
@@ -17,10 +17,10 @@ import {
 } from "./authz-catalog";
 
 describe("object authorization types", () => {
-  it("keeps stored grant types filterable while restricting the new-grant picker", () => {
-    expect(AUTHZ_OBJECT_TYPES).toContain("small_model");
-    expect(AUTHZ_OBJECT_TYPES).toContain("large_model");
-    expect(isAuthzObjectType("small_model")).toBe(true);
+  it("excludes models from every object-grant surface", () => {
+    expect(AUTHZ_OBJECT_TYPES).not.toContain("small_model");
+    expect(AUTHZ_OBJECT_TYPES).not.toContain("large_model");
+    expect(isAuthzObjectType("small_model")).toBe(false);
     expect(isAuthzObjectType("concept_group")).toBe(true);
 
     for (const type of ["small_model", "large_model", "concept_group", "object_type", "relation_type", "action_type", "metric", "risk_type"]) {
@@ -29,7 +29,7 @@ describe("object authorization types", () => {
     }
   });
 
-  it("exposes edition-aware filter catalogues without retired model resources", () => {
+  it("exposes edition-aware filter catalogues without model resources", () => {
     expect(COMMUNITY_OBJECT_GRANT_TYPES).toContain("catalog");
     expect(COMMUNITY_OBJECT_GRANT_TYPES).toContain("knowledge_network");
     expect(COMMUNITY_OBJECT_GRANT_TYPES).not.toContain("resource");

--- a/src/modules/system-admin/utils/authz-catalog.ts
+++ b/src/modules/system-admin/utils/authz-catalog.ts
@@ -6,9 +6,9 @@
  */
 
 // Object types available for object-level grants, aligned with bkn-safe's type vocabulary in
-// section 3 of frontend-object-grants-integration.md. Grants apply to a complete object instance,
-// such as a whole Catalog, not individual data resources. Type labels and operation vocabulary
-// reuse resource-catalog.
+// section 3 of frontend-object-grants-integration.md. Model access is a platform
+// baseline and is intentionally absent: it cannot be configured as an object grant.
+// Type labels and operation vocabulary reuse resource-catalog.
 import { resourceTypeLabel } from "@/modules/system-admin/utils/resource-catalog";
 
 export const AUTHZ_OBJECT_TYPES = [
@@ -21,8 +21,6 @@ export const AUTHZ_OBJECT_TYPES = [
   "action_type",
   "metric",
   "risk_type",
-  "small_model",
-  "large_model",
   "operator",
   "tool_box",
   "mcp",
@@ -50,10 +48,8 @@ export const COMMUNITY_OBJECT_GRANT_TYPES = [
   "skill",
 ] as const;
 
-/** Filterable grant types for the fine-grained editions; retired model grants stay readable only. */
-export const FINE_GRAINED_OBJECT_FILTER_TYPES = AUTHZ_OBJECT_TYPES.filter(
-  (type) => type !== "small_model" && type !== "large_model",
-);
+/** Filterable grant types for the fine-grained editions. */
+export const FINE_GRAINED_OBJECT_FILTER_TYPES = AUTHZ_OBJECT_TYPES;
 
 /** Type-level operations hidden by the object-grant UI because they are meaningless on concrete instances. */
 export const HIDDEN_INSTANCE_OPS = new Set(["create"]);


### PR DESCRIPTION
## What Changed

- [x] Remove the authorization action and drawer from large-model and small-model list pages.
- [x] Remove model resources from every object-grant picker and filter catalogue.
- [ ] Docs/doc 1 — Not applicable.

---

## Why

- Related Issue: Closes #625
- Related Feature: Platform-wide model access
- Background: Models are shared platform infrastructure. Users should not receive or manage per-model grants through the authorization UI.

---

## How

- Key implementation points: Keep model display and lifecycle controls driven by effective model permissions, while removing the separate authorization surface.
- Breaking changes (API, config, database, etc.): The frontend no longer offers model object authorization in any edition.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — Not applicable; this is a frontend-only UI change.
- [ ] Verified in test environment — Not run.

Test notes:

- node scripts/check-license-headers.mjs
- pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0
- pnpm exec vitest --run --maxWorkers=2: 295 files, 1667 tests passed
- pnpm exec tsc -b --pretty false
- NODE_OPTIONS=--max-old-space-size=3072 pnpm exec vite build
- pnpm audit --prod

---

## Risk & Rollback

- Potential risks: Users can no longer configure model-specific authorization from Studio, by design.
- Rollback plan: Revert this commit to restore the authorization menu and object-grant catalogue entries.

---

## Additional Notes

- The companion bkn-safe policy change is openbkn-ai/bkn-foundry#1521.
- No deployment was performed from this branch.