### PR TITLE
fix(execution-factory): list the draft tools on the MCP authoring page

### DIFF
--- a/src/modules/execution-factory/components/McpDetailDrawer.tsx
+++ b/src/modules/execution-factory/components/McpDetailDrawer.tsx
@@ -111,7 +111,8 @@ export function McpDetailDrawer({
 
         if (!marketMode) {
           try {
-            const tools = await listMcpTools(mcpId);
+            // The record above is the config, so count the draft's tools, not the release's.
+            const tools = await listMcpTools(mcpId, { draft: true });
             setToolCount(tools.length);
           } catch {
             setToolCount(mcpRecord.toolConfigs?.length ?? 0);

--- a/src/modules/execution-factory/scenes/McpDetailScene.tsx
+++ b/src/modules/execution-factory/scenes/McpDetailScene.tsx
@@ -119,7 +119,9 @@ export function McpDetailScene({ mcpId, onBack }: McpDetailSceneProps) {
     try {
       await loadRecord();
       try {
-        const nextTools = await listMcpTools(mcpId);
+        // Outside the catalog this page shows the config and debugs its draft, so it lists the
+        // draft too; while the server is editing, the default listing is the release.
+        const nextTools = await listMcpTools(mcpId, { draft: !catalogContext });
         setTools(nextTools);
         setSelectedTool(nextTools[0] ?? null);
       } catch (error) {
@@ -134,7 +136,7 @@ export function McpDetailScene({ mcpId, onBack }: McpDetailSceneProps) {
     } finally {
       setLoading(false);
     }
-  }, [loadRecord, mcpId]);
+  }, [catalogContext, loadRecord, mcpId]);
 
   useEffect(() => {
     void loadTools();

--- a/src/modules/execution-factory/services/mcp-tools-draft.service.test.ts
+++ b/src/modules/execution-factory/services/mcp-tools-draft.service.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2026 OpenBKN
+ * SPDX-License-Identifier: LicenseRef-OpenBKN
+ * Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+ * Conditions. See LICENSE for the full text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/framework/request/http", () => ({
+  http: { get: getMock },
+}));
+
+// While an MCP Server is editing, the proxy listing answers with its release; the authoring
+// page asks for the draft it debugs with `draft=true` (bkn-foundry#1523).
+describe("listMcpTools draft listing", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_USE_MOCK", "false");
+    getMock.mockReset();
+    getMock.mockResolvedValue({ data: { tools: [{ name: "draft_only_tool" }] } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("asks for the draft when requested", async () => {
+    const { listMcpTools } = await import("./mcp.service");
+
+    const tools = await listMcpTools("mcp-1", { draft: true });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["draft_only_tool"]);
+    const [url, config] = getMock.mock.calls[0] as [string, { params: Record<string, unknown> }];
+    expect(url).toContain("/mcp/proxy/mcp-1/tools");
+    expect(config.params.draft).toBe(true);
+  });
+
+  it("leaves the served listing untouched by default", async () => {
+    const { listMcpTools } = await import("./mcp.service");
+
+    await listMcpTools("mcp-1");
+
+    const [, config] = getMock.mock.calls[0] as [string, { params: Record<string, unknown> }];
+    expect(config.params.draft).toBeUndefined();
+  });
+});

--- a/src/modules/execution-factory/services/mcp.service.ts
+++ b/src/modules/execution-factory/services/mcp.service.ts
@@ -405,6 +405,11 @@ export async function deleteMcp(mcpId: string): Promise<void> {
 
 type McpToolsQuery = {
   all?: boolean;
+  /**
+   * List the draft instead of the released tools. They differ only while the server is
+   * editing: callers are served the release, and the authoring page debugs the draft.
+   */
+  draft?: boolean;
   page?: number;
   pageSize?: number;
   status?: "enabled" | "disabled";
@@ -454,6 +459,7 @@ export async function listMcpTools(
   }>(`${API_PREFIX}/mcp/proxy/${mcpId}/tools`, {
     params: {
       all: query.all || undefined,
+      draft: query.draft || undefined,
       page: query.page ?? 1,
       page_size: query.pageSize ?? 100,
       status: query.status,


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] `listMcpTools` takes a `draft` option that sends `draft=true` to the MCP proxy listing; nothing is sent by default.
- [x] The MCP detail page outside the catalog, and the list drawer outside market mode, ask for the draft.
- [ ] Docs: not applicable — the API change and its docs are in openbkn-ai/bkn-foundry#1527.

---

## Why

- Related Issue: Part of [openbkn-ai/bkn-foundry#1523](https://github.com/openbkn-ai/bkn-foundry/issues/1523) (the issue is closed by the backend PR, openbkn-ai/bkn-foundry#1527)
- Related Feature: MCP editing is served from its release (openbkn-ai/bkn-foundry#1518)
- Background: since openbkn-ai/bkn-foundry#1518 the proxy listing answers with the release while an MCP Server is editing, which is what every runtime caller runs. The detail page builds its tool rail, input form and Debug button from that listing while Debug runs the draft, so an author editing a server saw the released tools: a tool added in the draft could not be selected or debugged, and a removed one stayed listed.

---

## How

- Key implementation points:
  - `McpDetailScene` passes `{ draft: !catalogContext }`: the page outside the catalog shows the config (`getMcpDetail`) and debugs its draft, so it lists the draft; the catalog view (`?from=catalog`, `getMcpMarket`) keeps the served listing. `catalogContext` joins the `useCallback` dependencies.
  - `McpDetailDrawer` passes `{ draft: true }` outside market mode, where its record is the config too; market mode does not call the listing.
  - Other callers of `listMcpTools` (capability mounting, action-type tool binding) keep the served listing: they bind tools that runtime callers will execute.
- Breaking changes (API, config, database, etc.): none. The backend before openbkn-ai/bkn-foundry#1527 ignores the flag, so this PR can land first; the draft listing needs `view` permission once the backend lands.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable, no integration suite covers this page
- [x] Verified in test environment

Test notes:

- New `mcp-tools-draft.service.test.ts` checks the flag is sent when requested and absent by default; it fails before the service change.
- Pre-commit checks run: `node scripts/check-license-headers.mjs`, `pnpm exec eslint . --config eslint.config.typechecked.js --max-warnings 0`, `pnpm exec tsc -b --pretty false`, `pnpm exec vite build`, `pnpm audit --prod`, `pnpm test:execution-factory` (59 files, 276 tests), `pnpm i18n:check` — all pass. Full `pnpm exec vitest --run`: 1689/1690; the one failure is `BusinessProvenanceScene` (bkn-trace, untouched here), which passes 3/3 when run alone.
- Local vite dev server against the test server, with the backend from openbkn-ai/bkn-foundry#1527 deployed there, on an editing MCP Server whose release has tool A and whose draft has A and B:
  - before this change, the detail page listed [A]; after it, [A, B];
  - the catalog view lists [A] in both;
  - selecting the draft-only tool B and running Debug from the page calls `POST .../tool/list_knowledge_networks/debug` → 200.

---

## Risk & Rollback

- Potential risks: a user with only `execute` permission on the server who opens the management detail page directly gets 403 on the draft listing, shown as the page's tool-load error; such a user cannot read the management record either.
- Rollback plan: revert this PR; the page goes back to the served listing.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: before/after screenshots of the detail page were taken on the test server; not attached because they show a throwaway test server. The page and component have no component tests yet — a follow-up could mock `listMcpTools` and assert the management view passes `draft: true` and the catalog view does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
